### PR TITLE
Add Browser Method Body Diff for explicit same-assembly pairs

### DIFF
--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -186,7 +186,7 @@ capability they adapt, not ownership of the underlying product facts.
 
 ## Production surface inventory
 
-The seven rooted export assemblies contain 51 `[JSExport]` methods.
+The seven rooted export assemblies contain 54 `[JSExport]` methods.
 The generated `initializeRuntime()` and `runEntryPoint()` functions are
 generator-owned infrastructure and are not part of that count.
 
@@ -271,10 +271,13 @@ so absence remains a visible capability result rather than a missing binding.
 The module does not combine Analysis with call-graph topology; graph traversal
 has its own facade and product owner.
 
-### Source facade: 6 exports
+### Source facade: 9 exports
 
+- `CancelMethodBodyComparison`
 - `CancelSourceQuery`
 - `CancelTypeSourceQuery`
+- `QueryMethodBodyComparison`
+- `QueryMethodBodyComparisonTargets`
 - `QueryMemberAnnotatedSource`
 - `QueryMemberSource`
 - `QueryTypeMemberSource`
@@ -285,6 +288,9 @@ its public cancellation operations belong beside the work they cancel.
 Annotated source stays with source because the returned document and its
 viewer contract are the capability being requested; Analysis facts embedded in
 that product document do not transfer ownership to this adapter.
+Method Body Diff likewise projects native C#/IL comparison evidence through
+the shared query; its target inventory and keyed cancellation stay with that
+feature in the same facade.
 
 ### Call-graph facade: 2 exports
 

--- a/docs/design/inspect-web-method-body-comparison.md
+++ b/docs/design/inspect-web-method-body-comparison.md
@@ -168,6 +168,13 @@ retained workspaces to another realm. Future placement changes consume the
 [Worker runtime](inspect-web-worker-runtime.md) owner without changing pair
 meaning or adding feature-owned lifetime machinery.
 
+Inventory and comparison read already-retained inputs, so they use the keyed
+managed bridge without entering the Source acquisition coordinator. That
+coordinator's supersession is for acquiring Source; opening a local comparison
+must not cancel the member's ongoing Source request. The Release
+`BothExportsPreserveSourceAcquisitionAndReleaseOwnOperation` cases and real
+dialog acceptance gate this coexistence.
+
 Managed/transport failure or cancellation remains distinct from a query
 result. Successfully transporting a query outcome does not mean the comparison
 is exact or even completed. Research completed accounting can contain native

--- a/docs/design/inspect-web-method-body-comparison.md
+++ b/docs/design/inspect-web-method-body-comparison.md
@@ -49,11 +49,11 @@ comparison; existing Browser owners supply execution and presentation lifetime.
 
 | Owner | Consumed contract |
 | --- | --- |
-| [Direct-member query](direct-member-comparison.md#adapter-contract) | Two exact physical designations, same-method support, and designated rather than strict correspondence; the Browser-usable exact-target projection remains a step-6 prerequisite in #5925 |
+| [Direct-member query](direct-member-comparison.md#adapter-contract) | Two exact physical designations, same-method support, and designated rather than strict correspondence; Queries issues physical addresses through `AssemblyContextMethodAddressQuery` for this Browser consumer |
 | [Local comparison publication](local-comparison-publication.md#result-contract) | Original query-origin or Research-terminal evidence associated with one invocation |
 | Existing Browser implementation-member resolution and inspection scope | Reference/surface-to-implementation selection, retained participant access, and validated implementation body selection |
 | [Operation authority](inspect-web-operation-authority.md) | Current-view publication, cancellation, supersession, disposal, and quiescence |
-| [Managed operation bridge](inspect-web-managed-operation-bridge.md) and [Worker runtime](inspect-web-worker-runtime.md) | Generated feature transport, physical execution, cancellation forwarding, and managed release |
+| [Managed operation bridge](inspect-web-managed-operation-bridge.md) | Generated feature transport, keyed cancellation forwarding, and managed release |
 | [Shell interaction](inspect-web-shell-interaction.md) | Shared modal accessibility, Escape, and ordinary focus return |
 | [Surface composition](inspect-web-surface-composition.md#contextual-working-surface-actions) | Contextual-action placement and responsive continuity |
 | [Navigation consumer](inspect-web-navigation-consumer.md) | Ordinary member navigation, canonical location, and history |
@@ -109,9 +109,11 @@ input, not an asserted token in the implementation image.
 Existing Browser resolution returns a validated implementation body token,
 not a `MetadataMethodAddress`. The Browser cannot construct the missing
 module association by opening a metadata reader below Queries.
-The Queries-owned exact-target projection needed to consume that selection
-is an explicit prerequisite within #5925's step-6 adapter delivery. Its public
-API shape stays Queries-owned; this design does not claim it already exists.
+`AssemblyContextMethodAddressQuery` supplies that Queries-owned projection
+with this actual Browser consumer, as part of the existing adapter/host
+delivery rather than another standalone substrate milestone. It returns the
+existing typed assembly-context entry; its construction and failure semantics
+remain Queries-owned.
 
 The comparison consumes the resulting exact implementation participant and
 owner-issued physical method association through that public Queries boundary.
@@ -133,6 +135,16 @@ reinspect each endpoint, or construct a synthetic `ResearchComparison`.
 The context owner retains acquired input lifetime. Queries and Research retain
 their own access and stage cleanup responsibilities.
 
+This feature's transport uses an empty `PackageId` to distinguish a retained
+platform selection from a NuGet package. The version, framework, and assembly
+remain the exact selected coordinates. Unlike existing Source calls that pass
+a runtime pseudo-package ID, this request addresses a resident assembly
+directly; it does not ask package acquisition to interpret that ID.
+The retained lookup supports runtime and ASP.NET Core families only when those
+coordinates identify one scope and one assembly coordinate. Ambiguity is
+visible `ContextUnavailable`, not an arbitrary family choice or reacquisition.
+This is a feature-specific convention, not a change to other Source exports.
+
 ### Operation and result association
 
 Each submitted pair is the immutable input of one feature operation. The
@@ -148,6 +160,13 @@ query-origin versus Research-terminal category, and each requested mechanism's
 endpoint states, comparison verdict, applicable aligned evidence, and failure
 causes. The managed projection consumes original query evidence, not a
 recreated operation identified by display text.
+
+This first adopter follows the existing Source consumer's physical execution
+placement. The current Worker binding is a diagnostic canary, not the host of
+production Source operations. This feature does not migrate acquisition or
+retained workspaces to another realm. Future placement changes consume the
+[Worker runtime](inspect-web-worker-runtime.md) owner without changing pair
+meaning or adding feature-owned lifetime machinery.
 
 Managed/transport failure or cancellation remains distinct from a query
 result. Successfully transporting a query outcome does not mean the comparison

--- a/docs/design/inspect-web-method-body-comparison.md
+++ b/docs/design/inspect-web-method-body-comparison.md
@@ -29,9 +29,9 @@ Different names and declaring types are permitted; selecting the same method
 twice is also valid. This is explicit comparison, not candidate discovery or
 proof of semantic equivalence.
 
-The corresponding CLI consumer is `match --body`, being implemented with
-the shared query and adapter in
-[#5925](https://github.com/richlander/dotnet-inspect/issues/5925).
+The corresponding CLI consumer is `match --body`, landed with the shared query
+and adapter in
+[#5967](https://github.com/richlander/dotnet-inspect/pull/5967).
 The Browser follows that production cutover rather than introducing another
 unused shared substrate.
 
@@ -136,6 +136,14 @@ requesting both local C# and IL mechanisms. It consumes
 reinspect each endpoint, or construct a synthetic `ResearchComparison`.
 The context owner retains acquired input lifetime. Queries and Research retain
 their own access and stage cleanup responsibilities.
+
+The feature consumes the registry's protected-use leases and awaits their
+release before completing the managed operation. A removal-requested scope
+cannot become a new comparison context. Package labels that identify multiple
+eligible retained bindings produce visible `ContextUnavailable`, rather than
+choosing a generation. The
+[Browser registry](../../prototypes/inspect-web/README.md#artifact-backed-package-scope-adoption)
+continues to own admission, binding identity, and asynchronous retirement.
 
 This feature's transport uses an empty `PackageId` to distinguish a retained
 platform selection from a NuGet package. The version, framework, and assembly
@@ -245,7 +253,7 @@ under the new headings.
 | Gate | Adoption evidence |
 | --- | --- |
 | Release `AssemblyContextMethodAddressQueryTests` | Owner-issued module association, MethodDef validation, and typed context failures. |
-| Release `BrowserMethodBodyOperationTests` | Different/same pairs, reference-token drift, explicit accessors, missing/wrong context, original query failures, native body failure, platform retention, and coexistence with Source acquisition. |
+| Release `BrowserMethodBodyOperationTests` | Different/same pairs, reference-token drift, explicit accessors, missing/wrong context, original query failures, native body failure, platform retention, protected-use release, removal-requested and ambiguous retained contexts, and coexistence with Source acquisition. |
 | `method-body-comparison.test.ts`, `method-body-diff-view.test.ts` | Explicit submission, immutable pair association, routed-history disposal and late-result suppression, independent native outcomes, text rendering, and native line-operation lowering. |
 | `generate-inspect-web-engine-facade.sh --check`, Release `ProductionFacadeContextTests` | Compiler-derived typed transport in the existing seven-root facade set. |
 | `browser/method-body-production.spec.ts` against published Wasm | Actual shared-query results for the public package and compiled reference/implementation fixture; bodyless/accessor neighbors; dialog selection, keyboard focus, IL disclosure, narrow layout, unchanged navigation, same-document Back/Forward dismissal, and completed underlying Source. |
@@ -263,12 +271,12 @@ a local listener alone is not user-visible evidence.
 ## Delivery and retirement
 
 Tracker #4706 owns counts. The bounded physical-pair route has eight milestones.
-The shared runtime and CLI cutover in #5925 supply publication 5, adapter 6,
-and CLI 8; this adopter supplies Browser 9. Together with landed steps 1 and 18,
-the route reaches six of eight delivered milestones when both runtime slices
-land. The remaining two are scoped Queries and Research cleanups, steps 16/17.
-The Browser path, 1/18/5/6/9, is implemented end to end; its delivery depends on
-the shared runtime landing first. This feature adds no separate substrate
+The shared runtime and CLI cutover landed in #5967, supplying publication 5,
+adapter 6, and CLI 8; this adopter supplies Browser 9. Together with landed steps
+1 and 18, the route reaches six of eight delivered milestones when this Browser
+slice lands. The remaining two are scoped Queries and Research cleanups, steps
+16/17. The Browser path, 1/18/5/6/9, is implemented end to end on that landed
+shared runtime. This feature adds no separate substrate
 milestone and does not use a fixture-only comparison replacement.
 
 There is no existing Browser two-method comparison route to migrate in the

--- a/docs/design/inspect-web-method-body-comparison.md
+++ b/docs/design/inspect-web-method-body-comparison.md
@@ -246,9 +246,9 @@ under the new headings.
 | --- | --- |
 | Release `AssemblyContextMethodAddressQueryTests` | Owner-issued module association, MethodDef validation, and typed context failures. |
 | Release `BrowserMethodBodyOperationTests` | Different/same pairs, reference-token drift, explicit accessors, missing/wrong context, original query failures, native body failure, platform retention, and coexistence with Source acquisition. |
-| `method-body-comparison.test.ts`, `method-body-diff-view.test.ts` | Explicit submission, immutable pair association, replacement/dismissal, independent native outcomes, text rendering, and native line-operation lowering. |
+| `method-body-comparison.test.ts`, `method-body-diff-view.test.ts` | Explicit submission, immutable pair association, routed-history disposal and late-result suppression, independent native outcomes, text rendering, and native line-operation lowering. |
 | `generate-inspect-web-engine-facade.sh --check`, Release `ProductionFacadeContextTests` | Compiler-derived typed transport in the existing seven-root facade set. |
-| `browser/method-body-production.spec.ts` against published Wasm | Actual shared-query results for the public package and compiled reference/implementation fixture; bodyless/accessor neighbors; dialog selection, keyboard focus, IL disclosure, narrow layout, unchanged navigation, and completed underlying Source. |
+| `browser/method-body-production.spec.ts` against published Wasm | Actual shared-query results for the public package and compiled reference/implementation fixture; bodyless/accessor neighbors; dialog selection, keyboard focus, IL disclosure, narrow layout, unchanged navigation, same-document Back/Forward dismissal, and completed underlying Source. |
 
 The compiled input is `FixtureCatalog.InspectWebMethodBodies`, including its
 `reference` and `package` assets. Browser acceptance substitutes only the

--- a/docs/design/inspect-web-method-body-comparison.md
+++ b/docs/design/inspect-web-method-body-comparison.md
@@ -6,7 +6,9 @@ This is the target design for
 [#5963](https://github.com/richlander/dotnet-inspect/issues/5963), the bounded
 Browser adoption of local comparison in
 [#4706](https://github.com/richlander/dotnet-inspect/issues/4706), step 9.
-The feature is **unimplemented and unverified**.
+The feature is implemented through the existing Source facade and the shared
+direct-member query. The focused and published-Wasm gates below cover this
+adopter; broader portable comparison remains separate.
 
 Inspect Web Method Body Comparison is one focused feature owner. It owns the
 explicit pair interaction, its managed feature projection, and the Method Body
@@ -213,57 +215,61 @@ code, and diagnostics use the existing text-rendering
 conventions. The shared shell owns modal behavior; this feature only supplies
 its accessible title, controls, content, and loading/result announcements.
 
-## Demo and planned gates
+## Demo and gates
 
-**Design mockup**, not a shipped Browser demonstration:
+The published-Wasm acceptance uses
+`Microsoft.Extensions.Primitives` 10.0.0 / `net10.0`:
 
 ```text
-Inspect app.dll -> Left.Compute
+Inspect Microsoft.Extensions.Primitives -> StringSegment.Trim
 Action: Compare method bodies
 
 Method Body Diff
-Before: app.dll / Left.Compute()
-After:  app.dll / Right.Compute()       [choose method]
+Before: StringSegment.Trim()
+After:  StringSegment.TrimStart()      [choose method]
 [Compare] [Close]
 
-C#  Complete -- native body difference
-Before: return value + 1;              After: return value + 2;
-
-IL  Complete -- native operand difference
+Research: Completed
+C#: ProducedCSharp / NotExact          13 native rows
+IL: ProducedIlBody / OpcodeDiff        22 native rows
 [Show IL evidence]
 ```
 
-The neighboring interaction selects `Left.Compute()` on both sides and keeps
-two side-local occurrences. A valid bodyless After instead shows that native
-endpoint as `NoApplicableInput`, never an added member or an exact body.
+The neighboring interaction selects `Trim()` on both sides and reports native
+`Exact` independently for C# and IL. Selecting
+`IChangeToken.RegisterChangeCallback` as After reports
+`NoApplicableInput`, never an added member or an exact body.
 Closing a running comparison and opening another cannot display the old pair
 under the new headings.
 
-| Existing gate area | Required adoption evidence |
+| Gate | Adoption evidence |
 | --- | --- |
-| Release `engine.Tests`, paired feature/facade cases | Product-constructed different-name/type and same-method pairs reach the public query with exact implementation addresses; reference and implementation token differences do not substitute a method. |
-| Release `engine.Tests`, result projection cases | Original query non-success and Research/native evidence survive generated facade projection, including wrong image, bodyless input, native failure, and cancellation. |
-| Inspect Web TypeScript tests, feature coordinator/renderer | Explicit chooser submission, exact result labels, independent C#/IL outcomes, and existing-authority behavior on replacement/dismissal preserve ordinary navigation. |
-| Hosted Browser acceptance | Use the actual compiled-fixture assembly, compare the named pair and bodyless neighbor, exercise keyboard/modal return and a narrow viewport, and show the real public-query result rather than a mocked transport. |
+| Release `AssemblyContextMethodAddressQueryTests` | Owner-issued module association, MethodDef validation, and typed context failures. |
+| Release `BrowserMethodBodyOperationTests` | Different/same pairs, reference-token drift, explicit accessors, missing/wrong context, original query failures, native body failure, platform retention, and coexistence with Source acquisition. |
+| `method-body-comparison.test.ts`, `method-body-diff-view.test.ts` | Explicit submission, immutable pair association, replacement/dismissal, independent native outcomes, text rendering, and native line-operation lowering. |
+| `generate-inspect-web-engine-facade.sh --check`, Release `ProductionFacadeContextTests` | Compiler-derived typed transport in the existing seven-root facade set. |
+| `browser/method-body-production.spec.ts` against published Wasm | Actual shared-query results for the public package and compiled reference/implementation fixture; bodyless/accessor neighbors; dialog selection, keyboard focus, IL disclosure, narrow layout, unchanged navigation, and completed underlying Source. |
 
-These new gates and the hosted demonstration are **unimplemented and
-unverified**. Existing bridge, operation-authority, Queries, and Research gates
-remain evidence for their own contracts, not proof of this adoption.
+The compiled input is `FixtureCatalog.InspectWebMethodBodies`, including its
+`reference` and `package` assets. Browser acceptance substitutes only the
+fixture package download, not comparison transport or native evidence.
+It is opt-in via `INSPECT_WEB_METHOD_BODY_URL` and
+`INSPECT_WEB_METHOD_BODY_FIXTURE`; ordinary CI retains the focused contract
+gates. Existing bridge, operation-authority, Queries, and Research gates remain
+evidence for their own contracts.
 Use the [demo hosting runbook](../runbooks/inspect-web-demo-hosting.md);
 a local listener alone is not user-visible evidence.
 
 ## Delivery and retirement
 
-Tracker #4706 owns counts. The bounded physical-pair route has eight milestones:
-1 and 18 are complete; publication 5, adapter 6, CLI 8, Browser 9, and scoped
-Queries/Research cleanups 16/17 remain. The Browser path is 1, 18, 5, 6, 9:
-five milestones, two complete and three remaining at this design's creation.
-This preparation does not add a runtime milestone or complete step 9.
-
-Issue #5925 owns the shared runtime and CLI cutover. Browser implementation here
-follows that public boundary immediately, not another unconsumed substrate.
-This design can lock while that runtime is in flight; the Browser cannot claim
-delivery using a fixture-only query replacement.
+Tracker #4706 owns counts. The bounded physical-pair route has eight milestones.
+The shared runtime and CLI cutover in #5925 supply publication 5, adapter 6,
+and CLI 8; this adopter supplies Browser 9. Together with landed steps 1 and 18,
+the route reaches six of eight delivered milestones when both runtime slices
+land. The remaining two are scoped Queries and Research cleanups, steps 16/17.
+The Browser path, 1/18/5/6/9, is implemented end to end; its delivery depends on
+the shared runtime landing first. This feature adds no separate substrate
+milestone and does not use a fixture-only comparison replacement.
 
 There is no existing Browser two-method comparison route to migrate in the
 inspected baseline. Preserve single-member Source, Annotated Source, Facts,

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -52,6 +52,7 @@
     <Project Path="fixtures/diff/DiffAsmFixtures.Target/DiffAsmFixtures.Target.csproj" />
     <Project Path="fixtures/diff/DiffFixtures.V1/DiffFixtures.V1.csproj" />
     <Project Path="fixtures/diff/DiffFixtures.V2/DiffFixtures.V2.csproj" />
+    <Project Path="fixtures/inspect-web/InspectWeb.MethodBodyFixtures/InspectWeb.MethodBodyFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NamingFixtures/ILInspector.JsExportSurface.NamingFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.OperatorFixtures/ILInspector.JsExportSurface.OperatorFixtures.csproj" />

--- a/fixtures/inspect-web/InspectWeb.MethodBodyFixtures/InspectWeb.MethodBodyFixtures.csproj
+++ b/fixtures/inspect-web/InspectWeb.MethodBodyFixtures/InspectWeb.MethodBodyFixtures.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <Target Name="CopyMethodBodyReferenceFixture" AfterTargets="Build">
+    <Copy SourceFiles="$(TargetRefPath)" DestinationFolder="$(TargetDir)ref" SkipUnchangedFiles="true" />
+  </Target>
+  <Target Name="BuildMethodBodyFixturePackage" AfterTargets="CopyMethodBodyReferenceFixture">
+    <PropertyGroup>
+      <FixturePackageDirectory>$(IntermediateOutputPath)package/</FixturePackageDirectory>
+    </PropertyGroup>
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(FixturePackageDirectory)lib/$(TargetFramework)" />
+    <Copy SourceFiles="$(TargetRefPath)" DestinationFolder="$(FixturePackageDirectory)ref/$(TargetFramework)" />
+    <Copy SourceFiles="InspectWeb.MethodBodyFixtures.nuspec" DestinationFolder="$(FixturePackageDirectory)" />
+    <ZipDirectory SourceDirectory="$(FixturePackageDirectory)" DestinationFile="$(TargetDir)InspectWeb.MethodBodyFixtures.1.0.0.nupkg" Overwrite="true" />
+  </Target>
+</Project>

--- a/fixtures/inspect-web/InspectWeb.MethodBodyFixtures/InspectWeb.MethodBodyFixtures.nuspec
+++ b/fixtures/inspect-web/InspectWeb.MethodBodyFixtures/InspectWeb.MethodBodyFixtures.nuspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>InspectWeb.MethodBodyFixtures</id>
+    <version>1.0.0</version>
+    <authors>dotnet-inspect</authors>
+    <description>Compiled method-pair, bodyless, accessor, and reference-token fixtures.</description>
+  </metadata>
+</package>

--- a/fixtures/inspect-web/InspectWeb.MethodBodyFixtures/Methods.cs
+++ b/fixtures/inspect-web/InspectWeb.MethodBodyFixtures/Methods.cs
@@ -1,0 +1,19 @@
+namespace InspectWeb.MethodBodyFixtures;
+
+public class Left
+{
+    private static int ReferenceTokenDrift() => 99;
+    public static int Compute(int value) => value + 1;
+    public static int Compute(int value, int other) => value + other;
+    public int Value { get; set; }
+}
+
+public static class Right
+{
+    public static int Transform(int value) => value + 2;
+}
+
+public interface IBodyless
+{
+    int WithoutBody(int value);
+}

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -556,6 +556,8 @@ archive responses. Run the gate after building the frontend and publishing
 | `QueryTypeProjection` | one package/version/framework | `AssemblyContextTypeProjectionQuery.ExecuteParticipant(...)` |
 | `QueryMemberAnnotatedSource` | one package/version/framework | `AssemblyContextMemberProjectionQuery.ExecuteParticipant(...)` |
 | `QueryMemberSource`, `QueryTypeSource`, `QueryTypeMemberSource` | one package/version/framework | `AssemblyContextSourceQuery.ExecuteMemberAsync(...)` / `ExecuteTypeAsync(...)` |
+| `QueryMethodBodyComparisonTargets` | one already-retained package or platform implementation assembly | bounded API surface and `AssemblyContextMethodAddressQuery.ExecuteParticipant(...)` |
+| `QueryMethodBodyComparison` | two selected methods in that implementation assembly | `DirectMemberComparisonQuery.Execute(...)` |
 | `QueryPackageDependencies` | one package/version/framework | `PackageDependencyGroupsQuery.ExecuteAsync(content, ...)` and `AssemblyContextReferencesQuery.ExecuteParticipant(...)` |
 | `QueryPackageIntegrations` | one package/version/framework | `PackageWorkspaceIntegrationsQuery.Execute(realization)` |
 | `QueryPackageOpportunities` | one package/version/framework | `AssemblyContextIntegrationOpportunitiesQuery.Execute(group, prerequisites)` |
@@ -797,6 +799,47 @@ graph focus remains deferred to [#4054].
 ambiguity and diagnostic cases gate these host behaviors.
 
 [#4054]: https://github.com/richlander/dotnet-inspect/issues/4054
+
+## Method Body Diff
+
+Choose **Compare method bodies** for an explicitly selected method or accessor.
+The session-local dialog keeps that method as Before and offers the same
+implementation assembly's methods as After. Filtering and selecting do not run
+a comparison: choose **Compare** explicitly. Selecting the same method twice is
+valid, and bodyless methods remain available for native classification.
+
+C# and IL have independent outcomes and typed evidence. A bodyless
+`NoApplicableInput` endpoint is not equality, and one unavailable mechanism
+does not erase the other's evidence. Changing After clears the old result;
+dismissal disposes the dialog's operation session. Ordinary member navigation
+and shared links do not acquire comparison state.
+
+The Source facade consumes the shared Queries result rather than CLI text or
+another comparison algorithm. Its Queries-owned address projection supplies
+the module association for a validated implementation token. A missing retained
+context, a wrong module, or a changed physical designation is visible
+non-success, not a request to reacquire or substitute another assembly.
+
+Execution follows the existing Source host and managed-operation bridge.
+The Worker binding remains a canary, not a migration of these retained
+workspaces. Logical cancellation suppresses stale publication; synchronous
+managed CPU work does not promise prompt physical cancellation.
+
+The focused contract and adoption boundaries live in
+[Inspect Web Method Body Comparison](../../docs/design/inspect-web-method-body-comparison.md).
+The compiled fixture is registered as `FixtureCatalog.InspectWebMethodBodies`.
+An opt-in production-facade Browser case runs against the complete published
+Wasm site, not Vite's frontend-only build:
+
+```bash
+INSPECT_WEB_METHOD_BODY_URL=http://127.0.0.1:5199 \
+  npm run test:browser -- browser/method-body-production.spec.ts
+```
+
+Set `INSPECT_WEB_METHOD_BODY_FIXTURE` to that catalog fixture's `package`
+asset to include its compiled reference/implementation and accessor case.
+Only package acquisition is supplied with fixture bytes; comparison uses the
+published generated facade and product query.
 
 ## Unsupported
 

--- a/prototypes/inspect-web/browser/method-body-production.spec.ts
+++ b/prototypes/inspect-web/browser/method-body-production.spec.ts
@@ -115,7 +115,7 @@ test.describe("published Method Body Diff", () => {
 
   test("compiled reference package reaches the real comparison and accessor paths", async ({ page }, testInfo) => {
     test.skip(!fixturePackage, "Set INSPECT_WEB_METHOD_BODY_FIXTURE to the catalog package asset.");
-    await page.route("**/v3-flatcontainer/inspectweb.methodbodyfixtures/1.0.0/*.nupkg",
+    await page.route("**/inspectweb.methodbodyfixtures*.nupkg",
       route => route.fulfill({
         path: fixturePackage!,
         contentType: "application/octet-stream",
@@ -215,15 +215,18 @@ test.describe("published Method Body Diff", () => {
     await expect(after).toBeFocused();
     await expect(compare).toBeDisabled();
 
-    async function choose(method: string): Promise<void> {
+    async function choose(
+      method: string, type = "Microsoft.Extensions.Primitives.StringSegment",
+    ): Promise<void> {
       const option = after.locator("option").filter({
         hasText: new RegExp(`\\b${method}\\s*\\(`),
-      });
+      }).filter({ hasText: `${type} /` });
       await expect(option).toHaveCount(1);
       const label = await option.textContent();
       if (label === null)
         throw new Error(`No label for the product-issued ${method} selection.`);
       await after.selectOption({ label });
+      await expect(after).toBeFocused();
       await expect(dialog.locator("[data-method-body-comparison-outcome]")).toHaveCount(0);
     }
     async function submit(): Promise<void> {
@@ -249,7 +252,7 @@ test.describe("published Method Body Diff", () => {
     await expect(csharp.locator('[data-method-body-exact="true"]')).toBeVisible();
     await expect(il.locator('[data-method-body-exact="true"]')).toBeVisible();
 
-    await choose("RegisterChangeCallback");
+    await choose("RegisterChangeCallback", "Microsoft.Extensions.Primitives.IChangeToken");
     await submit();
     for (const lane of [csharp, il]) {
       await expect(lane.locator(
@@ -269,5 +272,7 @@ test.describe("published Method Body Diff", () => {
     await expect(action).toBeFocused();
     expect(page.url()).toBe(beforeUrl);
     expect(await page.evaluate(() => history.length)).toBe(beforeHistory);
+    await expect(page.getByRole("group", { name: "Source actions" })
+      .getByRole("button", { name: "Copy", exact: true })).toBeEnabled({ timeout: 60_000 });
   });
 });

--- a/prototypes/inspect-web/browser/method-body-production.spec.ts
+++ b/prototypes/inspect-web/browser/method-body-production.spec.ts
@@ -287,5 +287,25 @@ test.describe("published Method Body Diff", () => {
       return { url: location.href, build: host.buildIdentity() };
     });
     await writeFile(testInfo.outputPath("browser-demo.json"), JSON.stringify(demo, null, 2));
+
+    // Seed a route predecessor: member selections replace the canonical URL.
+    await page.evaluate(() => {
+      const currentUrl = location.href;
+      const currentState: unknown = history.state;
+      history.replaceState(null, "", "/demos");
+      history.pushState(currentState, "", currentUrl);
+    });
+    const timeOrigin = await page.evaluate(() => performance.timeOrigin);
+    await action.click();
+    await expect(dialog).toBeVisible();
+    await page.goBack();
+    expect(page.url()).not.toBe(beforeUrl);
+    expect(await page.evaluate(() => performance.timeOrigin)).toBe(timeOrigin);
+    await expect(dialog).toHaveCount(0);
+    await page.goForward();
+    await expect(page).toHaveURL(beforeUrl);
+    expect(await page.evaluate(() => performance.timeOrigin)).toBe(timeOrigin);
+    await expect(dialog).toHaveCount(0);
+    await expect(action).toBeEnabled();
   });
 });

--- a/prototypes/inspect-web/browser/method-body-production.spec.ts
+++ b/prototypes/inspect-web/browser/method-body-production.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { writeFile } from "node:fs/promises";
 
 const site = process.env.INSPECT_WEB_METHOD_BODY_URL;
 const fixturePackage = process.env.INSPECT_WEB_METHOD_BODY_FIXTURE;
@@ -85,9 +86,10 @@ test.describe("published Method Body Diff", () => {
       return { targets, different, same, noBody, cancellation };
     });
 
+    const evidencePath = testInfo.outputPath("native-comparisons.json");
+    await writeFile(evidencePath, JSON.stringify(evidence, null, 2));
     await testInfo.attach("native-comparisons.json", {
-      body: JSON.stringify(evidence, null, 2),
-      contentType: "application/json",
+      path: evidencePath, contentType: "application/json",
     });
     expect(evidence.cancellation.kind).toBe("NotActive");
     for (const result of [evidence.different, evidence.same, evidence.noBody]) {
@@ -168,9 +170,10 @@ test.describe("published Method Body Diff", () => {
       );
       return { launch, targets, compared, noBody, accessors, getter, setter };
     });
+    const evidencePath = testInfo.outputPath("compiled-fixture-comparisons.json");
+    await writeFile(evidencePath, JSON.stringify(evidence, null, 2));
     await testInfo.attach("compiled-fixture-comparisons.json", {
-      body: JSON.stringify(evidence, null, 2),
-      contentType: "application/json",
+      path: evidencePath, contentType: "application/json",
     });
     expect(evidence.targets.before.metadataToken).not.toBe(evidence.launch.token);
     expect(evidence.compared.kind).toBe("Succeeded");
@@ -225,6 +228,7 @@ test.describe("published Method Body Diff", () => {
       const label = await option.textContent();
       if (label === null)
         throw new Error(`No label for the product-issued ${method} selection.`);
+      await after.focus();
       await after.selectOption({ label });
       await expect(after).toBeFocused();
       await expect(dialog.locator("[data-method-body-comparison-outcome]")).toHaveCount(0);
@@ -243,8 +247,10 @@ test.describe("published Method Body Diff", () => {
     await expect(il.locator("details")).toHaveJSProperty("open", false);
     await il.locator("summary").click();
     await expect(il.locator('[data-method-body-row="il"]').first()).toBeVisible();
+    const differentScreenshot = testInfo.outputPath("different-methods.png");
+    await page.screenshot({ path: differentScreenshot, fullPage: true });
     await testInfo.attach("different-methods.png", {
-      body: await page.screenshot({ fullPage: true }), contentType: "image/png",
+      path: differentScreenshot, contentType: "image/png",
     });
 
     await choose("Trim");
@@ -264,8 +270,10 @@ test.describe("published Method Body Diff", () => {
     await expect(dialog).toBeVisible();
     expect(await page.evaluate(() =>
       document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+    const narrowScreenshot = testInfo.outputPath("bodyless-narrow.png");
+    await page.screenshot({ path: narrowScreenshot, fullPage: true });
     await testInfo.attach("bodyless-narrow.png", {
-      body: await page.screenshot({ fullPage: true }), contentType: "image/png",
+      path: narrowScreenshot, contentType: "image/png",
     });
     await page.keyboard.press("Escape");
     await expect(dialog).toHaveCount(0);
@@ -274,5 +282,10 @@ test.describe("published Method Body Diff", () => {
     expect(await page.evaluate(() => history.length)).toBe(beforeHistory);
     await expect(page.getByRole("group", { name: "Source actions" })
       .getByRole("button", { name: "Copy", exact: true })).toBeEnabled({ timeout: 60_000 });
+    const demo = await page.evaluate(async () => {
+      const host = await import("/inspect-web-host.js");
+      return { url: location.href, build: host.buildIdentity() };
+    });
+    await writeFile(testInfo.outputPath("browser-demo.json"), JSON.stringify(demo, null, 2));
   });
 });

--- a/prototypes/inspect-web/browser/method-body-production.spec.ts
+++ b/prototypes/inspect-web/browser/method-body-production.spec.ts
@@ -1,0 +1,273 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const site = process.env.INSPECT_WEB_METHOD_BODY_URL;
+const fixturePackage = process.env.INSPECT_WEB_METHOD_BODY_FIXTURE;
+
+async function openPublishedSite(page: Page, url = site!): Promise<void> {
+  await page.goto(url, { waitUntil: "networkidle" });
+  await page.waitForFunction(async () => {
+    const host = await import("/inspect-web-host.js");
+    try {
+      return host.buildIdentity() !== null;
+    } catch (error: unknown) {
+      if (error instanceof Error &&
+          error.message === "The .NET runtime facade is not initialized.")
+        return false;
+      throw error;
+    }
+  });
+}
+
+test.describe("published Method Body Diff", () => {
+  test.skip(!site, "Set INSPECT_WEB_METHOD_BODY_URL to the published Wasm site.");
+  test.setTimeout(180_000);
+
+  test("generated facade preserves real pair, exact, and bodyless outcomes", async ({ page }, testInfo) => {
+    await openPublishedSite(page);
+
+    const evidence = await page.evaluate(async () => {
+      const packages = await import("/inspect-web-package.js");
+      const source = await import("/inspect-web-source.js");
+      const cancellation = source.cancelMethodBodyComparison(
+        "method-body-production-not-active", "user",
+      );
+      const surface = await packages.queryPackage(
+        "Microsoft.Extensions.Primitives", "10.0.0", "net10.0",
+      );
+      const type = surface.types.find(
+        candidate => candidate.definitionId === "Microsoft.Extensions.Primitives.StringSegment",
+      );
+      const member = type?.api.find(candidate => candidate.name === "Trim");
+      if (!type || !member)
+        throw new Error("The published package does not contain StringSegment.Trim.");
+      const body = member.bodySelectors.find(
+        candidate => candidate.token === member.metadataToken,
+      );
+      if (!body)
+        throw new Error("StringSegment.Trim has no exact Browser body selector.");
+      const prepared = await source.queryMethodBodyComparisonTargets(
+        "method-body-production-targets",
+        surface.package, surface.version, surface.activeFramework,
+        type.assemblyId, type.definitionId,
+        body.memberName, body.selectorKey, body.token,
+      );
+      if (prepared.kind !== "Succeeded" || !prepared.value)
+        throw new Error(`Comparison preparation failed: ${JSON.stringify(prepared)}`);
+      const targets = prepared.value;
+      const after = targets.methods.find(candidate =>
+        candidate.typeIdentity === targets.before.typeIdentity &&
+        candidate.memberName === "TrimStart");
+      const bodyless = targets.methods.find(candidate =>
+        candidate.typeIdentity === "Microsoft.Extensions.Primitives.IChangeToken" &&
+        candidate.memberName === "RegisterChangeCallback");
+      if (!after || !bodyless)
+        throw new Error("The implementation inventory lost a demo method.");
+      const request = {
+        packageId: targets.packageId,
+        version: targets.version,
+        framework: targets.framework,
+        assembly: targets.assembly,
+        moduleVersionId: targets.moduleVersionId,
+        before: targets.before,
+        after,
+      };
+      const different = await source.queryMethodBodyComparison(
+        "method-body-production-different", JSON.stringify(request),
+      );
+      const same = await source.queryMethodBodyComparison(
+        "method-body-production-same",
+        JSON.stringify({ ...request, after: targets.before }),
+      );
+      const noBody = await source.queryMethodBodyComparison(
+        "method-body-production-bodyless",
+        JSON.stringify({ ...request, after: bodyless }),
+      );
+      return { targets, different, same, noBody, cancellation };
+    });
+
+    await testInfo.attach("native-comparisons.json", {
+      body: JSON.stringify(evidence, null, 2),
+      contentType: "application/json",
+    });
+    expect(evidence.cancellation.kind).toBe("NotActive");
+    for (const result of [evidence.different, evidence.same, evidence.noBody]) {
+      expect(result.kind).toBe("Succeeded");
+      expect(result.value?.stage).toBe("Research");
+      expect(result.value?.outcome).toBe("Completed");
+      expect(result.value?.producers).toHaveLength(2);
+      expect(result.value?.request.before).toEqual(evidence.targets.before);
+      for (const producer of result.value!.producers) {
+        expect(producer.before.moduleVersionId).toBe(evidence.targets.moduleVersionId);
+        expect(producer.after.moduleVersionId).toBe(evidence.targets.moduleVersionId);
+      }
+    }
+    const different = evidence.different.value!;
+    expect(different.producers.find(producer => producer.cSharp)?.cSharp?.isExact).toBe(false);
+    expect(different.producers.find(producer => producer.il)?.il?.isExact).toBe(false);
+    const same = evidence.same.value!;
+    expect(same.producers.find(producer => producer.cSharp)?.cSharp?.isExact).toBe(true);
+    expect(same.producers.find(producer => producer.il)?.il?.isExact).toBe(true);
+    for (const producer of evidence.noBody.value!.producers) {
+      expect(producer.after.state).toBe("NoApplicableInput");
+      expect(producer.nativeVerdict).not.toBe("Exact");
+    }
+  });
+
+  test("compiled reference package reaches the real comparison and accessor paths", async ({ page }, testInfo) => {
+    test.skip(!fixturePackage, "Set INSPECT_WEB_METHOD_BODY_FIXTURE to the catalog package asset.");
+    await page.route("**/v3-flatcontainer/inspectweb.methodbodyfixtures/1.0.0/*.nupkg",
+      route => route.fulfill({
+        path: fixturePackage!,
+        contentType: "application/octet-stream",
+        headers: { "access-control-allow-origin": "*" },
+      }));
+    await openPublishedSite(page);
+    const evidence = await page.evaluate(async () => {
+      const packages = await import("/inspect-web-package.js");
+      const source = await import("/inspect-web-source.js");
+      const surface = await packages.queryPackage(
+        "InspectWeb.MethodBodyFixtures", "1.0.0", "net11.0",
+      );
+      const type = surface.types.find(candidate =>
+        candidate.definitionId === "InspectWeb.MethodBodyFixtures.Left");
+      const member = type?.api.find(candidate =>
+        candidate.name === "Compute" && candidate.parameters.length === 1);
+      const launch = member?.bodySelectors.find(candidate =>
+        candidate.token === member.metadataToken);
+      if (!type || !member || !launch)
+        throw new Error("The compiled reference fixture lost Left.Compute(int).");
+      const prepared = await source.queryMethodBodyComparisonTargets(
+        "method-body-fixture-targets",
+        surface.package, surface.version, surface.activeFramework, type.assemblyId,
+        type.definitionId, launch.memberName, launch.selectorKey, launch.token,
+      );
+      if (prepared.kind !== "Succeeded" || !prepared.value)
+        throw new Error(`Fixture preparation failed: ${JSON.stringify(prepared)}`);
+      const targets = prepared.value;
+      const different = targets.methods.find(candidate => candidate.memberName === "Transform");
+      const bodyless = targets.methods.find(candidate => candidate.memberName === "WithoutBody");
+      const getter = targets.methods.find(candidate => candidate.memberName === "get_Value");
+      const setter = targets.methods.find(candidate => candidate.memberName === "set_Value");
+      if (!different || !bodyless || !getter || !setter)
+        throw new Error("The compiled implementation inventory lost a fixture method.");
+      const request = {
+        packageId: targets.packageId, version: targets.version,
+        framework: targets.framework, assembly: targets.assembly,
+        moduleVersionId: targets.moduleVersionId,
+        before: targets.before, after: different,
+      };
+      const compared = await source.queryMethodBodyComparison(
+        "method-body-fixture-different", JSON.stringify(request),
+      );
+      const noBody = await source.queryMethodBodyComparison(
+        "method-body-fixture-bodyless", JSON.stringify({ ...request, after: bodyless }),
+      );
+      const accessors = await source.queryMethodBodyComparison(
+        "method-body-fixture-accessors",
+        JSON.stringify({ ...request, before: getter, after: setter }),
+      );
+      return { launch, targets, compared, noBody, accessors, getter, setter };
+    });
+    await testInfo.attach("compiled-fixture-comparisons.json", {
+      body: JSON.stringify(evidence, null, 2),
+      contentType: "application/json",
+    });
+    expect(evidence.targets.before.metadataToken).not.toBe(evidence.launch.token);
+    expect(evidence.compared.kind).toBe("Succeeded");
+    expect(evidence.compared.value?.outcome).toBe("Completed");
+    expect(evidence.compared.value?.producers.find(producer => producer.cSharp)?.cSharp?.isExact).toBe(false);
+    expect(evidence.compared.value?.producers.find(producer => producer.il)?.il?.isExact).toBe(false);
+    expect(evidence.noBody.kind).toBe("Succeeded");
+    expect(evidence.noBody.value?.producers).toHaveLength(2);
+    for (const producer of evidence.noBody.value!.producers)
+      expect(producer.after.state).toBe("NoApplicableInput");
+    expect(evidence.accessors.kind).toBe("Succeeded");
+    expect(evidence.accessors.value?.producers).toHaveLength(2);
+    for (const producer of evidence.accessors.value!.producers) {
+      expect(producer.before.metadataToken).toBe(evidence.getter.metadataToken);
+      expect(producer.after.metadataToken).toBe(evidence.setter.metadataToken);
+    }
+  });
+
+  test("real dialog keeps explicit pairs, native outcomes, navigation, and focus", async ({ page }, testInfo) => {
+    const location = new URL(site!);
+    location.search = new URLSearchParams({
+      package: "Microsoft.Extensions.Primitives",
+      version: "10.0.0",
+      framework: "net10.0",
+    }).toString();
+    await openPublishedSite(page, location.href);
+    await page.locator("[data-type]").filter({
+      has: page.getByText("StringSegment", { exact: true }),
+    }).first().click({ timeout: 90_000 });
+    await page.locator("button.api-row[data-member]").filter({ hasText: /\bTrim\b/ }).click();
+    await page.locator('[data-member-section="source"]').click();
+    const action = page.locator("#compare-method-bodies");
+    await expect(action).toBeEnabled();
+    const beforeUrl = page.url();
+    const beforeHistory = await page.evaluate(() => history.length);
+    await action.click();
+    const dialog = page.locator("#method-body-diff-modal");
+    const after = dialog.locator("#method-body-diff-after");
+    const compare = dialog.locator("#method-body-diff-compare");
+    await expect(dialog).toBeVisible();
+    await expect(after).toBeEnabled();
+    await expect(after).toBeFocused();
+    await expect(compare).toBeDisabled();
+
+    async function choose(method: string): Promise<void> {
+      const option = after.locator("option").filter({
+        hasText: new RegExp(`\\b${method}\\s*\\(`),
+      });
+      await expect(option).toHaveCount(1);
+      const label = await option.textContent();
+      if (label === null)
+        throw new Error(`No label for the product-issued ${method} selection.`);
+      await after.selectOption({ label });
+      await expect(dialog.locator("[data-method-body-comparison-outcome]")).toHaveCount(0);
+    }
+    async function submit(): Promise<void> {
+      await compare.click();
+      await expect(dialog.locator("[data-method-body-comparison-outcome]"))
+        .toHaveText("Completed", { timeout: 60_000 });
+    }
+    const csharp = dialog.locator('[data-method-body-producer="CSharp"]');
+    const il = dialog.locator('[data-method-body-producer="IlBody"]');
+    await choose("TrimStart");
+    await submit();
+    await expect(csharp.locator('[data-method-body-exact="false"]')).toBeVisible();
+    await expect(il.locator("[data-method-body-il-outcome]")).toBeVisible();
+    await expect(il.locator("details")).toHaveJSProperty("open", false);
+    await il.locator("summary").click();
+    await expect(il.locator('[data-method-body-row="il"]').first()).toBeVisible();
+    await testInfo.attach("different-methods.png", {
+      body: await page.screenshot({ fullPage: true }), contentType: "image/png",
+    });
+
+    await choose("Trim");
+    await submit();
+    await expect(csharp.locator('[data-method-body-exact="true"]')).toBeVisible();
+    await expect(il.locator('[data-method-body-exact="true"]')).toBeVisible();
+
+    await choose("RegisterChangeCallback");
+    await submit();
+    for (const lane of [csharp, il]) {
+      await expect(lane.locator(
+        '[data-method-body-endpoint="after"] [data-method-body-endpoint-state]',
+      )).toHaveText("NoApplicableInput");
+      await expect(lane.locator("[data-method-body-exact]")).toHaveCount(0);
+    }
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(dialog).toBeVisible();
+    expect(await page.evaluate(() =>
+      document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+    await testInfo.attach("bodyless-narrow.png", {
+      body: await page.screenshot({ fullPage: true }), contentType: "image/png",
+    });
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+    await expect(action).toBeFocused();
+    expect(page.url()).toBe(beforeUrl);
+    expect(await page.evaluate(() => history.length)).toBe(beforeHistory);
+  });
+});

--- a/prototypes/inspect-web/browser/tsconfig.json
+++ b/prototypes/inspect-web/browser/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/prototypes/inspect-web/engine.Core/BrowserMemberResolution.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserMemberResolution.cs
@@ -132,31 +132,47 @@ internal static class BrowserMemberResolution
             scope.SurfaceParticipant(coordinate, surfaceAsset);
         BrowserWorkspaceParticipant participant =
             scope.ImplementationParticipant(surfaceParticipant);
+        Analysis.CallGraphMemberResolution resolution = scope.UseImplementationParticipant(
+            participant,
+            (group, member) => ResolveImplementationMember(
+                ImplementationSurface(group, member), typeId, memberName, selectorKey, metadataToken));
+        return new Resolved(surfaceParticipant, participant, resolution);
+    }
+
+    internal static ApiSurface ImplementationSurface(
+        AssemblyContextGroup group,
+        AssemblyContextParticipant participant)
+    {
         // One participant, under the same browser bounds as the package load: a body selector is
         // resolved against the implementation surface, and an over-budget implementation must
         // fail visibly rather than resolve against a silently shortened surface.
         AssemblyContextApiSurfaceResult implementationSurfaces =
-            scope.UseImplementationParticipant(
-                participant,
-                (group, member) => AssemblyContextApiSurfaceQuery.ExecuteBounded(
+            AssemblyContextApiSurfaceQuery.ExecuteBounded(
                     group,
                     ApiSurfaceScope.IncludeAll,
                     BrowserApiSurfacePolicy.Limits,
-                    [member]));
+                    [participant]);
         if (implementationSurfaces.Truncation is { } truncation)
         {
             throw new InvalidOperationException(
-                $"The implementation surface for '{typeId}' exceeds the browser projection "
+                $"The implementation surface exceeds the browser projection "
                 + $"bounds, so the selected body cannot be resolved. "
                 + BrowserApiSurfacePolicy.TruncationNotice(truncation));
         }
 
-        AssemblyApiSurface implementation = BrowserSurfaceProjection.Require(
+        return BrowserSurfaceProjection.Require(
             implementationSurfaces.Assemblies.Assemblies.Single(),
-            $"Implementation surface for '{typeId}'");
-        Analysis.CallGraphMemberResolution resolution =
+            "Implementation surface").Surface;
+    }
+
+    internal static Analysis.CallGraphMemberResolution ResolveImplementationMember(
+        ApiSurface implementation,
+        string typeId,
+        string memberName,
+        string selectorKey,
+        int metadataToken) =>
             Analysis.CallGraphMemberResolver.ResolveDefinitionIdentity(
-                implementation.Surface,
+                implementation,
                 typeId,
                 memberName,
                 selectorKey,
@@ -164,6 +180,4 @@ internal static class BrowserMemberResolution
             ?? throw new InvalidOperationException(
                 $"The implementation of '{typeId}.{memberName}' does not contain the selected "
                 + "API body.");
-        return new Resolved(surfaceParticipant, participant, resolution);
-    }
 }

--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -889,6 +889,23 @@ internal static class BrowserPackageWorkspace
         return FindOpenEntry(scope) is not null;
     }
 
+    internal static BrowserScopeLease<BrowserInspectionScope> LeaseRetainedPackageScope(
+        string packageId,
+        string version,
+        string framework)
+    {
+        string key = CompositeKey("packages", CompositeKey(
+            packageId.ToLowerInvariant(), version.ToLowerInvariant(), framework.ToLowerInvariant()));
+        var demand = new KeyedScopeDemand(key);
+        ScopeEntry[] candidates = Scopes.Where(demand.Joins).ToArray();
+        if (candidates is not [{ Scope: BrowserInspectionScope scope }])
+        {
+            throw new InvalidOperationException(
+                $"ContextUnavailable: the exact {packageId} {version} / {framework} workspace is not uniquely retained.");
+        }
+        return LeaseScope(scope);
+    }
+
     internal static void TouchScope(IAsyncDisposable scope)
     {
         ArgumentNullException.ThrowIfNull(scope);

--- a/prototypes/inspect-web/engine.Core/BrowserPlatformWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPlatformWorkspace.cs
@@ -150,6 +150,35 @@ internal static class BrowserPlatformWorkspace
         new(StringComparer.Ordinal);
     static long _targetClock;
 
+    internal static BrowserPlatformScopeResolution LeaseRetainedAssembly(
+        string framework, string version, string assembly)
+    {
+        string name = AssemblySimpleName(assembly);
+        BrowserPlatformScope[] scopes = Targets.Values
+            .Select(state => state.Scope)
+            .OfType<BrowserPlatformScope>()
+            .Distinct()
+            .Where(scope => BrowserPackageWorkspace.IsScopeRetained(scope)
+                && scope.Framework.Equals(framework, StringComparison.OrdinalIgnoreCase)
+                && scope.Coordinates.Any(coordinate =>
+                    coordinate.Version.Equals(version, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(coordinate.Assembly, name, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+        if (scopes.Length != 1)
+            throw new InvalidOperationException(
+                $"ContextUnavailable: no unique retained platform workspace contains {name} {version} / {framework}.");
+        BrowserPlatformScope retained = scopes[0];
+        RealizedMemberCoordinate.Platform[] coordinates = retained.Coordinates.Where(coordinate =>
+            coordinate.Version.Equals(version, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(coordinate.Assembly, name, StringComparison.OrdinalIgnoreCase)).ToArray();
+        if (coordinates.Length != 1)
+            throw new InvalidOperationException(
+                "ContextUnavailable: the retained platform assembly selection is ambiguous.");
+        RealizedMemberCoordinate.Platform selected = coordinates[0];
+        return new(retained, retained.Participant(selected.Family, name),
+            selected, BrowserPackageWorkspace.LeaseScope(retained));
+    }
+
     internal static Task<BrowserPlatformScopeResolution> OpenRuntimeAsync(
         string targetFramework,
         CancellationToken cancellationToken = default) =>

--- a/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyContracts.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyContracts.cs
@@ -1,0 +1,135 @@
+using System.Text.Json.Serialization;
+
+namespace InspectWeb.Engine.SourceFacade;
+
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserMethodBodyResultKind>))]
+public enum BrowserMethodBodyResultKind
+{
+    Succeeded,
+    Failed,
+    Canceled,
+}
+
+public sealed record BrowserMethodBodySelection(
+    string TypeIdentity,
+    string MemberName,
+    string SelectorKey,
+    int MetadataToken,
+    string Label);
+
+public sealed record BrowserMethodBodyTargets(
+    string PackageId,
+    string Version,
+    string Framework,
+    string Assembly,
+    string ModuleVersionId,
+    BrowserMethodBodySelection Before,
+    BrowserMethodBodySelection[] Methods);
+
+public sealed record BrowserMethodBodyComparisonRequest(
+    string PackageId,
+    string Version,
+    string Framework,
+    string Assembly,
+    string ModuleVersionId,
+    BrowserMethodBodySelection Before,
+    BrowserMethodBodySelection After);
+
+public sealed record BrowserMethodBodyTargetsResult(
+    int Version,
+    BrowserMethodBodyResultKind Kind,
+    BrowserMethodBodyTargets? Value,
+    BrowserTypeSourceFailureKind? FailureKind,
+    string? Error,
+    string? Diagnostic,
+    string? Reason);
+
+public sealed record BrowserMethodBodyComparisonResult(
+    int Version,
+    BrowserMethodBodyResultKind Kind,
+    BrowserMethodBodyComparison? Value,
+    BrowserTypeSourceFailureKind? FailureKind,
+    string? Error,
+    string? Diagnostic,
+    string? Reason);
+
+public sealed record BrowserMethodBodyComparison(
+    BrowserMethodBodyComparisonRequest Request,
+    string Stage,
+    string Outcome,
+    BrowserMethodBodyProducer[] Producers,
+    BrowserMethodBodyDiagnostic[] Diagnostics);
+
+public sealed record BrowserMethodBodyEndpoint(
+    string State,
+    string? ModuleVersionId,
+    int? MetadataToken,
+    string? TargetState,
+    string? Detail);
+
+public sealed record BrowserMethodBodyProducer(
+    string Producer,
+    string Outcome,
+    string NativeVerdict,
+    BrowserMethodBodyEndpoint Before,
+    BrowserMethodBodyEndpoint After,
+    BrowserCSharpBodyEvidence? CSharp,
+    BrowserIlBodyEvidence? Il,
+    BrowserMethodBodyDiagnostic[] Diagnostics);
+
+public sealed record BrowserMethodBodyDiagnostic(
+    string Kind,
+    string? Side,
+    string Message,
+    string? Detail,
+    int? HunkId = null,
+    int? SubjectToken = null,
+    string? Mechanism = null,
+    string? Path = null);
+
+public sealed record BrowserCSharpBodyEvidence(
+    bool IsExact,
+    BrowserCSharpBodyRow[] Rows);
+
+public sealed record BrowserCSharpBodyOperation(
+    string Kind,
+    string Value);
+
+public sealed record BrowserCSharpBodyRow(
+    string AssemblyIdentity,
+    string StableMemberKey,
+    string Member,
+    string ChangeId,
+    string Message,
+    int HunkId,
+    string Kind,
+    int? Line,
+    string? SourceCoordinate,
+    string Fidelity,
+    string Text,
+    string? OldValue,
+    string? NewValue,
+    BrowserCSharpBodyOperation? OldOperation,
+    BrowserCSharpBodyOperation? NewOperation);
+
+public sealed record BrowserIlBodyEvidence(
+    string Outcome,
+    bool IsExact,
+    bool IsAvailable,
+    string? Failure,
+    BrowserIlBodyRow[] Rows);
+
+public sealed record BrowserIlBodyRow(
+    int HunkId,
+    string Kind,
+    BrowserIlBodyOperation Operation,
+    string Message);
+
+public sealed record BrowserIlBodyOperation(
+    int Offset,
+    string OpcodeFamily,
+    BrowserIlBodyOperand? Operand);
+
+public sealed record BrowserIlBodyOperand(
+    string Kind,
+    string Value);

--- a/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyOperation.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyOperation.cs
@@ -30,7 +30,7 @@ public static partial class SourceExports
         int metadataToken)
     {
         var result = await RunMethodBodyOperation(operationId, _ =>
-            WithMethodBodyParticipant(packageId, version, targetFramework, assemblyName,
+            WithMethodBodyParticipantAsync(packageId, version, targetFramework, assemblyName,
                 (group, participant) =>
                 {
                     ApiSurface surface = SelectMethodBody(() =>
@@ -76,7 +76,7 @@ public static partial class SourceExports
                 ValidateMethodBodyRequest(parsed);
                 return parsed;
             });
-            return WithMethodBodyParticipant(
+            return WithMethodBodyParticipantAsync(
                 request.PackageId, request.Version, request.Framework, request.Assembly,
                 (group, participant) =>
                 {
@@ -143,25 +143,24 @@ public static partial class SourceExports
     }
 
     static Task<BrowserManagedOperationResult<T, string, string>> RunMethodBodyOperation<T>(
-        string operationId, Func<CancellationToken, T> query)
+        string operationId, Func<CancellationToken, Task<T>> query)
     {
         BrowserManagedOperationId id = BrowserManagedOperationId.From(operationId);
         return TypeSourceOperations.RunAsync<T, string, string, object>(
             id, null,
-            (token, _) =>
+            async (token, _) =>
             {
                 token.ThrowIfCancellationRequested();
-                BrowserManagedOperationBodyResult<T, string, string> result;
                 try
                 {
-                    result = new BrowserManagedOperationBodyResult<T, string, string>.Succeeded(query(token));
+                    return new BrowserManagedOperationBodyResult<T, string, string>.Succeeded(
+                        await query(token).ConfigureAwait(false));
                 }
                 catch (MethodBodyUnavailableException error)
                 {
-                    result = new BrowserManagedOperationBodyResult<T, string, string>.Failed(
+                    return new BrowserManagedOperationBodyResult<T, string, string>.Failed(
                         error.Message, error.ToString());
                 }
-                return Task.FromResult(result);
             },
             error => new(error.Message, error.ToString()));
     }
@@ -174,17 +173,17 @@ public static partial class SourceExports
             _ => throw new ArgumentOutOfRangeException(nameof(kind)),
         };
 
-    static T WithMethodBodyParticipant<T>(
+    static async Task<T> WithMethodBodyParticipantAsync<T>(
         string packageId, string version, string framework, string assembly,
         Func<AssemblyContextGroup, AssemblyContextParticipant, T> query)
     {
         if (packageId.Length == 0)
         {
-            using BrowserPlatformScopeResolution platform =
+            await using BrowserPlatformScopeResolution platform =
                 SelectMethodBody(() => BrowserPlatformWorkspace.LeaseRetainedAssembly(framework, version, assembly));
             return platform.Scope.UseParticipant(platform.Participant, query);
         }
-        using BrowserScopeLease<BrowserInspectionScope> lease =
+        await using BrowserScopeLease<BrowserInspectionScope> lease =
             SelectMethodBody(() => BrowserPackageWorkspace.LeaseRetainedPackageScope(packageId, version, framework));
         BrowserInspectionScope scope = lease.Scope;
         BrowserPackageCoordinate coordinate = scope.Coordinates[0];

--- a/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyOperation.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyOperation.cs
@@ -148,21 +148,20 @@ public static partial class SourceExports
         BrowserManagedOperationId id = BrowserManagedOperationId.From(operationId);
         return TypeSourceOperations.RunAsync<T, string, string, object>(
             id, null,
-            async (token, _) =>
+            (token, _) =>
             {
-                using BrowserSourceOperationLease operation =
-                    await BrowserSourceOperationCoordinator.BeginAsync(
-                        token, reason => TypeSourceOperations.RequestCancellation(id, reason));
                 token.ThrowIfCancellationRequested();
+                BrowserManagedOperationBodyResult<T, string, string> result;
                 try
                 {
-                    return new BrowserManagedOperationBodyResult<T, string, string>.Succeeded(query(token));
+                    result = new BrowserManagedOperationBodyResult<T, string, string>.Succeeded(query(token));
                 }
                 catch (MethodBodyUnavailableException error)
                 {
-                    return new BrowserManagedOperationBodyResult<T, string, string>.Failed(
+                    result = new BrowserManagedOperationBodyResult<T, string, string>.Failed(
                         error.Message, error.ToString());
                 }
+                return Task.FromResult(result);
             },
             error => new(error.Message, error.ToString()));
     }

--- a/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyOperation.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyOperation.cs
@@ -1,0 +1,272 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using DotnetInspector.Queries;
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+using ILInspector.Research;
+using InspectWeb.Engine;
+using InspectWeb.Engine.SourceFacade;
+
+[SupportedOSPlatform("browser")]
+public static partial class SourceExports
+{
+    [JSExport]
+    public static string CancelMethodBodyComparison(string operationId, string reason)
+    {
+        BrowserTypeSourceCancellation result = BrowserTypeSourceCancellation.From(
+            TypeSourceOperations.RequestCancellation(
+                BrowserManagedOperationId.From(operationId),
+                BrowserTypeSourceCancellation.ParseReason(reason)));
+        return JsonSerializer.Serialize(
+            result, BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation);
+    }
+
+    [JSExport]
+    public static async Task<string> QueryMethodBodyComparisonTargets(
+        string operationId, string packageId, string version, string targetFramework,
+        string assemblyName, string typeIdentity, string memberName, string selectorKey,
+        int metadataToken)
+    {
+        var result = await RunMethodBodyOperation(operationId, _ =>
+            WithMethodBodyParticipant(packageId, version, targetFramework, assemblyName,
+                (group, participant) =>
+                {
+                    ApiSurface surface = SelectMethodBody(() =>
+                        BrowserMemberResolution.ImplementationSurface(group, participant));
+                    CallGraphMemberResolution before = SelectMethodBody(() =>
+                        BrowserMemberResolution.ResolveImplementationMember(
+                            surface, typeIdentity, memberName, selectorKey, metadataToken));
+                    MetadataMethodAddress address = RequireMethodAddress(group, participant, before.BodyToken);
+                    BrowserMethodBodySelection[] methods = MethodBodyInventory(surface);
+                    BrowserMethodBodySelection selection = methods.SingleOrDefault(
+                        method => method.MetadataToken == before.BodyToken)
+                        ?? throw new MethodBodyUnavailableException(
+                            "SelectionUnavailable: the selected implementation body has no inventory identity.");
+                    return new BrowserMethodBodyTargets(
+                        packageId, version, targetFramework, assemblyName,
+                        address.ModuleVersionId.ToString("D"), selection, methods);
+                }));
+        BrowserMethodBodyTargetsResult wire = result switch
+        {
+            BrowserManagedOperationResult<BrowserMethodBodyTargets, string, string>.Succeeded success =>
+                new(1, BrowserMethodBodyResultKind.Succeeded, success.Value, null, null, null, null),
+            BrowserManagedOperationResult<BrowserMethodBodyTargets, string, string>.Failed failure =>
+                new(1, BrowserMethodBodyResultKind.Failed, null, MethodBodyFailureKind(failure.FailureKind),
+                    failure.Error, failure.Diagnostic, null),
+            BrowserManagedOperationResult<BrowserMethodBodyTargets, string, string>.Canceled canceled =>
+                new(1, BrowserMethodBodyResultKind.Canceled, null, null, null, null,
+                    BrowserTypeSourceCancellation.FormatReason(canceled.Reason)),
+            _ => throw new InvalidOperationException("Unknown managed method-body outcome."),
+        };
+        return JsonSerializer.Serialize(wire, BrowserSourceJsonContext.Default.BrowserMethodBodyTargetsResult);
+    }
+
+    [JSExport]
+    public static async Task<string> QueryMethodBodyComparison(string operationId, string requestJson)
+    {
+        var result = await RunMethodBodyOperation(operationId, token =>
+        {
+            BrowserMethodBodyComparisonRequest request = SelectMethodBody(() =>
+            {
+                BrowserMethodBodyComparisonRequest parsed = JsonSerializer.Deserialize(
+                    requestJson, BrowserSourceJsonContext.Default.BrowserMethodBodyComparisonRequest)
+                    ?? throw new ArgumentException("A method-body comparison request is required.");
+                ValidateMethodBodyRequest(parsed);
+                return parsed;
+            });
+            return WithMethodBodyParticipant(
+                request.PackageId, request.Version, request.Framework, request.Assembly,
+                (group, participant) =>
+                {
+                    ApiSurface surface = SelectMethodBody(() =>
+                        BrowserMemberResolution.ImplementationSurface(group, participant));
+                    BrowserMethodBodySelection[] inventory = MethodBodyInventory(surface);
+                    CallGraphMemberResolution before = Resolve(request.Before);
+                    CallGraphMemberResolution after = Resolve(request.After);
+                    MetadataMethodAddress beforeAddress = RequireMethodAddress(group, participant, before.BodyToken);
+                    MetadataMethodAddress afterAddress = RequireMethodAddress(group, participant, after.BodyToken);
+                    Guid expectedModule = Guid.Parse(request.ModuleVersionId);
+                    if (beforeAddress.ModuleVersionId != expectedModule
+                        || afterAddress.ModuleVersionId != expectedModule)
+                    {
+                        throw new MethodBodyUnavailableException(
+                            $"WrongImage: inventory module {expectedModule:D} is not the retained implementation "
+                            + $"module {beforeAddress.ModuleVersionId:D}; the pair was not retargeted.");
+                    }
+                    // Request labels are presentation input, never authority for the resolved pair.
+                    request = request with
+                    {
+                        Before = inventory.Single(method => method.MetadataToken == before.BodyToken),
+                        After = inventory.Single(method => method.MetadataToken == after.BodyToken),
+                    };
+                    LocalComparisonQueryResult comparison = DirectMemberComparisonQuery.Execute(
+                        group,
+                        new(new(participant, beforeAddress), new(participant, afterAddress),
+                            [ResearchProducerKind.CSharp, ResearchProducerKind.IlBody]),
+                        token);
+                    return BrowserMethodBodyProjection.Project(request, comparison);
+
+                    CallGraphMemberResolution Resolve(BrowserMethodBodySelection selection)
+                    {
+                        if (!inventory.Any(method => method.MetadataToken == selection.MetadataToken
+                            && method.TypeIdentity == selection.TypeIdentity
+                            && method.MemberName == selection.MemberName
+                            && method.SelectorKey == selection.SelectorKey))
+                            throw new MethodBodyUnavailableException(
+                                "SelectionUnavailable: the exact selector and MethodDef are not in this implementation inventory.");
+                        CallGraphMemberResolution resolved =
+                            SelectMethodBody(() => BrowserMemberResolution.ResolveImplementationMember(
+                                surface, selection.TypeIdentity, selection.MemberName,
+                                selection.SelectorKey, selection.MetadataToken));
+                        if (resolved.BodyToken != selection.MetadataToken)
+                            throw new MethodBodyUnavailableException(
+                                "SelectionUnavailable: the inventory body no longer resolves to its asserted MethodDef.");
+                        return resolved;
+                    }
+                });
+        });
+        BrowserMethodBodyComparisonResult wire = result switch
+        {
+            BrowserManagedOperationResult<BrowserMethodBodyComparison, string, string>.Succeeded success =>
+                new(1, BrowserMethodBodyResultKind.Succeeded, success.Value, null, null, null, null),
+            BrowserManagedOperationResult<BrowserMethodBodyComparison, string, string>.Failed failure =>
+                new(1, BrowserMethodBodyResultKind.Failed, null, MethodBodyFailureKind(failure.FailureKind),
+                    failure.Error, failure.Diagnostic, null),
+            BrowserManagedOperationResult<BrowserMethodBodyComparison, string, string>.Canceled canceled =>
+                new(1, BrowserMethodBodyResultKind.Canceled, null, null, null, null,
+                    BrowserTypeSourceCancellation.FormatReason(canceled.Reason)),
+            _ => throw new InvalidOperationException("Unknown managed method-body outcome."),
+        };
+        return JsonSerializer.Serialize(wire, BrowserSourceJsonContext.Default.BrowserMethodBodyComparisonResult);
+    }
+
+    static Task<BrowserManagedOperationResult<T, string, string>> RunMethodBodyOperation<T>(
+        string operationId, Func<CancellationToken, T> query)
+    {
+        BrowserManagedOperationId id = BrowserManagedOperationId.From(operationId);
+        return TypeSourceOperations.RunAsync<T, string, string, object>(
+            id, null,
+            async (token, _) =>
+            {
+                using BrowserSourceOperationLease operation =
+                    await BrowserSourceOperationCoordinator.BeginAsync(
+                        token, reason => TypeSourceOperations.RequestCancellation(id, reason));
+                token.ThrowIfCancellationRequested();
+                try
+                {
+                    return new BrowserManagedOperationBodyResult<T, string, string>.Succeeded(query(token));
+                }
+                catch (MethodBodyUnavailableException error)
+                {
+                    return new BrowserManagedOperationBodyResult<T, string, string>.Failed(
+                        error.Message, error.ToString());
+                }
+            },
+            error => new(error.Message, error.ToString()));
+    }
+
+    static BrowserTypeSourceFailureKind MethodBodyFailureKind(BrowserManagedOperationFailureKind kind) =>
+        kind switch
+        {
+            BrowserManagedOperationFailureKind.Expected => BrowserTypeSourceFailureKind.Expected,
+            BrowserManagedOperationFailureKind.Unexpected => BrowserTypeSourceFailureKind.Unexpected,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    static T WithMethodBodyParticipant<T>(
+        string packageId, string version, string framework, string assembly,
+        Func<AssemblyContextGroup, AssemblyContextParticipant, T> query)
+    {
+        if (packageId.Length == 0)
+        {
+            using BrowserPlatformScopeResolution platform =
+                SelectMethodBody(() => BrowserPlatformWorkspace.LeaseRetainedAssembly(framework, version, assembly));
+            return platform.Scope.UseParticipant(platform.Participant, query);
+        }
+        using BrowserScopeLease<BrowserInspectionScope> lease =
+            SelectMethodBody(() => BrowserPackageWorkspace.LeaseRetainedPackageScope(packageId, version, framework));
+        BrowserInspectionScope scope = lease.Scope;
+        BrowserPackageCoordinate coordinate = scope.Coordinates[0];
+        BrowserWorkspaceParticipant implementation = SelectMethodBody(() =>
+            scope.ImplementationParticipant(
+                scope.SurfaceParticipant(coordinate, coordinate.CompileAsset(assembly))));
+        return scope.UseImplementationParticipant(implementation, query);
+    }
+
+    static MetadataMethodAddress RequireMethodAddress(
+        AssemblyContextGroup group, AssemblyContextParticipant participant, int token) =>
+        AssemblyContextMethodAddressQuery.ExecuteParticipant(group, participant, token) switch
+        {
+            AssemblyContextEntry<MetadataMethodAddress>.Available available => available.Value,
+            AssemblyContextEntry<MetadataMethodAddress>.Rejected rejected =>
+                throw new MethodBodyUnavailableException(
+                    $"AddressRejected: {rejected.Failure.Kind}: {rejected.Failure.Detail}"),
+            AssemblyContextEntry<MetadataMethodAddress>.Failed failed =>
+                throw new MethodBodyUnavailableException($"AddressFailed: {failed.Error.Message}", failed.Error),
+            _ => throw new InvalidOperationException("Unknown method-address projection outcome."),
+        };
+
+    static BrowserMethodBodySelection[] MethodBodyInventory(ApiSurface surface)
+    {
+        if (surface.InspectionFailures.Count > 0)
+            throw new MethodBodyUnavailableException(
+                "InventoryFailed: " + string.Join("; ", surface.InspectionFailures.Select(failure => failure.ToString())));
+        var methods = new Dictionary<int, BrowserMethodBodySelection>();
+        foreach (ApiType type in surface.Types)
+        {
+            string identity = type.DefinitionName?.ToEscapedFullName()
+                ?? throw new MethodBodyUnavailableException($"InventoryFailed: '{type.FullName}' has no definition identity.");
+            foreach (ApiMember member in type.Members)
+            foreach (CallGraphMemberBodySelector body in CallGraphMemberResolver.CreateBodySelectors(type, member))
+            {
+                if ((body.BodyToken & unchecked((int)0xff000000)) != 0x06000000)
+                    continue;
+                string label = $"{type.FullName} / {member.Signature ?? member.Name}";
+                if (body.MemberName != member.Name)
+                    label += $" [{body.MemberName}]";
+                methods.TryAdd(body.BodyToken,
+                    new(identity, body.MemberName, body.SelectorKey, body.BodyToken, label));
+            }
+        }
+        return [.. methods.Values];
+    }
+
+    static void ValidateMethodBodyRequest(BrowserMethodBodyComparisonRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request.PackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Version);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Framework);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Assembly);
+        if (!Guid.TryParse(request.ModuleVersionId, out _))
+            throw new ArgumentException("WrongImage: a valid inventory module version ID is required.");
+        Validate(request.Before);
+        Validate(request.After);
+        static void Validate(BrowserMethodBodySelection selection)
+        {
+            ArgumentNullException.ThrowIfNull(selection);
+            ArgumentException.ThrowIfNullOrWhiteSpace(selection.TypeIdentity);
+            ArgumentException.ThrowIfNullOrWhiteSpace(selection.MemberName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(selection.SelectorKey);
+            if ((selection.MetadataToken & unchecked((int)0xff000000)) != 0x06000000
+                || (selection.MetadataToken & 0x00ffffff) == 0)
+                throw new ArgumentException("SelectionUnavailable: an inventory MethodDef is required.");
+        }
+    }
+
+    static T SelectMethodBody<T>(Func<T> select)
+    {
+        try
+        {
+            return select();
+        }
+        catch (Exception error) when (error is ArgumentException or InvalidOperationException
+            or JsonException or FormatException)
+        {
+            throw new MethodBodyUnavailableException(error.Message, error);
+        }
+    }
+
+    sealed class MethodBodyUnavailableException(string message, Exception? inner = null) : Exception(message, inner);
+}

--- a/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyProjection.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserMethodBodyProjection.cs
@@ -1,0 +1,218 @@
+using System.Collections.Immutable;
+using DotnetInspector.Queries;
+using ILInspector.Decompiler;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using ILInspector.Research;
+
+namespace InspectWeb.Engine.SourceFacade;
+
+internal static class BrowserMethodBodyProjection
+{
+    internal static BrowserMethodBodyComparison Project(
+        BrowserMethodBodyComparisonRequest request, LocalComparisonQueryResult result) =>
+        result switch
+        {
+            LocalComparisonQueryResult.NonSuccess failure => QueryFailure(request, failure),
+            LocalComparisonQueryResult.Published published => Research(request, published.Outcome),
+            _ => throw new ArgumentOutOfRangeException(nameof(result)),
+        };
+
+    static BrowserMethodBodyComparison QueryFailure(
+        BrowserMethodBodyComparisonRequest request, LocalComparisonQueryResult.NonSuccess result)
+    {
+        string? side = result.Side?.ToString();
+        (string Outcome, BrowserMethodBodyDiagnostic[] Diagnostics) failure = result.Failure switch
+        {
+            LocalComparisonQueryFailure.InvalidDesignation invalid =>
+                ("InvalidDesignation",
+                [
+                    new(invalid.Kind.ToString(), side, "The physical designation is unavailable.", null),
+                    .. invalid.MetadataFailures.Select(failure => new BrowserMethodBodyDiagnostic(
+                        failure.Kind, side, failure.Operation, failure.Detail,
+                        SubjectToken: failure.SubjectToken, Mechanism: failure.Mechanism.ToString())),
+                ]),
+            LocalComparisonQueryFailure.AccessRejected rejected =>
+                ("AccessRejected", [new(rejected.Cause.Kind.ToString(), side, rejected.Cause.Detail, null)]),
+            LocalComparisonQueryFailure.PopulationRejected rejected =>
+                ("PopulationRejected", [new(rejected.Cause.Kind.ToString(), side,
+                    "Query population admission was rejected.", rejected.Cause.ToString())]),
+            LocalComparisonQueryFailure.AdmissionRejected rejected =>
+                ("AdmissionRejected", [new(rejected.Cause.Kind.ToString(), side,
+                    rejected.Cause.Summary, rejected.Cause.Location.ToString())]),
+            LocalComparisonQueryFailure.PlanningRejected rejected =>
+                ("PlanningRejected", [new(rejected.Cause.Kind.ToString(), side,
+                    rejected.Cause.Summary, rejected.Cause.Location.ToString())]),
+            LocalComparisonQueryFailure.DesignationRejected rejected =>
+                ("DesignationRejected", [new(rejected.Cause.Kind.ToString(), side,
+                    "Research rejected the designated pair.", null)]),
+            LocalComparisonQueryFailure.DesignationUnavailable unavailable =>
+                ("DesignationUnavailable",
+                [.. unavailable.Cause.Endpoints.SelectMany(endpoint => TargetDiagnostics(endpoint))]),
+            LocalComparisonQueryFailure.Failed failed =>
+                ("Failed", [new("Failed", side, failed.Cause.Message, failed.Cause.ToString())]),
+            LocalComparisonQueryFailure.Cancelled canceled =>
+                ("Cancelled", [new("Cancelled", side, canceled.Cause.Message, canceled.Cause.ToString())]),
+            _ => throw new ArgumentOutOfRangeException(nameof(result)),
+        };
+        return new(request, "Query", failure.Outcome, [], failure.Diagnostics);
+    }
+
+    static IEnumerable<BrowserMethodBodyDiagnostic> TargetDiagnostics(ResearchDesignatedPairUnavailable endpoint)
+    {
+        yield return new(endpoint.Kind.ToString(), endpoint.Side.ToString(),
+            $"Target {endpoint.Attempt.Outcome.Kind}; domain {endpoint.Census.Health}.", null);
+        ResearchTargetDiagnostic? diagnostic = endpoint.Attempt.Outcome switch
+        {
+            ResearchTargetOutcome.NotFound value => value.ResearchDiagnostic,
+            ResearchTargetOutcome.Unavailable value => value.Diagnostic,
+            ResearchTargetOutcome.Failed value => value.Diagnostic,
+            _ => null,
+        };
+        if (diagnostic is not null)
+            yield return new(diagnostic.Kind.ToString(), endpoint.Side.ToString(), diagnostic.Summary, null);
+        MemberTargetDiagnostic? metadata = endpoint.Attempt.Outcome switch
+        {
+            ResearchTargetOutcome.NotFound value => value.MetadataDiagnostic,
+            ResearchTargetOutcome.Ambiguous value => value.Diagnostic,
+            ResearchTargetOutcome.Rejected value => value.Diagnostic,
+            _ => null,
+        };
+        if (metadata is not null)
+            yield return new(metadata.Kind.ToString(), endpoint.Side.ToString(), metadata.Message,
+                string.Join("; ", metadata.CandidateDetails()));
+    }
+
+    static BrowserMethodBodyComparison Research(
+        BrowserMethodBodyComparisonRequest request, ResearchProducerSessionOutcome outcome) =>
+        outcome switch
+        {
+            ResearchProducerSessionOutcome.Completed completed =>
+                new(request, "Research", "Completed",
+                    [.. completed.Completion.Results.Select(Producer)],
+                    Cleanup(completed.Completion.Cleanup)),
+            ResearchProducerSessionOutcome.Rejected rejected =>
+                new(request, "Research", "Rejected", [],
+                    [new(rejected.Rejection.Kind.ToString(), null, rejected.Rejection.Summary, null)]),
+            ResearchProducerSessionOutcome.Failed failed =>
+                new(request, "Research", "Failed", [],
+                    [Diagnostic(failed.Diagnostic), .. Cleanup(failed.Cleanup)]),
+            ResearchProducerSessionOutcome.Cancelled canceled =>
+                new(request, "Research", "Cancelled", [], Cleanup(canceled.Cleanup)),
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
+        };
+
+    static BrowserMethodBodyProducer Producer(ResearchProducerWorkResult work)
+    {
+        ResearchDesignatedPair pair = (work.Item.Basis as ResearchProducerWorkBasis.DesignatedPair)?.Pair
+            ?? throw new InvalidOperationException("A direct-member result must retain its designated pair.");
+        BrowserMethodBodyEndpoint before = Endpoint(pair.Before);
+        BrowserMethodBodyEndpoint after = Endpoint(pair.After);
+        var diagnostics = new List<BrowserMethodBodyDiagnostic>();
+        string name = work.Item.Producer.ToString();
+        switch (work.Outcome)
+        {
+            case ResearchProducerWorkOutcome.ProducedCSharp produced:
+                var csharp = produced.Result;
+                before = Inspection(before, csharp.Findings.OldInspection, "Before", diagnostics);
+                after = Inspection(after, csharp.Findings.NewInspection, "After", diagnostics);
+                BrowserCSharpBodyEvidence? csharpEvidence = null;
+                if (csharp.BodyDiff is { } body)
+                {
+                    csharpEvidence = new(body.IsExact,
+                        [.. Values(body.Rows).Select(row => new BrowserCSharpBodyRow(
+                            row.AssemblyIdentity, row.StableMemberKey, row.Member,
+                            row.ChangeId, row.Message, row.HunkId, row.Kind.ToString(),
+                            row.Line, row.SourceCoordinate, row.Fidelity, row.Text,
+                            row.OldValue, row.NewValue, Operation(row.OldOperation), Operation(row.NewOperation)))]);
+                    diagnostics.AddRange(Values(body.FailureRows).Select(failure =>
+                        new BrowserMethodBodyDiagnostic(failure.Kind.ToString(), failure.Side,
+                            failure.Message, failure.Detail, failure.HunkId)));
+                    diagnostics.AddRange(Values(body.IdentityFailures).Select(failure =>
+                        new BrowserMethodBodyDiagnostic(failure.Kind, failure.Side,
+                            "C# identity resolution failed.", failure.Detail,
+                            SubjectToken: failure.SubjectToken,
+                            Mechanism: failure.Mechanism.ToString(), Path: failure.Path)));
+                }
+                return new(name, "ProducedCSharp",
+                    csharpEvidence is null ? MissingBodyVerdict(before, after)
+                        : csharpEvidence.IsExact ? "Exact" : "NotExact",
+                    before, after, csharpEvidence, null, [.. diagnostics]);
+            case ResearchProducerWorkOutcome.ProducedIlBody produced:
+                var il = produced.Result;
+                before = Inspection(before, il.Findings.OldInspection, "Before", diagnostics);
+                after = Inspection(after, il.Findings.NewInspection, "After", diagnostics);
+                BrowserIlBodyEvidence? ilEvidence = null;
+                if (il.MemberDiff is { } member)
+                {
+                    ilEvidence = new(member.Diff.Outcome.ToString(), member.Diff.IsExact,
+                        member.Diff.IsAvailable, member.Diff.Failure,
+                        [.. Values(member.Diff.Rows).Select(row => new BrowserIlBodyRow(
+                            row.HunkId, row.Kind.ToString(),
+                            new(row.Operation.Offset, row.Operation.OpcodeFamily,
+                                row.Operation.Operand is { } operand
+                                    ? new(operand.Kind.ToString(), operand.Value) : null),
+                            row.Message))]);
+                    diagnostics.AddRange(Values(member.Diff.FailureRows).Select(failure =>
+                        new BrowserMethodBodyDiagnostic(failure.Kind.ToString(), failure.Side,
+                            failure.Message, failure.Detail)));
+                    diagnostics.AddRange(Values(member.IdentityFailures).Select(failure =>
+                        new BrowserMethodBodyDiagnostic(failure.Kind, failure.Side,
+                            "IL identity resolution failed.", failure.Detail,
+                            SubjectToken: failure.SubjectToken, Mechanism: failure.Mechanism.ToString())));
+                }
+                return new(name, "ProducedIlBody",
+                    ilEvidence?.Outcome ?? MissingBodyVerdict(before, after),
+                    before, after, null, ilEvidence, [.. diagnostics]);
+            case ResearchProducerWorkOutcome.Unavailable unavailable:
+                return new(name, "Unavailable", "NotRun", before, after, null, null,
+                    [new(unavailable.Reason.Kind.ToString(), unavailable.Reason.Input?.Side.ToString(),
+                        unavailable.Reason.Summary, null)]);
+            case ResearchProducerWorkOutcome.Failed failed:
+                return new(name, "Failed", "NotRun", before, after, null, null,
+                    [Diagnostic(failed.Diagnostic)]);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(work));
+        }
+    }
+
+    static BrowserMethodBodyEndpoint Endpoint(ResearchTargetAttempt attempt)
+    {
+        var resolved = attempt.Outcome as ResearchTargetOutcome.Resolved;
+        return new("NotInspected", resolved?.Address?.ModuleVersionId.ToString("D"),
+            resolved?.Address?.Token, attempt.Outcome.Kind.ToString(), null);
+    }
+
+    static BrowserMethodBodyEndpoint Inspection<T>(
+        BrowserMethodBodyEndpoint endpoint, FindingInspection<T> inspection,
+        string side, List<BrowserMethodBodyDiagnostic> diagnostics) where T : notnull
+    {
+        switch (inspection.Value)
+        {
+            case FindingInspection<T>.Complete:
+                return endpoint with { State = "Complete" };
+            case FindingInspection<T>.Absent absent:
+                return endpoint with { State = absent.Kind.ToString(), Detail = absent.Detail };
+            case FindingInspection<T>.Failed failed:
+                diagnostics.Add(new(failed.Error.Descriptor.Id.ToString(), side, failed.Error.Reason, null));
+                return endpoint with { State = "Failed", Detail = failed.Error.Reason };
+            default:
+                throw new ArgumentOutOfRangeException(nameof(inspection));
+        }
+    }
+
+    static string MissingBodyVerdict(BrowserMethodBodyEndpoint before, BrowserMethodBodyEndpoint after) =>
+        before.State == "Failed" || after.State == "Failed" ? "Unavailable" : "NotApplicable";
+
+    static BrowserMethodBodyDiagnostic Diagnostic(ResearchProducerDiagnostic diagnostic) =>
+        new(diagnostic.Kind.ToString(), null, diagnostic.Summary, diagnostic.Producer?.ToString());
+
+    static BrowserMethodBodyDiagnostic[] Cleanup(ImmutableArray<ResearchProducerCleanupOutcome> outcomes) =>
+        [.. Values(outcomes).OfType<ResearchProducerCleanupOutcome.Failed>().Select(failure =>
+            Diagnostic(failure.Diagnostic) with { Side = failure.Input.Side.ToString() })];
+
+    static BrowserCSharpBodyOperation? Operation(CSharpDiffOperation? operation) =>
+        operation is null ? null : new(operation.Kind.ToString(), operation.Value);
+
+    static ImmutableArray<T> Values<T>(ImmutableArray<T> values) => values.IsDefault ? [] : values;
+}

--- a/prototypes/inspect-web/engine.SourceExports/BrowserSourceContracts.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserSourceContracts.cs
@@ -193,6 +193,9 @@ public sealed record BrowserAnnotatedSource
 [JsonSerializable(typeof(BrowserSource))]
 [JsonSerializable(typeof(BrowserTypeSourceResult))]
 [JsonSerializable(typeof(BrowserTypeSourceCancellation))]
+[JsonSerializable(typeof(BrowserMethodBodyTargetsResult))]
+[JsonSerializable(typeof(BrowserMethodBodyComparisonResult))]
+[JsonSerializable(typeof(BrowserMethodBodyComparisonRequest))]
 [JsonSerializable(typeof(BrowserAnnotatedSource))]
 [JsonSerializable(typeof(string[]))]
 internal sealed partial class BrowserSourceJsonContext : JsonSerializerContext;

--- a/prototypes/inspect-web/engine.Tests/BrowserMethodBodyOperationTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserMethodBodyOperationTests.cs
@@ -29,7 +29,7 @@ public sealed class BrowserMethodBodyOperationTests
     [InlineData(true)]
     public async Task ExportPreservesDifferentAndSamePhysicalPair(bool same)
     {
-        using Fixture fixture = await Fixture.Open();
+        await using Fixture fixture = await Fixture.Open();
         BrowserMethodBodyTargets targets = await fixture.Targets();
         BrowserMethodBodySelection after = same ? targets.Before
             : Assert.Single(targets.Methods, method => method.MemberName == nameof(Right.Transform));
@@ -64,7 +64,7 @@ public sealed class BrowserMethodBodyOperationTests
     [Fact]
     public async Task BodylessMethodRemainsSelectableAndNativeNotApplicable()
     {
-        using Fixture fixture = await Fixture.Open();
+        await using Fixture fixture = await Fixture.Open();
         BrowserMethodBodyTargets targets = await fixture.Targets();
         BrowserMethodBodySelection bodyless = Assert.Single(targets.Methods,
             method => method.MemberName == nameof(IBodyless.WithoutBody));
@@ -84,7 +84,7 @@ public sealed class BrowserMethodBodyOperationTests
     [Fact]
     public async Task ReferenceTokenDriftAndExplicitAccessorsUseImplementationAddress()
     {
-        using Fixture fixture = await Fixture.Open(reference: true);
+        await using Fixture fixture = await Fixture.Open(reference: true);
         BrowserMethodBodyTargets targets = await fixture.Targets();
         int implementation = typeof(Left).GetMethod(nameof(Left.Compute), [typeof(int)])!.MetadataToken;
         Assert.NotEqual(fixture.Launch.MetadataToken, implementation);
@@ -104,7 +104,7 @@ public sealed class BrowserMethodBodyOperationTests
     [Fact]
     public async Task WrongImageAndMissingContextFailWithoutReacquisition()
     {
-        using Fixture fixture = await Fixture.Open();
+        await using Fixture fixture = await Fixture.Open();
         BrowserMethodBodyTargets targets = await fixture.Targets();
         var wrong = await Compare(Request(targets, targets.Before) with { ModuleVersionId = Guid.NewGuid().ToString() });
         Assert.Equal(BrowserMethodBodyResultKind.Failed, wrong.Kind);
@@ -112,7 +112,7 @@ public sealed class BrowserMethodBodyOperationTests
         Assert.Contains("WrongImage", wrong.Error);
         Assert.Null(wrong.Value);
 
-        BrowserPackageWorkspace.RemoveScope(fixture.Scope);
+        await BrowserPackageWorkspace.RemoveScopeAsync(fixture.Scope);
         var missing = await Compare(Request(targets, targets.Before));
         Assert.Equal(BrowserMethodBodyResultKind.Failed, missing.Kind);
         Assert.Contains("ContextUnavailable", missing.Error);
@@ -125,7 +125,7 @@ public sealed class BrowserMethodBodyOperationTests
     [Fact]
     public async Task InvalidSelectionDoesNotSubstituteAnotherOverloadOrAccessor()
     {
-        using Fixture fixture = await Fixture.Open();
+        await using Fixture fixture = await Fixture.Open();
         BrowserMethodBodyTargets targets = await fixture.Targets();
         BrowserMethodBodySelection other = Assert.Single(targets.Methods,
             method => method.MemberName == nameof(Right.Transform));
@@ -137,10 +137,60 @@ public sealed class BrowserMethodBodyOperationTests
     }
 
     [Fact]
+    public async Task SuccessfulComparisonReleasesProtectedScopeUse()
+    {
+        await using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+
+        var result = await Compare(Request(targets, targets.Before));
+
+        Assert.Equal(BrowserMethodBodyResultKind.Succeeded, result.Kind);
+        await BrowserPackageWorkspace.RemoveScopeAsync(fixture.Scope);
+        Assert.False(BrowserPackageWorkspace.IsScopeRetained(fixture.Scope));
+    }
+
+    [Fact]
+    public async Task RemovalRequestedScopeIsNotRevivedForComparison()
+    {
+        await using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        await using BrowserScopeLease<BrowserInspectionScope> holder =
+            BrowserPackageWorkspace.LeaseScope(fixture.Scope);
+        await BrowserPackageWorkspace.RemoveScopeAsync(fixture.Scope);
+
+        var result = await Compare(Request(targets, targets.Before));
+
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, result.Kind);
+        Assert.Equal(BrowserTypeSourceFailureKind.Expected, result.FailureKind);
+        Assert.Contains("ContextUnavailable", result.Error);
+        await holder.DisposeAsync();
+        Assert.False(BrowserPackageWorkspace.IsScopeRetained(fixture.Scope));
+    }
+
+    [Fact]
+    public async Task SameLabelRetainedGenerationsAreNotArbitrarilySelected()
+    {
+        await using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        await using Fixture replacement =
+            await Fixture.Open(brokenBody: true, packageId: targets.PackageId);
+        Assert.NotSame(fixture.Scope, replacement.Scope);
+
+        var result = await Compare(Request(targets, targets.Before));
+        BrowserMethodBodyTargetsResult inventory = await fixture.TargetsResult();
+
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, result.Kind);
+        Assert.Equal(BrowserTypeSourceFailureKind.Expected, result.FailureKind);
+        Assert.Contains("ContextUnavailable", result.Error);
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, inventory.Kind);
+        Assert.Contains("ContextUnavailable", inventory.Error);
+    }
+
+    [Fact]
     public async Task DisposedRetainedContextDoesNotBecomeAnEmptyInventory()
     {
-        using Fixture fixture = await Fixture.Open();
-        fixture.Scope.Dispose();
+        await using Fixture fixture = await Fixture.Open();
+        await fixture.Scope.DisposeAsync();
         BrowserMethodBodyTargetsResult result = await fixture.TargetsResult();
         Assert.Equal(BrowserMethodBodyResultKind.Failed, result.Kind);
         Assert.NotEmpty(result.Error!);
@@ -150,7 +200,7 @@ public sealed class BrowserMethodBodyOperationTests
     [Fact]
     public async Task NativeBodyFailureSurvivesSuccessfulResearchAccounting()
     {
-        using Fixture fixture = await Fixture.Open(brokenBody: true);
+        await using Fixture fixture = await Fixture.Open(brokenBody: true);
         BrowserMethodBodyTargets targets = await fixture.Targets();
         var result = await Compare(Request(targets,
             Assert.Single(targets.Methods, method => method.MemberName == nameof(Right.Transform))));
@@ -172,7 +222,7 @@ public sealed class BrowserMethodBodyOperationTests
     [InlineData(true)]
     public async Task OriginalQueryWrongImageAndCancellationRemainQueryOutcomes(bool canceled)
     {
-        using Fixture fixture = await Fixture.Open();
+        await using Fixture fixture = await Fixture.Open();
         BrowserMethodBodyTargets targets = await fixture.Targets();
         using var cancellation = new CancellationTokenSource();
         if (canceled)
@@ -200,7 +250,7 @@ public sealed class BrowserMethodBodyOperationTests
     [InlineData(true, "disposed")]
     public async Task BothExportsPreserveSourceAcquisitionAndReleaseOwnOperation(bool compare, string reason)
     {
-        using Fixture fixture = await Fixture.Open();
+        await using Fixture fixture = await Fixture.Open();
         BrowserMethodBodyTargets targets = await fixture.Targets();
         using BrowserSourceOperationLease holder = await BrowserSourceOperationCoordinator.BeginAsync();
         string id = Guid.NewGuid().ToString();
@@ -253,7 +303,7 @@ public sealed class BrowserMethodBodyOperationTests
             entry.Write(File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssemblyPath()));
         using var handler = new PlatformHandler(version, archiveBytes.ToArray());
         using var client = new HttpClient(handler);
-        using BrowserPlatformScopeResolution resolution = await BrowserPlatformWorkspace.OpenAssemblyAsync(
+        await using BrowserPlatformScopeResolution resolution = await BrowserPlatformWorkspace.OpenAssemblyAsync(
             framework, AssemblyName, "netcore.app", client,
             new UniformPackageSourceAuthorization([PackageSource.NuGetOrg]),
             TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
@@ -273,8 +323,8 @@ public sealed class BrowserMethodBodyOperationTests
         Assert.Equal(BrowserMethodBodyResultKind.Succeeded, result.Kind);
         Assert.Equal("Completed", result.Value!.Outcome);
         Assert.Equal(acquisitionRequests, handler.Requests);
-        resolution.Dispose();
-        BrowserPackageWorkspace.RemoveScope(resolution.Scope);
+        await resolution.DisposeAsync();
+        await BrowserPackageWorkspace.RemoveScopeAsync(resolution.Scope);
         var missing = await Compare(Request(targets.Value!, targets.Value!.Before));
         Assert.Equal(BrowserMethodBodyResultKind.Failed, missing.Kind);
         Assert.Contains("ContextUnavailable", missing.Error);
@@ -315,12 +365,13 @@ public sealed class BrowserMethodBodyOperationTests
         }
     }
 
-    sealed class Fixture(string packageId, BrowserInspectionScope scope, BrowserMethodBodySelection launch) : IDisposable
+    sealed class Fixture(string packageId, BrowserInspectionScope scope, BrowserMethodBodySelection launch) : IAsyncDisposable
     {
         internal BrowserInspectionScope Scope => scope;
         internal BrowserMethodBodySelection Launch => launch;
 
-        internal static async Task<Fixture> Open(bool reference = false, bool brokenBody = false)
+        internal static async Task<Fixture> Open(
+            bool reference = false, bool brokenBody = false, string? packageId = null)
         {
             byte[] implementation = File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssemblyPath());
             if (brokenBody)
@@ -333,7 +384,7 @@ public sealed class BrowserMethodBodyOperationTests
                     rva >= section.VirtualAddress && rva < section.VirtualAddress + section.SizeOfRawData);
                 implementation[section.PointerToRawData + rva - section.VirtualAddress] = 0;
             }
-            string id = "Method.Body." + Guid.NewGuid().ToString("N");
+            string id = packageId ?? "Method.Body." + Guid.NewGuid().ToString("N");
             using var bytes = new MemoryStream();
             using (var archive = new ZipArchive(bytes, ZipArchiveMode.Create, leaveOpen: true))
             {
@@ -345,13 +396,15 @@ public sealed class BrowserMethodBodyOperationTests
                     entry.Write(File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssetPath("reference")));
                 }
             }
-            BrowserPackageWorkspace.RegisterAcquiredPackage(
+            await BrowserPackageWorkspace.RegisterAcquiredPackageAsync(
                 new BrowserPackage(id, "1.0.0",
                     reference && !brokenBody
                         ? File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssetPath("package"))
                         : bytes.ToArray(),
                     fromCache: false));
-            BrowserInspectionScope scope = await BrowserPackageWorkspace.OpenScopeAsync(id, "1.0.0", Framework);
+            await using BrowserScopeLease<BrowserInspectionScope> lease =
+                await BrowserPackageWorkspace.OpenScopeAsync(id, "1.0.0", Framework);
+            BrowserInspectionScope scope = lease.Scope;
             ApiSurface surface = scope.UseSurface(group => Assert.IsType<AssemblyContextEntry<AssemblyApiSurface>.Available>(
                 AssemblyContextApiSurfaceQuery.ExecuteBounded(group, ApiSurfaceScope.IncludeAll,
                     BrowserApiSurfacePolicy.Limits).Assemblies.Assemblies.Single()).Value.Surface);
@@ -376,6 +429,6 @@ public sealed class BrowserMethodBodyOperationTests
             return Assert.IsType<BrowserMethodBodyTargets>(result.Value);
         }
 
-        public void Dispose() => BrowserPackageWorkspace.RemoveScope(scope);
+        public ValueTask DisposeAsync() => BrowserPackageWorkspace.RemoveScopeAsync(scope);
     }
 }

--- a/prototypes/inspect-web/engine.Tests/BrowserMethodBodyOperationTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserMethodBodyOperationTests.cs
@@ -1,0 +1,376 @@
+using System.IO.Compression;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using DotnetInspector.Queries;
+using DotnetInspector.Packages;
+using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+using ILInspector.Research;
+using InspectWeb.Engine.SourceFacade;
+using InspectWeb.MethodBodyFixtures;
+using NuGetFetch;
+
+namespace InspectWeb.Engine.Tests;
+
+[Collection("Type source operations")]
+[SupportedOSPlatform("browser")]
+public sealed class BrowserMethodBodyOperationTests
+{
+    const string AssemblyName = "InspectWeb.MethodBodyFixtures.dll";
+    const string Framework = "net11.0";
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExportPreservesDifferentAndSamePhysicalPair(bool same)
+    {
+        using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        BrowserMethodBodySelection after = same ? targets.Before
+            : Assert.Single(targets.Methods, method => method.MemberName == nameof(Right.Transform));
+        BrowserMethodBodyComparisonResult result = await Compare(Request(targets, after));
+        Assert.Equal(BrowserMethodBodyResultKind.Succeeded, result.Kind);
+        BrowserMethodBodyComparison value = Assert.IsType<BrowserMethodBodyComparison>(result.Value);
+        Assert.Equal("Research", value.Stage);
+        Assert.Equal("Completed", value.Outcome);
+        Assert.Equal(after, value.Request.After);
+        Assert.Equal(targets.Before, value.Request.Before);
+        Assert.Equal(2, value.Producers.Length);
+        foreach (BrowserMethodBodyProducer producer in value.Producers)
+        {
+            Assert.Equal(targets.ModuleVersionId, producer.Before.ModuleVersionId);
+            Assert.Equal(targets.ModuleVersionId, producer.After.ModuleVersionId);
+            Assert.Equal(targets.Before.MetadataToken, producer.Before.MetadataToken);
+            Assert.Equal(after.MetadataToken, producer.After.MetadataToken);
+            Assert.Equal("Complete", producer.Before.State);
+            Assert.Equal("Complete", producer.After.State);
+        }
+        BrowserCSharpBodyEvidence csharp = Assert.IsType<BrowserCSharpBodyEvidence>(value.Producers[0].CSharp);
+        BrowserIlBodyEvidence il = Assert.IsType<BrowserIlBodyEvidence>(value.Producers[1].Il);
+        Assert.Equal(same, csharp.IsExact);
+        Assert.Equal(same, il.IsExact);
+        if (!same)
+        {
+            Assert.NotEmpty(csharp.Rows);
+            Assert.Contains(il.Rows, row => row.Operation.Operand is not null);
+        }
+    }
+
+    [Fact]
+    public async Task BodylessMethodRemainsSelectableAndNativeNotApplicable()
+    {
+        using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        BrowserMethodBodySelection bodyless = Assert.Single(targets.Methods,
+            method => method.MemberName == nameof(IBodyless.WithoutBody));
+        var result = await Compare(Request(targets, bodyless));
+        Assert.Equal(BrowserMethodBodyResultKind.Succeeded, result.Kind);
+        Assert.Equal("Completed", result.Value!.Outcome);
+        Assert.All(result.Value.Producers, producer =>
+        {
+            Assert.Equal("NoApplicableInput", producer.After.State);
+            Assert.NotEmpty(producer.After.Detail!);
+            Assert.Null(producer.CSharp);
+            Assert.Null(producer.Il);
+            Assert.Equal("NotApplicable", producer.NativeVerdict);
+        });
+    }
+
+    [Fact]
+    public async Task ReferenceTokenDriftAndExplicitAccessorsUseImplementationAddress()
+    {
+        using Fixture fixture = await Fixture.Open(reference: true);
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        int implementation = typeof(Left).GetMethod(nameof(Left.Compute), [typeof(int)])!.MetadataToken;
+        Assert.NotEqual(fixture.Launch.MetadataToken, implementation);
+        Assert.Equal(implementation, targets.Before.MetadataToken);
+        Assert.Equal(typeof(Left).Module.ModuleVersionId.ToString("D"), targets.ModuleVersionId);
+        BrowserMethodBodySelection getter = Assert.Single(targets.Methods, method => method.MemberName == "get_Value");
+        BrowserMethodBodySelection setter = Assert.Single(targets.Methods, method => method.MemberName == "set_Value");
+        var result = await Compare(Request(targets, setter) with { Before = getter });
+        Assert.Equal(BrowserMethodBodyResultKind.Succeeded, result.Kind);
+        Assert.All(result.Value!.Producers, producer =>
+        {
+            Assert.Equal(getter.MetadataToken, producer.Before.MetadataToken);
+            Assert.Equal(setter.MetadataToken, producer.After.MetadataToken);
+        });
+    }
+
+    [Fact]
+    public async Task WrongImageAndMissingContextFailWithoutReacquisition()
+    {
+        using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        var wrong = await Compare(Request(targets, targets.Before) with { ModuleVersionId = Guid.NewGuid().ToString() });
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, wrong.Kind);
+        Assert.Equal(BrowserTypeSourceFailureKind.Expected, wrong.FailureKind);
+        Assert.Contains("WrongImage", wrong.Error);
+        Assert.Null(wrong.Value);
+
+        BrowserPackageWorkspace.RemoveScope(fixture.Scope);
+        var missing = await Compare(Request(targets, targets.Before));
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, missing.Kind);
+        Assert.Contains("ContextUnavailable", missing.Error);
+        Assert.False(BrowserPackageWorkspace.IsScopeRetained(fixture.Scope));
+        BrowserMethodBodyTargetsResult missingTargets = await fixture.TargetsResult();
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, missingTargets.Kind);
+        Assert.Contains("ContextUnavailable", missingTargets.Error);
+    }
+
+    [Fact]
+    public async Task InvalidSelectionDoesNotSubstituteAnotherOverloadOrAccessor()
+    {
+        using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        BrowserMethodBodySelection other = Assert.Single(targets.Methods,
+            method => method.MemberName == nameof(Right.Transform));
+        var bad = await Compare(Request(targets, other with { MetadataToken = targets.Before.MetadataToken }));
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, bad.Kind);
+        Assert.Contains("SelectionUnavailable", bad.Error);
+        var labels = await Compare(Request(targets, targets.Before with { Label = "Untrusted display label" }));
+        Assert.Equal(targets.Before.Label, labels.Value!.Request.After.Label);
+    }
+
+    [Fact]
+    public async Task DisposedRetainedContextDoesNotBecomeAnEmptyInventory()
+    {
+        using Fixture fixture = await Fixture.Open();
+        fixture.Scope.Dispose();
+        BrowserMethodBodyTargetsResult result = await fixture.TargetsResult();
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, result.Kind);
+        Assert.NotEmpty(result.Error!);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public async Task NativeBodyFailureSurvivesSuccessfulResearchAccounting()
+    {
+        using Fixture fixture = await Fixture.Open(brokenBody: true);
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        var result = await Compare(Request(targets,
+            Assert.Single(targets.Methods, method => method.MemberName == nameof(Right.Transform))));
+        Assert.Equal(BrowserMethodBodyResultKind.Succeeded, result.Kind);
+        Assert.Equal("Research", result.Value!.Stage);
+        Assert.Equal("Completed", result.Value.Outcome);
+        Assert.All(result.Value.Producers, producer =>
+        {
+            Assert.Equal("Failed", producer.Before.State);
+            Assert.Equal("Complete", producer.After.State);
+            Assert.Null(producer.CSharp);
+            Assert.Null(producer.Il);
+            Assert.NotEmpty(producer.Diagnostics);
+        });
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OriginalQueryWrongImageAndCancellationRemainQueryOutcomes(bool canceled)
+    {
+        using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
+        using var cancellation = new CancellationTokenSource();
+        if (canceled)
+            cancellation.Cancel();
+        LocalComparisonQueryResult original = fixture.Scope.UseImplementation(group =>
+        {
+            AssemblyContextParticipant participant = Assert.Single(group.Participants);
+            MetadataMethodAddress address = Assert.IsType<AssemblyContextEntry<MetadataMethodAddress>.Available>(
+                AssemblyContextMethodAddressQuery.ExecuteParticipant(group, participant, targets.Before.MetadataToken)).Value;
+            return DirectMemberComparisonQuery.Execute(group,
+                new(new(participant, canceled ? address : address with { ModuleVersionId = Guid.NewGuid() }),
+                    new(participant, address), ResearchProducerCatalog.Kinds), cancellation.Token);
+        });
+        BrowserMethodBodyComparison projected = BrowserMethodBodyProjection.Project(
+            Request(targets, targets.Before), original);
+        Assert.Equal("Query", projected.Stage);
+        Assert.Equal(canceled ? "Cancelled" : "DesignationUnavailable", projected.Outcome);
+        Assert.Empty(projected.Producers);
+        Assert.Contains(projected.Diagnostics,
+            diagnostic => diagnostic.Kind == (canceled ? "Cancelled" : "AddressEvidenceMismatch"));
+    }
+
+    [Theory]
+    [InlineData(false, "user")]
+    [InlineData(true, "disposed")]
+    public async Task BothExportsUseExistingCancellationAndRelease(bool compare, string reason)
+    {
+        using BrowserSourceOperationLease holder = await BrowserSourceOperationCoordinator.BeginAsync();
+        string id = Guid.NewGuid().ToString();
+        Task<string> pending = compare
+            ? SourceExports.QueryMethodBodyComparison(id, "{}")
+            : SourceExports.QueryMethodBodyComparisonTargets(
+                id, "not-resident", "1.0.0", Framework, AssemblyName, "Left", "Compute", "selector", 0);
+        Assert.False(pending.IsCompleted);
+        BrowserTypeSourceCancellation cancel = JsonSerializer.Deserialize(
+            SourceExports.CancelMethodBodyComparison(id, reason),
+            BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!;
+        Assert.Equal(BrowserTypeSourceCancellationKind.Requested, cancel.Kind);
+        using JsonDocument result = JsonDocument.Parse(await pending);
+        Assert.Equal("Canceled", result.RootElement.GetProperty("kind").GetString());
+        Assert.Equal(reason, result.RootElement.GetProperty("reason").GetString());
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, JsonSerializer.Deserialize(
+            SourceExports.CancelTypeSourceQuery(id, "user"),
+            BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!.Kind);
+        Task<BrowserSourceOperationLease> successor = BrowserSourceOperationCoordinator.BeginAsync().AsTask();
+        Assert.False(successor.IsCompleted);
+        holder.Dispose();
+        using BrowserSourceOperationLease next = await successor;
+    }
+
+    [Fact]
+    public async Task MalformedRequestIsVisibleExpectedFailureAndReleasesOperation()
+    {
+        string id = Guid.NewGuid().ToString();
+        var result = JsonSerializer.Deserialize(await SourceExports.QueryMethodBodyComparison(id, "{"),
+            BrowserSourceJsonContext.Default.BrowserMethodBodyComparisonResult)!;
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, result.Kind);
+        Assert.Equal(BrowserTypeSourceFailureKind.Expected, result.FailureKind);
+        Assert.Contains("JsonException", result.Diagnostic);
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, JsonSerializer.Deserialize(
+            SourceExports.CancelMethodBodyComparison(id, "user"),
+            BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!.Kind);
+    }
+
+    [Fact]
+    public async Task RetainedPlatformSelectionComparesWithoutAcquisitionAndRejectsMissingContext()
+    {
+        const string framework = "net11.0-method-body-platform";
+        const string version = "11.0.963";
+        using var archiveBytes = new MemoryStream();
+        using (var archive = new ZipArchive(archiveBytes, ZipArchiveMode.Create, leaveOpen: true))
+        using (Stream entry = archive.CreateEntry($"runtimes/linux-x64/lib/net11.0/{AssemblyName}").Open())
+            entry.Write(File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssemblyPath()));
+        using var handler = new PlatformHandler(version, archiveBytes.ToArray());
+        using var client = new HttpClient(handler);
+        using BrowserPlatformScopeResolution resolution = await BrowserPlatformWorkspace.OpenAssemblyAsync(
+            framework, AssemblyName, "netcore.app", client,
+            new UniformPackageSourceAuthorization([PackageSource.NuGetOrg]),
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        ApiSurface surface = resolution.Scope.UseParticipant(resolution.Participant,
+            BrowserMemberResolution.ImplementationSurface);
+        ApiType type = Assert.Single(surface.Types, type => type.FullName == typeof(Right).FullName);
+        ApiMember member = Assert.Single(type.Members, member => member.Name == nameof(Right.Transform));
+        CallGraphMemberBodySelector body = Assert.Single(CallGraphMemberResolver.CreateBodySelectors(type, member));
+        int acquisitionRequests = handler.Requests;
+        BrowserMethodBodyTargetsResult targets = JsonSerializer.Deserialize(
+            await SourceExports.QueryMethodBodyComparisonTargets(Guid.NewGuid().ToString(),
+                "", version, resolution.Scope.Framework, AssemblyName, type.DefinitionName!.ToEscapedFullName(),
+                body.MemberName, body.SelectorKey, body.BodyToken),
+            BrowserSourceJsonContext.Default.BrowserMethodBodyTargetsResult)!;
+        Assert.True(targets.Kind == BrowserMethodBodyResultKind.Succeeded, targets.Diagnostic);
+        var result = await Compare(Request(targets.Value!, targets.Value!.Before));
+        Assert.Equal(BrowserMethodBodyResultKind.Succeeded, result.Kind);
+        Assert.Equal("Completed", result.Value!.Outcome);
+        Assert.Equal(acquisitionRequests, handler.Requests);
+        resolution.Dispose();
+        BrowserPackageWorkspace.RemoveScope(resolution.Scope);
+        var missing = await Compare(Request(targets.Value!, targets.Value!.Before));
+        Assert.Equal(BrowserMethodBodyResultKind.Failed, missing.Kind);
+        Assert.Contains("ContextUnavailable", missing.Error);
+        Assert.Equal(acquisitionRequests, handler.Requests);
+    }
+
+    static BrowserMethodBodyComparisonRequest Request(BrowserMethodBodyTargets targets, BrowserMethodBodySelection after) =>
+        new(targets.PackageId, targets.Version, targets.Framework, targets.Assembly,
+            targets.ModuleVersionId, targets.Before, after);
+
+    static async Task<BrowserMethodBodyComparisonResult> Compare(BrowserMethodBodyComparisonRequest request) =>
+        JsonSerializer.Deserialize(await SourceExports.QueryMethodBodyComparison(
+            Guid.NewGuid().ToString(),
+            JsonSerializer.Serialize(request, BrowserSourceJsonContext.Default.BrowserMethodBodyComparisonRequest)),
+            BrowserSourceJsonContext.Default.BrowserMethodBodyComparisonResult)!;
+
+    sealed class PlatformHandler(string version, byte[] archive) : HttpMessageHandler
+    {
+        internal int Requests { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests++;
+            string url = request.RequestUri!.AbsoluteUri;
+            const string package = "microsoft.netcore.app.runtime.linux-x64";
+            HttpContent? content = url switch
+            {
+                $"https://api.nuget.org/v3-flatcontainer/{package}/index.json" =>
+                    new StringContent($$"""{"versions":["{{version}}"]}"""),
+                $"https://api.nuget.org/v3/registration5-gz-semver2/{package}/index.json" =>
+                    new StringContent($$$"""{"items":[{"items":[{"catalogEntry":{"version":"{{{version}}}","listed":true}}]}]}"""),
+                _ when url == $"https://api.nuget.org/v3-flatcontainer/{package}/{version}/{package}.{version}.nupkg" =>
+                    new ByteArrayContent(archive),
+                _ => null,
+            };
+            return Task.FromResult(new HttpResponseMessage(content is null
+                ? System.Net.HttpStatusCode.NotFound : System.Net.HttpStatusCode.OK) { Content = content });
+        }
+    }
+
+    sealed class Fixture(string packageId, BrowserInspectionScope scope, BrowserMethodBodySelection launch) : IDisposable
+    {
+        internal BrowserInspectionScope Scope => scope;
+        internal BrowserMethodBodySelection Launch => launch;
+
+        internal static async Task<Fixture> Open(bool reference = false, bool brokenBody = false)
+        {
+            byte[] implementation = File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssemblyPath());
+            if (brokenBody)
+            {
+                using var pe = new PEReader(new MemoryStream(implementation, writable: false));
+                var handle = (MethodDefinitionHandle)MetadataTokens.EntityHandle(
+                    typeof(Left).GetMethod(nameof(Left.Compute), [typeof(int)])!.MetadataToken);
+                int rva = pe.GetMetadataReader().GetMethodDefinition(handle).RelativeVirtualAddress;
+                SectionHeader section = pe.PEHeaders.SectionHeaders.Single(section =>
+                    rva >= section.VirtualAddress && rva < section.VirtualAddress + section.SizeOfRawData);
+                implementation[section.PointerToRawData + rva - section.VirtualAddress] = 0;
+            }
+            string id = "Method.Body." + Guid.NewGuid().ToString("N");
+            using var bytes = new MemoryStream();
+            using (var archive = new ZipArchive(bytes, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                using (Stream entry = archive.CreateEntry($"lib/{Framework}/{AssemblyName}").Open())
+                    entry.Write(implementation);
+                if (reference)
+                {
+                    using Stream entry = archive.CreateEntry($"ref/{Framework}/{AssemblyName}").Open();
+                    entry.Write(File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssetPath("reference")));
+                }
+            }
+            BrowserPackageWorkspace.RegisterAcquiredPackage(
+                new BrowserPackage(id, "1.0.0",
+                    reference && !brokenBody
+                        ? File.ReadAllBytes(FixtureCatalog.InspectWebMethodBodies.AssetPath("package"))
+                        : bytes.ToArray(),
+                    fromCache: false));
+            BrowserInspectionScope scope = await BrowserPackageWorkspace.OpenScopeAsync(id, "1.0.0", Framework);
+            ApiSurface surface = scope.UseSurface(group => Assert.IsType<AssemblyContextEntry<AssemblyApiSurface>.Available>(
+                AssemblyContextApiSurfaceQuery.ExecuteBounded(group, ApiSurfaceScope.IncludeAll,
+                    BrowserApiSurfacePolicy.Limits).Assemblies.Assemblies.Single()).Value.Surface);
+            ApiType type = Assert.Single(surface.Types, type => type.FullName == typeof(Left).FullName);
+            ApiMember method = Assert.Single(type.Members,
+                member => member.Name == nameof(Left.Compute) && member.SignatureModel?.Parameters.Count == 1);
+            CallGraphMemberBodySelector body = Assert.Single(CallGraphMemberResolver.CreateBodySelectors(type, method));
+            return new(id, scope, new(type.DefinitionName!.ToEscapedFullName(),
+                body.MemberName, body.SelectorKey, body.BodyToken, "Launch"));
+        }
+
+        internal async Task<BrowserMethodBodyTargetsResult> TargetsResult() =>
+            JsonSerializer.Deserialize(await SourceExports.QueryMethodBodyComparisonTargets(
+                Guid.NewGuid().ToString(), packageId, "1.0.0", Framework, AssemblyName,
+                launch.TypeIdentity, launch.MemberName, launch.SelectorKey, launch.MetadataToken),
+                BrowserSourceJsonContext.Default.BrowserMethodBodyTargetsResult)!;
+
+        internal async Task<BrowserMethodBodyTargets> Targets()
+        {
+            BrowserMethodBodyTargetsResult result = await TargetsResult();
+            Assert.True(result.Kind == BrowserMethodBodyResultKind.Succeeded, result.Diagnostic);
+            return Assert.IsType<BrowserMethodBodyTargets>(result.Value);
+        }
+
+        public void Dispose() => BrowserPackageWorkspace.RemoveScope(scope);
+    }
+}

--- a/prototypes/inspect-web/engine.Tests/BrowserMethodBodyOperationTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserMethodBodyOperationTests.cs
@@ -198,22 +198,27 @@ public sealed class BrowserMethodBodyOperationTests
     [Theory]
     [InlineData(false, "user")]
     [InlineData(true, "disposed")]
-    public async Task BothExportsUseExistingCancellationAndRelease(bool compare, string reason)
+    public async Task BothExportsPreserveSourceAcquisitionAndReleaseOwnOperation(bool compare, string reason)
     {
+        using Fixture fixture = await Fixture.Open();
+        BrowserMethodBodyTargets targets = await fixture.Targets();
         using BrowserSourceOperationLease holder = await BrowserSourceOperationCoordinator.BeginAsync();
         string id = Guid.NewGuid().ToString();
         Task<string> pending = compare
-            ? SourceExports.QueryMethodBodyComparison(id, "{}")
+            ? SourceExports.QueryMethodBodyComparison(id,
+                JsonSerializer.Serialize(Request(targets, targets.Before),
+                    BrowserSourceJsonContext.Default.BrowserMethodBodyComparisonRequest))
             : SourceExports.QueryMethodBodyComparisonTargets(
-                id, "not-resident", "1.0.0", Framework, AssemblyName, "Left", "Compute", "selector", 0);
-        Assert.False(pending.IsCompleted);
+                id, targets.PackageId, targets.Version, targets.Framework, targets.Assembly,
+                targets.Before.TypeIdentity, targets.Before.MemberName,
+                targets.Before.SelectorKey, targets.Before.MetadataToken);
+        using JsonDocument result = JsonDocument.Parse(await pending);
+        Assert.Equal("Succeeded", result.RootElement.GetProperty("kind").GetString());
+        Assert.False(holder.CancellationToken.IsCancellationRequested);
         BrowserTypeSourceCancellation cancel = JsonSerializer.Deserialize(
             SourceExports.CancelMethodBodyComparison(id, reason),
             BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!;
-        Assert.Equal(BrowserTypeSourceCancellationKind.Requested, cancel.Kind);
-        using JsonDocument result = JsonDocument.Parse(await pending);
-        Assert.Equal("Canceled", result.RootElement.GetProperty("kind").GetString());
-        Assert.Equal(reason, result.RootElement.GetProperty("reason").GetString());
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, cancel.Kind);
         Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, JsonSerializer.Deserialize(
             SourceExports.CancelTypeSourceQuery(id, "user"),
             BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!.Kind);

--- a/prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj
+++ b/prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj
@@ -18,5 +18,7 @@
     <Using Include="Xunit" />
     <ProjectReference Include="..\engine.Core\InspectWeb.Engine.Core.csproj" />
     <ProjectReference Include="..\engine\InspectWeb.Engine.csproj" />
+    <ProjectReference Include="..\..\..\fixtures\inspect-web\InspectWeb.MethodBodyFixtures\InspectWeb.MethodBodyFixtures.csproj" />
+    <ProjectReference Include="..\..\..\tests\DotnetInspector.FixtureInfrastructure\DotnetInspector.FixtureInfrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
+++ b/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
@@ -95,8 +95,11 @@ public sealed class ProductionFacadeContextTests
         ],
         [SourceAssembly] =
         [
+            "CancelMethodBodyComparison",
             "CancelSourceQuery",
             "CancelTypeSourceQuery",
+            "QueryMethodBodyComparison",
+            "QueryMethodBodyComparisonTargets",
             "QueryMemberAnnotatedSource",
             "QueryMemberSource",
             "QueryTypeMemberSource",
@@ -159,10 +162,10 @@ public sealed class ProductionFacadeContextTests
                 actual[assembly]);
         }
 
-        // 51 operations, and no operation name in two modules: a move that forgot to delete its
+        // 54 operations, and no operation name in two modules: a move that forgot to delete its
         // origin, or a name published twice, fails here rather than in the browser.
         string[] everyExport = [.. actual.Values.SelectMany(names => names)];
-        Assert.Equal(51, everyExport.Length);
+        Assert.Equal(54, everyExport.Length);
         Assert.Equal(
             everyExport.Length,
             everyExport.Distinct(StringComparer.Ordinal).Count());

--- a/prototypes/inspect-web/engine/facades/inspect-web-source.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-source.ts
@@ -4,6 +4,8 @@ export type BrowserAnnotatedSourceCapabilityUnavailableReason = "NotProjected" |
 
 export type BrowserAnnotatedSourceMedium = "CSharp" | "Il" | number;
 
+export type BrowserMethodBodyResultKind = "Succeeded" | "Failed" | "Canceled" | number;
+
 export type BrowserTypeSourceCancellationKind = "Requested" | "AlreadyRequested" | "NotActive" | number;
 
 export type BrowserTypeSourceFailureKind = "Expected" | "Unexpected" | number;
@@ -36,6 +38,34 @@ export interface BrowserAnnotatedSourceViewerCatalog {
   readonly destinations: BrowserAnnotatedSourceCapabilityAvailability;
 }
 
+export interface BrowserCSharpBodyEvidence {
+  readonly isExact: boolean;
+  readonly rows: ReadonlyArray<BrowserCSharpBodyRow>;
+}
+
+export interface BrowserCSharpBodyOperation {
+  readonly kind: string;
+  readonly value: string;
+}
+
+export interface BrowserCSharpBodyRow {
+  readonly assemblyIdentity: string;
+  readonly stableMemberKey: string;
+  readonly member: string;
+  readonly changeId: string;
+  readonly message: string;
+  readonly hunkId: number;
+  readonly kind: string;
+  readonly line: number | null;
+  readonly sourceCoordinate: string | null;
+  readonly fidelity: string;
+  readonly text: string;
+  readonly oldValue: string | null;
+  readonly newValue: string | null;
+  readonly oldOperation: BrowserCSharpBodyOperation | null;
+  readonly newOperation: BrowserCSharpBodyOperation | null;
+}
+
 export interface BrowserCallGraphTarget {
   readonly id: string;
   readonly assembly: string;
@@ -54,6 +84,118 @@ export interface BrowserCallGraphTarget {
   readonly kind: string;
   readonly platformPack: string | null;
   readonly surfaceAssemblyId: string | null;
+}
+
+export interface BrowserIlBodyEvidence {
+  readonly outcome: string;
+  readonly isExact: boolean;
+  readonly isAvailable: boolean;
+  readonly failure: string | null;
+  readonly rows: ReadonlyArray<BrowserIlBodyRow>;
+}
+
+export interface BrowserIlBodyOperand {
+  readonly kind: string;
+  readonly value: string;
+}
+
+export interface BrowserIlBodyOperation {
+  readonly offset: number;
+  readonly opcodeFamily: string;
+  readonly operand: BrowserIlBodyOperand | null;
+}
+
+export interface BrowserIlBodyRow {
+  readonly hunkId: number;
+  readonly kind: string;
+  readonly operation: BrowserIlBodyOperation;
+  readonly message: string;
+}
+
+export interface BrowserMethodBodyComparison {
+  readonly request: BrowserMethodBodyComparisonRequest;
+  readonly stage: string;
+  readonly outcome: string;
+  readonly producers: ReadonlyArray<BrowserMethodBodyProducer>;
+  readonly diagnostics: ReadonlyArray<BrowserMethodBodyDiagnostic>;
+}
+
+export interface BrowserMethodBodyComparisonRequest {
+  readonly packageId: string;
+  readonly version: string;
+  readonly framework: string;
+  readonly assembly: string;
+  readonly moduleVersionId: string;
+  readonly before: BrowserMethodBodySelection;
+  readonly after: BrowserMethodBodySelection;
+}
+
+export interface BrowserMethodBodyComparisonResult {
+  readonly version: number;
+  readonly kind: BrowserMethodBodyResultKind;
+  readonly value: BrowserMethodBodyComparison | null;
+  readonly failureKind: BrowserTypeSourceFailureKind | null;
+  readonly error: string | null;
+  readonly diagnostic: string | null;
+  readonly reason: string | null;
+}
+
+export interface BrowserMethodBodyDiagnostic {
+  readonly kind: string;
+  readonly side: string | null;
+  readonly message: string;
+  readonly detail: string | null;
+  readonly hunkId: number | null;
+  readonly subjectToken: number | null;
+  readonly mechanism: string | null;
+  readonly path: string | null;
+}
+
+export interface BrowserMethodBodyEndpoint {
+  readonly state: string;
+  readonly moduleVersionId: string | null;
+  readonly metadataToken: number | null;
+  readonly targetState: string | null;
+  readonly detail: string | null;
+}
+
+export interface BrowserMethodBodyProducer {
+  readonly producer: string;
+  readonly outcome: string;
+  readonly nativeVerdict: string;
+  readonly before: BrowserMethodBodyEndpoint;
+  readonly after: BrowserMethodBodyEndpoint;
+  readonly cSharp: BrowserCSharpBodyEvidence | null;
+  readonly il: BrowserIlBodyEvidence | null;
+  readonly diagnostics: ReadonlyArray<BrowserMethodBodyDiagnostic>;
+}
+
+export interface BrowserMethodBodySelection {
+  readonly typeIdentity: string;
+  readonly memberName: string;
+  readonly selectorKey: string;
+  readonly metadataToken: number;
+  readonly label: string;
+}
+
+export interface BrowserMethodBodyTargets {
+  readonly packageId: string;
+  readonly version: string;
+  readonly framework: string;
+  readonly assembly: string;
+  readonly moduleVersionId: string;
+  readonly before: BrowserMethodBodySelection;
+  readonly methods: ReadonlyArray<BrowserMethodBodySelection>;
+}
+
+export interface BrowserMethodBodyTargetsResult {
+  readonly version: number;
+  readonly kind: BrowserMethodBodyResultKind;
+  readonly value: BrowserMethodBodyTargets | null;
+  readonly failureKind: BrowserTypeSourceFailureKind | null;
+  readonly error: string | null;
+  readonly diagnostic: string | null;
+  readonly reason: string | null;
 }
 
 export interface BrowserSource {
@@ -81,10 +223,13 @@ export interface BrowserTypeSourceResult {
 
 type $ManagedExports = {
   readonly "SourceExports": {
+    readonly "CancelMethodBodyComparison.271973316": (operationId: string, reason: string) => string;
     readonly "CancelSourceQuery.19325221": () => void;
     readonly "CancelTypeSourceQuery.271973316": (operationId: string, reason: string) => string;
     readonly "QueryMemberAnnotatedSource.1135530322": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, typeQueryId: string, memberName: string, memberSignature: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>;
     readonly "QueryMemberSource.641907440": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>;
+    readonly "QueryMethodBodyComparison.451505237": (operationId: string, requestJson: string) => Promise<string>;
+    readonly "QueryMethodBodyComparisonTargets.642387634": (operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number) => Promise<string>;
     readonly "QueryTypeMemberSource.641907440": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>;
     readonly "QueryTypeSource.1160082336": (operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string) => Promise<string>;
   };
@@ -135,6 +280,14 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
   {
     let value: unknown = exports;
     value = $ownDataProperty(value, "SourceExports");
+    value = $ownDataProperty(value, "CancelMethodBodyComparison.271973316");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027SourceExports.CancelMethodBodyComparison.271973316\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "SourceExports");
     value = $ownDataProperty(value, "CancelSourceQuery.19325221");
     if (typeof value !== "function") {
       throw new Error("Managed export \u0027SourceExports.CancelSourceQuery.19325221\u0027 is not callable.");
@@ -162,6 +315,22 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
     value = $ownDataProperty(value, "QueryMemberSource.641907440");
     if (typeof value !== "function") {
       throw new Error("Managed export \u0027SourceExports.QueryMemberSource.641907440\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "SourceExports");
+    value = $ownDataProperty(value, "QueryMethodBodyComparison.451505237");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027SourceExports.QueryMethodBodyComparison.451505237\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "SourceExports");
+    value = $ownDataProperty(value, "QueryMethodBodyComparisonTargets.642387634");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027SourceExports.QueryMethodBodyComparisonTargets.642387634\u0027 is not callable.");
     }
   }
   {
@@ -217,6 +386,12 @@ export function runEntryPoint(
   return $requireRuntime().runMain(mainAssemblyName, args);
 }
 
+export function cancelMethodBodyComparison(operationId: string, reason: string): BrowserTypeSourceCancellation {
+  const $result = $requireManagedExports()["SourceExports"]["CancelMethodBodyComparison.271973316"](operationId, reason);
+  const $parsed: unknown = JSON.parse($result);
+  return $parsed as BrowserTypeSourceCancellation;
+}
+
 export function cancelSourceQuery(): void {
   return $requireManagedExports()["SourceExports"]["CancelSourceQuery.19325221"]();
 }
@@ -237,6 +412,18 @@ export async function queryMemberSource(packageId: string, version: string, targ
   const $result = await $requireManagedExports()["SourceExports"]["QueryMemberSource.641907440"](packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
   const $parsed: unknown = JSON.parse($result);
   return $parsed as BrowserSource;
+}
+
+export async function queryMethodBodyComparison(operationId: string, requestJson: string): Promise<BrowserMethodBodyComparisonResult> {
+  const $result = await $requireManagedExports()["SourceExports"]["QueryMethodBodyComparison.451505237"](operationId, requestJson);
+  const $parsed: unknown = JSON.parse($result);
+  return $parsed as BrowserMethodBodyComparisonResult;
+}
+
+export async function queryMethodBodyComparisonTargets(operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number): Promise<BrowserMethodBodyTargetsResult> {
+  const $result = await $requireManagedExports()["SourceExports"]["QueryMethodBodyComparisonTargets.642387634"](operationId, packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken);
+  const $parsed: unknown = JSON.parse($result);
+  return $parsed as BrowserMethodBodyTargetsResult;
 }
 
 export async function queryTypeMemberSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserSource> {

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-source.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-source.js
@@ -34,6 +34,14 @@ function $validateManagedExports(exports) {
     {
         let value = exports;
         value = $ownDataProperty(value, "SourceExports");
+        value = $ownDataProperty(value, "CancelMethodBodyComparison.271973316");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027SourceExports.CancelMethodBodyComparison.271973316\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "SourceExports");
         value = $ownDataProperty(value, "CancelSourceQuery.19325221");
         if (typeof value !== "function") {
             throw new Error("Managed export \u0027SourceExports.CancelSourceQuery.19325221\u0027 is not callable.");
@@ -61,6 +69,22 @@ function $validateManagedExports(exports) {
         value = $ownDataProperty(value, "QueryMemberSource.641907440");
         if (typeof value !== "function") {
             throw new Error("Managed export \u0027SourceExports.QueryMemberSource.641907440\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "SourceExports");
+        value = $ownDataProperty(value, "QueryMethodBodyComparison.451505237");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027SourceExports.QueryMethodBodyComparison.451505237\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "SourceExports");
+        value = $ownDataProperty(value, "QueryMethodBodyComparisonTargets.642387634");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027SourceExports.QueryMethodBodyComparisonTargets.642387634\u0027 is not callable.");
         }
     }
     {
@@ -104,6 +128,11 @@ export function initializeRuntime(runtime) {
 export function runEntryPoint(mainAssemblyName, args) {
     return $requireRuntime().runMain(mainAssemblyName, args);
 }
+export function cancelMethodBodyComparison(operationId, reason) {
+    const $result = $requireManagedExports()["SourceExports"]["CancelMethodBodyComparison.271973316"](operationId, reason);
+    const $parsed = JSON.parse($result);
+    return $parsed;
+}
 export function cancelSourceQuery() {
     return $requireManagedExports()["SourceExports"]["CancelSourceQuery.19325221"]();
 }
@@ -119,6 +148,16 @@ export async function queryMemberAnnotatedSource(packageId, version, targetFrame
 }
 export async function queryMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson) {
     const $result = await $requireManagedExports()["SourceExports"]["QueryMemberSource.641907440"](packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
+    const $parsed = JSON.parse($result);
+    return $parsed;
+}
+export async function queryMethodBodyComparison(operationId, requestJson) {
+    const $result = await $requireManagedExports()["SourceExports"]["QueryMethodBodyComparison.451505237"](operationId, requestJson);
+    const $parsed = JSON.parse($result);
+    return $parsed;
+}
+export async function queryMethodBodyComparisonTargets(operationId, packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken) {
+    const $result = await $requireManagedExports()["SourceExports"]["QueryMethodBodyComparisonTargets.642387634"](operationId, packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken);
     const $parsed = JSON.parse($result);
     return $parsed;
 }

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -13208,6 +13208,7 @@ function clearNavigationError() {
 
 function dismissModalsForRoutedNavigation() {
   closeGraphExplorerForNavigation();
+  methodBodyComparison.dispose();
   const dismissedAnnotatedSourceModal = dismissAnnotatedSourceModal(false);
   state.settings = false;
   state.keyboardHelp = false;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -181,6 +181,23 @@ import { renderMemberContractSections } from "./member-overview.ts";
 import { renderMemberFacts } from "./member-facts.ts";
 import { createOperationAuthorityPage } from "./operation-authority.ts";
 import {
+  createMethodBodyComparisonCoordinator,
+  createMethodBodyDiffState,
+  methodBodyComparisonPackageId,
+  type MethodBodyComparisonContext,
+  type MethodBodyDiffState,
+} from "./method-body-comparison.ts";
+import {
+  bindMethodBodyDiff,
+  METHOD_BODY_DIFF_ACTION_SELECTOR,
+  METHOD_BODY_DIFF_CHOOSER_SELECTOR,
+  METHOD_BODY_DIFF_FILTER_SELECTOR,
+  renderMethodBodyComparisonAction,
+  renderMethodBodyDiffModal,
+  type MethodBodyComparisonAvailability,
+  type MethodBodyDiffAction,
+} from "./method-body-diff-view.ts";
+import {
   createMetadataInspectionCoordinator,
   type AppExplorerState,
 } from "./metadata-inspection.ts";
@@ -487,6 +504,11 @@ let inspectPlatformOpportunities: AnalysisFacade["queryPlatformOpportunities"];
 let inspectPlatformPerformance: AnalysisFacade["queryPlatformPerformance"];
 let cancelSourceInspection: SourceFacade["cancelSourceQuery"];
 let cancelTypeSourceInspection: SourceFacade["cancelTypeSourceQuery"];
+let cancelMethodBodyComparisonQuery:
+  SourceFacade["cancelMethodBodyComparison"];
+let inspectMethodBodyComparison: SourceFacade["queryMethodBodyComparison"];
+let inspectMethodBodyComparisonTargets:
+  SourceFacade["queryMethodBodyComparisonTargets"];
 let inspectMemberAnnotatedSource: SourceFacade["queryMemberAnnotatedSource"];
 let inspectMemberSource: SourceFacade["queryMemberSource"];
 let inspectTypeMemberSource: SourceFacade["queryTypeMemberSource"];
@@ -572,6 +594,9 @@ async function loadEngineModule() {
   ({
     cancelSourceQuery: cancelSourceInspection,
     cancelTypeSourceQuery: cancelTypeSourceInspection,
+    cancelMethodBodyComparison: cancelMethodBodyComparisonQuery,
+    queryMethodBodyComparison: inspectMethodBodyComparison,
+    queryMethodBodyComparisonTargets: inspectMethodBodyComparisonTargets,
     queryMemberAnnotatedSource: inspectMemberAnnotatedSource,
     queryMemberSource: inspectMemberSource,
     queryTypeMemberSource: inspectTypeMemberSource,
@@ -799,6 +824,7 @@ const initialState = {
   memberAnnotatedKey: "",
   memberAnnotatedEmbedded: null,
   memberAnnotatedModal: null,
+  methodBodyDiff: createMethodBodyDiffState(),
   typeSource: null,
   typeSourceLoading: false,
   typeSourceError: "",
@@ -935,6 +961,7 @@ interface StateOverrides {
   memberAnnotated: AnnotatedSourceResult | null;
   memberAnnotatedEmbedded: AnnotatedSourceSession | null;
   memberAnnotatedModal: AnnotatedSourceSession | null;
+  methodBodyDiff: MethodBodyDiffState;
   typeSource: BrowserSource | null;
   typeMetadata: BrowserTypeMetadata | null;
   packageDependencies: BrowserPackageDependencies | null;
@@ -1014,6 +1041,7 @@ function captureCanonicalWorkspaceRestoreSnapshot():
 CanonicalWorkspaceRestoreSnapshot {
   sourceInspection.cancelCurrentRequest();
   cancelAnnotatedSourceRequest(state);
+  methodBodyComparison.dispose();
   const packages = structuredClone(state.packages);
   const activeKey = state.package
     ? packageIdentityKey(state.package)
@@ -1122,6 +1150,31 @@ const sourceInspection = createSourceInspectionCoordinator({
   describeError: errorMessage,
   render,
   renderPreservingMemberFocus,
+});
+const methodBodyComparison = createMethodBodyComparisonCoordinator({
+  state: state.methodBodyDiff,
+  operationAuthority,
+  queryTargets: (operationId, context) => inspectMethodBodyComparisonTargets(
+    operationId,
+    context.packageId,
+    context.version,
+    context.framework,
+    context.assembly,
+    context.typeIdentity,
+    context.memberName,
+    context.selectorKey,
+    context.metadataToken),
+  queryComparison: (operationId, requestJson) =>
+    inspectMethodBodyComparison(operationId, requestJson),
+  cancelMethodBodyComparison: (operationId, reason) => {
+    cancelMethodBodyComparisonQuery(operationId, reason);
+  },
+  reportOperationDiagnostic: diagnostic => {
+    console.error("Method Body Diff operation authority failure.", diagnostic);
+    return undefined;
+  },
+  describeError: errorMessage,
+  render,
 });
 const packageQueryController = createPackageQueryController(
   state.packageQueryState,
@@ -2877,6 +2930,9 @@ function currentSourceReloadKind() {
 }
 
 function clearMemberContentCache() {
+  // A member navigation replaces the launching context, so its dialog operations are
+  // released rather than left to publish into a different member.
+  methodBodyComparison.dispose();
   invalidateMemberDestinationWork(state);
   state.memberSource = null;
   state.memberSourceError = "";
@@ -3429,7 +3485,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   }
   const applicationModalOpen = state.settings || state.keyboardHelp;
   app.innerHTML = `
-    <div class="workbench"${state.memberAnnotatedModal || applicationModalOpen ? " inert" : ""}>
+    <div class="workbench"${state.memberAnnotatedModal || applicationModalOpen || state.methodBodyDiff.open ? " inert" : ""}>
       ${workbenchShellHtml({
         applicationScopeHtml: renderApplicationScopeBar(
           activeScope === "workspace" ? "workspace" : null,
@@ -3454,6 +3510,11 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
                       : "copy-type-source",
                     escapeHtml,
                   })
+                : ""}
+              ${sourcePageKind === "member" || annotatedPageContext
+                ? renderMethodBodyComparisonAction(
+                    methodBodyComparisonAvailability(),
+                    escapeHtml)
                 : ""}
             </div>`
           : "",
@@ -3518,7 +3579,12 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     ${state.keyboardHelp
       ? renderKeyboardHelpDialog(keyboardHelpBindings)
       : ""}
-    ${renderAnnotatedSourceModal()}`;
+    ${renderAnnotatedSourceModal()}
+    ${renderMethodBodyDiffModal({
+      state: state.methodBodyDiff,
+      escapeHtml,
+      highlightCSharp,
+    })}`;
 
   const packageIcon =
     document.querySelector<HTMLImageElement>("[data-package-icon]");
@@ -3558,6 +3624,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   }
   restorePackageQueryReturnFocus();
   restorePackageQueryWorkspaceFocus();
+  restoreMethodBodyDiffFocus();
   graphExplorer.afterRender(graphExplorerTarget());
   recordNav();
   const productDemosRouteVisible =
@@ -6299,6 +6366,184 @@ function applyAnnotatedSourceAction(action: AnnotatedSourceAction) {
   }
 }
 
+// Method Body Diff is a session-local dialog over the current member: it names why it is
+// unavailable instead of hiding, never picks an accessor on the person's behalf, and never
+// rewrites the canonical location or member navigation.
+function methodBodyComparisonAvailability(): MethodBodyComparisonAvailability {
+  if (!state.package || state.atPackageRoot || scope() !== "member") {
+    return {
+      available: false,
+      reason: "Select a member before comparing method bodies.",
+    };
+  }
+  const type = selectedType();
+  const member = selectedMember(type);
+  if (!type || !member) {
+    return {
+      available: false,
+      reason: "Select a member before comparing method bodies.",
+    };
+  }
+  const overload =
+    selectedConcreteOverload(member.overloads, state.selectedOverloadIndex);
+  if (!overload) {
+    return {
+      available: false,
+      reason: "Select one overload before comparing method bodies.",
+    };
+  }
+  const implementationBody = graphOnlyImplementationBody(overload);
+  const bodyTarget = state.selectedBodyTarget;
+  if (overload.bodySelectors.length > 1 && !implementationBody && !bodyTarget) {
+    return {
+      available: false,
+      reason:
+        "Select one accessor or body of this member before comparing method bodies.",
+    };
+  }
+  const metadataToken = implementationBody?.token
+    ?? bodyTarget?.metadataToken
+    ?? overload.metadataToken
+    ?? 0;
+  if (!metadataToken) {
+    return {
+      available: false,
+      reason:
+        "This selection has no implementation method body to compare.",
+    };
+  }
+  return { available: true, reason: "" };
+}
+
+function methodBodyComparisonContext(): MethodBodyComparisonContext | null {
+  const type = selectedType();
+  const member = selectedMember(type);
+  if (!type || !member) return null;
+  const overload =
+    selectedConcreteOverload(member.overloads, state.selectedOverloadIndex);
+  if (!overload) return null;
+  const implementationBody = graphOnlyImplementationBody(overload);
+  const bodyTarget = state.selectedBodyTarget;
+  const metadataToken = implementationBody?.token
+    ?? bodyTarget?.metadataToken
+    ?? overload.metadataToken
+    ?? 0;
+  if (!metadataToken) return null;
+  const pkg = currentPackage();
+  return {
+    packageId: methodBodyComparisonPackageId(pkg),
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    typeIdentity: type.definitionId ?? type.id,
+    memberName: implementationBody?.memberName
+      ?? bodyTarget?.memberName
+      ?? overload.name,
+    selectorKey: implementationBody?.selectorKey
+      ?? bodyTarget?.selectorKey
+      ?? overload.graphSelectorKey,
+    metadataToken,
+    label: overload.signature || overload.name,
+  };
+}
+
+let methodBodyDiffFocusIntent: "chooser" | "none" = "none";
+let methodBodyDiffFilterCaret: number | null = null;
+
+function restoreMethodBodyDiffFocus() {
+  if (!state.methodBodyDiff.open) {
+    methodBodyDiffFocusIntent = "none";
+    methodBodyDiffFilterCaret = null;
+    return;
+  }
+  if (methodBodyDiffFilterCaret !== null) {
+    const filter = document.querySelector<HTMLInputElement>(
+      METHOD_BODY_DIFF_FILTER_SELECTOR);
+    if (filter) {
+      const caret = Math.min(methodBodyDiffFilterCaret, filter.value.length);
+      filter.focus({ preventScroll: true });
+      filter.setSelectionRange(caret, caret);
+    }
+    methodBodyDiffFilterCaret = null;
+    return;
+  }
+  if (methodBodyDiffFocusIntent !== "chooser") return;
+  const chooser = document.querySelector<HTMLElement>(
+    METHOD_BODY_DIFF_CHOOSER_SELECTOR);
+  if (chooser) {
+    methodBodyDiffFocusIntent = "none";
+    chooser.focus({ preventScroll: true });
+    return;
+  }
+  document.querySelector<HTMLElement>("#method-body-diff-title")
+    ?.focus({ preventScroll: true });
+}
+
+function openMethodBodyDiff() {
+  const availability = methodBodyComparisonAvailability();
+  const context = availability.available
+    ? methodBodyComparisonContext()
+    : null;
+  methodBodyDiffFocusIntent = "chooser";
+  methodBodyDiffFilterCaret = null;
+  if (!context) {
+    methodBodyComparison.openUnavailable(
+      availability.reason
+        || "This selection has no implementation method body to compare.",
+      METHOD_BODY_DIFF_ACTION_SELECTOR);
+    return;
+  }
+  observeAsync(
+    methodBodyComparison.open(context, METHOD_BODY_DIFF_ACTION_SELECTOR),
+    "Preparing the method body comparison");
+  render();
+}
+
+function closeMethodBodyDiff(restoreLaunchFocus: boolean) {
+  if (!methodBodyComparison.isOpen()) return false;
+  const dismissal = methodBodyComparison.close();
+  methodBodyDiffFocusIntent = "none";
+  methodBodyDiffFilterCaret = null;
+  render();
+  if (restoreLaunchFocus && dismissal.returnFocusSelector) {
+    const selector = dismissal.returnFocusSelector;
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLElement>(selector)
+        ?.focus({ preventScroll: true });
+    });
+  }
+  return dismissal.handled;
+}
+
+function applyMethodBodyDiffAction(action: MethodBodyDiffAction) {
+  switch (action.kind) {
+    case "open":
+      openMethodBodyDiff();
+      return;
+    case "close":
+      closeMethodBodyDiff(true);
+      return;
+    case "select":
+      methodBodyComparison.selectCandidate(action.key);
+      return;
+    case "filter":
+      methodBodyDiffFilterCaret = action.caret;
+      methodBodyComparison.setFilter(action.value);
+      return;
+    case "compare":
+      observeAsync(
+        methodBodyComparison.compare(),
+        "Comparing the selected method bodies");
+      return;
+    default:
+      assertNever(action, "method body diff action");
+  }
+}
+
+function bindMethodBodyDiffEvents() {
+  bindMethodBodyDiff(document, { onAction: applyMethodBodyDiffAction });
+}
+
 function bindAnnotatedSourceEvents() {
   bindAnnotatedSource(document, {
     onAction: applyAnnotatedSourceAction,
@@ -6359,6 +6604,7 @@ function bindEvents() {
   bindGraphSourceEvents();
   bindDocViewerEvents();
   bindAnnotatedSourceEvents();
+  bindMethodBodyDiffEvents();
   bindPackageViewEvents();
   bindLibraryControlsEvents();
   workbenchShellBinding =
@@ -7602,6 +7848,7 @@ function workbenchModalOwnsFocus() {
     || state.graphSourceOpen
     || state.docViewerOpen
     || state.memberAnnotatedModal !== null
+    || state.methodBodyDiff.open
     || graphExplorer.isOpen;
 }
 
@@ -12501,6 +12748,7 @@ function workspaceKeyboardContextIsActive(): boolean {
     && !state.graphSourceOpen
     && !state.docViewerOpen
     && state.memberAnnotatedModal === null
+    && !state.methodBodyDiff.open
     && !state.spotlightOpen;
 }
 
@@ -12666,6 +12914,22 @@ registerContainedShortcuts(
   "annotated-source.contain-browser-shortcut",
   WORKBENCH_KEYBINDING_PRIORITY.annotatedSource,
   annotatedSourceContextIsActive,
+);
+
+const methodBodyDiffContextIsActive = () =>
+  workspaceModalContextIsAvailable() && state.methodBodyDiff.open;
+keybindings.register({
+  id: "method-body-diff.dismiss",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.methodBodyDiff,
+  when: methodBodyDiffContextIsActive,
+  run: () => closeMethodBodyDiff(true),
+});
+registerContainedShortcuts(
+  "method-body-diff.contain-browser-shortcut",
+  WORKBENCH_KEYBINDING_PRIORITY.methodBodyDiff,
+  methodBodyDiffContextIsActive,
 );
 
 keybindings.register({

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -183,6 +183,7 @@ import { createOperationAuthorityPage } from "./operation-authority.ts";
 import {
   createMethodBodyComparisonCoordinator,
   createMethodBodyDiffState,
+  isMethodBodyToken,
   methodBodyComparisonPackageId,
   type MethodBodyComparisonContext,
   type MethodBodyDiffState,
@@ -3411,6 +3412,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   }
   state.typeCursor = Math.min(state.typeCursor, Math.max(visible.length - 1, 0));
   const activeScope = scope();
+  const methodBodyPageContext = activeScope === "member";
   const sourcePageKind =
     activeScope === "type" && state.lens === "source"
       ? "type"
@@ -3484,6 +3486,10 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     app.focus({ preventScroll: true });
   }
   const applicationModalOpen = state.settings || state.keyboardHelp;
+  const methodBodyFocusedId = document.activeElement instanceof HTMLElement
+    && document.activeElement.closest("#method-body-diff-modal")
+    ? document.activeElement.id
+    : "";
   app.innerHTML = `
     <div class="workbench"${state.memberAnnotatedModal || applicationModalOpen || state.methodBodyDiff.open ? " inert" : ""}>
       ${workbenchShellHtml({
@@ -3491,8 +3497,8 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
           activeScope === "workspace" ? "workspace" : null,
           true,
           escapeHtml),
-        contextualActionsHtml: annotatedPageContext || sourcePageKind || callGraphPageContext || packageDependenciesWorkingSurface
-          ? `<div class="working-surface-actions" role="group" aria-label="${packageDependenciesWorkingSurface ? "Dependency graph actions" : callGraphPageContext ? "Call graph actions" : annotatedPageContext ? "Annotated Source actions" : "Source actions"}">
+        contextualActionsHtml: methodBodyPageContext || annotatedPageContext || sourcePageKind || callGraphPageContext || packageDependenciesWorkingSurface
+          ? `<div class="working-surface-actions" role="group" aria-label="${packageDependenciesWorkingSurface ? "Dependency graph actions" : callGraphPageContext ? "Call graph actions" : annotatedPageContext ? "Annotated Source actions" : sourcePageKind ? "Source actions" : "Member actions"}">
               ${packageDependenciesWorkingSurface
                 ? `<button type="button" id="dependency-graph-explore" data-graph-explore${dependencyGraphAvailable() ? "" : " disabled"}>Explore</button>`
                 : ""}
@@ -3511,7 +3517,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
                     escapeHtml,
                   })
                 : ""}
-              ${sourcePageKind === "member" || annotatedPageContext
+              ${methodBodyPageContext
                 ? renderMethodBodyComparisonAction(
                     methodBodyComparisonAvailability(),
                     escapeHtml)
@@ -3624,7 +3630,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   }
   restorePackageQueryReturnFocus();
   restorePackageQueryWorkspaceFocus();
-  restoreMethodBodyDiffFocus();
+  restoreMethodBodyDiffFocus(methodBodyFocusedId);
   graphExplorer.afterRender(graphExplorerTarget());
   recordNav();
   const productDemosRouteVisible =
@@ -6405,7 +6411,7 @@ function methodBodyComparisonAvailability(): MethodBodyComparisonAvailability {
     ?? bodyTarget?.metadataToken
     ?? overload.metadataToken
     ?? 0;
-  if (!metadataToken) {
+  if (!isMethodBodyToken(metadataToken)) {
     return {
       available: false,
       reason:
@@ -6428,7 +6434,7 @@ function methodBodyComparisonContext(): MethodBodyComparisonContext | null {
     ?? bodyTarget?.metadataToken
     ?? overload.metadataToken
     ?? 0;
-  if (!metadataToken) return null;
+  if (!isMethodBodyToken(metadataToken)) return null;
   const pkg = currentPackage();
   return {
     packageId: methodBodyComparisonPackageId(pkg),
@@ -6450,7 +6456,7 @@ function methodBodyComparisonContext(): MethodBodyComparisonContext | null {
 let methodBodyDiffFocusIntent: "chooser" | "none" = "none";
 let methodBodyDiffFilterCaret: number | null = null;
 
-function restoreMethodBodyDiffFocus() {
+function restoreMethodBodyDiffFocus(previousId = "") {
   if (!state.methodBodyDiff.open) {
     methodBodyDiffFocusIntent = "none";
     methodBodyDiffFilterCaret = null;
@@ -6467,7 +6473,14 @@ function restoreMethodBodyDiffFocus() {
     methodBodyDiffFilterCaret = null;
     return;
   }
-  if (methodBodyDiffFocusIntent !== "chooser") return;
+  if (methodBodyDiffFocusIntent !== "chooser") {
+    const previous = document.getElementById(previousId);
+    const target = previous?.matches(":disabled")
+      ? document.getElementById("method-body-diff-title")
+      : previous;
+    target?.focus({ preventScroll: true });
+    return;
+  }
   const chooser = document.querySelector<HTMLElement>(
     METHOD_BODY_DIFF_CHOOSER_SELECTOR);
   if (chooser) {

--- a/prototypes/inspect-web/src/facades/inspect-web-source.d.ts
+++ b/prototypes/inspect-web/src/facades/inspect-web-source.d.ts
@@ -1,5 +1,6 @@
 export type BrowserAnnotatedSourceCapabilityUnavailableReason = "NotProjected" | "ContextUnavailable" | number;
 export type BrowserAnnotatedSourceMedium = "CSharp" | "Il" | number;
+export type BrowserMethodBodyResultKind = "Succeeded" | "Failed" | "Canceled" | number;
 export type BrowserTypeSourceCancellationKind = "Requested" | "AlreadyRequested" | "NotActive" | number;
 export type BrowserTypeSourceFailureKind = "Expected" | "Unexpected" | number;
 export type BrowserTypeSourceResultKind = "Succeeded" | "Failed" | "Canceled" | number;
@@ -25,6 +26,31 @@ export interface BrowserAnnotatedSourceViewerCatalog {
     readonly findingEvidence: BrowserAnnotatedSourceCapabilityAvailability;
     readonly destinations: BrowserAnnotatedSourceCapabilityAvailability;
 }
+export interface BrowserCSharpBodyEvidence {
+    readonly isExact: boolean;
+    readonly rows: ReadonlyArray<BrowserCSharpBodyRow>;
+}
+export interface BrowserCSharpBodyOperation {
+    readonly kind: string;
+    readonly value: string;
+}
+export interface BrowserCSharpBodyRow {
+    readonly assemblyIdentity: string;
+    readonly stableMemberKey: string;
+    readonly member: string;
+    readonly changeId: string;
+    readonly message: string;
+    readonly hunkId: number;
+    readonly kind: string;
+    readonly line: number | null;
+    readonly sourceCoordinate: string | null;
+    readonly fidelity: string;
+    readonly text: string;
+    readonly oldValue: string | null;
+    readonly newValue: string | null;
+    readonly oldOperation: BrowserCSharpBodyOperation | null;
+    readonly newOperation: BrowserCSharpBodyOperation | null;
+}
 export interface BrowserCallGraphTarget {
     readonly id: string;
     readonly assembly: string;
@@ -43,6 +69,105 @@ export interface BrowserCallGraphTarget {
     readonly kind: string;
     readonly platformPack: string | null;
     readonly surfaceAssemblyId: string | null;
+}
+export interface BrowserIlBodyEvidence {
+    readonly outcome: string;
+    readonly isExact: boolean;
+    readonly isAvailable: boolean;
+    readonly failure: string | null;
+    readonly rows: ReadonlyArray<BrowserIlBodyRow>;
+}
+export interface BrowserIlBodyOperand {
+    readonly kind: string;
+    readonly value: string;
+}
+export interface BrowserIlBodyOperation {
+    readonly offset: number;
+    readonly opcodeFamily: string;
+    readonly operand: BrowserIlBodyOperand | null;
+}
+export interface BrowserIlBodyRow {
+    readonly hunkId: number;
+    readonly kind: string;
+    readonly operation: BrowserIlBodyOperation;
+    readonly message: string;
+}
+export interface BrowserMethodBodyComparison {
+    readonly request: BrowserMethodBodyComparisonRequest;
+    readonly stage: string;
+    readonly outcome: string;
+    readonly producers: ReadonlyArray<BrowserMethodBodyProducer>;
+    readonly diagnostics: ReadonlyArray<BrowserMethodBodyDiagnostic>;
+}
+export interface BrowserMethodBodyComparisonRequest {
+    readonly packageId: string;
+    readonly version: string;
+    readonly framework: string;
+    readonly assembly: string;
+    readonly moduleVersionId: string;
+    readonly before: BrowserMethodBodySelection;
+    readonly after: BrowserMethodBodySelection;
+}
+export interface BrowserMethodBodyComparisonResult {
+    readonly version: number;
+    readonly kind: BrowserMethodBodyResultKind;
+    readonly value: BrowserMethodBodyComparison | null;
+    readonly failureKind: BrowserTypeSourceFailureKind | null;
+    readonly error: string | null;
+    readonly diagnostic: string | null;
+    readonly reason: string | null;
+}
+export interface BrowserMethodBodyDiagnostic {
+    readonly kind: string;
+    readonly side: string | null;
+    readonly message: string;
+    readonly detail: string | null;
+    readonly hunkId: number | null;
+    readonly subjectToken: number | null;
+    readonly mechanism: string | null;
+    readonly path: string | null;
+}
+export interface BrowserMethodBodyEndpoint {
+    readonly state: string;
+    readonly moduleVersionId: string | null;
+    readonly metadataToken: number | null;
+    readonly targetState: string | null;
+    readonly detail: string | null;
+}
+export interface BrowserMethodBodyProducer {
+    readonly producer: string;
+    readonly outcome: string;
+    readonly nativeVerdict: string;
+    readonly before: BrowserMethodBodyEndpoint;
+    readonly after: BrowserMethodBodyEndpoint;
+    readonly cSharp: BrowserCSharpBodyEvidence | null;
+    readonly il: BrowserIlBodyEvidence | null;
+    readonly diagnostics: ReadonlyArray<BrowserMethodBodyDiagnostic>;
+}
+export interface BrowserMethodBodySelection {
+    readonly typeIdentity: string;
+    readonly memberName: string;
+    readonly selectorKey: string;
+    readonly metadataToken: number;
+    readonly label: string;
+}
+export interface BrowserMethodBodyTargets {
+    readonly packageId: string;
+    readonly version: string;
+    readonly framework: string;
+    readonly assembly: string;
+    readonly moduleVersionId: string;
+    readonly before: BrowserMethodBodySelection;
+    readonly methods: ReadonlyArray<BrowserMethodBodySelection>;
+}
+export interface BrowserMethodBodyTargetsResult {
+    readonly version: number;
+    readonly kind: BrowserMethodBodyResultKind;
+    readonly value: BrowserMethodBodyTargets | null;
+    readonly failureKind: BrowserTypeSourceFailureKind | null;
+    readonly error: string | null;
+    readonly diagnostic: string | null;
+    readonly reason: string | null;
 }
 export interface BrowserSource {
     readonly provider: string;
@@ -71,9 +196,12 @@ export interface JsExportRuntime {
 export declare function createRuntime(): Promise<JsExportRuntime>;
 export declare function initializeRuntime(runtime?: JsExportRuntime | PromiseLike<JsExportRuntime>): Promise<void>;
 export declare function runEntryPoint(mainAssemblyName?: string, args?: string[]): Promise<number>;
+export declare function cancelMethodBodyComparison(operationId: string, reason: string): BrowserTypeSourceCancellation;
 export declare function cancelSourceQuery(): void;
 export declare function cancelTypeSourceQuery(operationId: string, reason: string): BrowserTypeSourceCancellation;
 export declare function queryMemberAnnotatedSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, typeQueryId: string, memberName: string, memberSignature: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserAnnotatedSource>;
 export declare function queryMemberSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserSource>;
+export declare function queryMethodBodyComparison(operationId: string, requestJson: string): Promise<BrowserMethodBodyComparisonResult>;
+export declare function queryMethodBodyComparisonTargets(operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number): Promise<BrowserMethodBodyTargetsResult>;
 export declare function queryTypeMemberSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserSource>;
 export declare function queryTypeSource(operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserTypeSourceResult>;

--- a/prototypes/inspect-web/src/method-body-comparison.ts
+++ b/prototypes/inspect-web/src/method-body-comparison.ts
@@ -42,6 +42,10 @@ export function methodBodyComparisonPackageId(
   return pkg.isRuntimePack ? "" : pkg.id;
 }
 
+export function isMethodBodyToken(token: number): boolean {
+  return (token & 0xff000000) === 0x06000000 && (token & 0x00ffffff) !== 0;
+}
+
 export interface MethodBodyDiffState {
   open: boolean;
   context: MethodBodyComparisonContext | null;

--- a/prototypes/inspect-web/src/method-body-comparison.ts
+++ b/prototypes/inspect-web/src/method-body-comparison.ts
@@ -1,0 +1,613 @@
+import type {
+  BrowserMethodBodyComparison,
+  BrowserMethodBodyComparisonRequest,
+  BrowserMethodBodyComparisonResult,
+  BrowserMethodBodyResultKind,
+  BrowserMethodBodySelection,
+  BrowserMethodBodyTargets,
+  BrowserMethodBodyTargetsResult,
+  BrowserTypeSourceFailureKind,
+} from "./facades/inspect-web-source.d.ts";
+import type {
+  OperationAuthorityPage,
+  OperationCancelReason,
+  OperationDiagnostic,
+  OperationFeatureEvent,
+  OperationId,
+  OperationProducerAdapter,
+  OperationProducerSink,
+  OperationSession,
+} from "./operation-authority.ts";
+
+// The launching Before selection: the physical method or explicitly selected
+// accessor/body the person is inspecting, in its own implementation assembly.
+export interface MethodBodyComparisonContext {
+  packageId: string;
+  version: string;
+  framework: string;
+  assembly: string;
+  typeIdentity: string;
+  memberName: string;
+  selectorKey: string;
+  metadataToken: number;
+  label: string;
+}
+
+// A platform selection is resident in the retained runtime pack rather than an acquired
+// package, and the managed target signature discriminates it by an empty package id while
+// keeping the exact platform version, framework and resident assembly.
+export function methodBodyComparisonPackageId(
+  pkg: { readonly id: string; readonly isRuntimePack?: boolean },
+): string {
+  return pkg.isRuntimePack ? "" : pkg.id;
+}
+
+export interface MethodBodyDiffState {
+  open: boolean;
+  context: MethodBodyComparisonContext | null;
+  returnFocusSelector: string;
+  unavailableReason: string;
+  filter: string;
+  candidateKey: string;
+  targets: BrowserMethodBodyTargets | null;
+  targetsLoading: boolean;
+  targetsError: string;
+  submittedRequest: BrowserMethodBodyComparisonRequest | null;
+  comparison: BrowserMethodBodyComparison | null;
+  comparisonLoading: boolean;
+  comparisonError: string;
+}
+
+export function createMethodBodyDiffState(): MethodBodyDiffState {
+  return {
+    open: false,
+    context: null,
+    returnFocusSelector: "",
+    unavailableReason: "",
+    filter: "",
+    candidateKey: "",
+    targets: null,
+    targetsLoading: false,
+    targetsError: "",
+    submittedRequest: null,
+    comparison: null,
+    comparisonLoading: false,
+    comparisonError: "",
+  };
+}
+
+// One physical selection is identified by its declaring type, member, body selector and
+// MethodDef row; display text never identifies a candidate.
+export function methodBodySelectionKey(
+  selection: BrowserMethodBodySelection,
+): string {
+  return [
+    selection.typeIdentity,
+    selection.memberName,
+    selection.selectorKey,
+    String(selection.metadataToken),
+  ].join("\u241f");
+}
+
+// A same-method pair is a valid request, so the launching selection stays choosable even
+// when the inventory does not repeat it.
+export function methodBodyChoices(
+  targets: BrowserMethodBodyTargets,
+): readonly BrowserMethodBodySelection[] {
+  const beforeKey = methodBodySelectionKey(targets.before);
+  return targets.methods.some(
+    method => methodBodySelectionKey(method) === beforeKey)
+    ? targets.methods
+    : [targets.before, ...targets.methods];
+}
+
+export function filterMethodBodyChoices(
+  choices: readonly BrowserMethodBodySelection[],
+  filter: string,
+  selectedKey: string,
+): readonly BrowserMethodBodySelection[] {
+  const needle = filter.trim().toLowerCase();
+  if (!needle) return choices;
+  return choices.filter(choice => {
+    if (methodBodySelectionKey(choice) === selectedKey) return true;
+    return [
+      choice.label,
+      choice.typeIdentity,
+      choice.memberName,
+      choice.selectorKey,
+    ].some(value => value.toLowerCase().includes(needle));
+  });
+}
+
+export function methodBodyChoiceForKey(
+  targets: BrowserMethodBodyTargets | null,
+  key: string,
+): BrowserMethodBodySelection | null {
+  if (!targets || !key) return null;
+  return methodBodyChoices(targets).find(
+    choice => methodBodySelectionKey(choice) === key) ?? null;
+}
+
+export interface MethodBodyComparisonDependencies {
+  state: MethodBodyDiffState;
+  operationAuthority: OperationAuthorityPage;
+  queryTargets(
+    operationId: OperationId,
+    context: MethodBodyComparisonContext,
+  ): Promise<BrowserMethodBodyTargetsResult>;
+  queryComparison(
+    operationId: OperationId,
+    requestJson: string,
+  ): Promise<BrowserMethodBodyComparisonResult>;
+  cancelMethodBodyComparison(
+    operationId: OperationId,
+    reason: OperationCancelReason,
+  ): void;
+  readonly reportOperationDiagnostic: (
+    diagnostic: OperationDiagnostic,
+  ) => undefined;
+  describeError(error: unknown): string;
+  render(): void;
+}
+
+export interface MethodBodyDiffDismissal {
+  handled: boolean;
+  returnFocusSelector: string;
+}
+
+export interface MethodBodyComparisonCoordinator {
+  isOpen(): boolean;
+  open(
+    context: MethodBodyComparisonContext,
+    returnFocusSelector: string,
+  ): Promise<void>;
+  openUnavailable(reason: string, returnFocusSelector: string): void;
+  setFilter(value: string): void;
+  selectCandidate(key: string): boolean;
+  compare(): Promise<void>;
+  close(): MethodBodyDiffDismissal;
+  dispose(): boolean;
+}
+
+type MethodBodyCancelReason =
+  | "user"
+  | "superseded"
+  | "disposed"
+  | "feature-observer-failed"
+  | "timeout"
+  | "worker-restarted";
+
+function cancellationReason(reason: string | null): MethodBodyCancelReason {
+  switch (reason) {
+    case "user":
+    case "superseded":
+    case "disposed":
+    case "feature-observer-failed":
+    case "timeout":
+    case "worker-restarted":
+      return reason;
+    default:
+      throw new Error("Unknown method body comparison cancellation reason.");
+  }
+}
+
+// The managed envelope is transport, not a comparison verdict: a Succeeded envelope still
+// carries whatever Queries and Research concluded, and only a Failed or Canceled envelope
+// is a transport-level non-result.
+function reportEnvelope<TValue>(
+  sink: OperationProducerSink<TValue, unknown, never>,
+  subject: string,
+  version: number,
+  kind: BrowserMethodBodyResultKind,
+  value: TValue | null,
+  failureKind: BrowserTypeSourceFailureKind | null,
+  error: string | null,
+  diagnostic: string | null,
+  reason: string | null,
+): undefined {
+  try {
+    if (version !== 1)
+      throw new Error(`Unsupported ${subject} result version.`);
+    switch (kind) {
+      case "Succeeded":
+        if (value === null || typeof value !== "object")
+          throw new Error(`A ${subject} success carries no value.`);
+        sink.reportTerminal({ kind: "succeeded", value });
+        break;
+      case "Failed": {
+        if (typeof error !== "string" || typeof diagnostic !== "string")
+          throw new Error(`A ${subject} failure has no error or diagnostic.`);
+        const failure = new Error(error);
+        if (failureKind === "Expected")
+          sink.reportTerminal({ kind: "failed", error: failure });
+        else if (failureKind === "Unexpected")
+          sink.reportUnexpectedTerminal(failure, diagnostic);
+        else throw new Error(`Unknown ${subject} failure kind.`);
+        break;
+      }
+      case "Canceled":
+        sink.reportTerminal({
+          kind: "canceled",
+          reason: cancellationReason(reason),
+        });
+        break;
+      default:
+        throw new Error(`Unknown ${subject} result kind.`);
+    }
+  } catch (failure: unknown) {
+    sink.reportUnexpectedTerminal(failure, failure);
+  }
+  return undefined;
+}
+
+export function createMethodBodyComparisonCoordinator(
+  dependencies: MethodBodyComparisonDependencies,
+): MethodBodyComparisonCoordinator {
+  const { state } = dependencies;
+  type TargetsSession = OperationSession<
+    MethodBodyComparisonContext,
+    BrowserMethodBodyTargets,
+    unknown,
+    never,
+    never
+  >;
+  type ComparisonSession = OperationSession<
+    BrowserMethodBodyComparisonRequest,
+    BrowserMethodBodyComparison,
+    unknown,
+    never,
+    never
+  >;
+  interface DialogSessions {
+    readonly targets: TargetsSession;
+    readonly comparison: ComparisonSession;
+  }
+
+  let sessions: DialogSessions | null = null;
+  const comparisonRequests =
+    new Map<OperationId, BrowserMethodBodyComparisonRequest>();
+
+  const diagnose = (message: string, operationId: OperationId | null) => {
+    dependencies.reportOperationDiagnostic({
+      kind: "producer-contract",
+      operationId,
+      error: new Error(message),
+    });
+  };
+
+  // Feature publication runs inside the authority's observer depth, where other page
+  // owners cannot accept cancellation or replacement. Rendering is scheduled just past it.
+  const scheduleRender = (): undefined => {
+    queueMicrotask(() => {
+      dependencies.render();
+    });
+    return undefined;
+  };
+
+  const publishTargetsEvent = (
+    event: OperationFeatureEvent<BrowserMethodBodyTargets, unknown, never>,
+  ): undefined => {
+    switch (event.kind) {
+      case "started":
+      case "replaced":
+        state.targets = null;
+        state.targetsError = "";
+        state.targetsLoading = true;
+        scheduleRender();
+        break;
+      case "terminal":
+        state.targetsLoading = false;
+        if (event.outcome.kind === "succeeded")
+          state.targets = event.outcome.value;
+        else
+          state.targetsError =
+            dependencies.describeError(event.outcome.error)
+            || "The comparison inventory is unavailable.";
+        scheduleRender();
+        break;
+      case "canceled":
+      case "disposed":
+        state.targetsLoading = false;
+        break;
+      case "progress":
+        break;
+    }
+    return undefined;
+  };
+
+  const publishComparisonEvent = (
+    event: OperationFeatureEvent<BrowserMethodBodyComparison, unknown, never>,
+  ): undefined => {
+    switch (event.kind) {
+      case "started":
+      case "replaced": {
+        const request = comparisonRequests.get(event.operation.id) ?? null;
+        state.submittedRequest = request;
+        state.comparison = null;
+        state.comparisonError = "";
+        state.comparisonLoading = true;
+        scheduleRender();
+        break;
+      }
+      case "terminal": {
+        // The submitted request, not the current chooser, owns this publication.
+        const request = comparisonRequests.get(event.operationId) ?? null;
+        state.submittedRequest = request;
+        state.comparisonLoading = false;
+        if (event.outcome.kind === "succeeded")
+          state.comparison = event.outcome.value;
+        else
+          state.comparisonError =
+            dependencies.describeError(event.outcome.error)
+            || "The method body comparison did not complete.";
+        scheduleRender();
+        break;
+      }
+      case "canceled":
+      case "disposed":
+        state.comparisonLoading = false;
+        break;
+      case "progress":
+        break;
+    }
+    return undefined;
+  };
+
+  const targetsAdapter: OperationProducerAdapter<
+    MethodBodyComparisonContext,
+    BrowserMethodBodyTargets,
+    unknown,
+    never,
+    never
+  > = {
+    prepare: (identity, context, sink) => {
+      let cancellationRequested = false;
+      const quiesce = (): undefined => {
+        sink.reportQuiesced();
+        return undefined;
+      };
+      const boundaryFailure = (error: unknown): undefined => {
+        sink.reportUnexpectedTerminal(error, error);
+        return quiesce();
+      };
+      return {
+        kind: "prepared",
+        binding: {
+          requestCancellation: reason => {
+            if (cancellationRequested) return undefined;
+            cancellationRequested = true;
+            dependencies.cancelMethodBodyComparison(identity.id, reason);
+            return undefined;
+          },
+          activate: () => {
+            let query: Promise<BrowserMethodBodyTargetsResult>;
+            try {
+              query = dependencies.queryTargets(identity.id, context);
+            } catch (error: unknown) {
+              return boundaryFailure(error);
+            }
+            void query.then(result => {
+              reportEnvelope(
+                sink,
+                "method body target",
+                result.version,
+                result.kind,
+                result.value,
+                result.failureKind,
+                result.error,
+                result.diagnostic,
+                result.reason);
+              return quiesce();
+            }, boundaryFailure);
+            return undefined;
+          },
+          abandon: () => undefined,
+        },
+      };
+    },
+  };
+
+  const comparisonAdapter: OperationProducerAdapter<
+    BrowserMethodBodyComparisonRequest,
+    BrowserMethodBodyComparison,
+    unknown,
+    never,
+    never
+  > = {
+    prepare: (identity, request, sink) => {
+      comparisonRequests.set(identity.id, request);
+      let cancellationRequested = false;
+      const quiesce = (): undefined => {
+        comparisonRequests.delete(identity.id);
+        sink.reportQuiesced();
+        return undefined;
+      };
+      const boundaryFailure = (error: unknown): undefined => {
+        sink.reportUnexpectedTerminal(error, error);
+        return quiesce();
+      };
+      return {
+        kind: "prepared",
+        binding: {
+          requestCancellation: reason => {
+            if (cancellationRequested) return undefined;
+            cancellationRequested = true;
+            dependencies.cancelMethodBodyComparison(identity.id, reason);
+            return undefined;
+          },
+          activate: () => {
+            let query: Promise<BrowserMethodBodyComparisonResult>;
+            try {
+              query = dependencies.queryComparison(
+                identity.id,
+                JSON.stringify(request));
+            } catch (error: unknown) {
+              return boundaryFailure(error);
+            }
+            void query.then(result => {
+              reportEnvelope(
+                sink,
+                "method body comparison",
+                result.version,
+                result.kind,
+                result.value,
+                result.failureKind,
+                result.error,
+                result.diagnostic,
+                result.reason);
+              return quiesce();
+            }, boundaryFailure);
+            return undefined;
+          },
+          abandon: () => {
+            comparisonRequests.delete(identity.id);
+            return undefined;
+          },
+        },
+      };
+    },
+  };
+
+  const createSessions = (): DialogSessions => ({
+    targets: dependencies.operationAuthority.createSession({
+      feature: { publish: publishTargetsEvent },
+      diagnostic: {
+        report: diagnostic =>
+          dependencies.reportOperationDiagnostic(diagnostic),
+      },
+    }),
+    comparison: dependencies.operationAuthority.createSession({
+      feature: { publish: publishComparisonEvent },
+      diagnostic: {
+        report: diagnostic =>
+          dependencies.reportOperationDiagnostic(diagnostic),
+      },
+    }),
+  });
+
+  // Closing, navigation replacement and re-opening all release the feature operations
+  // through the existing authority boundary, which is what suppresses their late results.
+  const shutdown = (): boolean => {
+    const wasOpen = state.open;
+    if (sessions) {
+      const comparison = sessions.comparison.dispose();
+      const targets = sessions.targets.dispose();
+      if (comparison.kind === "rejected" || targets.kind === "rejected") {
+        diagnose(
+          "Method Body Diff disposal was rejected during feature publication.",
+          null);
+        return false;
+      }
+      sessions = null;
+    }
+    comparisonRequests.clear();
+    Object.assign(state, createMethodBodyDiffState());
+    return wasOpen;
+  };
+
+  const clearComparison = (): void => {
+    if (!sessions) return;
+    const cancellation = sessions.comparison.cancelCurrent("superseded");
+    if (cancellation.kind === "rejected") {
+      diagnose(
+        "Method Body Diff replacement was rejected during feature publication.",
+        null);
+      return;
+    }
+    state.comparison = null;
+    state.comparisonError = "";
+    state.comparisonLoading = false;
+    state.submittedRequest = null;
+  };
+
+  return {
+    isOpen: () => state.open,
+
+    async open(context, returnFocusSelector) {
+      shutdown();
+      state.open = true;
+      state.context = { ...context };
+      state.returnFocusSelector = returnFocusSelector;
+      sessions = createSessions();
+      const started = sessions.targets.start(state.context, targetsAdapter);
+      if (started.kind === "rejected") {
+        state.targetsLoading = false;
+        state.targetsError =
+          `The comparison inventory could not start: ${started.reason.kind}.`;
+        diagnose(
+          `Method Body Diff inventory start was rejected: ${started.reason.kind}.`,
+          null);
+        dependencies.render();
+        return;
+      }
+      await started.handle.quiesced;
+    },
+
+    openUnavailable(reason, returnFocusSelector) {
+      shutdown();
+      state.open = true;
+      state.returnFocusSelector = returnFocusSelector;
+      state.unavailableReason = reason;
+      dependencies.render();
+    },
+
+    setFilter(value) {
+      if (!state.open || state.filter === value) return;
+      state.filter = value;
+      dependencies.render();
+    },
+
+    // Choosing a candidate never compares, and it never leaves an older result under a
+    // newer pair.
+    selectCandidate(key) {
+      if (!state.open || state.candidateKey === key) return false;
+      state.candidateKey = key;
+      clearComparison();
+      dependencies.render();
+      return true;
+    },
+
+    async compare() {
+      if (!state.open || !sessions) return;
+      const targets = state.targets;
+      const after = methodBodyChoiceForKey(targets, state.candidateKey);
+      if (!targets || !after) {
+        state.comparisonError =
+          "Choose an After method before comparing method bodies.";
+        dependencies.render();
+        return;
+      }
+      const request: BrowserMethodBodyComparisonRequest = {
+        packageId: targets.packageId,
+        version: targets.version,
+        framework: targets.framework,
+        assembly: targets.assembly,
+        moduleVersionId: targets.moduleVersionId,
+        before: targets.before,
+        after,
+      };
+      const started = sessions.comparison.start(request, comparisonAdapter);
+      if (started.kind === "rejected") {
+        state.comparisonLoading = false;
+        state.comparisonError =
+          `The comparison could not start: ${started.reason.kind}.`;
+        diagnose(
+          `Method Body Diff comparison start was rejected: ${started.reason.kind}.`,
+          null);
+        dependencies.render();
+        return;
+      }
+      await started.handle.quiesced;
+    },
+
+    close() {
+      const returnFocusSelector = state.returnFocusSelector;
+      const handled = shutdown();
+      return { handled, returnFocusSelector };
+    },
+
+    dispose() {
+      return shutdown();
+    },
+  };
+}

--- a/prototypes/inspect-web/src/method-body-comparison.ts
+++ b/prototypes/inspect-web/src/method-body-comparison.ts
@@ -154,7 +154,7 @@ export interface MethodBodyComparisonDependencies {
   render(): void;
 }
 
-export interface MethodBodyDiffDismissal {
+interface MethodBodyDiffDismissal {
   handled: boolean;
   returnFocusSelector: string;
 }

--- a/prototypes/inspect-web/src/method-body-diff-view.ts
+++ b/prototypes/inspect-web/src/method-body-diff-view.ts
@@ -1,0 +1,558 @@
+import type {
+  BrowserCSharpBodyRow,
+  BrowserIlBodyRow,
+  BrowserMethodBodyComparison,
+  BrowserMethodBodyComparisonRequest,
+  BrowserMethodBodyDiagnostic,
+  BrowserMethodBodyEndpoint,
+  BrowserMethodBodyProducer,
+  BrowserMethodBodySelection,
+} from "./facades/inspect-web-source.d.ts";
+import type { EscapeHtml } from "./csharp-highlighting.ts";
+import {
+  filterMethodBodyChoices,
+  methodBodyChoices,
+  methodBodyChoiceForKey,
+  methodBodySelectionKey,
+  type MethodBodyDiffState,
+} from "./method-body-comparison.ts";
+import { trapModalTab } from "./shell-controls.ts";
+
+export const METHOD_BODY_DIFF_ACTION_SELECTOR = "#compare-method-bodies";
+export const METHOD_BODY_DIFF_CHOOSER_SELECTOR = "#method-body-diff-after";
+export const METHOD_BODY_DIFF_FILTER_SELECTOR = "#method-body-diff-filter";
+export const METHOD_BODY_DIFF_TITLE_SELECTOR = "#method-body-diff-title";
+
+export type MethodBodyDiffAction =
+  | { readonly kind: "open" }
+  | { readonly kind: "close" }
+  | { readonly kind: "compare" }
+  | { readonly kind: "select"; readonly key: string }
+  | { readonly kind: "filter"; readonly value: string; readonly caret: number };
+
+export interface MethodBodyDiffBindingActions {
+  readonly onAction: (action: MethodBodyDiffAction) => void;
+}
+
+export interface MethodBodyComparisonAvailability {
+  readonly available: boolean;
+  readonly reason: string;
+}
+
+export interface MethodBodyDiffRenderOptions {
+  readonly state: MethodBodyDiffState;
+  readonly escapeHtml: EscapeHtml;
+  readonly highlightCSharp: (value: string) => string;
+}
+
+function metadataToken(token: number | null | undefined): string {
+  if (token === null || token === undefined) return "no token";
+  return `0x${token.toString(16).padStart(8, "0")}`;
+}
+
+// The contextual action always states why it cannot run, so an unavailable implementation
+// target is visible rather than a hidden or silent control.
+export function renderMethodBodyComparisonAction(
+  availability: MethodBodyComparisonAvailability,
+  escapeHtml: EscapeHtml,
+): string {
+  const unavailable = !availability.available;
+  return `
+    <button id="compare-method-bodies" type="button"
+      data-method-body-action="open"
+      ${unavailable ? ' aria-describedby="compare-method-bodies-reason" disabled' : ""}
+      title="Compare this method body with another method in the same implementation assembly">Compare method bodies</button>
+    ${unavailable
+      ? `<span id="compare-method-bodies-reason" class="working-surface-note">${escapeHtml(availability.reason)}</span>`
+      : ""}`;
+}
+
+interface MethodBodyIdentityFields {
+  readonly label: string;
+  readonly typeIdentity: string;
+  readonly memberName: string;
+  readonly selectorKey: string;
+  readonly metadataToken: number;
+}
+
+function renderIdentity(
+  identity: MethodBodyIdentityFields | null,
+  escapeHtml: EscapeHtml,
+  empty: string,
+): string {
+  if (!identity)
+    return `<p class="method-body-empty">${escapeHtml(empty)}</p>`;
+  return `
+    <p class="method-body-label"><code>${escapeHtml(identity.label)}</code></p>
+    <dl class="method-body-identity">
+      <div><dt>Type</dt><dd><code>${escapeHtml(identity.typeIdentity)}</code></dd></div>
+      <div><dt>Member</dt><dd><code>${escapeHtml(identity.memberName)}</code></dd></div>
+      <div><dt>Body</dt><dd><code>${escapeHtml(identity.selectorKey)}</code></dd></div>
+      <div><dt>MethodDef</dt><dd><code>${escapeHtml(metadataToken(identity.metadataToken))}</code></dd></div>
+    </dl>`;
+}
+
+function renderSelectionIdentity(
+  selection: BrowserMethodBodySelection | null,
+  escapeHtml: EscapeHtml,
+  empty: string,
+): string {
+  return renderIdentity(selection, escapeHtml, empty);
+}
+
+function renderAssemblyLine(
+  request: BrowserMethodBodyComparisonRequest | null,
+  targetsAssembly: string,
+  targetsPackage: string,
+  targetsVersion: string,
+  targetsFramework: string,
+  targetsModuleVersionId: string,
+  escapeHtml: EscapeHtml,
+): string {
+  const assembly = request?.assembly ?? targetsAssembly;
+  const packageId = request?.packageId ?? targetsPackage;
+  const version = request?.version ?? targetsVersion;
+  const framework = request?.framework ?? targetsFramework;
+  const moduleVersionId = request?.moduleVersionId ?? targetsModuleVersionId;
+  if (!assembly) return "";
+  return `<p class="method-body-scope">
+      <span>${escapeHtml(assembly)}</span>
+      <span>${escapeHtml(packageId)} ${escapeHtml(version)} · ${escapeHtml(framework)}</span>
+      <span>MVID ${escapeHtml(moduleVersionId)}</span>
+    </p>`;
+}
+
+function renderChooser(
+  state: MethodBodyDiffState,
+  escapeHtml: EscapeHtml,
+): string {
+  const targets = state.targets;
+  if (state.targetsLoading) {
+    return `<p class="method-body-progress"><span class="loader"></span>Loading the implementation method inventory…</p>`;
+  }
+  if (state.targetsError) {
+    return `<p class="method-body-failure" role="alert">${escapeHtml(state.targetsError)}</p>`;
+  }
+  if (!targets) {
+    return `<p class="method-body-empty">No implementation method inventory is available.</p>`;
+  }
+  const choices = filterMethodBodyChoices(
+    methodBodyChoices(targets),
+    state.filter,
+    state.candidateKey);
+  const options = choices.map(choice => {
+    const key = methodBodySelectionKey(choice);
+    return `<option value="${escapeHtml(key)}"${key === state.candidateKey ? " selected" : ""}>${escapeHtml(choice.label)}</option>`;
+  }).join("");
+  return `
+    <div class="method-body-chooser">
+      <label class="method-body-field" for="method-body-diff-filter">
+        <span>Filter</span>
+        <input id="method-body-diff-filter" type="search"
+          data-method-body-filter autocomplete="off" spellcheck="false"
+          placeholder="Filter methods, types and bodies"
+          value="${escapeHtml(state.filter)}" />
+      </label>
+      <label class="method-body-field" for="method-body-diff-after">
+        <span>After method</span>
+        <select id="method-body-diff-after" data-method-body-candidate>
+          <option value=""${state.candidateKey ? "" : " selected"}>Choose a method…</option>
+          ${options}
+        </select>
+      </label>
+      <p class="method-body-choice-count">${choices.length} of ${methodBodyChoices(targets).length} methods shown</p>
+    </div>`;
+}
+
+function endpointState(
+  endpoint: BrowserMethodBodyEndpoint,
+  side: "before" | "after",
+  escapeHtml: EscapeHtml,
+): string {
+  const detail = [
+    endpoint.targetState ? `target ${endpoint.targetState}` : "",
+    endpoint.metadataToken === null || endpoint.metadataToken === undefined
+      ? ""
+      : metadataToken(endpoint.metadataToken),
+    endpoint.moduleVersionId ? `MVID ${endpoint.moduleVersionId}` : "",
+    endpoint.detail ?? "",
+  ].filter(Boolean).join(" · ");
+  return `<p class="method-body-endpoint" data-method-body-endpoint="${side}">
+      <strong>${side === "before" ? "Before" : "After"}</strong>
+      <span data-method-body-endpoint-state>${escapeHtml(endpoint.state)}</span>
+      ${detail ? `<small>${escapeHtml(detail)}</small>` : ""}
+    </p>`;
+}
+
+function renderDiagnostics(
+  diagnostics: readonly BrowserMethodBodyDiagnostic[],
+  escapeHtml: EscapeHtml,
+  label: string,
+): string {
+  if (diagnostics.length === 0) return "";
+  return `
+    <section class="method-body-diagnostics" aria-label="${escapeHtml(label)}">
+      <h4>${escapeHtml(label)}</h4>
+      <ul>
+        ${diagnostics.map(diagnostic => {
+          const scope = [
+            diagnostic.kind,
+            diagnostic.side ?? "",
+            diagnostic.mechanism ?? "",
+            diagnostic.hunkId === null || diagnostic.hunkId === undefined
+              ? ""
+              : `hunk ${diagnostic.hunkId}`,
+            diagnostic.subjectToken === null
+              || diagnostic.subjectToken === undefined
+              ? ""
+              : metadataToken(diagnostic.subjectToken),
+            diagnostic.path ?? "",
+          ].filter(Boolean).join(" · ");
+          return `<li>
+            <span class="method-body-diagnostic-scope">${escapeHtml(scope)}</span>
+            <span>${escapeHtml(diagnostic.message)}</span>
+            ${diagnostic.detail ? `<small>${escapeHtml(diagnostic.detail)}</small>` : ""}
+          </li>`;
+        }).join("")}
+      </ul>
+    </section>`;
+}
+
+function renderCSharpValue(
+  side: "old" | "new",
+  value: string | null,
+  operationKind: string | null,
+  operationValue: string | null,
+  escapeHtml: EscapeHtml,
+  highlightCSharp: (value: string) => string,
+): string {
+  return `<div class="method-body-value" data-method-body-value="${side}">
+      <span class="method-body-value-label">${side === "old" ? "Before" : "After"}</span>
+      ${value === null
+        ? `<span class="method-body-empty">no value</span>`
+        : `<pre class="language-csharp"><code class="language-csharp">${highlightCSharp(value)}</code></pre>`}
+      ${operationKind === null
+        ? ""
+        : `<small class="method-body-operation">${escapeHtml(operationKind)}: ${escapeHtml(operationValue ?? "")}</small>`}
+    </div>`;
+}
+
+// Native row evidence is lowered to DOM exactly as the producer reported it: no second
+// diff, no normalization, no reconstruction of a body from displayed text.
+function renderCSharpRow(
+  row: BrowserCSharpBodyRow,
+  escapeHtml: EscapeHtml,
+  highlightCSharp: (value: string) => string,
+): string {
+  const coordinates = [
+    row.line === null || row.line === undefined ? "" : `line ${row.line}`,
+    `hunk ${row.hunkId}`,
+    row.sourceCoordinate ?? "",
+    row.fidelity,
+  ].filter(Boolean).join(" · ");
+  return `
+    <li class="method-body-row" data-method-body-row="csharp"
+      data-method-body-kind="${escapeHtml(row.kind)}"
+      data-method-body-hunk="${row.hunkId}"
+      data-method-body-change="${escapeHtml(row.changeId)}"
+      data-method-body-member-key="${escapeHtml(row.stableMemberKey)}">
+      <p class="method-body-row-head">
+        <span class="method-body-row-kind">${escapeHtml(row.kind)}</span>
+        <span class="method-body-row-coordinates">${escapeHtml(coordinates)}</span>
+        <span class="method-body-row-member"
+          title="${escapeHtml(row.assemblyIdentity)}">${escapeHtml(row.member)}</span>
+      </p>
+      <pre class="language-csharp method-body-row-text"><code class="language-csharp">${highlightCSharp(row.text)}</code></pre>
+      <div class="method-body-row-values">
+        ${renderCSharpValue(
+          "old",
+          row.oldValue,
+          row.oldOperation?.kind ?? null,
+          row.oldOperation?.value ?? null,
+          escapeHtml,
+          highlightCSharp)}
+        ${renderCSharpValue(
+          "new",
+          row.newValue,
+          row.newOperation?.kind ?? null,
+          row.newOperation?.value ?? null,
+          escapeHtml,
+          highlightCSharp)}
+      </div>
+      <p class="method-body-row-message">${escapeHtml(row.message)}</p>
+    </li>`;
+}
+
+function renderIlRow(
+  row: BrowserIlBodyRow,
+  escapeHtml: EscapeHtml,
+): string {
+  const operand = row.operation.operand
+    ? `${row.operation.operand.kind}: ${row.operation.operand.value}`
+    : "no operand";
+  return `
+    <li class="method-body-row" data-method-body-row="il"
+      data-method-body-kind="${escapeHtml(row.kind)}"
+      data-method-body-hunk="${row.hunkId}">
+      <p class="method-body-row-head">
+        <span class="method-body-row-kind">${escapeHtml(row.kind)}</span>
+        <span class="method-body-row-coordinates">IL_${row.operation.offset.toString(16).padStart(4, "0")} · hunk ${row.hunkId}</span>
+        <span class="method-body-row-member">${escapeHtml(row.operation.opcodeFamily)}</span>
+      </p>
+      <p class="method-body-row-operand"><code>${escapeHtml(operand)}</code></p>
+      <p class="method-body-row-message">${escapeHtml(row.message)}</p>
+    </li>`;
+}
+
+function producerLabel(producer: string): string {
+  switch (producer) {
+    case "CSharp":
+      return "C#";
+    case "IlBody":
+      return "IL";
+    default:
+      return producer;
+  }
+}
+
+function exactness(isExact: boolean): string {
+  return isExact
+    ? "exact under this mechanism"
+    : "not exact under this mechanism";
+}
+
+// Each native lane keeps its own outcome, verdict, endpoints and evidence; one failed lane
+// never hides the other lane's usable evidence.
+function renderProducer(
+  producer: BrowserMethodBodyProducer,
+  escapeHtml: EscapeHtml,
+  highlightCSharp: (value: string) => string,
+): string {
+  const label = producerLabel(producer.producer);
+  const cSharp = producer.cSharp;
+  const il = producer.il;
+  const cSharpEvidence = cSharp
+    ? `<section class="method-body-evidence" data-method-body-evidence="csharp">
+        <p class="method-body-evidence-head">
+          <span data-method-body-exact="${cSharp.isExact}">${escapeHtml(exactness(cSharp.isExact))}</span>
+          <span>${cSharp.rows.length} row${cSharp.rows.length === 1 ? "" : "s"}</span>
+        </p>
+        ${cSharp.rows.length === 0
+          ? `<p class="method-body-empty">No aligned C# rows were reported.</p>`
+          : `<ol class="method-body-rows">${cSharp.rows.map(row =>
+              renderCSharpRow(row, escapeHtml, highlightCSharp)).join("")}</ol>`}
+      </section>`
+    : "";
+  const ilEvidence = il
+    ? `<section class="method-body-evidence" data-method-body-evidence="il">
+        <p class="method-body-evidence-head">
+          <span data-method-body-il-outcome>${escapeHtml(il.outcome)}</span>
+          <span data-method-body-exact="${il.isExact}">${escapeHtml(exactness(il.isExact))}</span>
+          <span>${il.isAvailable ? "IL evidence available" : "IL evidence unavailable"}</span>
+          ${il.failure ? `<span class="method-body-failure">${escapeHtml(il.failure)}</span>` : ""}
+        </p>
+        ${il.rows.length === 0
+          ? `<p class="method-body-empty">No IL instruction rows were reported.</p>`
+          : `<details class="method-body-il-disclosure">
+              <summary>${il.rows.length} IL instruction row${il.rows.length === 1 ? "" : "s"}</summary>
+              <ol class="method-body-rows">${il.rows.map(row =>
+                renderIlRow(row, escapeHtml)).join("")}</ol>
+            </details>`}
+      </section>`
+    : "";
+  const evidence = cSharpEvidence + ilEvidence;
+  return `
+    <section class="method-body-producer" data-method-body-producer="${escapeHtml(producer.producer)}"
+      aria-label="${escapeHtml(label)} comparison">
+      <header class="method-body-producer-head">
+        <h3>${escapeHtml(label)}</h3>
+        <p class="method-body-status">
+          <span data-method-body-outcome>${escapeHtml(producer.outcome)}</span>
+          <span data-method-body-verdict>${escapeHtml(producer.nativeVerdict)}</span>
+        </p>
+      </header>
+      <div class="method-body-endpoints">
+        ${endpointState(producer.before, "before", escapeHtml)}
+        ${endpointState(producer.after, "after", escapeHtml)}
+      </div>
+      ${evidence || `<p class="method-body-empty">This mechanism returned no aligned body evidence.</p>`}
+      ${renderDiagnostics(producer.diagnostics, escapeHtml, `${label} diagnostics`)}
+    </section>`;
+}
+
+function orderedProducers(
+  comparison: BrowserMethodBodyComparison,
+): readonly BrowserMethodBodyProducer[] {
+  // C# is the primary region; IL keeps its outcome visible next to it.
+  return [...comparison.producers].sort((left, right) =>
+    (left.producer === "CSharp" ? 0 : 1) - (right.producer === "CSharp" ? 0 : 1));
+}
+
+function renderResult(
+  state: MethodBodyDiffState,
+  escapeHtml: EscapeHtml,
+  highlightCSharp: (value: string) => string,
+): string {
+  if (state.comparisonLoading) {
+    return `<section class="method-body-result" aria-live="polite">
+        <p class="method-body-progress"><span class="loader"></span>Comparing the submitted method bodies…</p>
+      </section>`;
+  }
+  if (state.comparisonError) {
+    return `<section class="method-body-result" aria-live="polite">
+        <p class="method-body-failure" role="alert">${escapeHtml(state.comparisonError)}</p>
+      </section>`;
+  }
+  const comparison = state.comparison;
+  if (!comparison) {
+    return `<section class="method-body-result" aria-live="polite">
+        <p class="method-body-empty">Choose an After method, then select Compare.</p>
+      </section>`;
+  }
+  const request = comparison.request;
+  return `
+    <section class="method-body-result" aria-live="polite">
+      <header class="method-body-result-head">
+        <h3>Comparison</h3>
+        <p class="method-body-status">
+          <span data-method-body-stage>${escapeHtml(comparison.stage)}</span>
+          <span data-method-body-comparison-outcome>${escapeHtml(comparison.outcome)}</span>
+        </p>
+      </header>
+      <div class="method-body-pair method-body-result-pair">
+        <section data-method-body-side="before" aria-label="Compared Before method">
+          <h4>Before</h4>
+          ${renderSelectionIdentity(request.before, escapeHtml, "no Before method")}
+        </section>
+        <section data-method-body-side="after" aria-label="Compared After method">
+          <h4>After</h4>
+          ${renderSelectionIdentity(request.after, escapeHtml, "no After method")}
+        </section>
+      </div>
+      ${orderedProducers(comparison).map(producer =>
+        renderProducer(producer, escapeHtml, highlightCSharp)).join("")}
+      ${renderDiagnostics(comparison.diagnostics, escapeHtml, "Comparison diagnostics")}
+    </section>`;
+}
+
+export function renderMethodBodyDiffModal(
+  options: MethodBodyDiffRenderOptions,
+): string {
+  const { state, escapeHtml, highlightCSharp } = options;
+  if (!state.open) return "";
+  const targets = state.targets;
+  // Before is fixed by the launching selection: the owner-issued inventory identity once it
+  // arrives, and the launching coordinates while it is still loading.
+  const before: MethodBodyIdentityFields | null =
+    targets?.before ?? state.context;
+  const candidate = methodBodyChoiceForKey(targets, state.candidateKey);
+  const body = state.unavailableReason
+    ? `<section class="method-body-unavailable" role="alert">
+        <h3>Comparison is unavailable here</h3>
+        <p>${escapeHtml(state.unavailableReason)}</p>
+      </section>`
+    : `
+      <div class="method-body-pair">
+        <section data-method-body-side="before" aria-label="Before method">
+          <h3>Before</h3>
+          ${renderIdentity(
+            before,
+            escapeHtml,
+            "The launching method is unavailable.")}
+        </section>
+        <section data-method-body-side="after" aria-label="After method">
+          <h3>After</h3>
+          ${renderChooser(state, escapeHtml)}
+          ${renderSelectionIdentity(
+            candidate,
+            escapeHtml,
+            "No After method is chosen yet.")}
+        </section>
+      </div>
+      ${renderAssemblyLine(
+        state.comparison?.request ?? state.submittedRequest,
+        targets?.assembly ?? "",
+        targets?.packageId ?? "",
+        targets?.version ?? "",
+        targets?.framework ?? "",
+        targets?.moduleVersionId ?? "",
+        escapeHtml)}
+      <div class="method-body-actions">
+        <button id="method-body-diff-compare" type="button"
+          data-method-body-action="compare"${candidate && !state.comparisonLoading ? "" : " disabled"}>Compare</button>
+        ${candidate
+          ? ""
+          : `<span class="method-body-empty">Choose an After method to enable Compare.</span>`}
+      </div>
+      ${renderResult(state, escapeHtml, highlightCSharp)}`;
+  return `
+    <div id="method-body-diff-backdrop" class="method-body-modal-backdrop">
+      <section id="method-body-diff-modal" class="method-body-modal"
+        role="dialog" aria-modal="true" aria-labelledby="method-body-diff-title">
+        <header class="method-body-modal-head">
+          <div>
+            <p class="section-eyebrow">Compare method bodies</p>
+            <h2 id="method-body-diff-title" tabindex="-1">Method Body Diff</h2>
+          </div>
+          <div class="method-body-modal-head-actions">
+            <button id="method-body-diff-close" type="button"
+              data-method-body-action="close">Close</button>
+          </div>
+        </header>
+        <div class="method-body-modal-body">
+          ${body}
+        </div>
+      </section>
+    </div>`;
+}
+
+function isHtmlEventTarget(value: EventTarget | null): value is HTMLElement {
+  return value !== null && "dataset" in value && "addEventListener" in value;
+}
+
+function htmlTarget(value: EventTarget | null): HTMLElement | null {
+  return isHtmlEventTarget(value) ? value : null;
+}
+
+export function bindMethodBodyDiff(
+  root: ParentNode,
+  actions: MethodBodyDiffBindingActions,
+): void {
+  root.querySelectorAll<HTMLElement>("[data-method-body-action]")
+    .forEach(element => {
+      element.addEventListener("click", event => {
+        const target = htmlTarget(event.currentTarget);
+        const action = target?.dataset.methodBodyAction;
+        if (action === "open") actions.onAction({ kind: "open" });
+        else if (action === "close") actions.onAction({ kind: "close" });
+        else if (action === "compare") actions.onAction({ kind: "compare" });
+      });
+    });
+
+  const chooser =
+    root.querySelector<HTMLSelectElement>("[data-method-body-candidate]");
+  chooser?.addEventListener("change", () => {
+    actions.onAction({ kind: "select", key: chooser.value });
+  });
+
+  const filter =
+    root.querySelector<HTMLInputElement>("[data-method-body-filter]");
+  filter?.addEventListener("input", () => {
+    actions.onAction({
+      kind: "filter",
+      value: filter.value,
+      caret: filter.selectionStart ?? filter.value.length,
+    });
+  });
+
+  const backdrop =
+    root.querySelector<HTMLElement>("#method-body-diff-backdrop");
+  backdrop?.addEventListener("click", event => {
+    if (event.target === backdrop) actions.onAction({ kind: "close" });
+  });
+
+  const modal = root.querySelector<HTMLElement>("#method-body-diff-modal");
+  modal?.addEventListener("keydown", event => {
+    if (event.key === "Tab") trapModalTab(modal, event);
+  });
+}

--- a/prototypes/inspect-web/src/method-body-diff-view.ts
+++ b/prototypes/inspect-web/src/method-body-diff-view.ts
@@ -21,7 +21,6 @@ import { trapModalTab } from "./shell-controls.ts";
 export const METHOD_BODY_DIFF_ACTION_SELECTOR = "#compare-method-bodies";
 export const METHOD_BODY_DIFF_CHOOSER_SELECTOR = "#method-body-diff-after";
 export const METHOD_BODY_DIFF_FILTER_SELECTOR = "#method-body-diff-filter";
-export const METHOD_BODY_DIFF_TITLE_SELECTOR = "#method-body-diff-title";
 
 export type MethodBodyDiffAction =
   | { readonly kind: "open" }

--- a/prototypes/inspect-web/src/method-body-diff-view.ts
+++ b/prototypes/inspect-web/src/method-body-diff-view.ts
@@ -226,12 +226,13 @@ function renderCSharpValue(
   escapeHtml: EscapeHtml,
   highlightCSharp: (value: string) => string,
 ): string {
+  const text = value ?? operationValue;
   return `<div class="method-body-value" data-method-body-value="${side}">
       <span class="method-body-value-label">${side === "old" ? "Before" : "After"}</span>
-      ${value === null
+      ${text === null
         ? `<span class="method-body-empty">no value</span>`
-        : `<pre class="language-csharp"><code class="language-csharp">${highlightCSharp(value)}</code></pre>`}
-      ${operationKind === null
+        : `<pre class="language-csharp"><code class="language-csharp">${highlightCSharp(text)}</code></pre>`}
+      ${operationKind === null || operationKind === "Line"
         ? ""
         : `<small class="method-body-operation">${escapeHtml(operationKind)}: ${escapeHtml(operationValue ?? "")}</small>`}
     </div>`;
@@ -262,7 +263,9 @@ function renderCSharpRow(
         <span class="method-body-row-member"
           title="${escapeHtml(row.assemblyIdentity)}">${escapeHtml(row.member)}</span>
       </p>
-      <pre class="language-csharp method-body-row-text"><code class="language-csharp">${highlightCSharp(row.text)}</code></pre>
+      ${row.oldValue === null && row.newValue === null && row.oldOperation === null && row.newOperation === null
+        ? `<pre class="language-csharp method-body-row-text"><code class="language-csharp">${highlightCSharp(row.text)}</code></pre>`
+        : ""}
       <div class="method-body-row-values">
         ${renderCSharpValue(
           "old",

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -3292,3 +3292,84 @@ kbd {
 :root[data-theme="light"] .annotated-source-code .token.attribute,
 :root[data-theme="light"] .annotated-source-code .token.namespace,
 :root[data-theme="light"] .annotated-source-code .token.preprocessor { color: #6c4d91; }
+
+/* Method Body Diff is a session-local dialog: paired Before/After identity stays visible
+   when the columns stack, and each native lane keeps its own outcome region. */
+.working-surface-note { color: var(--dim); font: 11px/1.5 var(--mono); }
+.method-body-modal-backdrop { position: fixed; inset: 0; z-index: 72; display: grid; background: rgba(0, 0, 0, 0.72); }
+.method-body-modal { position: relative; min-width: 0; min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr); margin: 10px; overflow: hidden; border: 1px solid var(--line-strong); border-radius: 4px; background: var(--bg); }
+.method-body-modal-head { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 12px 14px; border-bottom: 1px solid var(--line); background: var(--panel); }
+.method-body-modal-head h2 { margin: 0; }
+.method-body-modal-head-actions { display: flex; align-items: center; gap: 7px; }
+.method-body-modal button,
+.method-body-modal select,
+.method-body-modal input { border: 1px solid var(--line-strong); background: var(--panel-raised); color: var(--muted); }
+.method-body-modal button { cursor: pointer; padding: 4px 10px; border-radius: 3px; font: 11px var(--mono); }
+.method-body-modal button:hover:not([disabled]) { border-color: var(--accent); color: var(--text); }
+.method-body-modal button:focus-visible,
+.method-body-modal select:focus-visible,
+.method-body-modal input:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
+.method-body-modal button[disabled] { opacity: .55; cursor: not-allowed; }
+.method-body-modal-body { min-height: 0; padding: 14px; overflow: auto; }
+.method-body-pair { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 12px; }
+.method-body-pair > section { min-width: 0; padding: 10px; border: 1px solid var(--line); border-radius: 3px; background: var(--panel); }
+.method-body-pair h3,
+.method-body-pair h4 { margin: 0 0 8px; }
+.method-body-label { margin: 0 0 8px; overflow-wrap: anywhere; }
+.method-body-identity { display: grid; gap: 5px; margin: 0; }
+.method-body-identity div { display: grid; grid-template-columns: 90px minmax(0, 1fr); gap: 8px; }
+.method-body-identity dt { color: var(--dim); font: 10px var(--mono); text-transform: uppercase; }
+.method-body-identity dd { margin: 0; overflow-wrap: anywhere; color: var(--text); font: 11px/1.5 var(--mono); }
+.method-body-chooser { display: grid; gap: 8px; margin-bottom: 10px; }
+.method-body-field { display: grid; gap: 4px; }
+.method-body-field > span { color: var(--dim); font: 10px var(--mono); text-transform: uppercase; }
+.method-body-field input,
+.method-body-field select { padding: 4px 6px; border-radius: 3px; font: 12px var(--mono); }
+.method-body-choice-count,
+.method-body-scope,
+.method-body-empty,
+.method-body-progress { margin: 6px 0 0; color: var(--dim); font: 11px/1.6 var(--mono); }
+.method-body-scope { display: flex; flex-wrap: wrap; gap: 10px; }
+.method-body-failure { margin: 6px 0 0; color: var(--yellow); font: 11px/1.6 var(--mono); }
+.method-body-actions { display: flex; align-items: center; gap: 10px; margin: 12px 0; }
+.method-body-result { display: grid; gap: 12px; margin-top: 6px; }
+.method-body-result-head,
+.method-body-producer-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.method-body-result-head h3,
+.method-body-producer-head h3 { margin: 0; }
+.method-body-status { display: flex; flex-wrap: wrap; gap: 10px; margin: 0; color: var(--muted); font: 11px var(--mono); }
+.method-body-producer { display: grid; gap: 10px; padding: 10px; border: 1px solid var(--line); border-radius: 3px; background: var(--panel); }
+.method-body-endpoints { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 10px; }
+.method-body-endpoint { display: grid; gap: 3px; margin: 0; color: var(--muted); font: 11px/1.5 var(--mono); }
+.method-body-endpoint small { color: var(--dim); overflow-wrap: anywhere; }
+.method-body-evidence { display: grid; gap: 8px; }
+.method-body-evidence-head { display: flex; flex-wrap: wrap; gap: 10px; margin: 0; color: var(--muted); font: 11px var(--mono); }
+.method-body-evidence-head [data-method-body-exact="true"] { color: var(--green); }
+.method-body-rows { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
+.method-body-row { display: grid; gap: 6px; padding: 8px; border: 1px solid var(--line); border-left: 3px solid var(--accent); border-radius: 3px; background: var(--panel-raised); }
+.method-body-row-head { display: flex; flex-wrap: wrap; gap: 10px; margin: 0; font: 10px var(--mono); }
+.method-body-row-kind { color: var(--text); text-transform: uppercase; }
+.method-body-row-coordinates,
+.method-body-row-member,
+.method-body-row-message,
+.method-body-row-operand { margin: 0; color: var(--dim); font: 11px/1.5 var(--mono); overflow-wrap: anywhere; }
+.method-body-row-text { margin: 0; overflow-x: auto; }
+.method-body-row-values { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; }
+.method-body-value { display: grid; gap: 4px; min-width: 0; padding: 6px; border: 1px solid var(--line); border-radius: 3px; }
+.method-body-value pre { margin: 0; overflow-x: auto; }
+.method-body-value-label { color: var(--dim); font: 10px var(--mono); text-transform: uppercase; }
+.method-body-operation { color: var(--blue); font: 10px var(--mono); overflow-wrap: anywhere; }
+.method-body-il-disclosure summary { cursor: pointer; color: var(--muted); font: 11px var(--mono); }
+.method-body-diagnostics h4 { margin: 0 0 6px; }
+.method-body-diagnostics ul { display: grid; gap: 6px; margin: 0; padding-left: 18px; }
+.method-body-diagnostics li { color: var(--muted); font: 11px/1.6 var(--mono); }
+.method-body-diagnostic-scope { color: var(--dim); text-transform: uppercase; }
+.method-body-diagnostics small { display: block; color: var(--dim); overflow-wrap: anywhere; }
+.method-body-unavailable h3 { margin: 0 0 6px; }
+.method-body-unavailable p { margin: 0; color: var(--muted); font: 12px/1.6 var(--mono); }
+
+@media (max-width: 820px) {
+  .method-body-pair,
+  .method-body-endpoints,
+  .method-body-row-values { grid-template-columns: 1fr; }
+}

--- a/prototypes/inspect-web/src/workbench-keybindings.ts
+++ b/prototypes/inspect-web/src/workbench-keybindings.ts
@@ -11,6 +11,7 @@ export const WORKBENCH_KEYBINDING_PRIORITY = {
   documentViewer: 310,
   graphSource: 320,
   annotatedSource: 325,
+  methodBodyDiff: 327,
   unavailableWorkspace: 330,
   settings: 340,
   metadataExplorer: 350,

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -748,10 +748,10 @@ test("Annotated Source composition requires a concrete overload and validated se
     /class="contextual-actions annotated-contextual-actions"/);
   assert.match(
     appSource,
-    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"/);
+    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : sourcePageKind \? "Source actions" : "Member actions"\}"/);
   assert.match(
     appSource,
-    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"/);
+    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : sourcePageKind \? "Source actions" : "Member actions"\}"/);
   assert.match(
     appSource,
     /detail-scroll\$\{annotatedWorkingSurface \? " annotated-working-surface" : ""\}/);

--- a/prototypes/inspect-web/test/method-body-comparison.test.ts
+++ b/prototypes/inspect-web/test/method-body-comparison.test.ts
@@ -1,0 +1,475 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createMethodBodyComparisonCoordinator,
+  createMethodBodyDiffState,
+  methodBodyComparisonPackageId,
+  filterMethodBodyChoices,
+  methodBodyChoices,
+  methodBodySelectionKey,
+  type MethodBodyComparisonContext,
+  type MethodBodyComparisonDependencies,
+  type MethodBodyDiffState,
+} from "../src/method-body-comparison.ts";
+import type {
+  BrowserMethodBodyComparison,
+  BrowserMethodBodyComparisonResult,
+  BrowserMethodBodySelection,
+  BrowserMethodBodyTargets,
+  BrowserMethodBodyTargetsResult,
+} from "../src/facades/inspect-web-source.d.ts";
+import type { OperationId } from "../src/operation-authority.ts";
+import { createOperationAuthorityPage } from "../src/operation-authority.ts";
+
+function selection(
+  overrides: Partial<BrowserMethodBodySelection> = {},
+): BrowserMethodBodySelection {
+  return {
+    typeIdentity: "Example.Widget",
+    memberName: "Build",
+    selectorKey: "method:Build()",
+    metadataToken: 0x06000001,
+    label: "Example.Widget.Build()",
+    ...overrides,
+  };
+}
+
+const before = selection();
+const after = selection({
+  memberName: "Rebuild",
+  selectorKey: "method:Rebuild()",
+  metadataToken: 0x06000002,
+  label: "Example.Widget.Rebuild()",
+});
+const bodyless = selection({
+  typeIdentity: "Example.IWidget",
+  memberName: "Accept",
+  selectorKey: "method:Accept()",
+  metadataToken: 0x06000003,
+  label: "Example.IWidget.Accept()",
+});
+
+function targets(
+  overrides: Partial<BrowserMethodBodyTargets> = {},
+): BrowserMethodBodyTargets {
+  return {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    moduleVersionId: "0f5f6a4a-6d59-4b0c-9e9e-2b7d1a6c1234",
+    before,
+    methods: [after, bodyless],
+    ...overrides,
+  };
+}
+
+function targetsResult(
+  value: BrowserMethodBodyTargets | null,
+  overrides: Partial<BrowserMethodBodyTargetsResult> = {},
+): BrowserMethodBodyTargetsResult {
+  return {
+    version: 1,
+    kind: "Succeeded",
+    value,
+    failureKind: null,
+    error: null,
+    diagnostic: null,
+    reason: null,
+    ...overrides,
+  };
+}
+
+function comparison(
+  request: BrowserMethodBodyComparison["request"],
+): BrowserMethodBodyComparison {
+  return {
+    request,
+    stage: "Research",
+    outcome: "Completed",
+    producers: [],
+    diagnostics: [],
+  };
+}
+
+function comparisonResult(
+  value: BrowserMethodBodyComparison | null,
+  overrides: Partial<BrowserMethodBodyComparisonResult> = {},
+): BrowserMethodBodyComparisonResult {
+  return {
+    version: 1,
+    kind: "Succeeded",
+    value,
+    failureKind: null,
+    error: null,
+    diagnostic: null,
+    reason: null,
+    ...overrides,
+  };
+}
+
+const context: MethodBodyComparisonContext = {
+  packageId: "Example.Package",
+  version: "1.2.3",
+  framework: "net10.0",
+  assembly: "Example.Package",
+  typeIdentity: "Example.Widget",
+  memberName: "Build",
+  selectorKey: "method:Build()",
+  metadataToken: 0x06000001,
+  label: "Widget Build()",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}
+
+interface Harness {
+  state: MethodBodyDiffState;
+  dependencies: MethodBodyComparisonDependencies;
+  targetQueries: Array<{
+    operationId: OperationId;
+    resolve: (value: BrowserMethodBodyTargetsResult) => void;
+  }>;
+  comparisonQueries: Array<{
+    operationId: OperationId;
+    requestJson: string;
+    resolve: (value: BrowserMethodBodyComparisonResult) => void;
+  }>;
+  cancellations: Array<{ operationId: string; reason: string }>;
+  diagnostics: unknown[];
+  renders: number;
+}
+
+function harness(): Harness {
+  const state = createMethodBodyDiffState();
+  const targetQueries: Harness["targetQueries"] = [];
+  const comparisonQueries: Harness["comparisonQueries"] = [];
+  const cancellations: Harness["cancellations"] = [];
+  const diagnostics: unknown[] = [];
+  const counters = { renders: 0 };
+  let nextOperation = 1;
+  const dependencies: MethodBodyComparisonDependencies = {
+    state,
+    operationAuthority: createOperationAuthorityPage({
+      allocation: {
+        createId: () => `method-body-operation-${nextOperation++}`,
+      },
+    }),
+    queryTargets: operationId => {
+      const pending = deferred<BrowserMethodBodyTargetsResult>();
+      targetQueries.push({ operationId, resolve: pending.resolve });
+      return pending.promise;
+    },
+    queryComparison: (operationId, requestJson) => {
+      const pending = deferred<BrowserMethodBodyComparisonResult>();
+      comparisonQueries.push({
+        operationId,
+        requestJson,
+        resolve: pending.resolve,
+      });
+      return pending.promise;
+    },
+    cancelMethodBodyComparison: (operationId, reason) => {
+      cancellations.push({ operationId, reason });
+    },
+    reportOperationDiagnostic: diagnostic => {
+      diagnostics.push(diagnostic);
+      return undefined;
+    },
+    describeError: error =>
+      error instanceof Error ? error.message : String(error),
+    render: () => {
+      counters.renders++;
+    },
+  };
+  return {
+    state,
+    dependencies,
+    targetQueries,
+    comparisonQueries,
+    cancellations,
+    diagnostics,
+    get renders() {
+      return counters.renders;
+    },
+  };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+test("the inventory loads once and choosing a candidate never compares", async () => {
+  const context7 = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(context7.dependencies);
+
+  const opening = coordinator.open(context, "#compare-method-bodies");
+  assert.equal(context7.state.open, true);
+  assert.equal(context7.state.targetsLoading, true);
+  assert.equal(context7.targetQueries.length, 1);
+  context7.targetQueries[0]!.resolve(targetsResult(targets()));
+  await opening;
+
+  assert.equal(context7.state.targetsLoading, false);
+  assert.deepEqual(context7.state.targets, targets());
+
+  coordinator.setFilter("Rebuild");
+  assert.equal(coordinator.selectCandidate(methodBodySelectionKey(after)), true);
+  assert.equal(coordinator.selectCandidate(methodBodySelectionKey(after)), false);
+  assert.equal(context7.comparisonQueries.length, 0);
+
+  const comparing = coordinator.compare();
+  assert.equal(context7.comparisonQueries.length, 1);
+  const submitted: unknown =
+    JSON.parse(context7.comparisonQueries[0]!.requestJson);
+  assert.deepEqual(submitted, {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    moduleVersionId: "0f5f6a4a-6d59-4b0c-9e9e-2b7d1a6c1234",
+    before,
+    after,
+  });
+  context7.comparisonQueries[0]!.resolve(
+    comparisonResult(comparison({
+      packageId: "Example.Package",
+      version: "1.2.3",
+      framework: "net10.0",
+      assembly: "Example.Package",
+      moduleVersionId: "0f5f6a4a-6d59-4b0c-9e9e-2b7d1a6c1234",
+      before,
+      after,
+    })));
+  await comparing;
+
+  assert.equal(context7.state.comparisonLoading, false);
+  assert.equal(context7.state.comparison?.outcome, "Completed");
+  assert.deepEqual(context7.state.submittedRequest?.after, after);
+  assert.equal(context7.diagnostics.length, 0);
+});
+
+test("a same-method pair is choosable and submitted unchanged", async () => {
+  const fixture = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(fixture.dependencies);
+  const opening = coordinator.open(context, "#compare-method-bodies");
+  fixture.targetQueries[0]!.resolve(
+    targetsResult(targets({ methods: [after] })));
+  await opening;
+
+  const choices = methodBodyChoices(fixture.state.targets!);
+  assert.deepEqual(choices.map(choice => choice.memberName), ["Build", "Rebuild"]);
+  coordinator.selectCandidate(methodBodySelectionKey(before));
+  void coordinator.compare();
+
+  const submitted: unknown =
+    JSON.parse(fixture.comparisonQueries[0]!.requestJson);
+  assert.deepEqual(submitted, {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    moduleVersionId: "0f5f6a4a-6d59-4b0c-9e9e-2b7d1a6c1234",
+    before,
+    after: before,
+  });
+});
+
+test("changing the pair clears the old result and cancels its operation", async () => {
+  const fixture = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(fixture.dependencies);
+  const opening = coordinator.open(context, "#compare-method-bodies");
+  fixture.targetQueries[0]!.resolve(targetsResult(targets()));
+  await opening;
+
+  coordinator.selectCandidate(methodBodySelectionKey(after));
+  void coordinator.compare();
+  const running = fixture.comparisonQueries[0]!;
+  assert.equal(fixture.state.comparisonLoading, true);
+
+  coordinator.selectCandidate(methodBodySelectionKey(bodyless));
+  assert.equal(fixture.state.comparisonLoading, false);
+  assert.equal(fixture.state.comparison, null);
+  assert.equal(fixture.state.submittedRequest, null);
+  assert.deepEqual(
+    fixture.cancellations,
+    [{ operationId: running.operationId, reason: "superseded" }]);
+
+  running.resolve(comparisonResult(comparison({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    moduleVersionId: "0f5f6a4a-6d59-4b0c-9e9e-2b7d1a6c1234",
+    before,
+    after,
+  })));
+  await settle();
+
+  assert.equal(fixture.state.comparison, null);
+  assert.equal(fixture.state.candidateKey, methodBodySelectionKey(bodyless));
+});
+
+test("closing the dialog cancels both lanes and suppresses late results", async () => {
+  const fixture = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(fixture.dependencies);
+  const opening = coordinator.open(context, "#compare-method-bodies");
+  fixture.targetQueries[0]!.resolve(targetsResult(targets()));
+  await opening;
+  coordinator.selectCandidate(methodBodySelectionKey(after));
+  void coordinator.compare();
+  const running = fixture.comparisonQueries[0]!;
+
+  const dismissal = coordinator.close();
+  assert.equal(dismissal.handled, true);
+  assert.equal(dismissal.returnFocusSelector, "#compare-method-bodies");
+  assert.deepEqual(
+    fixture.cancellations,
+    [{ operationId: running.operationId, reason: "disposed" }]);
+  assert.equal(fixture.state.open, false);
+  assert.equal(fixture.state.targets, null);
+
+  running.resolve(comparisonResult(comparison({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    moduleVersionId: "0f5f6a4a-6d59-4b0c-9e9e-2b7d1a6c1234",
+    before,
+    after,
+  })));
+  await settle();
+
+  assert.equal(fixture.state.open, false);
+  assert.equal(fixture.state.comparison, null);
+  assert.equal(fixture.state.comparisonLoading, false);
+  assert.equal(fixture.diagnostics.length, 0);
+});
+
+test("navigation replacement releases a running inventory query", async () => {
+  const fixture = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(fixture.dependencies);
+  void coordinator.open(context, "#compare-method-bodies");
+  const running = fixture.targetQueries[0]!;
+
+  assert.equal(coordinator.dispose(), true);
+  assert.deepEqual(
+    fixture.cancellations,
+    [{ operationId: running.operationId, reason: "disposed" }]);
+
+  running.resolve(targetsResult(targets()));
+  await settle();
+
+  assert.equal(fixture.state.open, false);
+  assert.equal(fixture.state.targets, null);
+  assert.equal(coordinator.dispose(), false);
+});
+
+test("an expected managed failure stays visible for its own lane", async () => {
+  const fixture = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(fixture.dependencies);
+  const opening = coordinator.open(context, "#compare-method-bodies");
+  fixture.targetQueries[0]!.resolve(targetsResult(null, {
+    kind: "Failed",
+    failureKind: "Expected",
+    error: "The implementation assembly is unavailable.",
+    diagnostic: "context-unavailable",
+  }));
+  await opening;
+
+  assert.equal(fixture.state.targetsLoading, false);
+  assert.equal(
+    fixture.state.targetsError,
+    "The implementation assembly is unavailable.");
+  assert.equal(fixture.state.targets, null);
+  assert.equal(fixture.diagnostics.length, 0);
+});
+
+test("a transported comparison failure never becomes an empty success", async () => {
+  const fixture = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(fixture.dependencies);
+  const opening = coordinator.open(context, "#compare-method-bodies");
+  fixture.targetQueries[0]!.resolve(targetsResult(targets()));
+  await opening;
+  coordinator.selectCandidate(methodBodySelectionKey(bodyless));
+  const comparing = coordinator.compare();
+  fixture.comparisonQueries[0]!.resolve(comparisonResult(null, {
+    kind: "Failed",
+    failureKind: "Expected",
+    error: "The designation is ambiguous.",
+    diagnostic: "ambiguous-designation",
+  }));
+  await comparing;
+
+  assert.equal(fixture.state.comparison, null);
+  assert.equal(fixture.state.comparisonError, "The designation is ambiguous.");
+  assert.deepEqual(fixture.state.submittedRequest?.after, bodyless);
+});
+
+test("an unavailable context opens with its visible reason and no query", () => {
+  const fixture = harness();
+  const coordinator =
+    createMethodBodyComparisonCoordinator(fixture.dependencies);
+
+  coordinator.openUnavailable(
+    "Select one accessor or body of this member before comparing method bodies.",
+    "#compare-method-bodies");
+
+  assert.equal(fixture.state.open, true);
+  assert.equal(
+    fixture.state.unavailableReason,
+    "Select one accessor or body of this member before comparing method bodies.");
+  assert.equal(fixture.targetQueries.length, 0);
+  assert.equal(coordinator.close().handled, true);
+});
+
+test("filtering keeps the chosen candidate selectable", () => {
+  const choices = methodBodyChoices(targets());
+  const filtered = filterMethodBodyChoices(
+    choices,
+    "Accept",
+    methodBodySelectionKey(after));
+
+  assert.deepEqual(
+    filtered.map(choice => choice.memberName),
+    ["Rebuild", "Accept"]);
+  assert.deepEqual(
+    filterMethodBodyChoices(choices, "", "").map(choice => choice.memberName),
+    ["Build", "Rebuild", "Accept"]);
+});
+
+test("a platform selection keeps its resident coordinates without a package id", () => {
+  assert.equal(
+    methodBodyComparisonPackageId({ id: "Example.Package" }),
+    "Example.Package");
+  assert.equal(
+    methodBodyComparisonPackageId({
+      id: "Microsoft.NETCore.App",
+      isRuntimePack: false,
+    }),
+    "Microsoft.NETCore.App");
+  // The retained platform workspace is not an acquired package: the managed target
+  // signature discriminates it by an empty package id, and version, framework and the
+  // resident assembly still identify the implementation exactly.
+  assert.equal(
+    methodBodyComparisonPackageId({
+      id: "Microsoft.NETCore.App",
+      isRuntimePack: true,
+    }),
+    "");
+});

--- a/prototypes/inspect-web/test/method-body-comparison.test.ts
+++ b/prototypes/inspect-web/test/method-body-comparison.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   createMethodBodyComparisonCoordinator,
   createMethodBodyDiffState,
+  isMethodBodyToken,
   methodBodyComparisonPackageId,
   filterMethodBodyChoices,
   methodBodyChoices,
@@ -21,6 +22,12 @@ import type {
 } from "../src/facades/inspect-web-source.d.ts";
 import type { OperationId } from "../src/operation-authority.ts";
 import { createOperationAuthorityPage } from "../src/operation-authority.ts";
+
+test("method actions require a MethodDef, not a property or field token", () => {
+  assert.equal(isMethodBodyToken(0x06000001), true);
+  for (const token of [0, 0x06000000, 0x04000001, 0x17000001])
+    assert.equal(isMethodBodyToken(token), false);
+});
 
 function selection(
   overrides: Partial<BrowserMethodBodySelection> = {},

--- a/prototypes/inspect-web/test/method-body-comparison.test.ts
+++ b/prototypes/inspect-web/test/method-body-comparison.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { stripTypeScriptTypes } from "node:module";
 import test from "node:test";
+import { runInNewContext } from "node:vm";
 
 import {
   createMethodBodyComparisonCoordinator,
@@ -383,6 +386,69 @@ test("navigation replacement releases a running inventory query", async () => {
   assert.equal(fixture.state.open, false);
   assert.equal(fixture.state.targets, null);
   assert.equal(coordinator.dispose(), false);
+});
+
+test("routed history to demos closes the dialog and rejects late inventory", async () => {
+  const fixture = harness();
+  const coordinator = createMethodBodyComparisonCoordinator(fixture.dependencies);
+  const opening = coordinator.open(context, "#compare-method-bodies");
+  const running = fixture.targetQueries[0]!;
+  const appSource = readFileSync(
+    new URL("../src/dotnet-inspect.ts", import.meta.url), "utf8");
+  const dismissal = appSource.match(
+    /function dismissModalsForRoutedNavigation\(\) \{[\s\S]*?\n\}/)?.[0];
+  const popstate = appSource.match(
+    /window\.addEventListener\("popstate",[\s\S]*?\n\}\);/)?.[0];
+  assert.ok(dismissal);
+  assert.ok(popstate);
+  const callbacks: { popstate?: () => void } = {};
+  const state = {
+    methodBodyDiff: fixture.state,
+    package: { id: context.packageId },
+    packageQueryOpen: false,
+    engineReady: true,
+    loading: false,
+    workspaceSubjectOpen: false,
+    atPackageRoot: false,
+  };
+  runInNewContext(stripTypeScriptTypes(`${dismissal}\n${popstate}`), {
+    state,
+    methodBodyComparison: coordinator,
+    window: {
+      addEventListener: (_event: string, handler: () => void) => {
+        callbacks.popstate = handler;
+      },
+    },
+    currentPackageQueryHandoff: () => null,
+    navigationSequence: { begin: () => 1 },
+    closeGraphExplorerForNavigation: () => {},
+    dismissAnnotatedSourceModal: () => false,
+    spotlight: { reset: () => {} },
+    sourceInspection: { clearGraphSource: () => {} },
+    documentInspection: { clear: () => {} },
+    invalidateMemberDestinationWork: () => {},
+    isPackageQueryPath: () => false,
+    isCreditsPath: () => false,
+    isProductHomeDemosPath: (path: string) => path === "/demos",
+    location: { pathname: "/demos" },
+    clearNavigationError: () => {},
+    clearWorkspaceRouteFailure: () => true,
+    render: () => {},
+    afterCurrentNavigationFrame: () => {},
+  });
+  assert.ok(callbacks.popstate);
+  callbacks.popstate();
+
+  assert.equal(state.workspaceSubjectOpen, true);
+  assert.equal(state.atPackageRoot, true);
+  assert.equal(fixture.state.open, false);
+  assert.deepEqual(
+    fixture.cancellations,
+    [{ operationId: running.operationId, reason: "disposed" }]);
+  running.resolve(targetsResult(targets()));
+  await opening;
+  assert.equal(fixture.state.targets, null);
+  assert.equal(fixture.state.targetsLoading, false);
 });
 
 test("an expected managed failure stays visible for its own lane", async () => {

--- a/prototypes/inspect-web/test/method-body-diff-view.test.ts
+++ b/prototypes/inspect-web/test/method-body-diff-view.test.ts
@@ -1,0 +1,400 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  createMethodBodyDiffState,
+  methodBodySelectionKey,
+  type MethodBodyDiffState,
+} from "../src/method-body-comparison.ts";
+import {
+  renderMethodBodyComparisonAction,
+  renderMethodBodyDiffModal,
+} from "../src/method-body-diff-view.ts";
+import type {
+  BrowserMethodBodyComparison,
+  BrowserMethodBodyProducer,
+  BrowserMethodBodySelection,
+  BrowserMethodBodyTargets,
+} from "../src/facades/inspect-web-source.d.ts";
+
+function escapeHtml(value: unknown) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const highlightCSharp = (value: string) => escapeHtml(value);
+
+function selection(
+  overrides: Partial<BrowserMethodBodySelection> = {},
+): BrowserMethodBodySelection {
+  return {
+    typeIdentity: "Example.Widget",
+    memberName: "Build",
+    selectorKey: "method:Build()",
+    metadataToken: 0x06000001,
+    label: "Example.Widget.Build()",
+    ...overrides,
+  };
+}
+
+const before = selection();
+const after = selection({
+  memberName: "Rebuild",
+  selectorKey: "method:Rebuild()",
+  metadataToken: 0x06000002,
+  label: "Example.Widget.Rebuild()",
+});
+const hostile = selection({
+  memberName: "<script>alert(1)</script>",
+  selectorKey: "method:<script>()",
+  metadataToken: 0x06000009,
+  label: "Example.Widget.<script>alert(1)</script>()",
+});
+
+const targets: BrowserMethodBodyTargets = {
+  packageId: "Example.Package",
+  version: "1.2.3",
+  framework: "net10.0",
+  assembly: "Example.Package",
+  moduleVersionId: "0f5f6a4a-6d59-4b0c-9e9e-2b7d1a6c1234",
+  before,
+  methods: [after, hostile],
+};
+
+const request = {
+  packageId: targets.packageId,
+  version: targets.version,
+  framework: targets.framework,
+  assembly: targets.assembly,
+  moduleVersionId: targets.moduleVersionId,
+  before,
+  after,
+};
+
+function endpoint(state: string, detail: string | null = null) {
+  return {
+    state,
+    targetState: "Resolved",
+    metadataToken: 0x06000001,
+    moduleVersionId: targets.moduleVersionId,
+    detail,
+  };
+}
+
+const cSharpProducer: BrowserMethodBodyProducer = {
+  producer: "CSharp",
+  outcome: "Completed",
+  nativeVerdict: "Different",
+  before: endpoint("BodyAvailable"),
+  after: endpoint("BodyAvailable"),
+  cSharp: {
+    isExact: false,
+    rows: [
+      {
+        assemblyIdentity: "Example.Package, Version=1.2.3.0",
+        stableMemberKey: "M:Example.Widget.Build",
+        changeId: "csharp-3-1",
+        kind: "Changed",
+        hunkId: 3,
+        line: 12,
+        member: "Example.Widget.Build()",
+        fidelity: "Exact",
+        sourceCoordinate: "Widget.cs(12,9)",
+        text: "return new Widget(\"<b>\");",
+        oldValue: "new Widget(\"a\")",
+        newValue: "new Widget(\"<b>\")",
+        oldOperation: { kind: "ObjectCreation", value: "Widget..ctor" },
+        newOperation: { kind: "ObjectCreation", value: "Widget..ctor" },
+        message: "The constructed argument changed.",
+      },
+    ],
+  },
+  il: null,
+  diagnostics: [],
+};
+
+const ilProducer: BrowserMethodBodyProducer = {
+  producer: "IlBody",
+  outcome: "Completed",
+  nativeVerdict: "Different",
+  before: endpoint("BodyAvailable"),
+  after: endpoint("NoBody", "the After method has no implementation body"),
+  cSharp: null,
+  il: {
+    isExact: false,
+    isAvailable: true,
+    outcome: "Compared",
+    failure: null,
+    rows: [
+      {
+        kind: "Removed",
+        hunkId: 1,
+        operation: {
+          offset: 6,
+          opcodeFamily: "Call",
+          operand: { kind: "MemberReference", value: "Widget..ctor" },
+        },
+        message: "The call was removed.",
+      },
+    ],
+  },
+  diagnostics: [
+    {
+      kind: "EndpointEvidence",
+      side: "after",
+      mechanism: "IlBody",
+      hunkId: null,
+      subjectToken: 0x06000002,
+      path: null,
+      message: "The After endpoint reported no body.",
+      detail: null,
+    },
+  ],
+};
+
+function comparison(
+  producers: readonly BrowserMethodBodyProducer[],
+  overrides: Partial<BrowserMethodBodyComparison> = {},
+): BrowserMethodBodyComparison {
+  return {
+    request,
+    stage: "Research",
+    outcome: "Completed",
+    producers,
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+function openState(
+  overrides: Partial<MethodBodyDiffState> = {},
+): MethodBodyDiffState {
+  return Object.assign(createMethodBodyDiffState(), {
+    open: true,
+    context: {
+      packageId: targets.packageId,
+      version: targets.version,
+      framework: targets.framework,
+      assembly: targets.assembly,
+      typeIdentity: before.typeIdentity,
+      memberName: before.memberName,
+      selectorKey: before.selectorKey,
+      metadataToken: before.metadataToken,
+      label: before.label,
+    },
+    targets,
+  }, overrides);
+}
+
+function render(state: MethodBodyDiffState): string {
+  return renderMethodBodyDiffModal({ state, escapeHtml, highlightCSharp });
+}
+
+test("an unavailable context states its reason on a visible control", () => {
+  const html = renderMethodBodyComparisonAction(
+    {
+      available: false,
+      reason: "Select one accessor or body <first>.",
+    },
+    escapeHtml);
+
+  assert.match(html, /id="compare-method-bodies"/);
+  assert.match(html, / disabled/);
+  assert.match(html, /aria-describedby="compare-method-bodies-reason"/);
+  assert.match(html, /Select one accessor or body &lt;first&gt;\./);
+  assert.doesNotMatch(html, /<first>/);
+
+  const available = renderMethodBodyComparisonAction(
+    { available: true, reason: "" },
+    escapeHtml);
+  assert.doesNotMatch(available, / disabled/);
+  assert.doesNotMatch(available, /compare-method-bodies-reason/);
+});
+
+test("the dialog explains an unavailable launch instead of comparing", () => {
+  const html = render(openState({
+    targets: null,
+    unavailableReason: "This member has no implementation method body.",
+  }));
+
+  assert.match(html, /role="dialog"/);
+  assert.match(html, /id="method-body-diff-title"/);
+  assert.match(html, /Comparison is unavailable here/);
+  assert.match(html, /This member has no implementation method body\./);
+  assert.doesNotMatch(html, /id="method-body-diff-compare"/);
+});
+
+test("Compare stays disabled until an After method is chosen", () => {
+  const unchosen = render(openState());
+  assert.match(
+    unchosen,
+    /id="method-body-diff-compare"[^>]*data-method-body-action="compare" disabled/);
+  assert.match(unchosen, /Choose an After method to enable Compare\./);
+  // The launching method is offered too: a same-method pair is a valid request.
+  assert.match(unchosen, /3 of 3 methods shown/);
+  assert.match(
+    unchosen,
+    /<option value="Example\.Widget␟Build␟method:Build\(\)␟100663297">/);
+
+  const chosen = render(openState({ candidateKey: methodBodySelectionKey(after) }));
+  assert.doesNotMatch(
+    chosen,
+    /id="method-body-diff-compare"[^>]*disabled/);
+  assert.match(chosen, /Choose an After method, then select Compare\./);
+});
+
+test("both compared identities come from the submitted request", () => {
+  const html = render(openState({
+    candidateKey: methodBodySelectionKey(hostile),
+    submittedRequest: request,
+    comparison: comparison([cSharpProducer, ilProducer]),
+  }));
+
+  const beforeSection = html.slice(
+    html.indexOf('data-method-body-side="before" aria-label="Compared Before method"'));
+  const afterSection = beforeSection.slice(
+    beforeSection.indexOf('data-method-body-side="after"'));
+  assert.match(beforeSection, /Example\.Widget\.Build\(\)/);
+  assert.match(afterSection, /Example\.Widget\.Rebuild\(\)/);
+  assert.match(afterSection, /0x06000002/);
+  assert.doesNotMatch(afterSection, /alert\(1\)/);
+});
+
+test("each native mechanism keeps its own outcome, verdict and evidence", () => {
+  const failedCSharp: BrowserMethodBodyProducer = {
+    ...cSharpProducer,
+    outcome: "Failed",
+    nativeVerdict: "Unavailable",
+    cSharp: null,
+    diagnostics: [
+      {
+        kind: "MechanismFailure",
+        side: null,
+        mechanism: "CSharp",
+        hunkId: null,
+        subjectToken: null,
+        path: null,
+        message: "The C# mechanism could not raise a body.",
+        detail: null,
+      },
+    ],
+  };
+  const html = render(openState({
+    comparison: comparison([ilProducer, failedCSharp]),
+  }));
+
+  const cSharpIndex = html.indexOf('data-method-body-producer="CSharp"');
+  const ilIndex = html.indexOf('data-method-body-producer="IlBody"');
+  assert.ok(cSharpIndex >= 0 && ilIndex > cSharpIndex, "C# is the primary region");
+
+  const cSharpSection = html.slice(cSharpIndex, ilIndex);
+  assert.match(cSharpSection, /<span data-method-body-outcome>Failed<\/span>/);
+  assert.match(cSharpSection, /<span data-method-body-verdict>Unavailable<\/span>/);
+  assert.match(cSharpSection, /This mechanism returned no aligned body evidence\./);
+  assert.doesNotMatch(cSharpSection, /data-method-body-exact="true"/);
+  assert.match(cSharpSection, /The C# mechanism could not raise a body\./);
+
+  const ilSection = html.slice(ilIndex);
+  assert.match(ilSection, /<span data-method-body-il-outcome>Compared<\/span>/);
+  assert.match(ilSection, /<details class="method-body-il-disclosure">/);
+  assert.match(ilSection, /IL_0006/);
+  assert.match(ilSection, /MemberReference: Widget\.\.ctor/);
+  assert.match(
+    ilSection,
+    /data-method-body-endpoint="after">\s*<strong>After<\/strong>\s*<span data-method-body-endpoint-state>NoBody<\/span>/);
+  assert.match(ilSection, /the After method has no implementation body/);
+});
+
+test("C# rows keep their kind, coordinates and both operation values", () => {
+  const html = render(openState({
+    comparison: comparison([cSharpProducer]),
+  }));
+
+  assert.match(
+    html,
+    /data-method-body-row="csharp"\s+data-method-body-kind="Changed"\s+data-method-body-hunk="3"/);
+  assert.match(html, /line 12 · hunk 3 · Widget\.cs\(12,9\) · Exact/);
+  assert.match(
+    html,
+    /data-method-body-value="old"[\s\S]*?new Widget\(&quot;a&quot;\)[\s\S]*?ObjectCreation: Widget\.\.ctor/);
+  assert.match(
+    html,
+    /data-method-body-value="new"[\s\S]*?new Widget\(&quot;&lt;b&gt;&quot;\)/);
+  assert.match(html, /data-method-body-change="csharp-3-1"/);
+  assert.match(html, /data-method-body-member-key="M:Example\.Widget\.Build"/);
+  assert.match(html, /not exact under this mechanism/);
+  assert.doesNotMatch(html, /<b>/);
+});
+
+test("hostile inventory text is escaped in the chooser and diagnostics", () => {
+  const html = render(openState({
+    candidateKey: methodBodySelectionKey(hostile),
+    comparison: comparison([], {
+      diagnostics: [
+        {
+          kind: "Request",
+          side: null,
+          mechanism: null,
+          hunkId: null,
+          subjectToken: null,
+          path: "<img src=x onerror=alert(1)>",
+          message: "<script>alert(2)</script>",
+          detail: "<b>detail</b>",
+        },
+      ],
+    }),
+  }));
+
+  assert.doesNotMatch(html, /<script>/);
+  assert.doesNotMatch(html, /<img /);
+  assert.doesNotMatch(html, /<b>detail<\/b>/);
+  assert.match(html, /&lt;script&gt;alert\(2\)&lt;\/script&gt;/);
+  assert.match(html, /&lt;img src=x onerror=alert\(1\)&gt;/);
+});
+
+test("an inventory failure stays visible in the chooser region", () => {
+  const html = render(openState({
+    targets: null,
+    targetsError: "The implementation assembly is unavailable.",
+  }));
+
+  assert.match(
+    html,
+    /class="method-body-failure" role="alert">The implementation assembly is unavailable\./);
+});
+
+test("paired regions carry side labels that survive stacking", () => {
+  const html = render(openState());
+  assert.match(html, /data-method-body-side="before" aria-label="Before method"/);
+  assert.match(html, /data-method-body-side="after" aria-label="After method"/);
+
+  const styles = readFileSync(
+    new URL("../src/styles.css", import.meta.url),
+    "utf8");
+  const responsive = styles.slice(styles.lastIndexOf("@media (max-width: 820px)"));
+  assert.match(
+    responsive,
+    /\.method-body-pair,\s*\.method-body-endpoints,\s*\.method-body-row-values \{ grid-template-columns: 1fr; \}/);
+});
+
+test("the app hosts the action, dialog and its release points", () => {
+  const source = readFileSync(
+    new URL("../src/dotnet-inspect.ts", import.meta.url),
+    "utf8");
+
+  assert.match(
+    source,
+    /sourcePageKind === "member" \|\| annotatedPageContext\s*\?\s*renderMethodBodyComparisonAction\(/);
+  assert.match(source, /renderMethodBodyDiffModal\(\{\s*state: state\.methodBodyDiff/);
+  assert.match(
+    source,
+    /function clearMemberContentCache\(\) \{[\s\S]{0,220}methodBodyComparison\.dispose\(\);/);
+  assert.match(
+    source,
+    /id: "method-body-diff\.dismiss",\s*key: "Escape",/);
+  assert.match(source, /state\.methodBodyDiff\.open/);
+});

--- a/prototypes/inspect-web/test/method-body-diff-view.test.ts
+++ b/prototypes/inspect-web/test/method-body-diff-view.test.ts
@@ -370,8 +370,8 @@ test("hostile inventory text is escaped in the chooser and diagnostics", () => {
     }),
   }));
 
-  assert.doesNotMatch(html, /<script>/);
-  assert.doesNotMatch(html, /<img /);
+  assert.doesNotMatch(html, /<script\b/i);
+  assert.doesNotMatch(html, /<img\b/i);
   assert.doesNotMatch(html, /<b>detail<\/b>/);
   assert.match(html, /&lt;script&gt;alert\(2\)&lt;\/script&gt;/);
   assert.match(html, /&lt;img src=x onerror=alert\(1\)&gt;/);

--- a/prototypes/inspect-web/test/method-body-diff-view.test.ts
+++ b/prototypes/inspect-web/test/method-body-diff-view.test.ts
@@ -388,7 +388,7 @@ test("the app hosts the action, dialog and its release points", () => {
 
   assert.match(
     source,
-    /sourcePageKind === "member" \|\| annotatedPageContext\s*\?\s*renderMethodBodyComparisonAction\(/);
+    /methodBodyPageContext\s*\?\s*renderMethodBodyComparisonAction\(/);
   assert.match(source, /renderMethodBodyDiffModal\(\{\s*state: state\.methodBodyDiff/);
   assert.match(
     source,

--- a/prototypes/inspect-web/test/method-body-diff-view.test.ts
+++ b/prototypes/inspect-web/test/method-body-diff-view.test.ts
@@ -330,6 +330,27 @@ test("C# rows keep their kind, coordinates and both operation values", () => {
   assert.doesNotMatch(html, /<b>/);
 });
 
+test("native line operations supply the paired C# text without duplicate body lines", () => {
+  const evidence = cSharpProducer.cSharp;
+  assert.ok(evidence);
+  const row = evidence.rows[0];
+  assert.ok(row);
+  const html = render(openState({
+    comparison: comparison([{
+      ...cSharpProducer,
+      cSharp: {
+        isExact: false,
+        rows: [{
+          ...row, text: "return 2;", oldValue: null, newValue: null,
+          oldOperation: null, newOperation: { kind: "Line", value: "return 2;" },
+        }],
+      },
+    }]),
+  }));
+  assert.match(html, /data-method-body-value="new"[\s\S]*<code class="language-csharp">return 2;<\/code>/);
+  assert.equal(html.split("return 2;").length - 1, 1);
+});
+
 test("hostile inventory text is escaped in the chooser and diagnostics", () => {
   const html = render(openState({
     candidateKey: methodBodySelectionKey(hostile),

--- a/prototypes/inspect-web/test/saved-workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/saved-workspace-navigation.test.ts
@@ -301,6 +301,7 @@ function harness() {
       clearGraphSource: () => {},
     },
     cancelAnnotatedSourceRequest: () => {},
+    methodBodyComparison: { dispose: () => {} },
     persistRecentPackages: () => {},
     persistPlatformRecent: () => {},
     refreshPackageStats: () => {},

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -134,10 +134,10 @@ test("Source composition uses shell actions and a full-area loaded surface", () 
     /const sourcePageKind =[\s\S]*activeScope === "type" && state\.lens === "source"[\s\S]*activeScope === "member"[\s\S]*state\.memberSection === "source"/);
   assert.match(
     appSource,
-    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"[\s\S]*renderSourcePageActions\(\{[\s\S]*copyButtonId: sourcePageKind === "member"[\s\S]*"copy-source"[\s\S]*"copy-type-source"/);
+    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : sourcePageKind \? "Source actions" : "Member actions"\}"[\s\S]*renderSourcePageActions\(\{[\s\S]*copyButtonId: sourcePageKind === "member"[\s\S]*"copy-source"[\s\S]*"copy-type-source"/);
   assert.match(
     appSource,
-    /contextualActionsHtml: annotatedPageContext \|\| sourcePageKind[\s\S]*class="working-surface-actions"/);
+    /contextualActionsHtml: methodBodyPageContext \|\| annotatedPageContext \|\| sourcePageKind[\s\S]*class="working-surface-actions"/);
   assert.doesNotMatch(
     appSource,
     /class="legacy-application-actions"/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3534,7 +3534,7 @@ test("Type Source completion settles behind workbench overlays", () => {
     ?? "";
   assert.match(
     appSource,
-    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\);[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| state\.docViewerOpen\s*\|\| state\.memberAnnotatedModal !== null\s*\|\| graphExplorer\.isOpen;/);
+    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\);[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| state\.docViewerOpen\s*\|\| state\.memberAnnotatedModal !== null\s*\|\| state\.methodBodyDiff\.open\s*\|\| graphExplorer\.isOpen;/);
   assert.match(
     appSource,
     /sourceInspection\.loadTypeSource\(\{[\s\S]*isVisible: \(\) =>\s*currentSourceOperationKind\(\) === "type"\s*&& !workbenchModalOwnsFocus\(\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3252,7 +3252,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /const navigationSeq = navigationSequence\.begin\(\);\s*let leftPackageQueryForWorkspaceSuccessor = false;\s*const dismissedAnnotatedSourceModal = dismissModalsForRoutedNavigation\(\)/);
   assert.match(
     appSource,
-    /function dismissModalsForRoutedNavigation\(\) \{\s*closeGraphExplorerForNavigation\(\);\s*const dismissedAnnotatedSourceModal = dismissAnnotatedSourceModal\(false\);\s*state\.settings = false;\s*state\.keyboardHelp = false;\s*state\.explorer = null;\s*spotlight\.reset\(\);\s*sourceInspection\.clearGraphSource\(\);\s*documentInspection\.clear\(\);\s*return dismissedAnnotatedSourceModal/);
+    /function dismissModalsForRoutedNavigation\(\) \{\s*closeGraphExplorerForNavigation\(\);\s*methodBodyComparison\.dispose\(\);\s*const dismissedAnnotatedSourceModal = dismissAnnotatedSourceModal\(false\);\s*state\.settings = false;\s*state\.keyboardHelp = false;\s*state\.explorer = null;\s*spotlight\.reset\(\);\s*sourceInspection\.clearGraphSource\(\);\s*documentInspection\.clear\(\);\s*return dismissedAnnotatedSourceModal/);
   assert.match(
     route,
     /dismissModalsForRoutedNavigation\(\);\s*navigationSequence\.begin\(\)/);

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextMethodAddressQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextMethodAddressQueryTests.cs
@@ -1,0 +1,93 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class AssemblyContextMethodAddressQueryTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void IssuesExactOwnerAddressIncludingBodyless(bool bodyless)
+    {
+        using var fixture = new Fixture();
+        var method = bodyless
+            ? typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))!
+            : typeof(string).GetMethod(nameof(string.ToString), Type.EmptyTypes)!;
+        var address = Assert.IsType<AssemblyContextEntry<MetadataMethodAddress>.Available>(
+            AssemblyContextMethodAddressQuery.ExecuteParticipant(
+                fixture.Group, fixture.Participant, method.MetadataToken)).Value;
+        Assert.Equal(method.MetadataToken, address.Token);
+        Assert.Equal(method.Module.ModuleVersionId, address.ModuleVersionId);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(0x02000001)]
+    [InlineData(0x06000000)]
+    [InlineData(0x06ffffff)]
+    [InlineData(-1)]
+    public void InvalidMethodDefIsFailed(int token)
+    {
+        using var fixture = new Fixture();
+        var failed = Assert.IsType<AssemblyContextEntry<MetadataMethodAddress>.Failed>(
+            AssemblyContextMethodAddressQuery.ExecuteParticipant(fixture.Group, fixture.Participant, token));
+        Assert.Contains("not a MethodDef", failed.Error.Message);
+    }
+
+    [Fact]
+    public void MissingImageIsRejected()
+    {
+        using var fixture = new Fixture(unavailable: true);
+        Assert.IsType<AssemblyContextEntry<MetadataMethodAddress>.Rejected>(
+            AssemblyContextMethodAddressQuery.ExecuteParticipant(fixture.Group, fixture.Participant, 0x06000001));
+    }
+
+    [Fact]
+    public void ForeignParticipantCannotBorrowAnotherContext()
+    {
+        using var first = new Fixture();
+        using var second = new Fixture();
+        Assert.Throws<ArgumentException>(() => AssemblyContextMethodAddressQuery.ExecuteParticipant(
+            first.Group, second.Participant, 0x06000001));
+    }
+
+    [Fact]
+    public void DisposedContextPreservesExistingAccessFailure()
+    {
+        using var fixture = new Fixture();
+        fixture.Dispose();
+        Assert.Throws<ObjectDisposedException>(() =>
+            AssemblyContextMethodAddressQuery.ExecuteParticipant(
+                fixture.Group, fixture.Participant, 0x06000001));
+    }
+
+    sealed class Fixture : IDisposable
+    {
+        readonly InspectionWorkspace _workspace = new();
+        internal Fixture(bool unavailable = false)
+        {
+            byte[] image = File.ReadAllBytes(typeof(string).Assembly.Location);
+            using var pe = new PEReader(new MemoryStream(image, writable: false));
+            Participant = new(ResolvedAssemblyReference.Create(
+                AssemblyReferenceIdentity.FromAssemblyDefinition(pe.GetMetadataReader()), null,
+                () => unavailable ? throw new FileNotFoundException("Fixture image unavailable.")
+                    : new MemoryStream(image, writable: false),
+                AssemblyResolutionProvenance.Local("method-address-fixture")), new MissingPolicy());
+            Group = _workspace.CreateAssemblyContextGroup([Participant]);
+        }
+        internal AssemblyContextGroup Group { get; }
+        internal AssemblyContextParticipant Participant { get; }
+        public void Dispose() => _workspace.Dispose();
+    }
+
+    sealed class MissingPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request) =>
+            new(Version, AssemblyBindingSelection.CannotSelect(
+                new AssemblyBindingFailure(AssemblyBindingFailureKind.CandidateUnavailable)));
+    }
+}

--- a/src/DotnetInspector.Queries/AssemblyContextMethodAddressQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextMethodAddressQuery.cs
@@ -1,0 +1,35 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>Issues a module-scoped address for a participant's physical MethodDef.</summary>
+public static class AssemblyContextMethodAddressQuery
+{
+    public static InspectionQuery<AssemblyContextEntry<MetadataMethodAddress>> Definition { get; } =
+        new("Assembly context method address", InspectionCost.Unbounded);
+
+    public static AssemblyContextEntry<MetadataMethodAddress> ExecuteParticipant(
+        AssemblyContextGroup group,
+        AssemblyContextParticipant participant,
+        int methodToken) =>
+        AssemblyContextQueryExecutor.ExecuteParticipantOverSnapshot(
+            group,
+            participant,
+            (_, snapshot) =>
+            {
+                using var image = new PEReader(snapshot.Content);
+                MetadataReader reader = image.GetMetadataReader();
+                int row = methodToken & 0x00ffffff;
+                if ((methodToken & unchecked((int)0xff000000)) != 0x06000000
+                    || row == 0 || row > reader.MethodDefinitions.Count)
+                {
+                    throw new ArgumentException(
+                        $"Token 0x{methodToken:X8} is not a MethodDef in this participant.",
+                        nameof(methodToken));
+                }
+                return MetadataMethodAddress.Create(reader, MetadataTokens.MethodDefinitionHandle(row));
+            });
+}

--- a/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
+++ b/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
@@ -111,6 +111,7 @@ public static class FixtureIds
     public const string DecompilerVbFinalizer = "decompiler.vb-finalizer";
 
     public const string HostileLiterals = "hostile.literals";
+    public const string InspectWebMethodBodies = "inspect-web.method-bodies";
     public const string SourceLinkMalformed = "sourcelink.malformed";
     public const string SourceLinkPartiallyMalformed = "sourcelink.partially-malformed";
     public const string SourceLinkNormalized = "sourcelink.normalized";
@@ -145,6 +146,15 @@ public static class FixtureCatalog
         "ILInspector.Metadata.AttributeEnumFixtures.dll",
         Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "metadata", "custom-attributes", "producer-truth");
+
+    public static readonly FixtureDefinition InspectWebMethodBodies = Fixture(
+        FixtureIds.InspectWebMethodBodies,
+        "InspectWeb.MethodBodyFixtures",
+        "InspectWeb.MethodBodyFixtures.dll",
+        ["inspect-web", "method-body", "reference-implementation"],
+        Boundaries(FixtureBoundary.SidecarAsset, FixtureBoundary.PostBuildTransformation),
+        Asset("reference", "InspectWeb.MethodBodyFixtures", "ref/InspectWeb.MethodBodyFixtures.dll"),
+        Asset("package", "InspectWeb.MethodBodyFixtures", "InspectWeb.MethodBodyFixtures.1.0.0.nupkg"));
 
     public static readonly FixtureDefinition DecompilerAuthoredRebuild = Fixture(
         FixtureIds.DecompilerAuthoredRebuild,
@@ -658,6 +668,7 @@ public static class FixtureCatalog
     public static readonly IReadOnlyList<FixtureDefinition> All =
     [
         MetadataAttributeEnums,
+        InspectWebMethodBodies,
         DecompilerAuthoredRebuild,
         HostileLiterals,
         SourceLinkMalformed,
@@ -1008,6 +1019,7 @@ public static class FixtureCatalog
         {
             "ILInspector.Metadata.AttributeEnumFixtures" =>
                 "fixtures/metadata/ILInspector.Metadata.AttributeEnumFixtures",
+            "InspectWeb.MethodBodyFixtures" => "fixtures/inspect-web/InspectWeb.MethodBodyFixtures",
             "DiffAsmFixtures.Caller" => "fixtures/diff/DiffAsmFixtures.Caller",
             "DiffAsmFixtures.LibA" => "fixtures/diff/DiffAsmFixtures.LibA",
             "DiffAsmFixtures.LibB" => "fixtures/diff/DiffAsmFixtures.LibB",


### PR DESCRIPTION
## Summary

Make local comparison useful in the Browser: an explicit same-assembly method
pair produces a session-local Method Body Diff view, preserving the requested
Before/After association and independent native C# and IL outcomes.

Closes #5963. Closes #5966, which names the same step-9 outcome rather than an
additional milestone. Parent tracker: #4706.

Design basis: the Browser feature owns
`docs/design/inspect-web-method-body-comparison.md#comparison-contract`, landed
in #5964. Queries owns exact physical-target projection and local publication;
the Browser consumes those outcomes through its existing Source facade,
managed bridge, operation authority, and shell modal boundaries.

This is slice 2, now targeting `main` after parent #5967 squash-merged as
`9028eb90796fde5b7a76d224d37da912c1addb10`. The parent delivered shared
publication, the physical-pair adapter, and CLI adoption.

Recovery head: `237ad14f7064161df3bd89c30fa82fee8a9730d4`.
Effective base: `7313ea4f21210d15f7e001a3e72d3622268b7059`.
The restack preserves all five Browser changes and adapts retained input use
to the landed registry's asynchronous leases. Round 4 is a fresh review;
previous clean reviews do not transfer.

## Demo

The implementation demo is hosted privately on **merritt**, loopback port
5199, stamped with historical candidate `2cb0e8c94`. It demonstrates the
feature, not the new recovery head. Port 5198 was already occupied;
no public ingress is enabled.

On the viewer machine:

```bash
ssh -N -T -L 5199:127.0.0.1:5199 merritt
```

[Open the package](http://127.0.0.1:5199/?package=Microsoft.Extensions.Primitives&version=10.0.0&framework=net10.0),
select `StringSegment.Trim`, then **Compare method bodies**. Choose After
explicitly; merely selecting or filtering does not compare.

Actual output from the published generated facade and real package:

| Pair | C# | IL |
| --- | --- | --- |
| `Trim` / `TrimStart` | `ProducedCSharp`, `NotExact`, 13 native rows | `ProducedIlBody`, `OpcodeDiff`, 22 native rows |
| `Trim` / `Trim` | `Exact` | `Exact` |
| `Trim` / `IChangeToken.RegisterChangeCallback` | After `NoApplicableInput`, `NotApplicable` | After `NoApplicableInput`, `NotApplicable` |

The dialog keeps IL's outcome visible while its instructions are collapsed.
The real UI acceptance also exercises a 390px viewport, selection focus,
Escape/focus return, unchanged URL/history, and completed underlying Source.
Before the round-2 fix, Back to `/demos` retained the old dialog. Now it closes,
late inventory is rejected, and Forward does not resurrect it. The Browser
case seeds a route predecessor and confirms navigation stays in the same
document, rather than accidentally passing because a reload clears state.
The separately compiled reference/implementation fixture exercises token
drift and explicit getter/setter comparison through actual Wasm acquisition
and comparison. Only that fixture's package download is supplied by the
harness; native results and generated comparison transport are not mocked.

## Adoption and boundaries

When this Browser slice lands, six of the bounded route's eight
delivery milestones are complete. Both selected host paths are complete.
The remaining two outcomes are caller-backed Queries and Research cleanups,
scoped steps 16 and 17. Broader assembly comparison, Source, and global
retirement remain separate.

There was no existing Browser two-method route to retire. Preserve ordinary
single-member Source, Annotated Source, Facts, and navigation. No new workspace
lens, canonical comparison packet, candidate ranking, or compatibility flag is
introduced.

The feature follows the existing Source consumer's physical execution
placement. The current Worker binding is only a canary, not the production
feature host; this PR does not migrate package acquisition or retained
workspaces into another realm. Logical cancellation and stale-publication
authority use existing contracts, with no prompt physical-cancellation or
Worker-adoption claim.

Real Browser acceptance exposed an integration defect before publication:
borrowing the acquisition-only Source coordinator canceled the underlying
member Source request. Comparison now uses the keyed managed bridge directly
for its retained-input CPU work. A positive managed coexistence case and the
real UI's post-dialog Source completion gate cover the correction.

Platform selections use an empty package ID with the exact selected version,
framework, and resident assembly. This feature-specific convention addresses
the existing retained platform scope without treating a runtime pseudo-package
as a NuGet acquisition request. Runtime and ASP.NET Core residency are supported
when the coordinate is unique; ambiguity stays visible `ContextUnavailable`.

## Validation

The post-parent restack is not content-free. Four Browser commits replay
unchanged; the initial adoption incorporates the new registry, 54-export
inventory, and both fixture-catalog entries. Separate commit `22f3dfe96`
awaits protected-use release and adapts fixtures to async acquisition and
retirement. It also proves removal-requested contexts are not revived and
equal package labels do not arbitrarily select a retained generation.
The final integration brings in current main's Metadata adoption.

| Gate | Result |
| --- | --- |
| Release `engine.Tests`: method-body, Type Source, layering, facade-context classes | 52 passed on `237ad14f7` |
| Release physical-address and direct-member comparison query classes | 33 passed |
| Comparison, Source, workspace navigation, and Spotlight TypeScript cases | 283 passed on `237ad14f7` |
| Package-management and TypeScript semantic-facts cases | 21 passed on `237ad14f7` |
| `npm run analyze` including knip | Passed on `237ad14f7` |
| Typecheck and frontend build | Passed on `237ad14f7` |
| Changed Markdown lint | Passed during recovery |
| Release Wasm publish with the prebuilt runtime profile below | Passed on `237ad14f7` |
| Published-Wasm `browser/method-body-production.spec.ts` | 3 passed on `237ad14f7`: real package, compiled fixture, actual dialog |
| Round-4 reviews | 2/2 clean: GPT-6 Astra and Claude Opus 5 at `237ad14f7` |
| Current-head CI | Pending at 2026-09-06T00:02:19Z; decompiler and Ubuntu jobs still running, no terminal failures observed |

Local managed engine gates use `WasmBuildNative=false`, `WasmEnableSIMD=true`,
and `WasmEnableExceptionHandling=true`; they do not claim a default native
Browser publish. A default native publish was attempted but hit the installed
macOS Emscripten wrapper's unquoted `Application Support` path. The central SDK
was not modified. The successful current-head Wasm publish and all three
Firefox acceptance cases use that same explicit prebuilt-runtime profile.
Previous default native publish evidence belongs to `2cb0e8c94`.

Round 1 found routed-navigation disposal, fixed before clean rounds 2 and 3.
[Round-3 reconciliation](https://github.com/richlander/dotnet-inspect/pull/5990#issuecomment-5553398363)
remains historical. Fresh round 4 is 2/2 clean at `237ad14f7`, with no blocking
findings or author changes. `review-clean` records that exact head, not merge
readiness. Round 4 closes under the non-boundary conflict-recovery cadence;
pending `ci-required` remains a landing gate. No merge is authorized.
