### PR TITLE
Preserve selected supplier acquisition for type Exception Regions

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -133,8 +133,8 @@ This is the API-surface slice in
 [#5853](https://github.com/richlander/dotnet-inspect/issues/5853), not complete
 descriptor adoption for every `type` operation. Existing source/PDB policy
 consumers keep receiving the selected type's descriptor; the next subsection
-owns source-context opening, and the following subsection owns type Analysis
-index acquisition. Runtime acquisition, remaining deep-body/decompiler
+owns source-context opening; later subsections own type Analysis-index
+acquisition and exception-region context opening. Runtime acquisition, remaining deep-body/decompiler
 acquisition, and acquired-PDB propagation remain focused successors under
 [#4867](https://github.com/richlander/dotnet-inspect/issues/4867).
 
@@ -206,8 +206,38 @@ consumer, not a new CLI dependency. Browser adoption remains under #4867.
 
 Descriptorless and standalone-member callers retain their path route. This
 does not select a runtime implementation or establish cross-image
-correspondence. Exception Regions, Body Shapes, whole-type decompiler
-acquisition, and acquired-PDB propagation remain separate successors.
+correspondence. The next subsection owns Exception Regions context opening;
+Body Shapes, whole-type decompiler acquisition, and acquired-PDB propagation
+remain separate successors.
+
+### Type exception-region context opening
+
+When type Exception Regions receives a selected API supplier descriptor, that
+descriptor opens the Metadata context, including for forwarded suppliers.
+Normal/projected output and effective discovery preserve the supplier through
+filtering. Its path projection is not an alternative opener: opening failures
+reach the command error boundary, not a path retry or successful empty output.
+
+`TypeExceptionRegionsAcquisition_UsesSelectedSupplier` and
+`TypeExceptionRegionsAcquisition_ReportsSelectedOpenFailure` gate this
+composition. Existing Exception Regions section cases cover catch/finally rows,
+genuine empty regions, and standalone member output;
+`TypeAnalysisAcquisition_SkipsOrdinaryApiOutput` also gates ordinary type output
+without selected-context acquisition.
+
+This is [#5999](https://github.com/richlander/dotnet-inspect/issues/5999)'s
+three-step production adoption under #4867: TypeCommand retains the supplier;
+the shared CLI exception-region helper consumes Metadata's existing
+descriptor opener; typed rows and Markout rendering, or command error
+reporting, publish the result. Type source-context opening is the analogous
+consumer. No new shared acquisition or rendering API is needed.
+
+Metadata still owns context validation, local symbol probing and region
+decoding. Their behavior and the section authorization policy are unchanged;
+this does not add network acquisition or a new per-method decode diagnostic
+policy. Descriptorless and standalone-member callers keep their existing path
+routes. API/runtime correspondence, runtime-image selection, Body Shapes,
+whole-type decompilation and other hosts remain separate adoption work.
 
 ## Command families
 

--- a/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
@@ -1656,6 +1656,120 @@ public class SourceForwarderResolutionTests
     [InlineData(true, false, false)]
     [InlineData(true, true, false)]
     [InlineData(false, false, true)]
+    public async Task TypeExceptionRegionsAcquisition_UsesSelectedSupplier(
+        bool isForwarded, bool discover, bool project)
+    {
+        int opens = 0;
+        byte[] image = File.ReadAllBytes(typeof(MemberExceptionRegionsFixture).Assembly.Location);
+        var fixture = CreateTypeSourceFixture(
+            AssemblyResolutionProvenance.Local("type-exception-regions"),
+            isForwarded,
+            () =>
+            {
+                opens++;
+                return new MemoryStream(image, writable: false);
+            },
+            typeof(MemberExceptionRegionsFixture));
+        try
+        {
+            var handler = new RecordingNotFoundHandler();
+            using var client = new HttpClient(handler);
+            var source = CreateApiSource(fixture.AssemblyPath, SourceKind.Library) with
+            {
+                TypeName = fixture.Type.FullName,
+                RuntimeAssemblyPath = typeof(object).Assembly.Location,
+                Context = new CommandContext(verbose: false, client),
+            };
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => TypeCommand.ExecuteResolvedAsync(
+                    new TypeOptions
+                    {
+                        TypeName = fixture.Type.FullName,
+                        MemberFilter = [nameof(MemberExceptionRegionsFixture.TryCatch)],
+                        Select = [SectionNames.ExceptionRegions],
+                        Discover = discover ? [SectionNames.ExceptionRegions] : null,
+                        Columns = project ? ["Clause"] : null,
+                        DocsExplicitlySet = true,
+                        TipLevel = TipLevel.Quiet,
+                        Verbosity = Verbosity.Minimal,
+                    },
+                    source,
+                    fixture.Loaded));
+
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("Error:", error);
+            Assert.Contains(discover ? "Clause" : "catch", output);
+            Assert.Equal(1, opens);
+            Assert.Empty(handler.RequestUris);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task TypeExceptionRegionsAcquisition_ReportsSelectedOpenFailure(
+        bool discover, bool invalidImage)
+    {
+        int opens = 0;
+        var fixture = CreateTypeSourceFixture(
+            AssemblyResolutionProvenance.Local("type-exception-regions"),
+            isForwarded: true,
+            () =>
+            {
+                opens++;
+                return invalidImage
+                    ? new MemoryStream([1, 2, 3], writable: false)
+                    : throw new IOException("Selected exception-region image could not be opened.");
+            },
+            typeof(MemberExceptionRegionsFixture));
+        try
+        {
+            var handler = new RecordingNotFoundHandler();
+            using var client = new HttpClient(handler);
+            var source = CreateApiSource(fixture.AssemblyPath, SourceKind.Library) with
+            {
+                TypeName = fixture.Type.FullName,
+                Context = new CommandContext(verbose: false, client),
+            };
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => TypeCommand.ExecuteResolvedAsync(
+                    new TypeOptions
+                    {
+                        TypeName = fixture.Type.FullName,
+                        Select = [SectionNames.ExceptionRegions],
+                        Discover = discover ? [SectionNames.ExceptionRegions] : null,
+                        DocsExplicitlySet = true,
+                        TipLevel = TipLevel.Quiet,
+                        Verbosity = Verbosity.Minimal,
+                    },
+                    source,
+                    fixture.Loaded));
+
+            Assert.Equal(1, exit);
+            Assert.Contains("Error:", error);
+            if (!invalidImage)
+                Assert.Contains("Selected exception-region image could not be opened.", error);
+            Assert.DoesNotContain("No exception regions", output);
+            Assert.Equal(1, opens);
+            Assert.Empty(handler.RequestUris);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, true)]
     public async Task TypeAnalysisAcquisition_UsesSelectedSupplier(
         bool isForwarded, bool discover, bool project)
     {

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -2631,7 +2631,8 @@ public class ApiCommand
                 var exceptionRegions = ApiAnalysisInspection.ResolveExceptionRegions(
                     exceptionRegionsDllPath,
                     type.Members.Where(member => member.MetadataToken is not null
-                        && ApiMemberSectionDescriptors.IsMethodLike(member)));
+                        && ApiMemberSectionDescriptors.IsMethodLike(member)),
+                    sourceAssembly);
                 ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegions, options.IncludeSections);
             }
 
@@ -3570,7 +3571,8 @@ public class ApiCommand
                 var exceptionRegions = ApiAnalysisInspection.ResolveExceptionRegions(
                     exceptionRegionsDllPath,
                     type.Members.Where(member => member.MetadataToken is not null
-                        && ApiMemberSectionDescriptors.IsMethodLike(member)));
+                        && ApiMemberSectionDescriptors.IsMethodLike(member)),
+                    acquisition?.SourceAssembly);
                 ApiOutputFormatter.PopulateTypeExceptionRegions(
                     view, type, exceptionRegions, renderOptions.IncludeSections);
             }

--- a/src/dotnet-inspect/Inspectors/ApiAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiAnalysisInspection.cs
@@ -121,9 +121,12 @@ internal static class ApiAnalysisInspection
 
     internal static IReadOnlyList<MemberExceptionRegion> ResolveExceptionRegions(
         string assemblyPath,
-        IEnumerable<ApiMember> members)
+        IEnumerable<ApiMember> members,
+        ResolvedAssemblyReference? sourceAssembly = null)
     {
-        using var context = PdbContext.Open(assemblyPath);
+        using var context = sourceAssembly is null
+            ? PdbContext.Open(assemblyPath)
+            : PdbContext.Open(sourceAssembly);
         return members
             .Where(member => member.MetadataToken is not null)
             .SelectMany(member => context.ResolveExceptionRegions(member.MetadataToken!.Value, out _)

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -56,6 +56,10 @@
 
 ### Source and implementation evidence
 
+- Type Exception Regions now opens the selected root or forwarded supplier
+  descriptor in normal/projected output and effective discovery. Opening
+  failures are visible command errors rather than successful path retries;
+  descriptorless and standalone-member behavior is unchanged (#5999).
 - Type Analysis-index sections now acquire bytes through the selected root or
   forwarded supplier descriptor, including effective discovery. Rejected
   acquisition is a visible command error rather than a path retry; ordinary


### PR DESCRIPTION
Preserve the selected acquisition so `type` remains a robust, capable
inspection consumer rather than silently replacing a supplier with its path.
This completes the existing Exception Regions consumer's three-step CLI
adoption, not a new substrate.

Closes #5999. Follows merged #5961 under the overall adoption tracker #4867.

## Claim and design basis

**One normative owner:**
[`docs/cli-architecture.md#type-exception-region-context-opening`](docs/cli-architecture.md#type-exception-region-context-opening).
Type Exception Regions opens the selected root or forwarded API supplier
descriptor in normal/projected output and effective discovery. Opening errors
reach the command boundary instead of retrying a readable path and succeeding.

Metadata's existing `PdbContext.Open(ResolvedAssemblyReference)` is the
consumed contract, not a changed owner. Type source-context opening (#5897) is
the direct analogous implementation. The conventional, simplest sufficient
design is to thread the already-retained supplier through the two render
sites and the existing shared CLI helper.

The production-host path has **three steps**, all complete in this slice:

1. TypeCommand retains the original selected supplier, including through
   filtering, using the composition already landed in #5961.
2. Both type-render paths hand it to the exception-region helper, which opens
   Metadata's context through that descriptor.
3. Existing typed rows and Markout rendering, or command error reporting,
   publish the result.

This retires the descriptor-backed type Exception Regions path reopen.
Descriptorless and standalone-member path behavior stays intact. No new
shared API, cache, snapshot or rendering model is introduced.

## Demo

The canonical CLI invocation still renders both catch and finally regions:

```sh
dotnet run --project src/dotnet-inspect -c Release -- \
  type DotnetInspector.Tests.MemberExceptionRegionsFixture \
  --library artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
  -S "Exception Regions" -v:m
```

Real output:

```text
# DotnetInspector.Tests.MemberExceptionRegionsFixture

## Exception Regions

| Member | Region | Clause | Try Range | Handler Range | Caught Type |
| ------ | ------ | ------ | --------- | ------------- | ----------- |
| `int TryCatch(int value)` | 1 | catch | IL_0000..IL_0007 | IL_0007..IL_000C | System.DivideByZeroException |
| `int TryFinally(int value)` | 1 | finally | IL_0000..IL_0006 | IL_0006..IL_0012 |  |
```

The acquisition difference needs a controlled internal supplier, not a CLI
flag. A file-based probe supplied an opener that throws while the path still
contains a readable assembly.

Before, at product base `2d05788a4a2fcf6aafb8376f732f4bc9ba6a811d`,
the same rows appeared, followed by:

```text
exit=0; selected-opener calls=0; path readable=True
```

After:

```text
Error: Selected acquisition is unavailable.
exit=1; selected-opener calls=1; path readable=True
```

The neighboring healthy opener still produces the catch/finally table:

```text
exit=0; selected-opener calls=1; path readable=True
```

Notice that healthy output is unchanged, but the selected acquisition can no
longer be bypassed. The committed cases also cover forwarded suppliers,
column projection, filtered effective discovery and an invalid selected image.

<details>
<summary>Reproduce the controlled-opener probe</summary>

Build `src/dotnet-inspect.Tests` in Release first. Save the following as
`/tmp/type-exception-demo.cs`, replace the project reference with the absolute
path to the worktree's CLI project, and run with the repository-selected SDK:

```sh
dotnet run /tmp/type-exception-demo.cs -c Release -- \
  "$PWD/artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll"
# Add `healthy` after the DLL argument for the neighboring case.
```

```csharp
#:project /absolute/worktree/src/dotnet-inspect/dotnet-inspect.csproj
#:property AssemblyName=dotnet-inspect.Tests
#:property EnablePreviewFeatures=true

using DotnetInspector.Commands;
using DotnetInspector.Inspectors;
using DotnetInspector.Models;
using DotnetInspector.Options;
using DotnetInspector.Packages;
using DotnetInspector.Sections;
using DotnetInspector.Services;
using ILInspector.Metadata;

NuGetCache.Initialize("dotnet-inspect");
string path = Path.GetFullPath(args[0]);
bool healthy = args.Length > 1 && args[1] == "healthy";
ApiSurface api = AssemblyReader.ExtractApiSurface(path)!;
ApiType type = api.Types.Single(
    candidate => candidate.FullName == "DotnetInspector.Tests.MemberExceptionRegionsFixture");
api.Types = [type];
type.SourceAssemblyPath = path;
var provenance = AssemblyResolutionProvenance.Local("type Exception Regions demo");
var initial = ResolvedAssemblyReference.CreateFromPath(path, provenance);
int opens = 0;
var selected = ResolvedAssemblyReference.Create(
    initial.Identity, path,
    () =>
    {
        opens++;
        return healthy
            ? File.OpenRead(path)
            : throw new IOException("Selected acquisition is unavailable.");
    },
    provenance);
var loaded = new ApiServices.LoadedApiSurface(
    api, path, path,
    new Dictionary<ApiType, ResolvedAssemblyReference>(ReferenceEqualityComparer.Instance)
    {
        [type] = selected,
    });
var source = new ApiSourceResult(
    SearchPath: path,
    RuntimeAssemblyPath: null,
    PackageName: null,
    PackageVersion: null,
    ResolvedPackagePath: null,
    PackageExtractPath: null,
    ApiSource: SourceKind.Library,
    ApiVersion: null,
    PlatformFramework: null,
    SelectedTfm: null,
    ProjectAssetsPath: null,
    TempDir: null,
    TypeName: type.FullName,
    PackageReplaySourceUrls: null,
    PackageReplayUsesOriginalSources: false,
    Context: new CommandContext(verbose: false));
int exit = await TypeCommand.ExecuteResolvedAsync(
    new TypeOptions
    {
        TypeName = type.FullName,
        Select = [SectionNames.ExceptionRegions],
        DocsExplicitlySet = true,
        TipLevel = TipLevel.Quiet,
        Verbosity = Verbosity.Minimal,
    },
    source, loaded);
Console.WriteLine($"exit={exit}; selected-opener calls={opens}; path readable={File.Exists(path)}");
```

</details>

## Compatibility and scope

Metadata context validation, local symbol probing, region decoding, genuine
empty regions, section authorization and output schemas are unchanged.
This is context-opening adoption, not a new per-method decode diagnostic
policy or runtime-image selection rule. The success cases include an unrelated
runtime candidate, but the fixture's `SourceAssemblyPath` wins path selection
before context opening. These gates prove selected-opener use and absence of
path fallback, not correspondence with a divergent runtime image.

Body Shapes, whole-type decompilation, API/runtime correspondence and other
host adoption remain separate #4867 successors. This consumes an existing
host-neutral Metadata capability without modifying its platform contract.

## Validation

- All eight new acquisition cases fail against the unchanged product baseline
  for the intended reason: selected opener unused or false success.
- Focused Release command: **16 passed**:

  ```sh
  dotnet run --project src/dotnet-inspect.Tests -c Release -- \
    --filter-method '*TypeExceptionRegionsAcquisition*' \
      '*ExceptionRegionsSection*' '*ExceptionRegionsAsOptIn' \
      '*TypeAnalysisAcquisition_SkipsOrdinaryApiOutput' --no-progress
  ```

- Changed Markdown passes `npx markdownlint-cli`.
- `dotnet build dotnet-inspect.slnx -c Release`: passed with no warnings/errors.
- Adjacent Release command: **81 passed**:

  ```sh
  dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- \
    --filter-class '*SourceForwarderResolutionTests' \
      '*MemberExceptionRegionsSectionTests' --no-progress
  ```

- Frozen head: `3fabb59ccb607bd244a041d3cf2650c5b1ba57bd`.
  Effective base: `2d05788a4a2fcf6aafb8376f732f4bc9ba6a811d`.
  Exact-head `ci-required` succeeded, observed at 2026-09-05 18:03:21 UTC.
  Round 1: GPT-6 Astra and Claude Opus 5 both returned **CLEAN** on that head.
