### PR TITLE
Restore main build after method-body evidence merge

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2991,7 +2991,6 @@ public static class ApiSurfaceExtractor
                     IsAbstract = extension.IsAbstract,
                     IsOverride = extension.IsOverride,
                     IsSealed = extension.IsSealed,
-                    HasMethodBody = extension.HasMethodBody,
                     IsUnsafe = extension.IsUnsafe,
                     MemorySafety = extension.MemorySafety,
                     MethodImplementation = extension.MethodImplementation,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1573,11 +1573,10 @@ public static class ApiOutputFormatter
             IsOverride = owner.IsOverride,
             IsSealed = owner.IsSealed,
             IsUnsafe = owner.IsUnsafe,
-            HasMethodBody = hasMethodBody,
             MemorySafety = owner.AccessorMemorySafety?.FirstOrDefault(
                 facts => facts.CallerContract.Evidence.MemberToken == token),
             MethodImplementation = implementation,
-            HasMethodBody = implementation?.HasBodyRva,
+            HasMethodBody = implementation?.HasBodyRva ?? hasMethodBody,
             Accessibility = accessibility,
             Documentation = owner.Documentation,
         };


### PR DESCRIPTION
Build robust, capable features that provide foundational capabilities or compelling user experiences, with results that are conventionally sound, delightfully new, or both.

## Summary

Restores the `main` build after #5653 and #5972 independently added method-body evidence to the same object initializers. The Metadata projection keeps the single existing value, while accessor projection prefers structured implementation evidence and falls back to the accessor-specific body flag.

This is a trivial integration repair: it removes compile-invalid duplicate assignments and preserves the two already-reviewed inputs without changing the owning contracts, so no adversarial review is required.

## Demo

Before:

```text
ApiSurfaceExtractor.cs(2998,21): error CS1912: Duplicate initialization of member HasMethodBody
ApiOutputFormatter.cs(1580,13): error CS1912: Duplicate initialization of member HasMethodBody
```

After:

```text
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

## Validation

- Full Release solution build.
- Metadata extension/implementation/memory-safety tests: 78 passed.
- CLI implementation, accessor projection, and Finding census tests: 94 passed, 1 pre-existing ilasm-dependent skip.

This PR unblocks the 0.25.0 release-preparation candidate.