### PR TITLE
Prepare 0.25.0 release

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.24.0
+version: 0.25.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 
@@ -19,6 +19,7 @@ and `--` sends remaining options to dotnet-inspect rather than `dnx`.
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden members. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
+| Correlate one member's Findings | `member Type Method:1 --package Foo -S "Finding Census" --json` returns one receipt-scoped Facts and annotated-source envelope. Load `skill query` for selection and format constraints. |
 | Discover legal query values or demos | `vocabulary -D`; select values with `vocabulary -S Accessibility`, `-S "C# Style Choices" --json`, or `-S "C# Body Kinds"`; use `demo list` for product-home scenarios. |
 | Find rendered body syntax | `library path/to.dll --where "Kind=ObjectCreationExpression"`, `type Type --library path/to.dll --where "Kind=InvocationExpression"`, or `member Type Method:1 --library path/to.dll --where "Kind=InvocationExpression"`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs or implementations | `diff --package Foo@old..new --breaking` (`--additive` new APIs; `--alloc-regressions` for allocation regressions); `match Type.MethodA Type.MethodB --package Foo --implementation` compares two methods with C#/IL; `match Type.Method --similar --package Foo` ranks structural candidates for discovery. |
@@ -26,7 +27,7 @@ and `--` sends remaining options to dotnet-inspect rather than `dnx`.
 | Inspect packages | `package Foo`; use `-D` to discover sections and `-S "Signals,Audit: Findings"` to audit text-bearing files and SourceLink mappings. Load `skill private-feeds` for custom/authenticated sources. |
 | Inspect a Workspace | `workspace --package Foo@version --tfm net10.0`; repeat `--package` to preserve an ordered package occurrence set. |
 | Inspect libraries | `library Foo` or `library path/to.dll`; use `-D` to discover sections and `-S "Unsafe Members"` for standalone unsafe evidence. Load `skill metadata` for raw ECMA-335 tables/heaps. |
-| Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
+| Dependencies and relationships | `dependency-evidence --package Foo --tfm net10.0` for direct declarations; `depends Type`, `extensions Type`, or `implements Interface` for traversed relationships. Load `skill relationships` for scopes and semantics. |
 
 ## Member lookup
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -118,6 +118,25 @@ populated members. Row formats require a concrete section or homogeneous
 family. Heterogeneous categories use Markdown/JSON; `Performance:*` flattens
 kinds and adds `Kind` when multiple kinds have rows.
 
+## Correlate one member's Findings
+
+Select `Finding Census` by its exact name for one body-backed method or
+accessor. It returns one indivisible envelope containing the census receipt,
+raw Facts, annotated-source document, and document-local fact-to-instance
+sidecar. The receipt scopes every instance key so display-identical Findings
+remain distinct.
+
+```bash
+dnx dotnet-inspect -y -- member JsonSerializer \
+  --package System.Text.Json Serialize:1 \
+  -S "Finding Census" --json
+```
+
+The section is explicit-only: categories, broad wildcards, and non-exact
+selectors omit or reject it. Markdown and exact singleton JSON preserve the
+envelope. Table, TSV, JSONL, count, row-window, field, and column projections
+fail because they cannot preserve the correlation document.
+
 ## Query rendered body shapes
 
 At library scope, select exact rendered C# syntax occurrences with the stable

--- a/skills/relationships/SKILL.md
+++ b/skills/relationships/SKILL.md
@@ -27,6 +27,23 @@ prefix; the command warns when that bound is reached. `depends` does not accept
 `--project` reads existing restored assets; restore/build first if dependencies
 changed.
 
+## What does the root declare directly?
+
+`dependency-evidence` reports one normalized snapshot of the direct
+dependencies declared by explicit package, nuspec, restored-project, or
+package-prefix roots. It preserves framework scopes, version constraints,
+restored resolution evidence, and root-set completion without walking the
+transitive dependency tree. Use `depends` when traversal is the goal.
+
+```bash
+dnx dotnet-inspect -y -- dependency-evidence \
+  --package Newtonsoft.Json --tfm net8.0
+dnx dotnet-inspect -y -- dependency-evidence \
+  --project ./src/App/App.csproj --nuspec ./artifacts/App.nuspec -v:n
+dnx dotnet-inspect -y -- dependency-evidence \
+  --package-prefix Microsoft.Extensions --tfm net10.0 --jsonl
+```
+
 ## What implements or extends it?
 
 `implements Interface` finds concrete implementors and subclasses;

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -20,7 +20,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.24.0</VersionPrefix>
+    <VersionPrefix>0.25.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Build robust, capable features that provide foundational capabilities or compelling user experiences, with results that are conventionally sound, delightfully new, or both.

## Summary

Prepares dotnet-inspect 0.25.0 by synchronizing the package `VersionPrefix`, embedded router version, and shipped product guidance for capabilities added since 0.24.0. Version 0.24.0 is already published, and 0.25.0 is unclaimed across the pointer, five Native AOT, and managed fallback package IDs.

This is a trivial release-metadata and documentation change: it changes no command behavior, package shape, compatibility contract, or runtime implementation, so it requires no adversarial review.

#6009 has merged and restored `main`. This PR is now the bottom open slice, retargeted and restacked onto merge commit `818ebaf44`; the release-preparation diff contains only its own metadata and shipped-guidance changes.

## Demo

The Release apphost and embedded router report the intended version:

```text
$ dotnet-inspect --version
0.25.0+a8ca236

$ dotnet-inspect skill | head -4
---
name: dotnet-inspect
version: 0.25.0
description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
```

The router and focused skills now expose direct dependency evidence and the exact member Finding census envelope.

## Shipped documentation checkpoint

- `README.md` already reflects the release command surface, including static schema discovery, direct dependency evidence, folder-feed version queries, authored-source diff evidence, and Finding census selection.
- Existing focused updates in `compatibility` and `private-feeds` accurately describe authored-source comparison and folder-feed version discovery.
- This checkpoint adds `dependency-evidence` to the router and `relationships` skill, and adds exact Finding census selection and format constraints to the router and `query` skill.
- No tracked product skill was added, removed, or relocated since 0.24.0. The runtime registry and embedded-resource set agree with all 11 focused skills.
- The embedded `release-notes.md` contains the accumulated user-visible release entries; GitHub release notes remain generated from the tag range by `release.yml`.

## Validation

- .NET SDK `11.0.100-preview.7.26381.103`.
- Full Release solution build with 0 warnings and 0 errors.
- `SkillCommandTests`: 23 passed.
- Release apphost `--version`, router frontmatter, and `skill list` smoke checks.
- `markdownlint` on all changed `SKILL.md` files.
- NuGet confirms 0.25.0 is unpublished for all seven package IDs.