### PR TITLE
Fix duplicate HasMethodBody initializer breaking Release build

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2995,7 +2995,6 @@ public static class ApiSurfaceExtractor
                     IsUnsafe = extension.IsUnsafe,
                     MemorySafety = extension.MemorySafety,
                     MethodImplementation = extension.MethodImplementation,
-                    HasMethodBody = extension.HasMethodBody,
                     IsExtension = true,
                     ExtendedType = extension.ExtendedType,
                     DeclaringType = declaringType.FullName,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1573,7 +1573,6 @@ public static class ApiOutputFormatter
             IsOverride = owner.IsOverride,
             IsSealed = owner.IsSealed,
             IsUnsafe = owner.IsUnsafe,
-            HasMethodBody = hasMethodBody,
             MemorySafety = owner.AccessorMemorySafety?.FirstOrDefault(
                 facts => facts.CallerContract.Evidence.MemberToken == token),
             MethodImplementation = implementation,


### PR DESCRIPTION
## Demo

Before (main `6c9a5b1`):

```text
$ dotnet build src/ILInspector.Metadata/ILInspector.Metadata.csproj -c Release --nologo -v:q
ApiSurfaceExtractor.cs(2998,21): error CS1912: Duplicate initialization of member HasMethodBody
Build FAILED. 0 warnings, 1 error.
```

After this PR:

```text
$ dotnet build dotnet-inspect.slnx -c Release --nologo -v:q
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

## Root cause

Two independent duplicate-initializer errors block the Release build, both
from the same pattern (a later commit added `HasMethodBody` again without
noticing an earlier assignment already existed):

1. `src/ILInspector.Metadata/ApiSurfaceExtractor.cs`: the attached-extension
   `ApiMember` projection set `HasMethodBody = extension.HasMethodBody`
   twice, back to back. Both copies are identical, so the second is a no-op
   removed as dead code.
2. `src/dotnet-inspect/Output/ApiOutputFormatter.cs`'s `Accessor()` helper set
   `HasMethodBody` twice with **different** sources: the accessor-specific
   `hasMethodBody` parameter, and `implementation?.HasBodyRva` (derived from
   `MethodImplementation` facts added in a later commit).
   `ApiMethodImplementationJsonTests.AccessorProjectionKeepsExactMethodImplementation`
   asserts `accessor.HasMethodBody == expected.HasBodyRva`, so the
   `implementation?.HasBodyRva` assignment is the one that must remain; the
   earlier `hasMethodBody`-parameter assignment is dead and is removed.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — Build succeeded, 0
  warnings, 0 errors.
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — 6049
  succeeded, 0 failed, 31 skipped (pre-existing, unrelated tool-dependency
  skips).
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 2827
  succeeded, 0 failed, 3 skipped (pre-existing, missing `ildasm`/`ilasm`).

Fixes #6007