### PR TITLE
Fix macOS case-insensitive filesystem collision in source-inventory probe fixture

### DIFF
--- a/prototypes/inspect-web/test/typescript-semantic-facts.test.ts
+++ b/prototypes/inspect-web/test/typescript-semantic-facts.test.ts
@@ -1727,7 +1727,7 @@ test("only the adapter imports unstable TypeScript packages and the scan is non-
       "probe.mjs",
       "probe.cjs",
       "probe.jsx",
-      "probe.TS",
+      "probe-upper.TS",
     ];
     for (const name of names) {
       writeFileSync(join(scripts, name), "", "utf8");


### PR DESCRIPTION
## Demo

Before (macOS, pristine `origin/main`):

```text
$ cd prototypes/inspect-web && npm ci && node --test test/typescript-semantic-facts.test.ts
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
8 !== 9
    at test/typescript-semantic-facts.test.ts:1734:12
```

After this PR:

```text
$ node --test test/typescript-semantic-facts.test.ts
✔ only the adapter imports unstable TypeScript packages and the scan is non-vacuous (23.180708ms)
ℹ tests 21
ℹ pass 21
ℹ fail 0
```

## Root cause

The non-vacuity fixture wrote nine probe files (`probe.ts`, `probe.mts`, ...,
and `probe.TS` to exercise the case-insensitive extension comparison in
`projectSourceFiles`) into a scratch directory, then asserted the walk found
all nine. On macOS's default case-insensitive filesystem, `probe.ts` and
`probe.TS` are the same path — the second `writeFileSync` silently
overwrote the first, leaving only 8 files on disk. The walk correctly
reported 8; only the fixture's file count was wrong.

The uppercase-extension probe is deliberate (added after a round-2 finding
where `public/probe.JS` shipped through every gate), so removing it would
regress that coverage. Instead, per the issue's suggested fix, the uppercase
probe now uses a distinct stem (`probe-upper.TS`) so it no longer collides
with `probe.ts` while still exercising the same case-insensitive extension
match.

Not caught by CI, which runs on Linux (case-sensitive).

## Validation

- `cd prototypes/inspect-web && npm ci && node --test test/typescript-semantic-facts.test.ts`
  — 21/21 passed (macOS), including the previously-failing
  "only the adapter imports unstable TypeScript packages and the scan is
  non-vacuous" test.

Fixes #4977