### PR TITLE
Fix JS export JsonInclude wire contract

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -54,6 +54,8 @@
     <Project Path="fixtures/diff/DiffFixtures.V2/DiffFixtures.V2.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj" />
+    <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/ILInspector.JsExportSurface.NestedContextFixtures.csproj" />
+    <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NamingFixtures/ILInspector.JsExportSurface.NamingFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.OperatorFixtures/ILInspector.JsExportSurface.OperatorFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.PublishabilityFixtures/ILInspector.JsExportSurface.PublishabilityFixtures.csproj" />

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -53,6 +53,7 @@
     <Project Path="fixtures/diff/DiffFixtures.V1/DiffFixtures.V1.csproj" />
     <Project Path="fixtures/diff/DiffFixtures.V2/DiffFixtures.V2.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
+    <Project Path="fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NamingFixtures/ILInspector.JsExportSurface.NamingFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.OperatorFixtures/ILInspector.JsExportSurface.OperatorFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.PublishabilityFixtures/ILInspector.JsExportSurface.PublishabilityFixtures.csproj" />

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -54,6 +54,7 @@
     <Project Path="fixtures/diff/DiffFixtures.V2/DiffFixtures.V2.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj" />
+    <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NestedContextConstructorFixtures/ILInspector.JsExportSurface.NestedContextConstructorFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/ILInspector.JsExportSurface.NestedContextFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.NamingFixtures/ILInspector.JsExportSurface.NamingFixtures.csproj" />

--- a/fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj
+++ b/fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/MemberConverterFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/MemberConverterFixtureExports.cs
@@ -1,0 +1,32 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.MemberConverterFixtures;
+
+public sealed class ConverterControlledDto
+{
+    [JsonConverter(typeof(JsonStringEnumConverter<Status>))]
+    public Status Value { get; set; } = Status.One;
+}
+
+public enum Status
+{
+    One,
+    Two,
+}
+
+[JsonSerializable(typeof(ConverterControlledDto))]
+internal sealed partial class ConverterFixtureJsonContext
+    : JsonSerializerContext;
+
+[SupportedOSPlatform("browser")]
+public static partial class MemberConverterFixtureExports
+{
+    [JSExport]
+    public static string GetValue() =>
+        JsonSerializer.Serialize(
+            new ConverterControlledDto(),
+            ConverterFixtureJsonContext.Default.ConverterControlledDto);
+}

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextConstructorFixtures/ILInspector.JsExportSurface.NestedContextConstructorFixtures.csproj
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextConstructorFixtures/ILInspector.JsExportSurface.NestedContextConstructorFixtures.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextConstructorFixtures/NestedContextConstructorFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextConstructorFixtures/NestedContextConstructorFixtureExports.cs
@@ -1,0 +1,40 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.NestedContextConstructorFixtures;
+
+#pragma warning disable SYSLIB1038
+[SupportedOSPlatform("browser")]
+public partial class NestedContextConstructorBoundDto
+{
+    [JsonInclude]
+    private HiddenValue Hidden { get; }
+
+    [JsonConstructor]
+    private NestedContextConstructorBoundDto(HiddenValue hidden)
+    {
+        Hidden = hidden;
+    }
+
+    public int Read() => (int)Hidden;
+
+    [JSExport]
+    public static int ReadHidden(string json) =>
+        JsonSerializer.Deserialize(
+            json,
+            NestedContextJsonContext.Default
+                .NestedContextConstructorBoundDto)!.Read();
+
+    private enum HiddenValue
+    {
+        Zero,
+        One,
+    }
+
+    [JsonSerializable(typeof(NestedContextConstructorBoundDto))]
+    private sealed partial class NestedContextJsonContext
+        : JsonSerializerContext;
+}
+#pragma warning restore SYSLIB1038

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/CrossNamespacePartialAccessibilityFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/CrossNamespacePartialAccessibilityFixtureExports.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.NestedContextFixtures.Owners
+{
+#pragma warning disable CS0414
+#pragma warning disable SYSLIB1038
+    public class PartiallyAccessibleBaseOwner
+    {
+        public string Public { get; set; } = "public";
+
+        [JsonInclude]
+        private KeyValuePair<ReachableValue, HiddenValue> Mixed =
+            new(ReachableValue.Value, HiddenValue.Value);
+
+        protected enum ReachableValue
+        {
+            Value,
+        }
+
+        private enum HiddenValue
+        {
+            Value,
+        }
+    }
+#pragma warning restore SYSLIB1038
+#pragma warning restore CS0414
+}
+
+namespace ILInspector.JsExportSurface.NestedContextFixtures.Contexts
+{
+    using ILInspector.JsExportSurface.NestedContextFixtures.Owners;
+
+    [SupportedOSPlatform("browser")]
+    public partial class PartiallyAccessibleDerivedOwner
+        : PartiallyAccessibleBaseOwner
+    {
+        [JSExport]
+        public static string GetPartiallyAccessible() =>
+            JsonSerializer.Serialize(
+                new PartiallyAccessibleBaseOwner(),
+                PartiallyAccessibleJsonContext.Default
+                    .PartiallyAccessibleBaseOwner);
+
+        public static string SerializeValue() =>
+            GetPartiallyAccessible();
+
+        [JsonSerializable(typeof(PartiallyAccessibleBaseOwner))]
+        private sealed partial class PartiallyAccessibleJsonContext
+            : JsonSerializerContext;
+    }
+}

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/ILInspector.JsExportSurface.NestedContextFixtures.csproj
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/ILInspector.JsExportSurface.NestedContextFixtures.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/NestedContextFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/NestedContextFixtureExports.cs
@@ -7,7 +7,29 @@ namespace ILInspector.JsExportSurface.NestedContextFixtures;
 
 public sealed record SimpleDto(string Value);
 
+public sealed partial class CrossContextTopDto
+{
+    public string Public { get; set; } = "";
+
+#pragma warning disable CS0414
+    [JsonInclude]
+    private HiddenValue Hidden = HiddenValue.Value;
+#pragma warning restore CS0414
+
+    private enum HiddenValue
+    {
+        Value,
+    }
+
+    [JsonSerializable(typeof(CrossContextNestedDto))]
+    internal sealed partial class CrossContextNestedJsonContext
+        : JsonSerializerContext;
+}
+
+public sealed record CrossContextNestedDto(int Value);
+
 [JsonSerializable(typeof(SimpleDto))]
+[JsonSerializable(typeof(CrossContextTopDto))]
 internal sealed partial class TopLevelFixtureJsonContext
     : JsonSerializerContext;
 
@@ -19,6 +41,21 @@ public static partial class NestedContextFixtureExports
         JsonSerializer.Serialize(
             new SimpleDto("simple"),
             TopLevelFixtureJsonContext.Default.SimpleDto);
+
+    [JSExport]
+    public static int ReadThroughDifferentContexts(
+        string first,
+        string second)
+    {
+        CrossContextTopDto top = JsonSerializer.Deserialize(
+            first,
+            TopLevelFixtureJsonContext.Default.CrossContextTopDto)!;
+        CrossContextNestedDto nested = JsonSerializer.Deserialize(
+            second,
+            CrossContextTopDto.CrossContextNestedJsonContext.Default
+                .CrossContextNestedDto)!;
+        return top.Public.Length + nested.Value;
+    }
 }
 
 #pragma warning disable CS0414

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/NestedContextFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/NestedContextFixtureExports.cs
@@ -1,0 +1,78 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.NestedContextFixtures;
+
+public sealed record SimpleDto(string Value);
+
+[JsonSerializable(typeof(SimpleDto))]
+internal sealed partial class TopLevelFixtureJsonContext
+    : JsonSerializerContext;
+
+[SupportedOSPlatform("browser")]
+public static partial class NestedContextFixtureExports
+{
+    [JSExport]
+    public static string GetSimple() =>
+        JsonSerializer.Serialize(
+            new SimpleDto("simple"),
+            TopLevelFixtureJsonContext.Default.SimpleDto);
+}
+
+#pragma warning disable CS0414
+#pragma warning disable SYSLIB1038
+[SupportedOSPlatform("browser")]
+public partial class NestedContextSafeDto
+{
+    public string Public { get; set; } = "public";
+
+    [JsonInclude]
+    [JsonIgnore]
+    private HiddenValue Ignored = HiddenValue.Value;
+
+    [JsonInclude]
+    private static HiddenValue Shared = HiddenValue.Value;
+
+    [JsonInclude]
+    private HiddenValue this[int index]
+    {
+        get => HiddenValue.Value;
+        set
+        {
+        }
+    }
+
+    private enum HiddenValue
+    {
+        Value,
+    }
+
+    [JSExport]
+    public static string GetNestedSafe() =>
+        JsonSerializer.Serialize(
+            new NestedContextSafeDto(),
+            NestedContextJsonContext.Default.NestedContextSafeDto);
+
+    [JsonSerializable(typeof(NestedContextSafeDto))]
+    private sealed partial class NestedContextJsonContext
+        : JsonSerializerContext;
+}
+
+internal sealed partial class UnreachedNestedContextDto
+{
+    [JsonInclude]
+    private HiddenValue Hidden = HiddenValue.Value;
+
+    private enum HiddenValue
+    {
+        Value,
+    }
+
+    [JsonSerializable(typeof(UnreachedNestedContextDto))]
+    private sealed partial class UnreachedNestedContextJsonContext
+        : JsonSerializerContext;
+}
+#pragma warning restore SYSLIB1038
+#pragma warning restore CS0414

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.csproj
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/NestedContextUnsupportedExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/NestedContextUnsupportedExports.cs
@@ -1,0 +1,42 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
+
+#pragma warning disable CS0414
+#pragma warning disable SYSLIB1038
+[SupportedOSPlatform("browser")]
+public partial class NestedContextProtectedValueDto
+{
+    [JsonInclude]
+    private HiddenProtected ProtectedField = HiddenProtected.Value;
+
+    [JsonInclude]
+    private HiddenPrivateProtected PrivateProtectedField =
+        HiddenPrivateProtected.Value;
+
+    protected enum HiddenProtected
+    {
+        Value,
+    }
+
+    private protected enum HiddenPrivateProtected
+    {
+        Value,
+    }
+
+    [JSExport]
+    public static string GetProtectedValues() =>
+        JsonSerializer.Serialize(
+            new NestedContextProtectedValueDto(),
+            NestedContextJsonContext.Default
+                .NestedContextProtectedValueDto);
+
+    [JsonSerializable(typeof(NestedContextProtectedValueDto))]
+    private sealed partial class NestedContextJsonContext
+        : JsonSerializerContext;
+}
+#pragma warning restore SYSLIB1038
+#pragma warning restore CS0414

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/NestedContextUnsupportedExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/NestedContextUnsupportedExports.cs
@@ -7,8 +7,7 @@ namespace ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
 
 #pragma warning disable CS0414
 #pragma warning disable SYSLIB1038
-[SupportedOSPlatform("browser")]
-public partial class NestedContextProtectedValueDto
+public class NestedContextBaseOwner
 {
     [JsonInclude]
     private HiddenProtected ProtectedField = HiddenProtected.Value;
@@ -26,15 +25,20 @@ public partial class NestedContextProtectedValueDto
     {
         Value,
     }
+}
 
+[SupportedOSPlatform("browser")]
+public partial class NestedContextProtectedValueDto
+    : NestedContextBaseOwner
+{
     [JSExport]
     public static string GetProtectedValues() =>
         JsonSerializer.Serialize(
-            new NestedContextProtectedValueDto(),
+            new NestedContextBaseOwner(),
             NestedContextJsonContext.Default
-                .NestedContextProtectedValueDto);
+                .NestedContextBaseOwner);
 
-    [JsonSerializable(typeof(NestedContextProtectedValueDto))]
+    [JsonSerializable(typeof(NestedContextBaseOwner))]
     private sealed partial class NestedContextJsonContext
         : JsonSerializerContext;
 }

--- a/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/NestedContextUnsupportedExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/NestedContextUnsupportedExports.cs
@@ -3,44 +3,53 @@ using System.Runtime.Versioning;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
-
+namespace ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.Owners
+{
 #pragma warning disable CS0414
 #pragma warning disable SYSLIB1038
-public class NestedContextBaseOwner
-{
-    [JsonInclude]
-    private HiddenProtected ProtectedField = HiddenProtected.Value;
-
-    [JsonInclude]
-    private HiddenPrivateProtected PrivateProtectedField =
-        HiddenPrivateProtected.Value;
-
-    protected enum HiddenProtected
+    public class NestedContextBaseOwner
     {
-        Value,
+        [JsonInclude]
+        private HiddenProtected ProtectedField = HiddenProtected.Value;
+
+        [JsonInclude]
+        private HiddenPrivateProtected PrivateProtectedField =
+            HiddenPrivateProtected.Value;
+
+        protected enum HiddenProtected
+        {
+            Value,
+        }
+
+        private protected enum HiddenPrivateProtected
+        {
+            Value,
+        }
     }
-
-    private protected enum HiddenPrivateProtected
-    {
-        Value,
-    }
-}
-
-[SupportedOSPlatform("browser")]
-public partial class NestedContextProtectedValueDto
-    : NestedContextBaseOwner
-{
-    [JSExport]
-    public static string GetProtectedValues() =>
-        JsonSerializer.Serialize(
-            new NestedContextBaseOwner(),
-            NestedContextJsonContext.Default
-                .NestedContextBaseOwner);
-
-    [JsonSerializable(typeof(NestedContextBaseOwner))]
-    private sealed partial class NestedContextJsonContext
-        : JsonSerializerContext;
-}
 #pragma warning restore SYSLIB1038
 #pragma warning restore CS0414
+}
+
+namespace ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.Contexts
+{
+    using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.Owners;
+
+    public class NestedContextIntermediateOwner
+        : NestedContextBaseOwner;
+
+    [SupportedOSPlatform("browser")]
+    public partial class NestedContextProtectedValueDto
+        : NestedContextIntermediateOwner
+    {
+        [JSExport]
+        public static string GetProtectedValues() =>
+            JsonSerializer.Serialize(
+                new NestedContextBaseOwner(),
+                NestedContextJsonContext.Default
+                    .NestedContextBaseOwner);
+
+        [JsonSerializable(typeof(NestedContextBaseOwner))]
+        private sealed partial class NestedContextJsonContext
+            : JsonSerializerContext;
+    }
+}

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
@@ -15,9 +15,28 @@ public sealed record BlobDto(
     byte[]?[] Blobs,
     IReadOnlyDictionary<string, byte[]?> BlobsByName);
 
+public sealed class HiddenTypeJsonIncludeDto
+{
+    public string Public { get; set; } = "public";
+
+    [JsonInclude]
+    private HiddenValue HiddenProperty { get; set; } = HiddenValue.Value;
+
+    [JsonInclude]
+    private HiddenValue HiddenField = HiddenValue.Value;
+
+    private enum HiddenValue
+    {
+        Value,
+    }
+
+    public int Read() => (int)HiddenField + (int)HiddenProperty;
+}
+
 [JsonSerializable(typeof(WidgetDto))]
 [JsonSerializable(typeof(RuntimeAPI))]
 [JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(HiddenTypeJsonIncludeDto))]
 [JsonSerializable(typeof(global::@string), TypeInfoPropertyName = "StringDto")]
 [JsonSerializable(typeof(global::@byte), TypeInfoPropertyName = "ByteDto")]
 [JsonSerializable(typeof(global::KeywordHolder))]
@@ -143,6 +162,15 @@ public static partial class TypeScriptFixtureExports
                     ["none"] = null,
                 }),
             BlobFixtureJsonContext.Default.BlobDto);
+    }
+
+    [JSExport]
+    public static async Task<string> GetHiddenTypeJsonIncludeAsync()
+    {
+        await Task.Yield();
+        return JsonSerializer.Serialize(
+            new HiddenTypeJsonIncludeDto(),
+            FixtureJsonContext.Default.HiddenTypeJsonIncludeDto);
     }
 
     [JSExport]

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -32,6 +32,19 @@ public sealed class JsExportSurface
     public IReadOnlyList<ApiType> Enums { get; init; } = [];
 
     /// <summary>
+    /// Complete extracted same-assembly type inventory available when the
+    /// surface came from <see cref="JsExportSurfaceBuilder"/> rather than a
+    /// hand-composed test fixture.
+    /// </summary>
+    /// <remarks>
+    /// Consumers use this only for same-assembly wire-contract decisions that
+    /// must distinguish "not discovered for emission" from "not present in the
+    /// assembly at all".
+    /// </remarks>
+    [JsonIgnore]
+    public IReadOnlyList<ApiType> AllTypes { get; init; } = [];
+
+    /// <summary>
     /// The wire directions each declared type was reached in, keyed by the
     /// <see cref="ApiType"/> instances published in <see cref="Records"/> and
     /// <see cref="Enums"/>.

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -176,6 +176,27 @@ public sealed class JsExportFunction
     [JsonIgnore]
     public IReadOnlyList<string> ParameterWireContextScopeKeys
         { get; init; } = [];
+
+    /// <summary>
+    /// Authenticated per-call associations between a wire-contract root type,
+    /// the source-generated serializer context scope that supplied it, and the
+    /// direction it participates in.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<JsExportWireTypeContextPath> WireTypeContextPaths
+        { get; init; } = [];
+}
+
+public sealed class JsExportWireTypeContextPath
+{
+    public required JsonWireDirection Direction { get; init; }
+
+    [JsonIgnore]
+    public IReadOnlyList<ApiTypeReferenceIdentity> TypeReferences
+        { get; init; } = [];
+
+    [JsonIgnore]
+    public IReadOnlyList<string> ContextScopeKeys { get; init; } = [];
 }
 
 public enum JsExportDelegateKind

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -137,6 +137,15 @@ public sealed class JsExportFunction
         { get; init; } = [];
 
     /// <summary>
+    /// Authenticated source-generated serializer-context scopes that produced
+    /// <see cref="ReturnWireTypeReferences"/>. Present only on body-backed
+    /// surfaces.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<string> ReturnWireContextScopeKeys
+        { get; init; } = [];
+
+    /// <summary>
     /// Exact structural shape of <see cref="ReturnWireType"/>. This keeps
     /// primitive nodes distinct from producer-defined types whose C# display
     /// spelling is identical.
@@ -157,6 +166,15 @@ public sealed class JsExportFunction
 
     [JsonIgnore]
     public IReadOnlyList<ApiTypeReferenceIdentity> ParameterWireTypeReferences
+        { get; init; } = [];
+
+    /// <summary>
+    /// Authenticated source-generated serializer-context scopes that produced
+    /// <see cref="ParameterWireTypeReferences"/>. Present only on body-backed
+    /// surfaces.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<string> ParameterWireContextScopeKeys
         { get; init; } = [];
 }
 

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -193,20 +193,21 @@ public static class JsExportSurfaceBuilder
         var policiesByType = new Dictionary<ApiType, HashSet<JsonWireNamingPolicy>>();
         var registeredJsonTypeInfoGetterModes =
             new Dictionary<int, JsonSourceGenerationMode>();
+        var registeredJsonTypeInfoContextScopeKeys =
+            new Dictionary<int, string>();
         var registeredJsonTypeInfoDefaultGetterTokens =
             new Dictionary<int, int>();
         var registeredJsonTypeInfoShapes =
             new Dictionary<int, ApiTypeShape>();
         var unsupportedJsonTypeInfoGetterReasons =
             new Dictionary<int, string>();
-        var processedContextScopesByType =
-            new Dictionary<ApiType, HashSet<string?>>(
-                ReferenceEqualityComparer.Instance);
         var queue = new Queue<(
             string? Name,
             ApiTypeReferenceIdentity? Identity,
-            JsonWireNamingPolicy Policy,
-            MetadataTypeDefinitionName? ContextDefinitionName)>();
+            JsonWireNamingPolicy Policy)>();
+        var contextDefinitionNamesByScopeKey =
+            new Dictionary<string, MetadataTypeDefinitionName>(
+                StringComparer.Ordinal);
 
         foreach (ApiType type in surface.Types)
         {
@@ -328,6 +329,25 @@ public static class JsExportSurfaceBuilder
                                             FormatMemberLocation(type, member),
                                             "serializer-context property generation modes conflict");
                                     }
+                                    if (type.DefinitionName is { } contextDefinitionName)
+                                    {
+                                        string contextScopeKey =
+                                            ContextScopeKey(
+                                                contextDefinitionName);
+                                        if (!registeredJsonTypeInfoContextScopeKeys.TryAdd(
+                                                getterToken,
+                                                contextScopeKey)
+                                            && registeredJsonTypeInfoContextScopeKeys[
+                                                    getterToken] != contextScopeKey)
+                                        {
+                                            throw new UnsupportedJsExportSurfaceException(
+                                                FormatMemberLocation(type, member),
+                                                "serializer-context scope evidence conflicts");
+                                        }
+                                        contextDefinitionNamesByScopeKey[
+                                            contextScopeKey] =
+                                                contextDefinitionName;
+                                    }
                                     if (defaultContextGetterToken is { } defaultGetter
                                         && !registeredJsonTypeInfoDefaultGetterTokens.TryAdd(
                                             getterToken,
@@ -358,8 +378,7 @@ public static class JsExportSurfaceBuilder
                                 queue.Enqueue((
                                     null,
                                     reference,
-                                    policy,
-                                    type.DefinitionName));
+                                    policy));
                             }
                             break;
                         case RegisteredRootPropertyMatch.Unsupported:
@@ -415,8 +434,7 @@ public static class JsExportSurfaceBuilder
                         queue.Enqueue((
                             null,
                             reference,
-                            policy,
-                            type.DefinitionName));
+                            policy));
                     }
                 }
                 else
@@ -427,8 +445,7 @@ public static class JsExportSurfaceBuilder
                         queue.Enqueue((
                             candidate,
                             null,
-                            policy,
-                            type.DefinitionName));
+                            policy));
                     }
                 }
             }
@@ -436,12 +453,8 @@ public static class JsExportSurfaceBuilder
 
         while (queue.Count > 0)
         {
-            (
-                string? name,
-                ApiTypeReferenceIdentity? identity,
-                JsonWireNamingPolicy namingPolicy,
-                MetadataTypeDefinitionName? contextDefinitionName) =
-                queue.Dequeue();
+            (string? name, ApiTypeReferenceIdentity? identity,
+                JsonWireNamingPolicy namingPolicy) = queue.Dequeue();
             ApiType? type = null;
             if (identity is not null)
                 typesByScopedIdentity.TryGetValue(identity, out type);
@@ -456,7 +469,10 @@ public static class JsExportSurfaceBuilder
                 policiesByType.Add(type, policies);
             }
 
-            policies.Add(namingPolicy);
+            if (!policies.Add(namingPolicy))
+            {
+                continue;
+            }
 
             type.JsonPropertyNamingPolicy = policies.Count == 1
                 ? namingPolicy
@@ -470,31 +486,12 @@ public static class JsExportSurfaceBuilder
                     records.Add(type);
             }
 
-            if (!TryRegisterContextScope(
-                    processedContextScopesByType,
-                    type,
-                    contextDefinitionName))
-            {
-                continue;
-            }
-
             if (type.Kind == "enum"
                 || type.JsonConverterAttributeCount > 0)
                 continue;
 
             foreach (ApiMember member in type.Members)
             {
-                if (JsonWireMemberRules
-                    .RequiresContextRelativeValueTypeAccessibilityEvidence(
-                        member,
-                        surface.AssemblyIdentity,
-                        typesByScopedIdentity,
-                        contextDefinitionName))
-                {
-                    throw new UnsupportedJsExportSurfaceException(
-                        FormatMemberLocation(type, member),
-                        "[JsonInclude] members whose same-assembly value types depend on nested JsonSerializerContext accessibility are unsupported");
-                }
                 if (!JsonWireMemberRules.IsSerialized(
                         member,
                         surface.AssemblyIdentity,
@@ -518,8 +515,7 @@ public static class JsExportSurfaceBuilder
                         queue.Enqueue((
                             null,
                             reference,
-                            namingPolicy,
-                            contextDefinitionName));
+                            namingPolicy));
                     }
                 }
                 else
@@ -530,8 +526,7 @@ public static class JsExportSurfaceBuilder
                         queue.Enqueue((
                             candidate,
                             null,
-                            namingPolicy,
-                            contextDefinitionName));
+                            namingPolicy));
                     }
                 }
             }
@@ -549,12 +544,27 @@ public static class JsExportSurfaceBuilder
                         function,
                         token,
                         registeredJsonTypeInfoGetterModes,
+                        registeredJsonTypeInfoContextScopeKeys,
                         registeredJsonTypeInfoDefaultGetterTokens,
                         registeredJsonTypeInfoShapes,
                         unsupportedJsonTypeInfoGetterReasons);
                 }
             }
         }
+
+        Dictionary<ApiType, JsonWireDirection> wireDirections =
+            ResolveWireDirections(
+                functions,
+                surface.AssemblyIdentity,
+                typesByScopedIdentity,
+                discovered);
+        RejectReachedContextRelativeValueTypeAccessibility(
+            functions,
+            wireDirections,
+            surface.AssemblyIdentity,
+            typesByScopedIdentity,
+            discovered,
+            contextDefinitionNamesByScopeKey);
 
         return new JsExportSurface
         {
@@ -563,11 +573,7 @@ public static class JsExportSurfaceBuilder
             Records = records,
             Enums = enums,
             AllTypes = surface.Types,
-            WireDirections = ResolveWireDirections(
-                functions,
-                surface.AssemblyIdentity,
-                typesByScopedIdentity,
-                discovered),
+            WireDirections = wireDirections,
         };
     }
 
@@ -666,24 +672,191 @@ public static class JsExportSurfaceBuilder
         || member.RuntimeJsExportAttributeCount > 0
         || member.HasMalformedRuntimeJsExportAttribute;
 
-    static bool TryRegisterContextScope(
-        Dictionary<ApiType, HashSet<string?>> processedContextScopesByType,
-        ApiType type,
-        MetadataTypeDefinitionName? contextDefinitionName)
+    static void RejectReachedContextRelativeValueTypeAccessibility(
+        IReadOnlyList<JsExportFunction> functions,
+        IReadOnlyDictionary<ApiType, JsonWireDirection> wireDirections,
+        ApiAssemblyIdentity? assemblyIdentity,
+        Dictionary<ApiTypeReferenceIdentity, ApiType> typesByScopedIdentity,
+        HashSet<ApiType> discovered,
+        IReadOnlyDictionary<string, MetadataTypeDefinitionName>
+            contextDefinitionNamesByScopeKey)
     {
-        if (!processedContextScopesByType.TryGetValue(
-                type,
-                out HashSet<string?>? scopes))
+        if (assemblyIdentity is null
+            || contextDefinitionNamesByScopeKey.Count == 0
+            || functions.Count == 0)
         {
-            scopes = new HashSet<string?>(StringComparer.Ordinal);
-            processedContextScopesByType.Add(type, scopes);
+            return;
         }
 
-        return scopes.Add(
-            contextDefinitionName is null
-                ? null
-                : $"{contextDefinitionName.Namespace}:{string.Join(".", contextDefinitionName.Segments)}");
+        Dictionary<ApiType, Dictionary<string, JsonWireDirection>>
+            reachedContextScopesByType =
+            ResolveReachedContextScopes(
+                functions,
+                assemblyIdentity,
+                typesByScopedIdentity,
+                discovered);
+        foreach ((ApiType type,
+            Dictionary<string, JsonWireDirection> contextDirections)
+            in reachedContextScopesByType)
+        {
+            if (!wireDirections.TryGetValue(type, out JsonWireDirection directions)
+                || directions == JsonWireDirection.None
+                || type.Kind == "enum"
+                || type.JsonConverterAttributeCount > 0)
+            {
+                continue;
+            }
+
+            foreach ((string contextScopeKey,
+                JsonWireDirection contextDirectionsForType)
+                in contextDirections)
+            {
+                if (!contextDefinitionNamesByScopeKey.TryGetValue(
+                        contextScopeKey,
+                        out MetadataTypeDefinitionName? contextDefinitionName))
+                {
+                    continue;
+                }
+
+                foreach (ApiMember member in type.Members)
+                {
+                    if (!JsonWireMemberRules
+                        .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                            member,
+                            contextDirectionsForType,
+                            assemblyIdentity,
+                            typesByScopedIdentity,
+                            contextDefinitionName))
+                    {
+                        continue;
+                    }
+
+                    throw new UnsupportedJsExportSurfaceException(
+                        FormatMemberLocation(type, member),
+                        "[JsonInclude] members whose same-assembly value types depend on nested JsonSerializerContext accessibility are unsupported");
+                }
+            }
+        }
     }
+
+    static Dictionary<ApiType, Dictionary<string, JsonWireDirection>>
+        ResolveReachedContextScopes(
+        IReadOnlyList<JsExportFunction> functions,
+        ApiAssemblyIdentity assemblyIdentity,
+        Dictionary<ApiTypeReferenceIdentity, ApiType> typesByScopedIdentity,
+        HashSet<ApiType> discovered)
+    {
+        var reachedContextScopesByType =
+            new Dictionary<ApiType, Dictionary<string, JsonWireDirection>>(
+                ReferenceEqualityComparer.Instance);
+        var queue = new Queue<(
+            ApiType Type,
+            JsonWireDirection Direction,
+            string ContextScopeKey)>();
+
+        void Seed(
+            IReadOnlyList<ApiTypeReferenceIdentity> references,
+            IReadOnlyList<string> contextScopeKeys,
+            JsonWireDirection direction)
+        {
+            if (contextScopeKeys.Count == 0)
+                return;
+
+            foreach (ApiTypeReferenceIdentity reference in references)
+            {
+                if (!reference.Assembly.Equals(assemblyIdentity)
+                    || !typesByScopedIdentity.TryGetValue(
+                        reference,
+                        out ApiType? type)
+                    || !discovered.Contains(type))
+                {
+                    continue;
+                }
+
+                foreach (string contextScopeKey in contextScopeKeys)
+                {
+                    queue.Enqueue((type, direction, contextScopeKey));
+                }
+            }
+        }
+
+        foreach (JsExportFunction function in functions)
+        {
+            Seed(
+                function.ReturnWireTypeReferences,
+                function.ReturnWireContextScopeKeys,
+                JsonWireDirection.Serialize);
+            Seed(
+                function.ParameterWireTypeReferences,
+                function.ParameterWireContextScopeKeys,
+                JsonWireDirection.Deserialize);
+        }
+
+        while (queue.Count > 0)
+        {
+            (ApiType type, JsonWireDirection direction, string contextScopeKey) =
+                queue.Dequeue();
+            if (!reachedContextScopesByType.TryGetValue(
+                    type,
+                    out Dictionary<string, JsonWireDirection>?
+                        reachedScopes))
+            {
+                reachedScopes =
+                    new Dictionary<string, JsonWireDirection>(
+                        StringComparer.Ordinal);
+                reachedContextScopesByType.Add(type, reachedScopes);
+            }
+
+            reachedScopes.TryGetValue(
+                contextScopeKey,
+                out JsonWireDirection existing);
+            JsonWireDirection updated = existing | direction;
+            if (updated == existing)
+                continue;
+            reachedScopes[contextScopeKey] = updated;
+
+            if (type.Kind == "enum" || type.JsonConverterAttributeCount > 0)
+                continue;
+
+            foreach (ApiMember member in type.Members)
+            {
+                if (!JsonWireMemberRules.IsSerialized(
+                        member,
+                        direction,
+                        assemblyIdentity,
+                        typesByScopedIdentity)
+                    || member.JsonConverterAttributeCount > 0
+                    || member.SignatureModel is null)
+                {
+                    continue;
+                }
+
+                foreach (ApiTypeReferenceIdentity reference
+                    in member.SignatureModel.ReturnTypeReferences)
+                {
+                    if (!reference.Assembly.Equals(assemblyIdentity)
+                        || !typesByScopedIdentity.TryGetValue(
+                            reference,
+                            out ApiType? nestedType)
+                        || !discovered.Contains(nestedType))
+                    {
+                        continue;
+                    }
+
+                    queue.Enqueue((
+                        nestedType,
+                        direction,
+                        contextScopeKey));
+                }
+            }
+        }
+
+        return reachedContextScopesByType;
+    }
+
+    static string ContextScopeKey(
+        MetadataTypeDefinitionName contextDefinitionName) =>
+        $"{contextDefinitionName.Namespace}:{string.Join(".", contextDefinitionName.Segments)}";
 
     static int? GetDefaultContextGetterToken(
         ApiType context,

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -457,7 +457,10 @@ public static class JsExportSurfaceBuilder
 
             foreach (ApiMember member in type.Members)
             {
-                if (!JsonWireMemberRules.IsSerialized(member)
+                if (!JsonWireMemberRules.IsSerialized(
+                        member,
+                        surface.AssemblyIdentity,
+                        typesByScopedIdentity)
                     || member.JsonConverterAttributeCount > 0)
                     continue;
                 if (member.SignatureDecodeStatus
@@ -515,6 +518,7 @@ public static class JsExportSurfaceBuilder
             Enums = enums,
             WireDirections = ResolveWireDirections(
                 functions,
+                surface.AssemblyIdentity,
                 typesByScopedIdentity,
                 discovered),
         };
@@ -539,6 +543,7 @@ public static class JsExportSurfaceBuilder
     /// </remarks>
     static Dictionary<ApiType, JsonWireDirection> ResolveWireDirections(
         List<JsExportFunction> functions,
+        ApiAssemblyIdentity? assemblyIdentity,
         Dictionary<ApiTypeReferenceIdentity, ApiType> typesByScopedIdentity,
         HashSet<ApiType> discovered)
     {
@@ -585,7 +590,11 @@ public static class JsExportSurfaceBuilder
 
             foreach (ApiMember member in type.Members)
             {
-                if (!JsonWireMemberRules.IsSerialized(member, direction)
+                if (!JsonWireMemberRules.IsSerialized(
+                        member,
+                        direction,
+                        assemblyIdentity,
+                        typesByScopedIdentity)
                     || member.JsonConverterAttributeCount > 0
                     || member.SignatureModel is null)
                 {

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -199,10 +199,14 @@ public static class JsExportSurfaceBuilder
             new Dictionary<int, ApiTypeShape>();
         var unsupportedJsonTypeInfoGetterReasons =
             new Dictionary<int, string>();
+        var processedContextScopesByType =
+            new Dictionary<ApiType, HashSet<string?>>(
+                ReferenceEqualityComparer.Instance);
         var queue = new Queue<(
             string? Name,
             ApiTypeReferenceIdentity? Identity,
-            JsonWireNamingPolicy Policy)>();
+            JsonWireNamingPolicy Policy,
+            MetadataTypeDefinitionName? ContextDefinitionName)>();
 
         foreach (ApiType type in surface.Types)
         {
@@ -351,7 +355,11 @@ public static class JsExportSurfaceBuilder
                             foreach (ApiTypeReferenceIdentity reference
                                 in EnumerateNamedTypes(root!.Type!))
                             {
-                                queue.Enqueue((null, reference, policy));
+                                queue.Enqueue((
+                                    null,
+                                    reference,
+                                    policy,
+                                    type.DefinitionName));
                             }
                             break;
                         case RegisteredRootPropertyMatch.Unsupported:
@@ -404,7 +412,11 @@ public static class JsExportSurfaceBuilder
                         {
                             continue;
                         }
-                        queue.Enqueue((null, reference, policy));
+                        queue.Enqueue((
+                            null,
+                            reference,
+                            policy,
+                            type.DefinitionName));
                     }
                 }
                 else
@@ -412,7 +424,11 @@ public static class JsExportSurfaceBuilder
                     foreach (string candidate
                         in ExtractCandidateTypeNames(rootTypeName))
                     {
-                        queue.Enqueue((candidate, null, policy));
+                        queue.Enqueue((
+                            candidate,
+                            null,
+                            policy,
+                            type.DefinitionName));
                     }
                 }
             }
@@ -420,8 +436,12 @@ public static class JsExportSurfaceBuilder
 
         while (queue.Count > 0)
         {
-            (string? name, ApiTypeReferenceIdentity? identity,
-                JsonWireNamingPolicy namingPolicy) = queue.Dequeue();
+            (
+                string? name,
+                ApiTypeReferenceIdentity? identity,
+                JsonWireNamingPolicy namingPolicy,
+                MetadataTypeDefinitionName? contextDefinitionName) =
+                queue.Dequeue();
             ApiType? type = null;
             if (identity is not null)
                 typesByScopedIdentity.TryGetValue(identity, out type);
@@ -436,8 +456,7 @@ public static class JsExportSurfaceBuilder
                 policiesByType.Add(type, policies);
             }
 
-            if (!policies.Add(namingPolicy))
-                continue;
+            policies.Add(namingPolicy);
 
             type.JsonPropertyNamingPolicy = policies.Count == 1
                 ? namingPolicy
@@ -451,12 +470,31 @@ public static class JsExportSurfaceBuilder
                     records.Add(type);
             }
 
+            if (!TryRegisterContextScope(
+                    processedContextScopesByType,
+                    type,
+                    contextDefinitionName))
+            {
+                continue;
+            }
+
             if (type.Kind == "enum"
                 || type.JsonConverterAttributeCount > 0)
                 continue;
 
             foreach (ApiMember member in type.Members)
             {
+                if (JsonWireMemberRules
+                    .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                        member,
+                        surface.AssemblyIdentity,
+                        typesByScopedIdentity,
+                        contextDefinitionName))
+                {
+                    throw new UnsupportedJsExportSurfaceException(
+                        FormatMemberLocation(type, member),
+                        "[JsonInclude] members whose same-assembly value types depend on nested JsonSerializerContext accessibility are unsupported");
+                }
                 if (!JsonWireMemberRules.IsSerialized(
                         member,
                         surface.AssemblyIdentity,
@@ -477,7 +515,11 @@ public static class JsExportSurfaceBuilder
                     foreach (ApiTypeReferenceIdentity reference
                         in member.SignatureModel.ReturnTypeReferences)
                     {
-                        queue.Enqueue((null, reference, namingPolicy));
+                        queue.Enqueue((
+                            null,
+                            reference,
+                            namingPolicy,
+                            contextDefinitionName));
                     }
                 }
                 else
@@ -485,7 +527,11 @@ public static class JsExportSurfaceBuilder
                     foreach (string candidate
                         in ExtractCandidateTypeNames(propertyType))
                     {
-                        queue.Enqueue((candidate, null, namingPolicy));
+                        queue.Enqueue((
+                            candidate,
+                            null,
+                            namingPolicy,
+                            contextDefinitionName));
                     }
                 }
             }
@@ -516,6 +562,7 @@ public static class JsExportSurfaceBuilder
             Functions = functions,
             Records = records,
             Enums = enums,
+            AllTypes = surface.Types,
             WireDirections = ResolveWireDirections(
                 functions,
                 surface.AssemblyIdentity,
@@ -618,6 +665,25 @@ public static class JsExportSurfaceBuilder
         member.HasRuntimeJsExport
         || member.RuntimeJsExportAttributeCount > 0
         || member.HasMalformedRuntimeJsExportAttribute;
+
+    static bool TryRegisterContextScope(
+        Dictionary<ApiType, HashSet<string?>> processedContextScopesByType,
+        ApiType type,
+        MetadataTypeDefinitionName? contextDefinitionName)
+    {
+        if (!processedContextScopesByType.TryGetValue(
+                type,
+                out HashSet<string?>? scopes))
+        {
+            scopes = new HashSet<string?>(StringComparer.Ordinal);
+            processedContextScopesByType.Add(type, scopes);
+        }
+
+        return scopes.Add(
+            contextDefinitionName is null
+                ? null
+                : $"{contextDefinitionName.Namespace}:{string.Join(".", contextDefinitionName.Segments)}");
+    }
 
     static int? GetDefaultContextGetterToken(
         ApiType context,

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -722,6 +722,7 @@ public static class JsExportSurfaceBuilder
                 {
                     if (!JsonWireMemberRules
                         .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                            type,
                             member,
                             contextDirectionsForType,
                             assemblyIdentity,
@@ -782,14 +783,14 @@ public static class JsExportSurfaceBuilder
 
         foreach (JsExportFunction function in functions)
         {
-            Seed(
-                function.ReturnWireTypeReferences,
-                function.ReturnWireContextScopeKeys,
-                JsonWireDirection.Serialize);
-            Seed(
-                function.ParameterWireTypeReferences,
-                function.ParameterWireContextScopeKeys,
-                JsonWireDirection.Deserialize);
+            foreach (JsExportWireTypeContextPath path
+                in function.WireTypeContextPaths)
+            {
+                Seed(
+                    path.TypeReferences,
+                    path.ContextScopeKeys,
+                    path.Direction);
+            }
         }
 
         while (queue.Count > 0)

--- a/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
@@ -96,6 +96,8 @@ public static class JsonWireContractResolver
         int metadataToken,
         IReadOnlyDictionary<int, JsonSourceGenerationMode>
             registeredJsonTypeInfoGetterModes,
+        IReadOnlyDictionary<int, string>
+            registeredJsonTypeInfoContextScopeKeys,
         IReadOnlyDictionary<int, int>
             registeredJsonTypeInfoDefaultGetterTokens,
         IReadOnlyDictionary<int, ApiTypeShape>
@@ -104,6 +106,8 @@ public static class JsonWireContractResolver
             unsupportedJsonTypeInfoGetterReasons)
     {
         var parameterTypes = new List<TypeRef>();
+        var parameterContextScopeKeys = new HashSet<string>(
+            StringComparer.Ordinal);
 
         foreach (DirectCall call in bodyIndex.DirectCalls)
         {
@@ -125,13 +129,16 @@ public static class JsonWireContractResolver
                     call,
                     dto,
                     registeredJsonTypeInfoGetterModes,
+                    registeredJsonTypeInfoContextScopeKeys,
                     registeredJsonTypeInfoDefaultGetterTokens,
                     registeredJsonTypeInfoShapes,
                     unsupportedJsonTypeInfoGetterReasons,
                     JsonWireDirection.Deserialize,
-                    out _))
+                    out _,
+                    out ImmutableArray<string> contextScopeKeys))
             {
                 parameterTypes.Add(dto);
+                parameterContextScopeKeys.UnionWith(contextScopeKeys);
             }
         }
 
@@ -139,6 +146,7 @@ public static class JsonWireContractResolver
             bodyIndex,
             metadataToken,
             registeredJsonTypeInfoGetterModes,
+            registeredJsonTypeInfoContextScopeKeys,
             registeredJsonTypeInfoDefaultGetterTokens,
             registeredJsonTypeInfoShapes,
             unsupportedJsonTypeInfoGetterReasons);
@@ -158,6 +166,9 @@ public static class JsonWireContractResolver
             ReturnWireTypeReferences = returnType is not null
                 ? [.. ReferencedTypes(returnType.Value.Type).Distinct()]
                 : [],
+            ReturnWireContextScopeKeys = returnType is not null
+                ? returnType.Value.ContextScopeKeys
+                : [],
             ReturnWireTypeShape = returnType?.Shape,
             ParameterWireTypes =
                 [.. parameterTypes.Select(
@@ -166,6 +177,8 @@ public static class JsonWireContractResolver
                 [.. parameterTypes
                     .SelectMany(ReferencedTypes)
                     .Distinct()],
+            ParameterWireContextScopeKeys =
+                [.. parameterContextScopeKeys],
         };
     }
 
@@ -174,6 +187,8 @@ public static class JsonWireContractResolver
         int metadataToken,
         IReadOnlyDictionary<int, JsonSourceGenerationMode>
             registeredJsonTypeInfoGetterModes,
+        IReadOnlyDictionary<int, string>
+            registeredJsonTypeInfoContextScopeKeys,
         IReadOnlyDictionary<int, int>
             registeredJsonTypeInfoDefaultGetterTokens,
         IReadOnlyDictionary<int, ApiTypeShape>
@@ -226,6 +241,8 @@ public static class JsonWireContractResolver
 
         TypeRef? dto = null;
         ApiTypeShape? dtoShape = null;
+        var contextScopeKeys = new HashSet<string>(
+            StringComparer.Ordinal);
         foreach (MethodResultSink sink in sinks)
         {
             if (!TryGetCompleteSourceCallOffsets(
@@ -251,13 +268,16 @@ public static class JsonWireContractResolver
                         source,
                         sourceDto,
                         registeredJsonTypeInfoGetterModes,
+                        registeredJsonTypeInfoContextScopeKeys,
                         registeredJsonTypeInfoDefaultGetterTokens,
                         registeredJsonTypeInfoShapes,
                         unsupportedJsonTypeInfoGetterReasons,
                         JsonWireDirection.Serialize,
-                        out ApiTypeShape? sourceShape)
+                        out ApiTypeShape? sourceShape,
+                        out ImmutableArray<string> sourceContextScopeKeys)
                     || sourceShape is null)
                     return null;
+                contextScopeKeys.UnionWith(sourceContextScopeKeys);
                 if (dto is null)
                 {
                     dto = sourceDto;
@@ -272,7 +292,7 @@ public static class JsonWireContractResolver
         }
 
         return dto is not null && dtoShape is not null
-            ? new(dto, dtoShape)
+            ? new(dto, dtoShape, [.. contextScopeKeys])
             : null;
     }
 
@@ -349,6 +369,8 @@ public static class JsonWireContractResolver
         TypeRef dto,
         IReadOnlyDictionary<int, JsonSourceGenerationMode>
             registeredJsonTypeInfoGetterModes,
+        IReadOnlyDictionary<int, string>
+            registeredJsonTypeInfoContextScopeKeys,
         IReadOnlyDictionary<int, int>
             registeredJsonTypeInfoDefaultGetterTokens,
         IReadOnlyDictionary<int, ApiTypeShape>
@@ -356,15 +378,19 @@ public static class JsonWireContractResolver
         IReadOnlyDictionary<int, string>
             unsupportedJsonTypeInfoGetterReasons,
         JsonWireDirection direction,
-        out ApiTypeShape? authenticatedShape)
+        out ApiTypeShape? authenticatedShape,
+        out ImmutableArray<string> authenticatedContextScopeKeys)
     {
         authenticatedShape = null;
+        var authenticatedContexts = new HashSet<string>(
+            StringComparer.Ordinal);
         CallArgumentSource? argument =
             serializerCall.ArgumentSources.FirstOrDefault(
                 source => source.ArgumentIndex == 1);
         if (argument is not { IsComplete: true }
             || argument.SourceCallOffsets.IsDefaultOrEmpty)
         {
+            authenticatedContextScopeKeys = [];
             return false;
         }
 
@@ -376,6 +402,7 @@ public static class JsonWireContractResolver
                 sourceOffset);
             if (source is null)
             {
+                authenticatedContextScopeKeys = [];
                 return false;
             }
             if (unsupportedJsonTypeInfoGetterReasons.TryGetValue(
@@ -397,7 +424,14 @@ public static class JsonWireContractResolver
                     source.Callee.ReturnType,
                     dto))
             {
+                authenticatedContextScopeKeys = [];
                 return false;
+            }
+            if (registeredJsonTypeInfoContextScopeKeys.TryGetValue(
+                    source.CalleeDefinitionToken,
+                    out string? contextScopeKey))
+            {
+                authenticatedContexts.Add(contextScopeKey);
             }
             if (registeredJsonTypeInfoDefaultGetterTokens.TryGetValue(
                     source.CalleeDefinitionToken,
@@ -417,10 +451,12 @@ public static class JsonWireContractResolver
             }
             else if (!authenticatedShape.Equals(sourceShape))
             {
+                authenticatedContextScopeKeys = [];
                 return false;
             }
         }
 
+        authenticatedContextScopeKeys = [.. authenticatedContexts];
         return authenticatedShape is not null;
     }
 
@@ -748,5 +784,6 @@ public static class JsonWireContractResolver
 
     readonly record struct AuthenticatedWireType(
         TypeRef Type,
-        ApiTypeShape Shape);
+        ApiTypeShape Shape,
+        IReadOnlyList<string> ContextScopeKeys);
 }

--- a/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
@@ -108,6 +108,8 @@ public static class JsonWireContractResolver
         var parameterTypes = new List<TypeRef>();
         var parameterContextScopeKeys = new HashSet<string>(
             StringComparer.Ordinal);
+        var wireTypeContextPaths =
+            new List<JsExportWireTypeContextPath>();
 
         foreach (DirectCall call in bodyIndex.DirectCalls)
         {
@@ -139,6 +141,14 @@ public static class JsonWireContractResolver
             {
                 parameterTypes.Add(dto);
                 parameterContextScopeKeys.UnionWith(contextScopeKeys);
+                wireTypeContextPaths.Add(
+                    new JsExportWireTypeContextPath
+                    {
+                        Direction = JsonWireDirection.Deserialize,
+                        TypeReferences =
+                            [.. ReferencedTypes(dto).Distinct()],
+                        ContextScopeKeys = contextScopeKeys,
+                    });
             }
         }
 
@@ -179,6 +189,18 @@ public static class JsonWireContractResolver
                     .Distinct()],
             ParameterWireContextScopeKeys =
                 [.. parameterContextScopeKeys],
+            WireTypeContextPaths = returnType is not null
+                ? [.. wireTypeContextPaths,
+                    new JsExportWireTypeContextPath
+                    {
+                        Direction = JsonWireDirection.Serialize,
+                        TypeReferences =
+                            [.. ReferencedTypes(
+                                returnType.Value.Type).Distinct()],
+                        ContextScopeKeys =
+                            [.. returnType.Value.ContextScopeKeys],
+                    }]
+                : [.. wireTypeContextPaths],
         };
     }
 

--- a/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
@@ -181,6 +181,7 @@ public static class JsonWireMemberRules
     /// member.
     /// </summary>
     public static bool RequiresContextRelativeValueTypeAccessibilityEvidence(
+        ApiType declaringType,
         ApiMember member,
         JsonWireDirection directions,
         ApiAssemblyIdentity? assemblyIdentity,
@@ -191,7 +192,10 @@ public static class JsonWireMemberRules
         if (assemblyIdentity is null
             || contextDefinitionName is null
             || !member.HasJsonInclude
-            || !IsSerialized(member, directions))
+            || !RequiresWireParticipationOrConstructorBinding(
+                declaringType,
+                member,
+                directions))
         {
             return false;
         }
@@ -225,6 +229,7 @@ public static class JsonWireMemberRules
             typesByScopedIdentity,
         MetadataTypeDefinitionName? contextDefinitionName) =>
         RequiresContextRelativeValueTypeAccessibilityEvidence(
+            new ApiType(),
             member,
             JsonWireDirection.Both,
             assemblyIdentity,
@@ -314,6 +319,17 @@ public static class JsonWireMemberRules
         return hasJsonInclude || accessibility is null;
     }
 
+    static bool RequiresWireParticipationOrConstructorBinding(
+        ApiType declaringType,
+        ApiMember member,
+        JsonWireDirection directions) =>
+        IsSerialized(member, directions)
+        || ((directions & JsonWireDirection.Deserialize)
+                != JsonWireDirection.None
+            && RequiresConstructorBindingEvidence(
+                declaringType,
+                member));
+
     static bool HasAccessibleValueType(
         ApiMember member,
         ApiAssemblyIdentity? assemblyIdentity,
@@ -373,6 +389,8 @@ public static class JsonWireMemberRules
     {
         if (!IsSourceGeneratorTypeAccessible(
                 type,
+                assemblyIdentity,
+                typesByScopedIdentity,
                 contextDefinitionName))
             return false;
 
@@ -420,20 +438,180 @@ public static class JsonWireMemberRules
 
     static bool IsSourceGeneratorTypeAccessible(
         ApiType type,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity,
         MetadataTypeDefinitionName? contextDefinitionName)
     {
         if (type.Accessibility is null or "internal" or "protected internal")
             return true;
 
-        return type.Accessibility is "private"
-            or "protected"
-            or "private protected"
-            && contextDefinitionName is not null
-            && type.DefinitionName is { Segments.Length: > 1 } definitionName
-            && contextDefinitionName.Namespace == definitionName.Namespace
-            && ContextIsNestedWithin(
+        if (contextDefinitionName is null
+            || type.DefinitionName is not { Segments.Length: > 1 } definitionName
+            || contextDefinitionName.Namespace != definitionName.Namespace)
+        {
+            return false;
+        }
+
+        return type.Accessibility switch
+        {
+            "private" => ContextIsNestedWithin(
                 contextDefinitionName.Segments,
-                definitionName.Segments[..^1]);
+                definitionName.Segments[..^1]),
+            "protected" or "private protected" =>
+                ContextCanReachProtectedDeclaringType(
+                    definitionName,
+                    contextDefinitionName,
+                    assemblyIdentity,
+                    typesByScopedIdentity),
+            _ => false,
+        };
+    }
+
+    static bool ContextCanReachProtectedDeclaringType(
+        MetadataTypeDefinitionName definitionName,
+        MetadataTypeDefinitionName contextDefinitionName,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity)
+    {
+        IReadOnlyList<string> declaringSegments =
+            definitionName.Segments[..^1];
+        foreach (MetadataTypeDefinitionName contextContainer
+            in ContextContainerDefinitionNames(contextDefinitionName))
+        {
+            if (DefinitionNamesEqual(
+                    contextContainer.Namespace,
+                    contextContainer.Segments,
+                    definitionName.Namespace,
+                    declaringSegments))
+            {
+                return true;
+            }
+
+            if (TryGetType(
+                    contextContainer,
+                    assemblyIdentity,
+                    typesByScopedIdentity,
+                    out ApiType? contextType)
+                && contextType is not null
+                && InheritsFrom(
+                    contextType,
+                    definitionName.Namespace,
+                    declaringSegments,
+                    assemblyIdentity,
+                    typesByScopedIdentity))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static IEnumerable<MetadataTypeDefinitionName>
+        ContextContainerDefinitionNames(
+        MetadataTypeDefinitionName contextDefinitionName)
+    {
+        for (int count = 1;
+            count < contextDefinitionName.Segments.Length;
+            count++)
+        {
+            MetadataTypeDefinitionNameResult containerName =
+                MetadataTypeDefinitionName.Create(
+                    contextDefinitionName.Namespace,
+                    [.. contextDefinitionName.Segments[..count]]);
+            if (containerName is MetadataTypeDefinitionNameResult.Valid
+                { Name: var definitionName })
+            {
+                yield return definitionName;
+            }
+        }
+    }
+
+    static bool TryGetType(
+        MetadataTypeDefinitionName definitionName,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity,
+        out ApiType? type)
+    {
+        string fullName = string.IsNullOrEmpty(definitionName.Namespace)
+            ? string.Join(".", definitionName.Segments)
+            : $"{definitionName.Namespace}."
+                + string.Join(".", definitionName.Segments);
+        return typesByScopedIdentity.TryGetValue(
+            new ApiTypeReferenceIdentity(
+                assemblyIdentity,
+                fullName,
+                definitionName),
+            out type);
+    }
+
+    static bool InheritsFrom(
+        ApiType type,
+        string expectedNamespace,
+        IReadOnlyList<string> expectedSegments,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity)
+    {
+        var visited = new HashSet<ApiType>(
+            ReferenceEqualityComparer.Instance);
+        ApiType? current = type;
+        while (current is not null
+            && visited.Add(current)
+            && current.BaseTypeReference is { } baseTypeReference
+            && baseTypeReference.Assembly.Equals(assemblyIdentity))
+        {
+            if (DefinitionNamesEqual(
+                    baseTypeReference.DefinitionName?.Namespace,
+                    baseTypeReference.DefinitionName?.Segments,
+                    expectedNamespace,
+                    expectedSegments))
+            {
+                return true;
+            }
+
+            if (!typesByScopedIdentity.TryGetValue(
+                    baseTypeReference,
+                    out current))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    static bool DefinitionNamesEqual(
+        string? leftNamespace,
+        IReadOnlyList<string>? leftSegments,
+        string rightNamespace,
+        IReadOnlyList<string> rightSegments)
+    {
+        if (!string.Equals(
+                leftNamespace,
+                rightNamespace,
+                StringComparison.Ordinal)
+            || leftSegments is null
+            || leftSegments.Count != rightSegments.Count)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < leftSegments.Count; index++)
+        {
+            if (!string.Equals(
+                    leftSegments[index],
+                    rightSegments[index],
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     static bool ContextIsNestedWithin(

--- a/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
@@ -14,6 +14,22 @@ public static class JsonWireMemberRules
         IsSerialized(member, JsonWireDirection.Both);
 
     /// <summary>
+    /// The direction-independent membership rule, additionally requiring every
+    /// same-assembly named value type to remain accessible to the generated
+    /// serializer context.
+    /// </summary>
+    public static bool IsSerialized(
+        ApiMember member,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity) =>
+        IsSerialized(
+            member,
+            JsonWireDirection.Both,
+            assemblyIdentity,
+            typesByScopedIdentity);
+
+    /// <summary>
     /// True when the member appears in the contract for at least one of the
     /// requested <paramref name="directions"/>.
     /// </summary>
@@ -47,6 +63,23 @@ public static class JsonWireMemberRules
     }
 
     /// <summary>
+    /// True when the member appears in the contract for at least one of the
+    /// requested <paramref name="directions"/>, and every same-assembly named
+    /// value type remains accessible to the generated serializer context.
+    /// </summary>
+    public static bool IsSerialized(
+        ApiMember member,
+        JsonWireDirection directions,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity) =>
+        HasAccessibleValueType(
+            member,
+            assemblyIdentity,
+            typesByScopedIdentity)
+            && IsSerialized(member, directions);
+
+    /// <summary>
     /// True when the member's presence differs between serialization and
     /// deserialization, which is exactly when one declaration cannot describe
     /// both directions.
@@ -54,6 +87,27 @@ public static class JsonWireMemberRules
     public static bool IsDirectionSensitive(ApiMember member) =>
         IsSerialized(member, JsonWireDirection.Serialize)
             != IsSerialized(member, JsonWireDirection.Deserialize);
+
+    /// <summary>
+    /// True when the member's presence differs between serialization and
+    /// deserialization after accounting for same-assembly value-type
+    /// accessibility.
+    /// </summary>
+    public static bool IsDirectionSensitive(
+        ApiMember member,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity) =>
+        IsSerialized(
+            member,
+            JsonWireDirection.Serialize,
+            assemblyIdentity,
+            typesByScopedIdentity)
+            != IsSerialized(
+                member,
+                JsonWireDirection.Deserialize,
+                assemblyIdentity,
+                typesByScopedIdentity);
 
     /// <summary>
     /// True when deserialization may bind a getter-only property, or a
@@ -98,6 +152,25 @@ public static class JsonWireMemberRules
                 member.Accessibility,
                 member.HasJsonInclude);
     }
+
+    /// <summary>
+    /// True when deserialization may bind the member through a constructor
+    /// shape this projection does not currently model, provided the member's
+    /// value type remains accessible to the generated serializer context.
+    /// </summary>
+    public static bool RequiresConstructorBindingEvidence(
+        ApiType declaringType,
+        ApiMember member,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity) =>
+        HasAccessibleValueType(
+            member,
+            assemblyIdentity,
+            typesByScopedIdentity)
+            && RequiresConstructorBindingEvidence(
+                declaringType,
+                member);
 
     /// <summary>
     /// True when the member carries authentic <c>[JsonIgnore]</c> metadata that
@@ -181,4 +254,97 @@ public static class JsonWireMemberRules
             : memberAccessibility;
         return hasJsonInclude || accessibility is null;
     }
+
+    static bool HasAccessibleValueType(
+        ApiMember member,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity)
+    {
+        if (assemblyIdentity is null)
+            return true;
+
+        IReadOnlyList<ApiTypeReferenceIdentity>? references =
+            member.SignatureModel?.ReturnTypeReferences;
+        if (references is null || references.Count == 0)
+            return true;
+
+        return references.All(reference =>
+            IsAccessibleValueTypeReference(
+                reference,
+                assemblyIdentity,
+                typesByScopedIdentity));
+    }
+
+    static bool IsAccessibleValueTypeReference(
+        ApiTypeReferenceIdentity reference,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity)
+    {
+        if (!reference.Assembly.Equals(assemblyIdentity))
+            return true;
+
+        return typesByScopedIdentity.TryGetValue(
+                reference,
+                out ApiType? type)
+            && IsAccessibleValueType(
+                type,
+                assemblyIdentity,
+                typesByScopedIdentity);
+    }
+
+    static bool IsAccessibleValueType(
+        ApiType type,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity)
+    {
+        if (!IsSourceGeneratorTypeAccessible(type.Accessibility))
+            return false;
+
+        if (type.DefinitionName?.Segments.Length is not > 1)
+            return true;
+
+        ApiTypeReferenceIdentity? declaringTypeIdentity =
+            DeclaringTypeIdentity(type, assemblyIdentity);
+        return declaringTypeIdentity is not null
+            && typesByScopedIdentity.TryGetValue(
+                declaringTypeIdentity,
+                out ApiType? declaringType)
+            && IsAccessibleValueType(
+                declaringType,
+                assemblyIdentity,
+                typesByScopedIdentity);
+    }
+
+    static ApiTypeReferenceIdentity? DeclaringTypeIdentity(
+        ApiType type,
+        ApiAssemblyIdentity assemblyIdentity)
+    {
+        if (type.DefinitionName?.Segments.Length is not > 1)
+            return null;
+
+        int separator = type.FullName.LastIndexOf('.');
+        if (separator < 0)
+            return null;
+
+        MetadataTypeDefinitionNameResult parentName =
+            MetadataTypeDefinitionName.Create(
+                type.DefinitionName.Namespace,
+                [.. type.DefinitionName.Segments[..^1]]);
+        return parentName is MetadataTypeDefinitionNameResult.Valid
+            {
+                Name: var definitionName,
+            }
+            ? new ApiTypeReferenceIdentity(
+                assemblyIdentity,
+                type.FullName[..separator],
+                definitionName)
+            : null;
+    }
+
+    static bool IsSourceGeneratorTypeAccessible(
+        string? accessibility) =>
+        accessibility is null or "internal" or "protected internal";
 }

--- a/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
@@ -182,6 +182,7 @@ public static class JsonWireMemberRules
     /// </summary>
     public static bool RequiresContextRelativeValueTypeAccessibilityEvidence(
         ApiMember member,
+        JsonWireDirection directions,
         ApiAssemblyIdentity? assemblyIdentity,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
             typesByScopedIdentity,
@@ -189,7 +190,8 @@ public static class JsonWireMemberRules
     {
         if (assemblyIdentity is null
             || contextDefinitionName is null
-            || !member.HasJsonInclude)
+            || !member.HasJsonInclude
+            || !IsSerialized(member, directions))
         {
             return false;
         }
@@ -215,6 +217,19 @@ public static class JsonWireMemberRules
                 typesByScopedIdentity,
                 contextDefinitionName));
     }
+
+    public static bool RequiresContextRelativeValueTypeAccessibilityEvidence(
+        ApiMember member,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity,
+        MetadataTypeDefinitionName? contextDefinitionName) =>
+        RequiresContextRelativeValueTypeAccessibilityEvidence(
+            member,
+            JsonWireDirection.Both,
+            assemblyIdentity,
+            typesByScopedIdentity,
+            contextDefinitionName);
 
     /// <summary>
     /// True when the member carries authentic <c>[JsonIgnore]</c> metadata that
@@ -410,7 +425,9 @@ public static class JsonWireMemberRules
         if (type.Accessibility is null or "internal" or "protected internal")
             return true;
 
-        return type.Accessibility == "private"
+        return type.Accessibility is "private"
+            or "protected"
+            or "private protected"
             && contextDefinitionName is not null
             && type.DefinitionName is { Segments.Length: > 1 } definitionName
             && contextDefinitionName.Namespace == definitionName.Namespace

--- a/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
@@ -41,8 +41,7 @@ public static class JsonWireMemberRules
         return member.Kind switch
         {
             "property" => IsSerializedProperty(member, directions),
-            "field" => member.HasJsonInclude
-                && IsSourceGeneratorAccessible(member.Accessibility),
+            "field" => member.HasJsonInclude,
             _ => false,
         };
     }
@@ -180,11 +179,6 @@ public static class JsonWireMemberRules
         string? accessibility = hasAccessor is true
             ? accessorAccessibility
             : memberAccessibility;
-        return hasJsonInclude
-            ? IsSourceGeneratorAccessible(accessibility)
-            : accessibility is null;
+        return hasJsonInclude || accessibility is null;
     }
-
-    static bool IsSourceGeneratorAccessible(string? accessibility) =>
-        accessibility is null or "internal" or "protected internal";
 }

--- a/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
@@ -205,21 +205,16 @@ public static class JsonWireMemberRules
         if (references is null || references.Count == 0)
             return false;
 
-        return references.Any(reference =>
-            reference.Assembly.Equals(assemblyIdentity)
-            && typesByScopedIdentity.TryGetValue(
-                reference,
-                out ApiType? type)
-            && !IsAccessibleValueType(
-                type,
+        return !HasAccessibleValueType(
+                member,
                 assemblyIdentity,
                 typesByScopedIdentity,
                 contextDefinitionName: null)
-            && IsAccessibleValueType(
-                type,
+            && HasAccessibleValueType(
+                member,
                 assemblyIdentity,
                 typesByScopedIdentity,
-                contextDefinitionName));
+                contextDefinitionName);
     }
 
     public static bool RequiresContextRelativeValueTypeAccessibilityEvidence(
@@ -335,6 +330,18 @@ public static class JsonWireMemberRules
         ApiAssemblyIdentity? assemblyIdentity,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
             typesByScopedIdentity)
+        => HasAccessibleValueType(
+            member,
+            assemblyIdentity,
+            typesByScopedIdentity,
+            contextDefinitionName: null);
+
+    static bool HasAccessibleValueType(
+        ApiMember member,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity,
+        MetadataTypeDefinitionName? contextDefinitionName)
     {
         if (assemblyIdentity is null)
             return true;
@@ -348,7 +355,8 @@ public static class JsonWireMemberRules
             IsAccessibleValueTypeReference(
                 reference,
                 assemblyIdentity,
-                typesByScopedIdentity));
+                typesByScopedIdentity,
+                contextDefinitionName));
     }
 
     static bool IsAccessibleValueTypeReference(
@@ -356,6 +364,18 @@ public static class JsonWireMemberRules
         ApiAssemblyIdentity assemblyIdentity,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
             typesByScopedIdentity)
+        => IsAccessibleValueTypeReference(
+            reference,
+            assemblyIdentity,
+            typesByScopedIdentity,
+            contextDefinitionName: null);
+
+    static bool IsAccessibleValueTypeReference(
+        ApiTypeReferenceIdentity reference,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity,
+        MetadataTypeDefinitionName? contextDefinitionName)
     {
         if (!reference.Assembly.Equals(assemblyIdentity))
             return true;
@@ -366,7 +386,8 @@ public static class JsonWireMemberRules
             && IsAccessibleValueType(
                 type,
                 assemblyIdentity,
-                typesByScopedIdentity);
+                typesByScopedIdentity,
+                contextDefinitionName);
     }
 
     static bool IsAccessibleValueType(
@@ -447,17 +468,19 @@ public static class JsonWireMemberRules
             return true;
 
         if (contextDefinitionName is null
-            || type.DefinitionName is not { Segments.Length: > 1 } definitionName
-            || contextDefinitionName.Namespace != definitionName.Namespace)
+            || type.DefinitionName is not { Segments.Length: > 1 } definitionName)
         {
             return false;
         }
 
         return type.Accessibility switch
         {
-            "private" => ContextIsNestedWithin(
-                contextDefinitionName.Segments,
-                definitionName.Segments[..^1]),
+            "private"
+                when contextDefinitionName.Namespace
+                    == definitionName.Namespace =>
+                ContextIsNestedWithin(
+                    contextDefinitionName.Segments,
+                    definitionName.Segments[..^1]),
             "protected" or "private protected" =>
                 ContextCanReachProtectedDeclaringType(
                     definitionName,

--- a/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireMemberRules.cs
@@ -173,6 +173,50 @@ public static class JsonWireMemberRules
                 member);
 
     /// <summary>
+    /// True when a <c>[JsonInclude]</c> member references a same-assembly value
+    /// type that ordinary top-level source generation cannot access, but a
+    /// nested serializer context rooted inside the same declaring type could.
+    /// This is a real runtime distinction that the current surface model does
+    /// not project, so callers must fail visibly rather than silently drop the
+    /// member.
+    /// </summary>
+    public static bool RequiresContextRelativeValueTypeAccessibilityEvidence(
+        ApiMember member,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity,
+        MetadataTypeDefinitionName? contextDefinitionName)
+    {
+        if (assemblyIdentity is null
+            || contextDefinitionName is null
+            || !member.HasJsonInclude)
+        {
+            return false;
+        }
+
+        IReadOnlyList<ApiTypeReferenceIdentity>? references =
+            member.SignatureModel?.ReturnTypeReferences;
+        if (references is null || references.Count == 0)
+            return false;
+
+        return references.Any(reference =>
+            reference.Assembly.Equals(assemblyIdentity)
+            && typesByScopedIdentity.TryGetValue(
+                reference,
+                out ApiType? type)
+            && !IsAccessibleValueType(
+                type,
+                assemblyIdentity,
+                typesByScopedIdentity,
+                contextDefinitionName: null)
+            && IsAccessibleValueType(
+                type,
+                assemblyIdentity,
+                typesByScopedIdentity,
+                contextDefinitionName));
+    }
+
+    /// <summary>
     /// True when the member carries authentic <c>[JsonIgnore]</c> metadata that
     /// cannot be honored: more than one row, or a row whose constructor or
     /// <c>Condition</c> argument could not be read.
@@ -299,8 +343,22 @@ public static class JsonWireMemberRules
         ApiAssemblyIdentity assemblyIdentity,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
             typesByScopedIdentity)
+        => IsAccessibleValueType(
+            type,
+            assemblyIdentity,
+            typesByScopedIdentity,
+            contextDefinitionName: null);
+
+    static bool IsAccessibleValueType(
+        ApiType type,
+        ApiAssemblyIdentity assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            typesByScopedIdentity,
+        MetadataTypeDefinitionName? contextDefinitionName)
     {
-        if (!IsSourceGeneratorTypeAccessible(type.Accessibility))
+        if (!IsSourceGeneratorTypeAccessible(
+                type,
+                contextDefinitionName))
             return false;
 
         if (type.DefinitionName?.Segments.Length is not > 1)
@@ -315,7 +373,8 @@ public static class JsonWireMemberRules
             && IsAccessibleValueType(
                 declaringType,
                 assemblyIdentity,
-                typesByScopedIdentity);
+                typesByScopedIdentity,
+                contextDefinitionName);
     }
 
     static ApiTypeReferenceIdentity? DeclaringTypeIdentity(
@@ -345,6 +404,39 @@ public static class JsonWireMemberRules
     }
 
     static bool IsSourceGeneratorTypeAccessible(
-        string? accessibility) =>
-        accessibility is null or "internal" or "protected internal";
+        ApiType type,
+        MetadataTypeDefinitionName? contextDefinitionName)
+    {
+        if (type.Accessibility is null or "internal" or "protected internal")
+            return true;
+
+        return type.Accessibility == "private"
+            && contextDefinitionName is not null
+            && type.DefinitionName is { Segments.Length: > 1 } definitionName
+            && contextDefinitionName.Namespace == definitionName.Namespace
+            && ContextIsNestedWithin(
+                contextDefinitionName.Segments,
+                definitionName.Segments[..^1]);
+    }
+
+    static bool ContextIsNestedWithin(
+        IReadOnlyList<string> contextSegments,
+        IReadOnlyList<string> declaringSegments)
+    {
+        if (contextSegments.Count <= declaringSegments.Count)
+            return false;
+
+        for (int index = 0; index < declaringSegments.Count; index++)
+        {
+            if (!string.Equals(
+                    contextSegments[index],
+                    declaringSegments[index],
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -1245,8 +1245,9 @@ public class ApiMember
 
     /// <summary>
     /// True when the member carries <c>[JsonInclude]</c>. Source-generated STJ
-    /// can honor the opt-in only when the generated context can access the
-    /// member or relevant accessor.
+    /// can honor the opt-in for non-public accessors and fields, but
+    /// same-assembly named value types still participate only when the
+    /// generated context can access those types.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool HasJsonInclude { get; set; }

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -43,8 +43,16 @@ static class DtsEmitter
         TypeScriptGenerationDiagnostics? diagnostics = null)
     {
         ApiType[] declarationTypes = GetDeclarationTypes(surface);
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            declaredTypesByScopedIdentity =
+                DeclaredTypesByScopedIdentity(
+                    surface,
+                    declarationTypes);
         ValidateTypeNames(declarationTypes);
-        ValidateWireNames(declarationTypes);
+        ValidateWireNames(
+            surface.AssemblyIdentity,
+            declarationTypes,
+            declaredTypesByScopedIdentity);
         ValidateFunctionNames(surface.Functions);
 
         var sb = new StringBuilder();
@@ -52,6 +60,7 @@ static class DtsEmitter
             sb,
             surface,
             declarationTypes,
+            declaredTypesByScopedIdentity,
             diagnostics);
 
         foreach (JsExportFunction function in surface.Functions.OrderBy(f => f.Name, StringComparer.Ordinal))
@@ -71,14 +80,23 @@ static class DtsEmitter
         IReadOnlyDictionary<ApiType, string>? allocatedTypeNames = null)
     {
         ApiType[] declarationTypes = GetDeclarationTypes(surface);
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            declaredTypesByScopedIdentity =
+                DeclaredTypesByScopedIdentity(
+                    surface,
+                    declarationTypes);
         ValidateTypeNames(declarationTypes, allocatedTypeNames);
-        ValidateWireNames(declarationTypes);
+        ValidateWireNames(
+            surface.AssemblyIdentity,
+            declarationTypes,
+            declaredTypesByScopedIdentity);
 
         var sb = new StringBuilder();
         EmitWireDeclarations(
             sb,
             surface,
             declarationTypes,
+            declaredTypesByScopedIdentity,
             diagnostics,
             allocatedTypeNames);
         return sb.ToString();
@@ -106,10 +124,34 @@ static class DtsEmitter
                 .Where(type => ShouldEmit(surface, type)),
         ];
 
+    static IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+        DeclaredTypesByScopedIdentity(
+            ILInspector.JsExportSurface.JsExportSurface surface,
+            IEnumerable<ApiType> declarationTypes) =>
+        surface.AssemblyIdentity is { } assembly
+            ? declarationTypes
+                .Select(type => (
+                    Identity: new ApiTypeReferenceIdentity(
+                        assembly,
+                        type.FullName,
+                        type.DefinitionName),
+                    Type: type))
+                .GroupBy(candidate => candidate.Identity)
+                .Where(group => group
+                    .Select(candidate => candidate.Type)
+                    .Distinct()
+                    .Count() == 1)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.First().Type)
+            : new Dictionary<ApiTypeReferenceIdentity, ApiType>();
+
     static void EmitWireDeclarations(
         StringBuilder sb,
         ILInspector.JsExportSurface.JsExportSurface surface,
         ApiType[] declarationTypes,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            declaredTypesByScopedIdentity,
         TypeScriptGenerationDiagnostics? diagnostics,
         IReadOnlyDictionary<ApiType, string>? allocatedTypeNames = null)
     {
@@ -143,6 +185,8 @@ static class DtsEmitter
                     out JsonWireDirection recordDirections)
                     ? recordDirections
                     : JsonWireDirection.Both,
+                surface.AssemblyIdentity,
+                declaredTypesByScopedIdentity,
                 AllocatedTypeName(record, allocatedTypeNames),
                 typeEnvironment,
                 diagnostics);
@@ -478,6 +522,9 @@ static class DtsEmitter
         StringBuilder sb,
         ApiType record,
         JsonWireDirection directions,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            declaredTypesByScopedIdentity,
         string declarationName,
         TypeMappingEnvironment typeEnvironment,
         TypeScriptGenerationDiagnostics? diagnostics)
@@ -495,7 +542,10 @@ static class DtsEmitter
             EmitBlockedType(sb, declarationName);
             return;
         }
-        if (HasUnsupportedRecordWireShape(record))
+        if (HasUnsupportedRecordWireShape(
+                record,
+                assemblyIdentity,
+                declaredTypesByScopedIdentity))
         {
             ReportUnsupportedJsonWireShape(record.Name, diagnostics);
             EmitBlockedType(sb, declarationName);
@@ -507,7 +557,9 @@ static class DtsEmitter
                 member => JsonWireMemberRules
                     .RequiresConstructorBindingEvidence(
                         record,
-                        member)))
+                        member,
+                        assemblyIdentity,
+                        declaredTypesByScopedIdentity)))
         {
             ReportUnsupportedConstructorBinding(
                 record.Name,
@@ -517,7 +569,11 @@ static class DtsEmitter
         }
 
         if (directions == JsonWireDirection.Both
-            && record.Members.Any(JsonWireMemberRules.IsDirectionSensitive))
+            && record.Members.Any(member =>
+                JsonWireMemberRules.IsDirectionSensitive(
+                    member,
+                    assemblyIdentity,
+                    declaredTypesByScopedIdentity)))
         {
             ReportDirectionSplitWireShape(record.Name, diagnostics);
             EmitBlockedType(sb, declarationName);
@@ -527,7 +583,9 @@ static class DtsEmitter
         var members = record.Members
             .Where(member => JsonWireMemberRules.IsSerialized(
                 member,
-                directions))
+                directions,
+                assemblyIdentity,
+                declaredTypesByScopedIdentity))
             .Select(member => (
                 Member: member,
                 ResolvedName: member.JsonPropertyName ?? ApplyNamingPolicy(member.Name, namingPolicy)))
@@ -570,7 +628,11 @@ static class DtsEmitter
         sb.Append("}\n\n");
     }
 
-    static void ValidateWireNames(IEnumerable<ApiType> types)
+    static void ValidateWireNames(
+        ApiAssemblyIdentity? assemblyIdentity,
+        IEnumerable<ApiType> types,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            declaredTypesByScopedIdentity)
     {
         foreach (ApiType type in types)
         {
@@ -644,7 +706,10 @@ static class DtsEmitter
                 type.JsonPropertyNamingPolicy ?? JsonWireNamingPolicy.None;
             var resolvedNames = new HashSet<string>(StringComparer.Ordinal);
             foreach (ApiMember member in type.Members
-                .Where(JsonWireMemberRules.IsSerialized))
+                .Where(member => JsonWireMemberRules.IsSerialized(
+                    member,
+                    assemblyIdentity,
+                    declaredTypesByScopedIdentity)))
             {
                 string resolvedName = member.JsonPropertyName
                     ?? ApplyNamingPolicy(member.Name, namingPolicy);
@@ -895,12 +960,19 @@ static class DtsEmitter
             || !type.HasJsonStringEnumConverter
             || type.JsonConverterAttributeCount != 1);
 
-    static bool HasUnsupportedRecordWireShape(ApiType type)
+    static bool HasUnsupportedRecordWireShape(
+        ApiType type,
+        ApiAssemblyIdentity? assemblyIdentity,
+        IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
+            declaredTypesByScopedIdentity)
     {
         if (type.HasUnsupportedJsonWireAttributes
             || type.Members.Any(member =>
                 member.HasUnsupportedJsonWireAttributes
-                && JsonWireMemberRules.IsSerialized(member)))
+                && JsonWireMemberRules.IsSerialized(
+                    member,
+                    assemblyIdentity,
+                    declaredTypesByScopedIdentity)))
         {
             return true;
         }

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -47,7 +47,9 @@ static class DtsEmitter
             declaredTypesByScopedIdentity =
                 DeclaredTypesByScopedIdentity(
                     surface,
-                    declarationTypes);
+                    TypeInventory(
+                        surface,
+                        declarationTypes));
         ValidateTypeNames(declarationTypes);
         ValidateWireNames(
             surface.AssemblyIdentity,
@@ -84,7 +86,9 @@ static class DtsEmitter
             declaredTypesByScopedIdentity =
                 DeclaredTypesByScopedIdentity(
                     surface,
-                    declarationTypes);
+                    TypeInventory(
+                        surface,
+                        declarationTypes));
         ValidateTypeNames(declarationTypes, allocatedTypeNames);
         ValidateWireNames(
             surface.AssemblyIdentity,
@@ -127,9 +131,9 @@ static class DtsEmitter
     static IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
         DeclaredTypesByScopedIdentity(
             ILInspector.JsExportSurface.JsExportSurface surface,
-            IEnumerable<ApiType> declarationTypes) =>
+            IEnumerable<ApiType> types) =>
         surface.AssemblyIdentity is { } assembly
-            ? declarationTypes
+            ? types
                 .Select(type => (
                     Identity: new ApiTypeReferenceIdentity(
                         assembly,
@@ -145,6 +149,13 @@ static class DtsEmitter
                     group => group.Key,
                     group => group.First().Type)
             : new Dictionary<ApiTypeReferenceIdentity, ApiType>();
+
+    static IEnumerable<ApiType> TypeInventory(
+        ILInspector.JsExportSurface.JsExportSurface surface,
+        ApiType[] declarationTypes) =>
+        surface.AllTypes.Count > 0
+            ? surface.AllTypes
+            : declarationTypes;
 
     static void EmitWireDeclarations(
         StringBuilder sb,

--- a/tests/ILInspector.JsExportSurface.Tests/ControlPropertyNameFixture.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/ControlPropertyNameFixture.cs
@@ -109,6 +109,51 @@ internal sealed class SourceGeneratedJsonIncludeHiddenTypeFixture
 }
 #pragma warning restore CS0414
 
+internal sealed class ConverterControlledAccessibleEnumFixture
+{
+    [JsonConverter(
+        typeof(
+            JsonStringEnumConverter<
+                ConverterControlledAccessibleEnum>))]
+    public ConverterControlledAccessibleEnum ConvertedField
+        { get; set; } =
+        ConverterControlledAccessibleEnum.One;
+}
+
+public enum ConverterControlledAccessibleEnum
+{
+    One,
+    Two,
+}
+
+#pragma warning disable CS0414
+#pragma warning disable SYSLIB1038
+internal sealed partial class NestedContextJsonIncludeHiddenTypeFixture
+{
+    [JsonInclude]
+    private HiddenValue HiddenField = HiddenValue.Value;
+
+    private enum HiddenValue
+    {
+        Value,
+    }
+
+    public int Read() => (int)HiddenField;
+
+    public static string SerializeValue() =>
+        JsonSerializer.Serialize(
+            new NestedContextJsonIncludeHiddenTypeFixture(),
+            NestedContextJsonContext.Default
+                .NestedContextJsonIncludeHiddenTypeFixture);
+
+    [JsonSerializable(
+        typeof(NestedContextJsonIncludeHiddenTypeFixture))]
+    private sealed partial class NestedContextJsonContext
+        : JsonSerializerContext;
+}
+#pragma warning restore SYSLIB1038
+#pragma warning restore CS0414
+
 internal sealed class JsonIgnoreNeverFixture
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]

--- a/tests/ILInspector.JsExportSurface.Tests/ControlPropertyNameFixture.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/ControlPropertyNameFixture.cs
@@ -89,6 +89,26 @@ internal sealed class SourceGeneratedJsonIncludeAccessibilityFixture
 #pragma warning restore SYSLIB1038
 #pragma warning restore CS0414
 
+#pragma warning disable CS0414
+internal sealed class SourceGeneratedJsonIncludeHiddenTypeFixture
+{
+    public string Public { get; set; } = "public";
+
+    [JsonInclude]
+    private HiddenValue HiddenProperty { get; set; } = HiddenValue.Value;
+
+    [JsonInclude]
+    private HiddenValue HiddenField = HiddenValue.Value;
+
+    enum HiddenValue
+    {
+        Value,
+    }
+
+    public int Read() => (int)HiddenField + (int)HiddenProperty;
+}
+#pragma warning restore CS0414
+
 internal sealed class JsonIgnoreNeverFixture
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
@@ -148,6 +168,7 @@ internal enum ControlPropertyNameEnumFixture
 
 [JsonSerializable(typeof(ControlFieldPropertyNameFixture))]
 [JsonSerializable(typeof(SourceGeneratedJsonIncludeAccessibilityFixture))]
+[JsonSerializable(typeof(SourceGeneratedJsonIncludeHiddenTypeFixture))]
 internal sealed partial class ControlPropertyNameFixtureJsonContext : JsonSerializerContext;
 
 internal sealed partial class ControlPropertyNameFixtureJsonContext

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -1265,6 +1265,43 @@ public sealed class DtsEmitterTests
     }
 
     [Fact]
+    public void Emit_PreservesMemberConverterDiagnosticsWhenValueTypeIsNotDeclared()
+    {
+        using FileStream stream = File.OpenRead(
+            typeof(ConverterControlledAccessibleEnumFixture)
+                .Assembly.Location);
+        using var peReader = new PEReader(stream);
+        ApiSurface apiSurface = ApiSurfaceExtractor.Extract(
+            peReader,
+            includeAll: true);
+        ApiType record = Assert.Single(
+            apiSurface.Types,
+            type => type.Name
+                == nameof(ConverterControlledAccessibleEnumFixture));
+        var diagnostics = new TypeScriptGenerationDiagnostics();
+
+        string dts = DtsEmitter.Emit(
+            new ILInspector.JsExportSurface.JsExportSurface
+            {
+                AssemblyIdentity = apiSurface.AssemblyIdentity,
+                Records = [record],
+                AllTypes = apiSurface.Types,
+            },
+            diagnostics);
+
+        Assert.Contains(
+            "  readonly ConvertedField: unknown;",
+            dts,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            diagnostics.UnmappedTypes,
+            diagnostic =>
+                diagnostic.Location == "ConverterControlledAccessibleEnumFixture.ConvertedField"
+                && diagnostic.CSharpType
+                    == "unsupported custom JsonConverter");
+    }
+
+    [Fact]
     public void Emit_AllowsExactlyOneSupportedStringEnumConverter()
     {
         var enumType = new ApiType
@@ -2718,6 +2755,18 @@ public sealed class DtsEmitterTests
             StringComparison.Ordinal);
         Assert.DoesNotContain("hiddenProperty", json, StringComparison.Ordinal);
         Assert.DoesNotContain("hiddenField", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SourceGeneratedJson_IncludesPrivateValueTypesWhenContextIsNested()
+    {
+        string json =
+            NestedContextJsonIncludeHiddenTypeFixture.SerializeValue();
+
+        Assert.Contains(
+            "\"HiddenField\":0",
+            json,
+            StringComparison.Ordinal);
     }
 
     [Theory]

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -2612,7 +2612,7 @@ public sealed class DtsEmitterTests
     }
 
     [Fact]
-    public void Emit_UsesGetterAccessibilityForCompiledProperties()
+    public void Emit_UsesJsonIncludeToReachNonPublicCompiledMembers()
     {
         using FileStream stream = File.OpenRead(
             typeof(GetterAccessibilityFixture).Assembly.Location);
@@ -2636,13 +2636,13 @@ public sealed class DtsEmitterTests
 
         Assert.DoesNotContain("SetterOnlyAtWire", dts, StringComparison.Ordinal);
         Assert.DoesNotContain("NoGetter", dts, StringComparison.Ordinal);
-        Assert.DoesNotContain("IncludedPrivateGetter", dts, StringComparison.Ordinal);
+        Assert.Contains("  readonly IncludedPrivateGetter: string;", dts, StringComparison.Ordinal);
         Assert.Contains("  readonly IncludedInternalGetter: string;", dts, StringComparison.Ordinal);
         Assert.Contains("  readonly PublicGetter: string;", dts, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void SourceGeneratedJson_OmitsInaccessibleJsonIncludedMembers()
+    public void SourceGeneratedJson_IncludesJsonIncludedNonPublicMembers()
     {
         var value = new SourceGeneratedJsonIncludeAccessibilityFixture
         {
@@ -2655,8 +2655,14 @@ public sealed class DtsEmitterTests
             ControlPropertyNameFixtureJsonContext.Default
                 .SourceGeneratedJsonIncludeAccessibilityFixture);
 
-        Assert.DoesNotContain("IncludedPrivateGetter", json, StringComparison.Ordinal);
-        Assert.DoesNotContain("IncludedPrivateField", json, StringComparison.Ordinal);
+        Assert.Contains(
+            "\"IncludedPrivateGetter\":\"private-getter\"",
+            json,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"IncludedPrivateField\":\"private-field\"",
+            json,
+            StringComparison.Ordinal);
         Assert.Contains(
             "\"IncludedInternalGetter\":\"internal-getter\"",
             json,
@@ -2668,7 +2674,7 @@ public sealed class DtsEmitterTests
     }
 
     [Fact]
-    public void Emit_MatchesSourceGeneratedJsonIncludeAccessibility()
+    public void Emit_MatchesSourceGeneratedJsonIncludedNonPublicMembers()
     {
         using FileStream stream = File.OpenRead(
             typeof(SourceGeneratedJsonIncludeAccessibilityFixture)
@@ -2692,8 +2698,8 @@ public sealed class DtsEmitterTests
 
         string dts = DtsEmitter.Emit(surface);
 
-        Assert.DoesNotContain("IncludedPrivateGetter", dts, StringComparison.Ordinal);
-        Assert.DoesNotContain("IncludedPrivateField", dts, StringComparison.Ordinal);
+        Assert.Contains("  readonly IncludedPrivateGetter: string;", dts, StringComparison.Ordinal);
+        Assert.Contains("  readonly IncludedPrivateField: string;", dts, StringComparison.Ordinal);
         Assert.Contains("  readonly IncludedInternalGetter: string;", dts, StringComparison.Ordinal);
         Assert.Contains("  readonly IncludedInternalField: string;", dts, StringComparison.Ordinal);
     }

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -3,9 +3,12 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Runtime.Versioning;
 using System.Text.Json;
 using ILInspector.Analysis;
 using ILInspector.JsExportSurface.Fixtures;
+using ILInspector.JsExportSurface.NestedContextConstructorFixtures;
+using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
 using ILInspector.Metadata;
 
@@ -2767,6 +2770,33 @@ public sealed class DtsEmitterTests
             "\"HiddenField\":0",
             json,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [SupportedOSPlatform("browser")]
+    public void SourceGeneratedJson_IncludesProtectedValueTypesThroughDerivedNestedContext()
+    {
+        string json =
+            NestedContextProtectedValueDto.GetProtectedValues();
+
+        Assert.Contains(
+            "\"ProtectedField\":0",
+            json,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"PrivateProtectedField\":0",
+            json,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [SupportedOSPlatform("browser")]
+    public void SourceGeneratedJson_BindsConstructorOnlyNestedContextValueTypes()
+    {
+        int value = NestedContextConstructorBoundDto.ReadHidden(
+            """{"Hidden":1}""");
+
+        Assert.Equal(1, value);
     }
 
     [Theory]

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -2704,6 +2704,22 @@ public sealed class DtsEmitterTests
         Assert.Contains("  readonly IncludedInternalField: string;", dts, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void SourceGeneratedJson_OmitsJsonIncludedMembersWithInaccessibleValueTypes()
+    {
+        string json = JsonSerializer.Serialize(
+            new SourceGeneratedJsonIncludeHiddenTypeFixture(),
+            ControlPropertyNameFixtureJsonContext.Default
+                .SourceGeneratedJsonIncludeHiddenTypeFixture);
+
+        Assert.Contains(
+            "\"Public\":\"public\"",
+            json,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("hiddenProperty", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("hiddenField", json, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(nameof(InheritedWireDerivedFixture))]
     [InlineData(nameof(NumberHandlingWireFixture))]

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -8,7 +8,8 @@ using System.Text.Json;
 using ILInspector.Analysis;
 using ILInspector.JsExportSurface.Fixtures;
 using ILInspector.JsExportSurface.NestedContextConstructorFixtures;
-using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
+using ILInspector.JsExportSurface.NestedContextFixtures.Contexts;
+using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.Contexts;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
 using ILInspector.Metadata;
 
@@ -2797,6 +2798,20 @@ public sealed class DtsEmitterTests
             """{"Hidden":1}""");
 
         Assert.Equal(1, value);
+    }
+
+    [Fact]
+    [SupportedOSPlatform("browser")]
+    public void SourceGeneratedJson_OmitsPartiallyAccessibleCompoundValueTypes()
+    {
+        string json =
+            PartiallyAccessibleDerivedOwner.SerializeValue();
+
+        Assert.Contains(
+            "\"Public\":\"public\"",
+            json,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("Mixed", json, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
@@ -23,6 +23,8 @@ const getKeywordMapAsyncKey =
   facadeSource.match(/"(GetKeywordMapAsync\.-?\d+)"/)?.[1];
 const getBlobAsyncKey =
   facadeSource.match(/"(GetBlobAsync\.-?\d+)"/)?.[1];
+const getHiddenTypeJsonIncludeAsyncKey =
+  facadeSource.match(/"(GetHiddenTypeJsonIncludeAsync\.-?\d+)"/)?.[1];
 const getNullableWidgetAsyncKey =
   facadeSource.match(/"(GetNullableWidgetAsync\.-?\d+)"/)?.[1];
 const getJsonElementKey =
@@ -69,6 +71,11 @@ assert.ok(
 assert.ok(
   getBlobAsyncKey,
   "The generated GetBlobAsync runtime dispatch key was not found.",
+);
+assert.ok(
+  getHiddenTypeJsonIncludeAsyncKey,
+  "The generated GetHiddenTypeJsonIncludeAsync runtime dispatch key "
+    + "was not found.",
 );
 assert.ok(
   getNullableWidgetAsyncKey,
@@ -146,6 +153,9 @@ function managedExports(methods = {}) {
                 blobs: ["AQ==", null],
                 blobsByName: { none: null },
               })),
+            [getHiddenTypeJsonIncludeAsyncKey]:
+              methods.getHiddenTypeJsonIncludeAsync
+              ?? (async () => JSON.stringify({ public: "public" })),
             [getNullableWidgetAsyncKey]:
               methods.getNullableWidgetAsync
               ?? (async (name) => JSON.stringify({ name, count: 1 })),
@@ -286,6 +296,10 @@ async function freshFacade() {
   assert.deepEqual(
     await facade.getNullableWidgetAsync("nullable"),
     { name: "nullable", count: 1 },
+  );
+  assert.deepEqual(
+    await facade.getHiddenTypeJsonIncludeAsync(),
+    { public: "public" },
   );
   assert.deepEqual(facade.getJsonElement(), { value: "json" });
   const observed = [];

--- a/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
+++ b/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="../../src/TsJsExport.Contracts/TsJsExport.Contracts.csproj" />
     <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
     <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj" />
+    <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.NestedContextConstructorFixtures/ILInspector.JsExportSurface.NestedContextConstructorFixtures.csproj" />
     <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/ILInspector.JsExportSurface.NestedContextFixtures.csproj" />
     <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.csproj" />
     <ProjectReference

--- a/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
+++ b/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
@@ -28,6 +28,8 @@
     <ProjectReference Include="../../src/TsJsExport.Contracts/TsJsExport.Contracts.csproj" />
     <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
     <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj" />
+    <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.NestedContextFixtures/ILInspector.JsExportSurface.NestedContextFixtures.csproj" />
+    <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures/ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.csproj" />
     <ProjectReference
       Include="../../fixtures/js-export/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj"
       ReferenceOutputAssembly="false" />

--- a/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
+++ b/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="../../src/ts-jsexport/ts-jsexport.csproj" />
     <ProjectReference Include="../../src/TsJsExport.Contracts/TsJsExport.Contracts.csproj" />
     <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
+    <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.MemberConverterFixtures/ILInspector.JsExportSurface.MemberConverterFixtures.csproj" />
     <ProjectReference
       Include="../../fixtures/js-export/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj"
       ReferenceOutputAssembly="false" />

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -3620,6 +3620,27 @@ public sealed class JsExportSurfaceBuilderTests
     }
 
     [Fact]
+    public void Build_RejectsContextRelativeJsonIncludeValueTypeAccessibility()
+    {
+        using FileStream stream = File.OpenRead(
+            typeof(NestedContextJsonIncludeHiddenTypeFixture)
+                .Assembly.Location);
+        using var peReader = new PEReader(stream);
+        ApiSurface apiSurface = ApiSurfaceExtractor.Extract(
+            peReader,
+            includeAll: true);
+
+        UnsupportedJsExportSurfaceException ex =
+            Assert.Throws<UnsupportedJsExportSurfaceException>(
+                () => JsExportSurfaceBuilder.Build(apiSurface));
+
+        Assert.Contains(
+            "[JsonInclude] members whose same-assembly value types depend on nested JsonSerializerContext accessibility are unsupported",
+            ex.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Extract_DecodesByteBackedReadCommentHandlingOption()
     {
         using FileStream stream = File.OpenRead(

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -39,7 +39,7 @@ public sealed class JsExportSurfaceBuilderTests
         using var peReader = new PEReader(stream);
         ApiSurface apiSurface = ApiSurfaceExtractor.Extract(
             peReader,
-            includeAll: false);
+            includeAll: true);
         return JsExportSurfaceBuilder.Build(
             apiSurface,
             OpenWireContractBodyIndex(path));
@@ -3617,27 +3617,6 @@ public sealed class JsExportSurfaceBuilderTests
         Assert.True(included.HasJsonIgnoreNever);
         Assert.True(excluded.HasJsonIgnore);
         Assert.False(excluded.HasJsonIgnoreNever);
-    }
-
-    [Fact]
-    public void Build_RejectsContextRelativeJsonIncludeValueTypeAccessibility()
-    {
-        using FileStream stream = File.OpenRead(
-            typeof(NestedContextJsonIncludeHiddenTypeFixture)
-                .Assembly.Location);
-        using var peReader = new PEReader(stream);
-        ApiSurface apiSurface = ApiSurfaceExtractor.Extract(
-            peReader,
-            includeAll: true);
-
-        UnsupportedJsExportSurfaceException ex =
-            Assert.Throws<UnsupportedJsExportSurfaceException>(
-                () => JsExportSurfaceBuilder.Build(apiSurface));
-
-        Assert.Contains(
-            "[JsonInclude] members whose same-assembly value types depend on nested JsonSerializerContext accessibility are unsupported",
-            ex.Message,
-            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
@@ -374,6 +374,198 @@ public sealed class JsonWireMemberRulesTests
     }
 
     [Fact]
+    public void ContextRelativeAccessibilityIncludesConstructorBoundDeserializeMembers()
+    {
+        ApiAssemblyIdentity assembly = new(
+            "Fixture",
+            new Version(1, 0, 0, 0),
+            culture: null,
+            publicKeyToken: null);
+        MetadataTypeDefinitionName dtoDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["Dto"]))
+                .Name;
+        MetadataTypeDefinitionName hiddenDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["Dto", "HiddenValue"]))
+                .Name;
+        MetadataTypeDefinitionName contextDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["Dto", "NestedContextJsonContext"]))
+                .Name;
+        ApiTypeReferenceIdentity dtoReference = new(
+            assembly,
+            "Fixture.Dto",
+            dtoDefinition);
+        ApiTypeReferenceIdentity hiddenReference = new(
+            assembly,
+            "Fixture.Dto.HiddenValue",
+            hiddenDefinition);
+        var declaringType = new ApiType
+        {
+            Namespace = "Fixture",
+            Name = "Dto",
+            DefinitionName = dtoDefinition,
+            Kind = "class",
+        };
+        var member = new ApiMember
+        {
+            Name = "Hidden",
+            Kind = "property",
+            HasGetter = true,
+            HasSetter = false,
+            HasJsonInclude = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnTypeReferences = [hiddenReference],
+            },
+        };
+        declaringType.Members =
+        [
+            member,
+            new ApiMember
+            {
+                Name = ".ctor",
+                Kind = "constructor",
+                SignatureModel = new ApiSignature
+                {
+                    Parameters =
+                    [
+                        new ApiParameter
+                        {
+                            Name = "hidden",
+                            Type = "Fixture.Dto.HiddenValue",
+                        },
+                    ],
+                },
+            },
+        ];
+        var typesByScopedIdentity =
+            new Dictionary<ApiTypeReferenceIdentity, ApiType>
+            {
+                [dtoReference] = declaringType,
+                [hiddenReference] = new ApiType
+                {
+                    Namespace = "Fixture",
+                    Name = "Dto.HiddenValue",
+                    DefinitionName = hiddenDefinition,
+                    Accessibility = "private",
+                    Kind = "enum",
+                },
+            };
+
+        Assert.True(
+            JsonWireMemberRules
+                .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                    declaringType,
+                    member,
+                    JsonWireDirection.Deserialize,
+                    assembly,
+                    typesByScopedIdentity,
+                    contextDefinition));
+    }
+
+    [Fact]
+    public void ContextRelativeAccessibilityTreatsDerivedContextAsProtectedAccess()
+    {
+        ApiAssemblyIdentity assembly = new(
+            "Fixture",
+            new Version(1, 0, 0, 0),
+            culture: null,
+            publicKeyToken: null);
+        MetadataTypeDefinitionName baseDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["BaseOwner"]))
+                .Name;
+        MetadataTypeDefinitionName derivedDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["DerivedOwner"]))
+                .Name;
+        MetadataTypeDefinitionName hiddenDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["BaseOwner", "HiddenValue"]))
+                .Name;
+        MetadataTypeDefinitionName contextDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["DerivedOwner", "NestedContextJsonContext"]))
+                .Name;
+        ApiTypeReferenceIdentity baseReference = new(
+            assembly,
+            "Fixture.BaseOwner",
+            baseDefinition);
+        ApiTypeReferenceIdentity derivedReference = new(
+            assembly,
+            "Fixture.DerivedOwner",
+            derivedDefinition);
+        ApiTypeReferenceIdentity hiddenReference = new(
+            assembly,
+            "Fixture.BaseOwner.HiddenValue",
+            hiddenDefinition);
+        var declaringType = new ApiType
+        {
+            Namespace = "Fixture",
+            Name = "BaseOwner",
+            DefinitionName = baseDefinition,
+            Kind = "class",
+        };
+        ApiMember member = new()
+        {
+            Name = "Hidden",
+            Kind = "field",
+            HasJsonInclude = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnTypeReferences = [hiddenReference],
+            },
+        };
+        var typesByScopedIdentity =
+            new Dictionary<ApiTypeReferenceIdentity, ApiType>
+            {
+                [baseReference] = declaringType,
+                [derivedReference] = new ApiType
+                {
+                    Namespace = "Fixture",
+                    Name = "DerivedOwner",
+                    DefinitionName = derivedDefinition,
+                    Kind = "class",
+                    BaseTypeReference = baseReference,
+                },
+                [hiddenReference] = new ApiType
+                {
+                    Namespace = "Fixture",
+                    Name = "BaseOwner.HiddenValue",
+                    DefinitionName = hiddenDefinition,
+                    Accessibility = "protected",
+                    Kind = "enum",
+                },
+            };
+
+        Assert.True(
+            JsonWireMemberRules
+                .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                    declaringType,
+                    member,
+                    JsonWireDirection.Serialize,
+                    assembly,
+                    typesByScopedIdentity,
+                    contextDefinition));
+    }
+
+    [Fact]
     public void GetterOnlyDeserializePropertyRequiresConstructorEvidence()
     {
         ApiMember getterOnly = Property();

--- a/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
@@ -565,6 +565,237 @@ public sealed class JsonWireMemberRulesTests
                     contextDefinition));
     }
 
+    [Theory]
+    [InlineData("protected")]
+    [InlineData("private protected")]
+    public void ContextRelativeAccessibilityTreatsCrossNamespaceDerivedContextAsProtectedAccess(
+        string accessibility)
+    {
+        ApiAssemblyIdentity assembly = new(
+            "Fixture",
+            new Version(1, 0, 0, 0),
+            culture: null,
+            publicKeyToken: null);
+        MetadataTypeDefinitionName baseDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Owners",
+                    ["BaseOwner"]))
+                .Name;
+        MetadataTypeDefinitionName intermediateDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Contexts",
+                    ["IntermediateOwner"]))
+                .Name;
+        MetadataTypeDefinitionName derivedDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Contexts",
+                    ["DerivedOwner"]))
+                .Name;
+        MetadataTypeDefinitionName hiddenDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Owners",
+                    ["BaseOwner", "HiddenValue"]))
+                .Name;
+        MetadataTypeDefinitionName contextDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Contexts",
+                    ["DerivedOwner", "NestedContextJsonContext"]))
+                .Name;
+        ApiTypeReferenceIdentity baseReference = new(
+            assembly,
+            "Owners.BaseOwner",
+            baseDefinition);
+        ApiTypeReferenceIdentity intermediateReference = new(
+            assembly,
+            "Contexts.IntermediateOwner",
+            intermediateDefinition);
+        ApiTypeReferenceIdentity derivedReference = new(
+            assembly,
+            "Contexts.DerivedOwner",
+            derivedDefinition);
+        ApiTypeReferenceIdentity hiddenReference = new(
+            assembly,
+            "Owners.BaseOwner.HiddenValue",
+            hiddenDefinition);
+        var declaringType = new ApiType
+        {
+            Namespace = "Owners",
+            Name = "BaseOwner",
+            DefinitionName = baseDefinition,
+            Kind = "class",
+        };
+        ApiMember member = new()
+        {
+            Name = "Hidden",
+            Kind = "field",
+            HasJsonInclude = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnTypeReferences = [hiddenReference],
+            },
+        };
+        var typesByScopedIdentity =
+            new Dictionary<ApiTypeReferenceIdentity, ApiType>
+            {
+                [baseReference] = declaringType,
+                [intermediateReference] = new ApiType
+                {
+                    Namespace = "Contexts",
+                    Name = "IntermediateOwner",
+                    DefinitionName = intermediateDefinition,
+                    Kind = "class",
+                    BaseTypeReference = baseReference,
+                },
+                [derivedReference] = new ApiType
+                {
+                    Namespace = "Contexts",
+                    Name = "DerivedOwner",
+                    DefinitionName = derivedDefinition,
+                    Kind = "class",
+                    BaseTypeReference = intermediateReference,
+                },
+                [hiddenReference] = new ApiType
+                {
+                    Namespace = "Owners",
+                    Name = "BaseOwner.HiddenValue",
+                    DefinitionName = hiddenDefinition,
+                    Accessibility = accessibility,
+                    Kind = "enum",
+                },
+            };
+
+        Assert.True(
+            JsonWireMemberRules
+                .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                    declaringType,
+                    member,
+                    JsonWireDirection.Serialize,
+                    assembly,
+                    typesByScopedIdentity,
+                    contextDefinition));
+    }
+
+    [Fact]
+    public void ContextRelativeAccessibilityRequiresCompleteCompoundValueTypeAccess()
+    {
+        ApiAssemblyIdentity assembly = new(
+            "Fixture",
+            new Version(1, 0, 0, 0),
+            culture: null,
+            publicKeyToken: null);
+        MetadataTypeDefinitionName baseDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Owners",
+                    ["BaseOwner"]))
+                .Name;
+        MetadataTypeDefinitionName derivedDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Contexts",
+                    ["DerivedOwner"]))
+                .Name;
+        MetadataTypeDefinitionName reachableDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Owners",
+                    ["BaseOwner", "ReachableValue"]))
+                .Name;
+        MetadataTypeDefinitionName hiddenDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Owners",
+                    ["BaseOwner", "HiddenValue"]))
+                .Name;
+        MetadataTypeDefinitionName contextDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Contexts",
+                    ["DerivedOwner", "NestedContextJsonContext"]))
+                .Name;
+        ApiTypeReferenceIdentity baseReference = new(
+            assembly,
+            "Owners.BaseOwner",
+            baseDefinition);
+        ApiTypeReferenceIdentity derivedReference = new(
+            assembly,
+            "Contexts.DerivedOwner",
+            derivedDefinition);
+        ApiTypeReferenceIdentity reachableReference = new(
+            assembly,
+            "Owners.BaseOwner.ReachableValue",
+            reachableDefinition);
+        ApiTypeReferenceIdentity hiddenReference = new(
+            assembly,
+            "Owners.BaseOwner.HiddenValue",
+            hiddenDefinition);
+        var declaringType = new ApiType
+        {
+            Namespace = "Owners",
+            Name = "BaseOwner",
+            DefinitionName = baseDefinition,
+            Kind = "class",
+        };
+        ApiMember member = new()
+        {
+            Name = "Mixed",
+            Kind = "field",
+            HasJsonInclude = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnTypeReferences =
+                [
+                    reachableReference,
+                    hiddenReference,
+                ],
+            },
+        };
+        var typesByScopedIdentity =
+            new Dictionary<ApiTypeReferenceIdentity, ApiType>
+            {
+                [baseReference] = declaringType,
+                [derivedReference] = new ApiType
+                {
+                    Namespace = "Contexts",
+                    Name = "DerivedOwner",
+                    DefinitionName = derivedDefinition,
+                    Kind = "class",
+                    BaseTypeReference = baseReference,
+                },
+                [reachableReference] = new ApiType
+                {
+                    Namespace = "Owners",
+                    Name = "BaseOwner.ReachableValue",
+                    DefinitionName = reachableDefinition,
+                    Accessibility = "protected",
+                    Kind = "enum",
+                },
+                [hiddenReference] = new ApiType
+                {
+                    Namespace = "Owners",
+                    Name = "BaseOwner.HiddenValue",
+                    DefinitionName = hiddenDefinition,
+                    Accessibility = "private",
+                    Kind = "enum",
+                },
+            };
+
+        Assert.False(
+            JsonWireMemberRules
+                .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                    declaringType,
+                    member,
+                    JsonWireDirection.Serialize,
+                    assembly,
+                    typesByScopedIdentity,
+                    contextDefinition));
+    }
+
     [Fact]
     public void GetterOnlyDeserializePropertyRequiresConstructorEvidence()
     {

--- a/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
@@ -253,6 +253,127 @@ public sealed class JsonWireMemberRulesTests
     }
 
     [Fact]
+    public void ContextRelativeAccessibilityIgnoresMembersOutsideTheWireContract()
+    {
+        ApiAssemblyIdentity assembly = new(
+            "Fixture",
+            new Version(1, 0, 0, 0),
+            culture: null,
+            publicKeyToken: null);
+        MetadataTypeDefinitionName dtoDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["Dto"]))
+                .Name;
+        MetadataTypeDefinitionName hiddenDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["Dto", "HiddenValue"]))
+                .Name;
+        MetadataTypeDefinitionName contextDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["Dto", "NestedContextJsonContext"]))
+                .Name;
+        ApiTypeReferenceIdentity dtoReference = new(
+            assembly,
+            "Fixture.Dto",
+            dtoDefinition);
+        ApiTypeReferenceIdentity hiddenReference = new(
+            assembly,
+            "Fixture.Dto.HiddenValue",
+            hiddenDefinition);
+        var typesByScopedIdentity =
+            new Dictionary<ApiTypeReferenceIdentity, ApiType>
+            {
+                [dtoReference] = new ApiType
+                {
+                    Namespace = "Fixture",
+                    Name = "Dto",
+                    DefinitionName = dtoDefinition,
+                    Kind = "class",
+                },
+                [hiddenReference] = new ApiType
+                {
+                    Namespace = "Fixture",
+                    Name = "Dto.HiddenValue",
+                    DefinitionName = hiddenDefinition,
+                    Accessibility = "private",
+                    Kind = "enum",
+                },
+            };
+
+        ApiMember ignored = new()
+        {
+            Name = "Ignored",
+            Kind = "field",
+            HasJsonInclude = true,
+            JsonIgnoreConditions = [JsonWireIgnoreCondition.Always],
+            SignatureModel = new ApiSignature
+            {
+                ReturnTypeReferences = [hiddenReference],
+            },
+        };
+        ApiMember @static = new()
+        {
+            Name = "Static",
+            Kind = "field",
+            HasJsonInclude = true,
+            IsStatic = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnTypeReferences = [hiddenReference],
+            },
+        };
+        ApiMember indexer = new()
+        {
+            Name = "Item",
+            Kind = "property",
+            HasGetter = true,
+            HasSetter = true,
+            HasJsonInclude = true,
+            IndexParameterCount = 1,
+            SignatureModel = new ApiSignature
+            {
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Name = "index",
+                        Type = "int",
+                    },
+                ],
+                ReturnTypeReferences = [hiddenReference],
+            },
+        };
+
+        Assert.False(
+            JsonWireMemberRules
+                .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                    ignored,
+                    assembly,
+                    typesByScopedIdentity,
+                    contextDefinition));
+        Assert.False(
+            JsonWireMemberRules
+                .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                    @static,
+                    assembly,
+                    typesByScopedIdentity,
+                    contextDefinition));
+        Assert.False(
+            JsonWireMemberRules
+                .RequiresContextRelativeValueTypeAccessibilityEvidence(
+                    indexer,
+                    assembly,
+                    typesByScopedIdentity,
+                    contextDefinition));
+    }
+
+    [Fact]
     public void GetterOnlyDeserializePropertyRequiresConstructorEvidence()
     {
         ApiMember getterOnly = Property();

--- a/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
@@ -155,6 +155,57 @@ public sealed class JsonWireMemberRulesTests
             JsonWireMemberRules.IsSerialized(
                 privateSetter,
                 JsonWireDirection.Deserialize));
+
+        ApiMember includedPrivateGetter = Property();
+        includedPrivateGetter.HasGetter = true;
+        includedPrivateGetter.GetterAccessibility = "private";
+        includedPrivateGetter.HasSetter = true;
+        includedPrivateGetter.HasJsonInclude = true;
+
+        Assert.True(
+            JsonWireMemberRules.IsSerialized(
+                includedPrivateGetter,
+                JsonWireDirection.Serialize));
+        Assert.True(
+            JsonWireMemberRules.IsSerialized(
+                includedPrivateGetter,
+                JsonWireDirection.Deserialize));
+
+        ApiMember includedPrivateSetter = Property();
+        includedPrivateSetter.HasSetter = true;
+        includedPrivateSetter.SetterAccessibility = "private";
+        includedPrivateSetter.HasJsonInclude = true;
+
+        Assert.True(
+            JsonWireMemberRules.IsSerialized(
+                includedPrivateSetter,
+                JsonWireDirection.Serialize));
+        Assert.True(
+            JsonWireMemberRules.IsSerialized(
+                includedPrivateSetter,
+                JsonWireDirection.Deserialize));
+    }
+
+    [Fact]
+    public void JsonIncludedFieldsParticipateRegardlessOfAccessibility()
+    {
+        var privateField = new ApiMember
+        {
+            Name = "Value",
+            Kind = "field",
+            Accessibility = "private",
+            HasJsonInclude = true,
+        };
+
+        Assert.True(JsonWireMemberRules.IsSerialized(privateField));
+        Assert.True(
+            JsonWireMemberRules.IsSerialized(
+                privateField,
+                JsonWireDirection.Serialize));
+        Assert.True(
+            JsonWireMemberRules.IsSerialized(
+                privateField,
+                JsonWireDirection.Deserialize));
     }
 
     [Fact]

--- a/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonWireMemberRulesTests.cs
@@ -209,6 +209,50 @@ public sealed class JsonWireMemberRulesTests
     }
 
     [Fact]
+    public void JsonIncludedMembersRequireAccessibleSameAssemblyValueTypes()
+    {
+        ApiAssemblyIdentity assembly = new(
+            "Fixture",
+            new Version(1, 0, 0, 0),
+            culture: null,
+            publicKeyToken: null);
+        MetadataTypeDefinitionName hiddenDefinition =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Fixture",
+                    ["Dto", "HiddenValue"]))
+                .Name;
+        ApiTypeReferenceIdentity hiddenReference = new(
+            assembly,
+            "Fixture.Dto.HiddenValue",
+            hiddenDefinition);
+        var hiddenType = new ApiType
+        {
+            Namespace = "Fixture",
+            Name = "Dto.HiddenValue",
+            DefinitionName = hiddenDefinition,
+            Accessibility = "private",
+            Kind = "enum",
+        };
+        ApiMember member = Property();
+        member.HasJsonInclude = true;
+        member.SignatureModel = new ApiSignature
+        {
+            ReturnType = "Fixture.Dto.HiddenValue",
+            ReturnTypeReferences = [hiddenReference],
+        };
+
+        Assert.False(
+            JsonWireMemberRules.IsSerialized(
+                member,
+                assembly,
+                new Dictionary<ApiTypeReferenceIdentity, ApiType>
+                {
+                    [hiddenReference] = hiddenType,
+                }));
+    }
+
+    [Fact]
     public void GetterOnlyDeserializePropertyRequiresConstructorEvidence()
     {
         ApiMember getterOnly = Property();

--- a/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
@@ -2,7 +2,7 @@ using ILInspector.JsExportSurface.Fixtures;
 using ILInspector.JsExportSurface.MemberConverterFixtures;
 using ILInspector.JsExportSurface.NestedContextConstructorFixtures;
 using ILInspector.JsExportSurface.NestedContextFixtures;
-using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
+using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.Contexts;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
 using ILInspector.JsExportSurface.TypeScriptFixtures;
 using TsJsExport;
@@ -247,11 +247,20 @@ public sealed class TsJsExportCommandTests
                 """,
                 source,
                 StringComparison.Ordinal);
+            Assert.Contains(
+                """
+                export interface PartiallyAccessibleBaseOwner {
+                  readonly Public: string;
+                }
+                """,
+                source,
+                StringComparison.Ordinal);
             Assert.DoesNotContain(
                 "UnreachedNestedContextDto",
                 source,
                 StringComparison.Ordinal);
             Assert.DoesNotContain("Ignored", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Mixed", source, StringComparison.Ordinal);
             Assert.DoesNotContain("Shared", source, StringComparison.Ordinal);
             Assert.DoesNotContain("Item", source, StringComparison.Ordinal);
             Assert.DoesNotContain("HiddenValue", source, StringComparison.Ordinal);

--- a/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
@@ -1,5 +1,7 @@
 using ILInspector.JsExportSurface.Fixtures;
 using ILInspector.JsExportSurface.MemberConverterFixtures;
+using ILInspector.JsExportSurface.NestedContextFixtures;
+using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
 using ILInspector.JsExportSurface.TypeScriptFixtures;
 using TsJsExport;
@@ -175,6 +177,103 @@ public sealed class TsJsExportCommandTests
             Assert.Empty(output.ToString());
             Assert.Contains(
                 "ConverterControlledDto.Value: unsupported custom JsonConverter has no TypeScript mapping.",
+                error.ToString(),
+                StringComparison.Ordinal);
+            Assert.Equal(existing, File.ReadAllText(outputPath));
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Invoke_IgnoresUnserializedNestedContextMembersAndUnreachedContexts()
+    {
+        string outputPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"ts-jsexport-nested-context-safe-{Guid.NewGuid():N}.ts");
+        try
+        {
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            int exitCode = TsJsExportCommand.Invoke(
+                [
+                    typeof(NestedContextFixtureExports).Assembly.Location,
+                    "--runtime-module",
+                    "./dotnet.js",
+                    "--output",
+                    outputPath,
+                ],
+                output,
+                error);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(output.ToString());
+            Assert.Empty(error.ToString());
+
+            string source = File.ReadAllText(outputPath);
+            Assert.Contains(
+                """
+                export interface NestedContextSafeDto {
+                  readonly Public: string;
+                }
+                """,
+                source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                """
+                export interface SimpleDto {
+                  readonly Value: string;
+                }
+                """,
+                source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "UnreachedNestedContextDto",
+                source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("Ignored", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Shared", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Item", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("HiddenValue", source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Invoke_RejectsReachedNestedContextProtectedValueTypes()
+    {
+        string outputPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"ts-jsexport-nested-context-unsupported-{Guid.NewGuid():N}.ts");
+        const string existing = "// existing output\n";
+        try
+        {
+            File.WriteAllText(outputPath, existing);
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            int exitCode = TsJsExportCommand.Invoke(
+                [
+                    typeof(NestedContextProtectedValueDto)
+                        .Assembly.Location,
+                    "--runtime-module",
+                    "./dotnet.js",
+                    "--output",
+                    outputPath,
+                ],
+                output,
+                error);
+
+            Assert.Equal(1, exitCode);
+            Assert.Empty(output.ToString());
+            Assert.Contains(
+                "same-assembly value types depend on nested JsonSerializerContext accessibility are unsupported",
                 error.ToString(),
                 StringComparison.Ordinal);
             Assert.Equal(existing, File.ReadAllText(outputPath));

--- a/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
@@ -1,5 +1,6 @@
 using ILInspector.JsExportSurface.Fixtures;
 using ILInspector.JsExportSurface.MemberConverterFixtures;
+using ILInspector.JsExportSurface.NestedContextConstructorFixtures;
 using ILInspector.JsExportSurface.NestedContextFixtures;
 using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
@@ -230,6 +231,22 @@ public sealed class TsJsExportCommandTests
                 """,
                 source,
                 StringComparison.Ordinal);
+            Assert.Contains(
+                """
+                export interface CrossContextTopDto {
+                  readonly Public: string;
+                }
+                """,
+                source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                """
+                export interface CrossContextNestedDto {
+                  readonly Value: number;
+                }
+                """,
+                source,
+                StringComparison.Ordinal);
             Assert.DoesNotContain(
                 "UnreachedNestedContextDto",
                 source,
@@ -238,6 +255,7 @@ public sealed class TsJsExportCommandTests
             Assert.DoesNotContain("Shared", source, StringComparison.Ordinal);
             Assert.DoesNotContain("Item", source, StringComparison.Ordinal);
             Assert.DoesNotContain("HiddenValue", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Hidden:", source, StringComparison.Ordinal);
         }
         finally
         {
@@ -261,6 +279,45 @@ public sealed class TsJsExportCommandTests
             int exitCode = TsJsExportCommand.Invoke(
                 [
                     typeof(NestedContextProtectedValueDto)
+                        .Assembly.Location,
+                    "--runtime-module",
+                    "./dotnet.js",
+                    "--output",
+                    outputPath,
+                ],
+                output,
+                error);
+
+            Assert.Equal(1, exitCode);
+            Assert.Empty(output.ToString());
+            Assert.Contains(
+                "same-assembly value types depend on nested JsonSerializerContext accessibility are unsupported",
+                error.ToString(),
+                StringComparison.Ordinal);
+            Assert.Equal(existing, File.ReadAllText(outputPath));
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Invoke_RejectsNestedContextConstructorBoundValueTypes()
+    {
+        string outputPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"ts-jsexport-nested-context-constructor-{Guid.NewGuid():N}.ts");
+        const string existing = "// existing output\n";
+        try
+        {
+            File.WriteAllText(outputPath, existing);
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            int exitCode = TsJsExportCommand.Invoke(
+                [
+                    typeof(NestedContextConstructorBoundDto)
                         .Assembly.Location,
                     "--runtime-module",
                     "./dotnet.js",

--- a/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.JsExportSurface.Fixtures;
+using ILInspector.JsExportSurface.MemberConverterFixtures;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
 using ILInspector.JsExportSurface.TypeScriptFixtures;
 using TsJsExport;
@@ -139,6 +140,44 @@ public sealed class TsJsExportCommandTests
             Assert.DoesNotContain("hiddenProperty", source, StringComparison.Ordinal);
             Assert.DoesNotContain("hiddenField", source, StringComparison.Ordinal);
             Assert.DoesNotContain("HiddenValue", source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Invoke_PreservesUnsupportedMemberConverterDiagnostic()
+    {
+        string outputPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"ts-jsexport-member-converter-{Guid.NewGuid():N}.ts");
+        const string existing = "// existing output\n";
+        try
+        {
+            File.WriteAllText(outputPath, existing);
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            int exitCode = TsJsExportCommand.Invoke(
+                [
+                    typeof(MemberConverterFixtureExports).Assembly.Location,
+                    "--runtime-module",
+                    "./dotnet.js",
+                    "--output",
+                    outputPath,
+                ],
+                output,
+                error);
+
+            Assert.Equal(1, exitCode);
+            Assert.Empty(output.ToString());
+            Assert.Contains(
+                "ConverterControlledDto.Value: unsupported custom JsonConverter has no TypeScript mapping.",
+                error.ToString(),
+                StringComparison.Ordinal);
+            Assert.Equal(existing, File.ReadAllText(outputPath));
         }
         finally
         {

--- a/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/TsJsExportCommandTests.cs
@@ -1,5 +1,6 @@
 using ILInspector.JsExportSurface.Fixtures;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
+using ILInspector.JsExportSurface.TypeScriptFixtures;
 using TsJsExport;
 using TsJsExport.ContextFixtures.Alpha;
 using TsJsExport.ContextFixtures.Host;
@@ -93,6 +94,51 @@ public sealed class TsJsExportCommandTests
                 error.ToString(),
                 StringComparison.Ordinal);
             Assert.Equal(existing, File.ReadAllText(outputPath));
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void Invoke_OmitsJsonIncludedMembersWhoseValueTypesAreInaccessible()
+    {
+        string outputPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"ts-jsexport-hidden-jsoninclude-{Guid.NewGuid():N}.ts");
+        try
+        {
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            int exitCode = TsJsExportCommand.Invoke(
+                [
+                    typeof(TypeScriptFixtureExports).Assembly.Location,
+                    "--runtime-module",
+                    "./dotnet.js",
+                    "--output",
+                    outputPath,
+                ],
+                output,
+                error);
+
+            Assert.Equal(0, exitCode);
+            Assert.Empty(output.ToString());
+            Assert.Empty(error.ToString());
+
+            string source = File.ReadAllText(outputPath);
+            Assert.Contains(
+                """
+                export interface HiddenTypeJsonIncludeDto {
+                  readonly public: string;
+                }
+                """,
+                source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("hiddenProperty", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("hiddenField", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("HiddenValue", source, StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
Fixes #4752.

## Demo

Before, the runtime regression reproduced on current `main` with the repository SDK/runtime:

```sh
dotnet run --project tests/ILInspector.JsExportSurface.Tests -c Release -- --filter-method "*SourceGeneratedJson_OmitsInaccessibleJsonIncludedMembers*"
```

```text
failed ILInspector.JsExportSurface.Tests.DtsEmitterTests.SourceGeneratedJson_OmitsInaccessibleJsonIncludedMembers (16ms)
  Assert.DoesNotContain() Failure: Sub-string found
             ↓ (pos 2)
  String: "{"IncludedPrivateGetter":"private-getter","Include"···
  Found:  "IncludedPrivateGetter"
```

After this change, the corrected regression test passes and the emitted `.d.ts` contract matches the runtime JSON contract for the same fixture:

```sh
dotnet run --project tests/ILInspector.JsExportSurface.Tests -c Release -- --filter-method "*SourceGeneratedJson_IncludesJsonIncludedNonPublicMembers*"
```

```text
Test run summary: Passed! - /Users/rich/git/dotnet-inspect/.worktrees/fix-4752/tests/ILInspector.JsExportSurface.Tests/bin/Release/net11.0/ILInspector.JsExportSurface.Tests.dll (net11.0|arm64)
  total: 1
  failed: 0
  succeeded: 1
  skipped: 0
  duration: 124ms
```

## Root cause

`ILInspector.JsExportSurface` had hard-coded older `System.Text.Json` source-generator rules: `JsonWireMemberRules` treated `[JsonInclude]` members as participating only when the member/accessor accessibility was effectively public or internal, so `DtsEmitter` omitted `IncludedPrivateGetter` and `IncludedPrivateField` from the generated TypeScript contract.

That assumption no longer matches the repository runtime contract. The repository SDK is `11.0.100-preview.7.26381.103`, which carries the `System.Text.Json` change from [dotnet/runtime#124650](https://github.com/dotnet/runtime/pull/124650) and the [.NET 11 Preview 4 libraries release notes](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview4/libraries.md#systemtextjson-improvements): the source generator now uses `[UnsafeAccessor]` or cached reflection delegates for inaccessible members, explicitly enabling `[JsonInclude]` on inaccessible properties and fields. Under that runtime, the generated `JsonTypeInfo` includes the fixture's private-getter property and private field, so the failing test was exposing a real product/runtime mismatch rather than a bad runtime.

This change updates the JS-export wire-member rule to treat authentic `[JsonInclude]` properties and fields as part of the generated JSON contract regardless of accessor/member accessibility, and updates the regression tests to assert the current runtime behavior.

## Validation

```text
dotnet run --project tests/ILInspector.JsExportSurface.Tests -c Release
Test run summary: Passed!
  total: 493
  failed: 0
  succeeded: 493
  skipped: 0
```

```text
dotnet build dotnet-inspect.slnx -c Release
Build succeeded.
    0 Warning(s)
    0 Error(s)
```
