### PR TITLE
Restore call-graph version-skew warning coverage

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -15430,7 +15430,48 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_CallGraph_VersionSkewedCallerScopeIsCompleteAndEmpty()
+    public async Task Member_CallGraph_VersionSkewedCallerScopeWarns()
+    {
+        string directory = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-version-skew-").FullName;
+        try
+        {
+            string caller =
+                FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath();
+            File.Copy(
+                caller,
+                Path.Combine(directory, Path.GetFileName(caller)));
+
+            var (exit, output, error) = await RunAppAsync(
+                "member",
+                "--library",
+                FixtureCatalog.AnalysisCallerGraphTargetV2.AssemblyPath(),
+                "-m",
+                "Api.Ping",
+                "--index",
+                "1",
+                "-S",
+                "Call Graph",
+                "--bin",
+                directory,
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("## Call Graph", output);
+            Assert.DoesNotContain("Shared.Entry.Run", output);
+            Assert.Contains(
+                "Warning: Call graph results are incomplete because one or more assembly bindings could not be completely reconciled within the selected graph scope.",
+                error);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Member_CallGraph_VersionSkewedCallerScopeWithExactTargetBindingIsCompleteAndEmpty()
     {
         string directory = Directory.CreateTempSubdirectory(
             "dotnet-inspect-version-skew-").FullName;


### PR DESCRIPTION
Fixes #5345.

**Claim:** restore end-to-end CLI coverage for the real incomplete caller-scope version-skew path while preserving the exact-bound complete-empty contract.

**Evidence:** the CLI still emits the incomplete call-graph warning when only a skewed caller candidate is available; the stale failing test had stopped constructing that condition after #5251 because it copied the exact v1 target alongside the caller.

**Compatibility:** no product behavior change. The exact-bound v1-present case remains a complete empty graph with no warning.

## Demo

Before, the stale gate no longer represented incomplete skew and the original assertion failed on the #5251 baseline:

```text
Assert.Contains() Failure: Sub-string not found
String:    ""
Not found: "Warning: Call graph results are incomplete because"...
src/dotnet-inspect.Tests/CommandExecutionTests.cs:15189
```

After, the restored warning case copies only the caller assembly into `--bin`, so the command still renders the empty graph and also emits the expected incompleteness warning:

```text
$ dotnet run --project src/dotnet-inspect -c Release --no-build -- member \
    --library artifacts/bin/ILInspector.Analysis.CallerGraphTargetV2/release/ILInspector.Analysis.CallerGraphTarget.dll \
    -m Api.Ping --index 1 -S "Call Graph" \
    --bin /tmp/caller-only --tips q

# Target.Api.Ping

Type: Target.Api | Library: ILInspector.Analysis.CallerGraphTarget | Source: Library

## Callers

No callers found in this assembly.

## Call Graph

No inbound callers or outbound calls found for this method.

Warning: Call graph results are incomplete because one or more assembly bindings could not be completely reconciled within the selected graph scope.
```

Neighboring exact-binding case (caller plus exact `Target` v1 in `--bin`) remains complete and warning-free:

```text
$ dotnet run --project src/dotnet-inspect -c Release --no-build -- member \
    --library artifacts/bin/ILInspector.Analysis.CallerGraphTargetV2/release/ILInspector.Analysis.CallerGraphTarget.dll \
    -m Api.Ping --index 1 -S "Call Graph" \
    --bin /tmp/caller-plus-target-v1 --tips q

# Target.Api.Ping

Type: Target.Api | Library: ILInspector.Analysis.CallerGraphTarget | Source: Library

## Callers

No callers found in this assembly.

## Call Graph

No inbound callers or outbound calls found for this method.
```

## Root cause

I took path **(b)**.

#5251 changed caller-scope admission to honor binding-miss name ownership and exact ECMA assembly identity when planning caller scopes. Once the test directory contains both the caller assembly and `Target` v1, the caller's exact reference to `Target` v1 is conclusively resolved to that v1 assembly and ruled out for a graph rooted at `Target` v2. That is an authoritative `Complete(empty)` result, not `Incomplete(partial)`, so the CLI correctly omits the warning there.

The completeness-warning mechanism itself stayed intact. The existing focused query gate `CrossLibrary_VersionSkewRetainsIncompleteDiagnostics` already proves the incomplete path when the exact requested target is unavailable and only the skewed candidate remains. This PR restores the CLI regression test to that real incomplete construction by copying only the caller assembly for the warning case, and it keeps the exact-binding no-warning case as a neighboring command test.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- --filter-method '*Member_CallGraph_VersionSkewedCallerScope*'` → 2 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- --filter-class 'DotnetInspector.Tests.CommandExecutionTests'` → 1718 total, 0 failed, 1715 passed, 3 skipped
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build` → 6081 total, 0 failed, 6050 passed, 31 skipped
