### PR TITLE
Make SkeletonEmit duplicate-type canary deterministic

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -34,11 +34,11 @@ public class SkeletonEmitTests
             $"Skeleton failed to compile for {FixtureType}.Sum: {sum.Status} / {sum.Detail}");
         Assert.Equal(FidelityCheck.CompileBackStatus.Exact, sum.Status);
 
-        string path = CreateAssemblyWithDuplicateUnrelatedType();
+        var duplicateAssembly = CreateAssemblyWithDuplicateUnrelatedType();
         try
         {
             var duplicateType = Assert.Single(FidelityCheck.Evaluate(
-                path,
+                duplicateAssembly.Path,
                 type => type == FixtureType,
                 method => method.Method == "Sum"));
 
@@ -47,7 +47,7 @@ public class SkeletonEmitTests
         }
         finally
         {
-            File.Delete(path);
+            Directory.Delete(duplicateAssembly.Directory, recursive: true);
         }
     }
 
@@ -137,9 +137,12 @@ public class SkeletonEmitTests
             $"Skeleton dropped the generic constraint on {method}: {result.Status} / {result.Detail}");
     }
 
-    static string CreateAssemblyWithDuplicateUnrelatedType()
+    static (string Directory, string Path) CreateAssemblyWithDuplicateUnrelatedType()
     {
-        byte[] bytes = File.ReadAllBytes(typeof(SkeletonEmitFixture).Assembly.Location);
+        string sourcePath = typeof(SkeletonEmitFixture).Assembly.Location;
+        string sourceDirectory = Path.GetDirectoryName(sourcePath)
+            ?? throw new InvalidOperationException("The fixture assembly has no containing directory.");
+        byte[] bytes = File.ReadAllBytes(sourcePath);
         byte[] original = "WholeModuleHazardBravo\0"u8.ToArray();
         byte[] replacement = "WholeModuleHazardAlpha\0"u8.ToArray();
         Assert.Equal(original.Length, replacement.Length);
@@ -155,11 +158,33 @@ public class SkeletonEmitTests
         }
         Assert.True(replacements > 0, "Expected the unrelated hazard type name in the assembly metadata.");
 
-        string path = Path.Combine(
+        string directory = Path.Combine(
             Path.GetTempPath(),
-            $"fidelity-check-whole-module-{Guid.NewGuid():N}.dll");
+            $"fidelity-check-whole-module-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string targetFileName = Path.GetFileName(sourcePath);
+        string path = Path.Combine(directory, targetFileName);
         File.WriteAllBytes(path, bytes);
-        return path;
+
+        // FidelityCheck resolves sibling DLLs from the target directory. Mirror
+        // the fixture's real output closure inside a private temp directory so
+        // unrelated /tmp DLLs cannot poison this duplicate-type canary.
+        foreach (string sibling in Directory.EnumerateFiles(sourceDirectory, "*.dll"))
+        {
+            if (Path.GetFileName(sibling).Equals(targetFileName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            File.Copy(sibling, Path.Combine(directory, Path.GetFileName(sibling)));
+        }
+
+        string sourceDeps = Path.ChangeExtension(sourcePath, ".deps.json");
+        if (File.Exists(sourceDeps))
+        {
+            File.Copy(
+                sourceDeps,
+                Path.Combine(directory, Path.GetFileName(sourceDeps)));
+        }
+
+        return (directory, path);
     }
 }
 


### PR DESCRIPTION
## Demo

Before (reported in #5658 when the duplicate-type canary picked up an unrelated `/tmp` sibling DLL and failed before the duplicate declaration was reached):

```text
Assert.Contains() Failure: Sub-string not found
String:    "CS0009: Metadata file '/tmp/dotnet-inspect-partial"...
Not found: "CS0101"
  src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs(46,0)
```

After (the canary now runs from an isolated temporary output directory that mirrors the real fixture closure, so it reaches the intended duplicate-type diagnostic path deterministically):

```text
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.SkeletonEmitTests
=== TEST EXECUTION SUMMARY ===
   ILInspector.Decompiler.Tests  Total: 8, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 14.184s
```

Neighboring case (the full slow decompiler suite still stays green, aside from the existing filesystem-specific case-only skip):

```text
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release
=== TEST EXECUTION SUMMARY ===
   ILInspector.Decompiler.Tests  Total: 6428, Errors: 0, Failed: 0, Skipped: 1, Not Run: 0, Time: 1586.602s
```

## Root cause

`CreateAssemblyWithDuplicateUnrelatedType()` wrote its mutated fixture directly into `/tmp` as a lone DLL. `FidelityCheck` resolves sibling references from the target assembly's directory, so that made the compile-back closure depend on every unrelated `*.dll` already sitting in `/tmp`. In the bad run from #5658, one of those stray temp DLLs was admitted as a sibling metadata reference first, and Roslyn failed with `CS0009` on that unrelated file before it ever reached the duplicate-type declaration the gate was supposed to prove.

The fix keeps the duplicate-type mutation, but stages it in a private temporary directory that mirrors the fixture assembly's real output closure: the mutated target DLL, its sibling DLLs, and its `.deps.json`. That preserves the whole-module compile-back contract while removing ambient `/tmp` pollution from the test's inputs, so the canary once again proves the duplicate type surfaces as `CS0101`.

## Validation

```text
$ dotnet build dotnet-inspect.slnx -c Release
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.24
```

```text
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.SkeletonEmitTests
=== TEST EXECUTION SUMMARY ===
   ILInspector.Decompiler.Tests  Total: 8, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 14.184s
```

```text
$ dotnet run --project src/ILInspector.Decompiler.Tests -c Release
=== TEST EXECUTION SUMMARY ===
   ILInspector.Decompiler.Tests  Total: 6428, Errors: 0, Failed: 0, Skipped: 1, Not Run: 0, Time: 1586.602s
```
