### PR TITLE
Add website-first NuGet Gallery discovery

### DIFF
--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -186,7 +186,7 @@ capability they adapt, not ownership of the underlying product facts.
 
 ## Production surface inventory
 
-The seven rooted export assemblies contain 50 `[JSExport]` methods.
+The seven rooted export assemblies contain 51 `[JSExport]` methods.
 The generated `initializeRuntime()` and `runEntryPoint()` functions are
 generator-owned infrastructure and are not part of that count.
 
@@ -210,12 +210,13 @@ calls. `ConfigureHost` configures shared `InspectWeb.Engine.Core` policy before 
 entry point starts application work. `AsyncLoweringCanary` remains the
 deployment smoke's deterministic awaited operation.
 
-### Package facade: 18 exports
+### Package facade: 19 exports
 
 - `ActivateWorkspacePackageOccurrence`
 - `CancelPackageQuery`
 - `ClearWorkspacePackageOccurrences`
 - `GetPackageDocument`
+- `ListGalleryDiscoveryCatalog`
 - `ListPackageQueryFacets`
 - `LoadRuntimePack`
 - `LoadRuntimePackAssembly`
@@ -530,6 +531,10 @@ declarations remain authoritative. Of its 50 managed exports, 48 are bound by
 [`dotnet-inspect.ts`](../../prototypes/inspect-web/src/dotnet-inspect.ts).
 Generated lifecycle functions are not included in these counts.
 
+Website Gallery adoption (#6019) subsequently adds the synchronous startup
+operation `listGalleryDiscoveryCatalog`. It participates in the same typed
+catalog handoff; the historical counts in this migration snapshot exclude it.
+
 | Current call class | Count | Generated operations | Consumer handoff to prepare |
 | --- | ---: | --- | --- |
 | Bootstrap/diagnostic only | 2 | `configureHost`, `asyncLoweringCanary` | Retain bootstrap/diagnostic ownership; do not expose a blanket facade proxy. |
@@ -817,7 +822,7 @@ The partition is implemented when all of the following hold:
 1. `ProductionFacadeContext_DeclaresExactAssemblySet` reads the compiled
    `InspectWebJsExportContext` and proves its root identities equal the seven
    expected managed assemblies.
-2. `ProductionFacadePartition_AssignsEveryJsExportExactlyOnce` derives 50
+2. `ProductionFacadePartition_AssignsEveryJsExportExactlyOnce` derives 51
    current exports across the seven expected assemblies with no omission or
    duplicate.
 3. `ProductionFacadeProjects_HaveAcyclicOwnerReferences` proves the host,

--- a/docs/design/nuget-gallery-discovery.md
+++ b/docs/design/nuget-gallery-discovery.md
@@ -7,15 +7,29 @@ NuGet Gallery discovery in `NuGetFetch` is the sole normative owner.
 [Delivery tracker #5919](https://github.com/richlander/dotnet-inspect/issues/5919)
 records eight milestones from this design through both CLI and browser adoption.
 
-**Typed request/catalog implemented; transport and delegation remain unverified.**
+**Shared transport, local selection, and the website consumer are implemented;
+Source Delegation and CLI execution adoption remain future work.**
 [Milestone 2, #5934](https://github.com/richlander/dotnet-inspect/issues/5934),
 adds `NuGetGalleryDiscoveryRequest`, `NuGetGalleryPackageType`, and
-`NuGetGalleryDiscoveryCatalog` in NuGetFetch. These express inert source intent;
-they do not authorize access or advertise executable Gallery discovery.
+`NuGetGalleryDiscoveryCatalog` in NuGetFetch. These express inert source intent
+without authorizing access. `INuGetGalleryPackageSourceClient.DiscoverAsync`
+executes that intent through the existing authorized Gallery source.
 Existing Gallery keyword/prefix search, typed source results, deadlines, and
-the semantic row-selection language remain unchanged. The discovery transport,
-general Source Delegation protocol, and product-row/host adoption are still
-future work. Closed design issues are not implementation evidence.
+the semantic row-selection language remain supported. The website consumes
+`PackageQuery.PlanGallery` over the admitted response; it does not implement
+provider behavior in TypeScript. Closed design issues are not implementation
+evidence.
+
+For [website-first adoption #6019](https://github.com/richlander/dotnet-inspect/issues/6019),
+the user explicitly approved ordinary shared acquisition before implementation
+of Source Delegation. That consumer acquires the complete bounded metadata
+response and applies its own local selection; it does not accept delegation
+candidates, advertise delegated operations, or claim the protocol's guarantees.
+The capacity, admission, provenance, and finite-input requirements below still
+apply. Source Delegation and its L2 adapter remain separately tracked follow-ups
+in #5919. CLI query discovery is owned by
+[PR #6004](https://github.com/richlander/dotnet-inspect/pull/6004), not this
+website slice.
 
 The user goal is inexpensive discovery: find popular packages, tools, or
 templates without already knowing a package name. Gallery capabilities should
@@ -208,13 +222,13 @@ V3 search DTO; its count interpretation does not change generic feed parsing,
 which deliberately tolerates sources without useful `totalHits`.
 
 Basic discovery acquires search metadata only. Manifest, registration, archive,
-and assembly enrichment are separate capability-bearing work. The enforcing
-future gate is `GalleryDiscoveryUsesSearchMetadataOnly`; the property is
-unverified until that gate runs against the product adapter.
+and assembly enrichment are separate capability-bearing work.
+`GalleryDiscoveryClientTests.GalleryDiscoveryUsesSearchMetadataOnly` exercises
+that boundary against the product adapter.
 
 ## Source delegation and semantic limits
 
-The initial adoption supports **acquisition-only row handoff** for one declared
+The initial Source Delegation adoption supports **acquisition-only row handoff** for one declared
 bounded Gallery response input. The delegated operation prefix is empty;
 semantic `Head`, predicates, ordering, and other stages stay in the caller's
 exact residual. NuGetFetch consumes the owner-formed candidate and does not
@@ -310,7 +324,9 @@ CLI gestures / browser controls
 The CLI should consume its existing semantic `-n` lowering, not forward the
 token to HTTP. The browser should express the equivalent typed selection.
 Both should disclose the bounded Gallery input independently of the selected
-row count. The shared product binding owns its default capacity; the example
+row count. The approved first website consumer uses ordinary shared acquisition
+and local Package Query evaluation before the delegation/L2 stages in this
+eventual composition. The shared product binding owns its default capacity; the example
 below uses 200, not a new CLI flag or a mandatory source default.
 CLI text/Markdown/JSON lowering uses the existing Markout/Sections path.
 Browser interactive controls and cards remain host-specific rendering over
@@ -345,7 +361,7 @@ its acquisition cost and semantic-selection boundary.
 [#5919](https://github.com/richlander/dotnet-inspect/issues/5919) owns the
 eight-milestone sequence and retirement of the Gallery page's required-prefix
 assumption. Exact package lookup, literal prefix profiling, generic feeds, and
-existing content facets stay supported. No host behavior changes in this PR.
+existing content facets stay supported.
 
 Demand-windowed streaming is separately tracked by
 [#5816](https://github.com/richlander/dotnet-inspect/issues/5816).
@@ -402,31 +418,37 @@ curl --compressed --get \
 ```
 
 A subsequent GET with `Origin: https://dotnet-inspect.net` returned
-`Access-Control-Allow-Origin: *` on 2026-09-05 UTC. Browser adoption still
-requires a real browser run against the product path.
+`Access-Control-Allow-Origin: *` on 2026-09-05 UTC. The opt-in live
+`Gallery Package Query website over real Wasm` scenario also exercises the
+published production page through Firefox and the actual Gallery CORS path.
+This observation is reproducible with `INSPECT_WEB_GALLERY_LIVE=1`; it is not
+a permanent provider-availability claim.
 
 ### Release gates
 
-These gates are required before their respective implementation claims ship.
-Except for the request/catalog gate, they remain unimplemented and unverified.
+These Release gates cover the implemented ordinary-acquisition path.
+Delegation and L2 binding retain their separately owned, future gates.
 
 | Gate | Outcome established |
 | --- | --- |
-| `GalleryDiscoveryRequestAndCatalogTests` | Implemented in `src/NuGetFetch.Tests`: termless/type-filtered intent, explicit/default orders, prerelease intent, custom valid package types, invalid/unknown selections, bounded-input identity, and immutable descriptor discovery retain their declared meaning. Provider execution remains a later gate. |
-| `GalleryDiscoveryUsesSearchMetadataOnly` | The product adapter returns basic browse rows with only search transport; no per-package enrichment is requested. |
-| `GalleryDiscoveryProviderProjection` | Lifetime versus version downloads, optional missing fields, required-field failures, source association, provider ordering, and selector evidence are preserved. |
-| `GalleryDiscoveryFiniteInputSelection` | Product acquisition preserves K and the whole provider response; the shared adopter's residual matches `RowSelectionExecutor` over that exact finite input, including ties and zero/fewer/exactly/more-than-N rows. The fixed index/auxiliary divergence detects replacing K with N. |
-| `GalleryDiscoveryCompletionEvidence` | Evidence binds complete acquisition to the predeclared finite input, never to population exhaustion. Short/empty responses and approximate totals retain that distinction; malformed/duplicate rows, truncated transport, cancellation, and resource failures do not become complete inputs. |
-| `GalleryDiscoveryDelegationBoundaries` | Nonempty delegated prefixes, whole-population completion, out-of-range capacity, and upstream Count decline before source work; accepted failures do not fall back. Local predicate/Head composition retains the declared candidate scope. |
+| `GalleryDiscoveryRequestAndCatalogTests` | Termless/type-filtered intent, explicit/default orders, prerelease intent, custom valid package types, invalid/unknown selections, bounded-input identity, and immutable descriptor discovery retain their declared meaning. |
+| `GalleryDiscoveryClientTests.GalleryDiscoveryUsesSearchMetadataOnly` | The product adapter returns basic browse rows with only search transport; no per-package enrichment is requested. |
+| `GalleryDiscoveryClientTests` | Lifetime versus version downloads, optional missing fields, required-field failures, source association, and provider ordering are preserved. Short/empty responses and approximate totals remain finite inputs; malformed/duplicate rows, truncated transport, cancellation, deadlines, and resource failures do not become successful inputs. |
+| `PackageQueryGalleryTests.MetadataSelectionEqualsHeadOverTheFullResponseIncludingTies` and `CapacityDependentRankingDoesNotReplaceHeadWithSmallerAcquisition` | Acquisition preserves K and the whole provider response; local selection matches `RowSelectionExecutor` over that exact finite input, including ties and zero/fewer/exactly/more-than-N rows. The fixed index/auxiliary divergence detects replacing K with N. |
+| Remaining `PackageQueryGalleryTests` | Explicit manifest/content predicates retain the same finite input and real manifest evidence; local Head stops additional enrichment, while failures and cancellation remain visible. |
+| `BrowserPackageQueryOperationsTests` and `package-query*.test.ts` | Catalog/request/row projection, finite completion, source controls, stale-generation rejection, and demand credit preserve the shared input and result meaning. |
+| `Gallery Package Query website over real Wasm` | The actual published page performs termless type-filtered browse and neighboring text search with K=200, nullable metadata, and honest finite completion. The live-provider case is opt-in. |
+| `GalleryDiscoveryDelegationBoundaries` (**unimplemented/unverified**) | Future protocol adoption must decline nonempty delegated prefixes, whole-population completion, and upstream Count before source work; accepted failures must not fall back. |
 
-The adoption consumes the Source Delegation and RowSelection owners' own gates;
-these tests do not replace their effect-protocol or reference-semantics evidence.
-The L2 and host milestones separately gate binding and CLI/browser equivalence.
+The ordinary-acquisition path consumes RowSelection's reference semantics.
+Future protocol adoption must also consume the Source Delegation owner's gates;
+these tests do not replace effect-protocol evidence. The L2 and CLI milestones
+separately gate their binding and host equivalence.
 A live provider probe detects observed provider drift but does not prove future
 provider honesty; deterministic fixtures enforce adapter behavior in CI.
 
-No new scheduling protocol is defined here. Atomic one-response adoption uses
-the existing delegation contract; concurrent execution or incremental
+No new scheduling protocol is defined here. Future delegated one-response
+adoption uses the existing delegation contract; concurrent execution or incremental
 publication would require separate owner work and corresponding model evidence.
 
 [v3-search]: https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -92,6 +92,47 @@ bespoke logic the way it did before that split existed.
 
 ## Is this CLI-side or core?
 
+### Gallery source input
+
+[Website-first adoption #6019](https://github.com/richlander/dotnet-inspect/issues/6019)
+extends the shared Package Query input, not the CLI grammar. Its claim is that
+local package-facet evaluation and match selection preserve the exact bounded
+Gallery input supplied by NuGetFetch. The concrete first consumer is the
+Package Query website; [#5919](https://github.com/richlander/dotnet-inspect/issues/5919)
+retains the eight-milestone path through CLI adoption.
+
+The [Gallery discovery owner](nuget-gallery-discovery.md) supplies optional
+search text, package-type selection, source order, and one fully admitted
+response of capacity K. These source selectors are distinct from the existing
+manifest/content facets. Selecting an inspection facet never silently rewrites
+it as a Gallery selector. Literal-prefix profiling remains a separate operation.
+
+With no inspection facets, the query returns metadata rows without acquiring
+manifests or archives. Rows retain unavailable optional metadata as unavailable
+and do not manufacture manifest facts. Selecting an inspection facet explicitly
+permits its existing acquisition/evaluation tier; content facets retain their
+explicit provider requirement and 20-candidate ceiling.
+
+The local match bound N selects matching packages in incoming order, independently
+of K. A match limit may stop further enrichment, as it does for prefix queries,
+but cannot shorten the already acquired source response. Completion distinguishes
+the acquired candidate count, processed candidates, and displayed matches.
+Finishing this finite response never means exhausting the Gallery population;
+any provider total remains an estimate. Failures and cancellation retain the
+existing visible query-event contract.
+
+The user approved this ordinary acquisition/local-evaluation path before the
+general Source Delegation protocol and L2 adapter. This slice claims neither
+delegated operation execution nor upstream Count. The finite-input selection
+gate compares local selection with the row reference evaluator over the same
+acquired response, including the capacity-dependent ranking counterexample.
+
+CLI `-Q` and query-companion discovery belong to
+[PR #6004](https://github.com/richlander/dotnet-inspect/pull/6004). A source
+catalog entry or browser control does not advertise an implemented CLI binding.
+
+### Existing layering
+
 Core. Concretely:
 
 - **L1 — `DotnetInspector.Queries`.** The facet-matching engine belongs here,

--- a/docs/design/package-query-experience.md
+++ b/docs/design/package-query-experience.md
@@ -1,8 +1,8 @@
 # The package query experience
 
 This document defines the UX for a full-bleed inspect-web surface: a
-grep.app-style wide query over nuget.org, built on the streaming package
-profile introduced by
+grep.app-style wide query over nuget.org, combining Gallery discovery with the
+explicit package inspection introduced by
 [#4551](https://github.com/richlander/dotnet-inspect/pull/4551) and the
 product-owned package-query contract introduced by
 [#5020](https://github.com/richlander/dotnet-inspect/pull/5020). It extends
@@ -17,7 +17,8 @@ browser front end for that one product surface.
 end-to-end latency and Browser-pressure work.
 
 **What is enforced.** The production integration supplies the `/query` page,
-prefix form, product-issued facet catalog, streaming Browser engine source,
+optional Gallery search form, source-owned type/order catalog, product-issued
+inspection facets, streaming Browser engine source,
 explicitly bounded package-content acquisition, cancellation, honest partial
 and bounded completion states, and typed Workspace handoff. The controller,
 adapter, route, renderer, and engine projection are enforced by the
@@ -51,7 +52,7 @@ the view opens, so the natural shape is a graph you walk.
 
 The package query experience has no fixed object. The object *is* the query:
 a scope (a prefix, a curated set, a feed) plus a predicate (TFM shape,
-dependency shape, download volume) evaluated over an open-ended, streaming set
+dependency shape, download volume) evaluated over a bounded candidate set
 of packages. The natural shape is a **funnel**: cast wide, narrow with facets,
 and hand off the packages that survive to the existing single-package
 workbench rather than re-implementing package inspection inside the funnel.
@@ -63,31 +64,37 @@ for the survivors. Two different questions get two different shapes.
 ## Object model
 
 ```text
-QueryRequest       — scope + predicate + declared bound (top N / all-bounded)
+QueryRequest       — source input + predicates + independent source/match bounds
     |
     v
 QueryOutcome       — streamed QueryResultRow[] + partial failures + completion state
     |
     v
-QueryResultRow     — one package's manifest/content-derived projection + which
+QueryResultRow     — one package's metadata/manifest/content projection + which
                       predicate terms matched + why
 ```
 
 This mirrors the existing `NuGetSearchOutcome` shape (`Results` + `Failures`,
 never a success-shaped empty result) rather than inventing a new error
-convention. The runtime `QueryRequest` carries the package-ID prefix, selected
-opaque product facet descriptors, and independent candidate and match limits.
-The query bar accepts either a literal prefix or the familiar equivalent with
-one trailing `*`; the product plan removes that suffix before source work and
-evidence construction.
+convention. The runtime `QueryRequest` carries optional Gallery search text,
+source package-type and order selections, prerelease intent, selected opaque
+inspection facets, and independent candidate and match limits. Blank text
+browses; nonempty text remains Gallery search text, including any `*`. The
+website does not reinterpret it as a literal prefix or predicate language.
+The source controls project `NuGetGalleryDiscoveryCatalog`, while the shared
+[Package Query input contract](package-query-cli.md#gallery-source-input)
+owns composition with local selection. The user approved ordinary shared
+acquisition before Source Delegation for [#6019](https://github.com/richlander/dotnet-inspect/issues/6019);
+no delegation-protocol guarantee is implied.
 Facet descriptors come from `PackageQuery.Facets`; the browser does not own an
 independent predicate table. It preserves the product-issued ID, label,
 summary, weight, tier, optional compatibility-selection group, and optional
 display group. A descriptor also states whether it can form an OR-union with
 other combining members of its selection group.
 
-Rows carry the highest evidence tier used by the request: `nuspec` for search
-and manifest evidence, or `package-content` when a selected facet opens the
+Rows carry the highest evidence tier used by the request: `search-metadata`
+for basic discovery, `nuspec` for explicit manifest evaluation, or
+`package-content` when a selected facet opens the
 package archive. Package-content requests are accepted only with at most 20
 candidates. The Browser supplies that capability through its existing
 admitted package store and shared operation deadline; acquisition or
@@ -106,7 +113,7 @@ and
 
 ```text
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│  Package ID prefix [ Microsoft.                              ] [ Run query ]   │
+│  Search (optional) [ Microsoft hosting                        ] [ Run query ]   │
 ├───────────────┬────────────────────────────────────────────────────────────--┤
 │ Facets         │  Microsoft.Extensions.Hosting           nuspec              │
 │                │    Verified source · Has dependencies                       │
@@ -120,10 +127,17 @@ and
 └───────────────┴────────────────────────────────────────────────────────────--┘
 ```
 
-- **Query bar**: a required package-ID prefix input plus Run and, while
-  streaming, Cancel. It is not a free-text predicate language — see
+- **Query bar**: optional Gallery search text plus Run and, while streaming,
+  Cancel. Blank text enables browsing without inventing a package prefix.
+  It is not a free-text predicate language — see
   [Non-goals](#v1-non-goals).
-- **Facet rail**: derived from `PackageQuery.Facets`, not from a browser-owned
+- **Gallery filters**: catalog-driven package-type and source-order controls,
+  with explicit prerelease selection. All types and automatic ordering mean
+  omitted source selections, not invented provider values. Controls stay
+  separate from inspection predicates; basic results require search metadata
+  only. The website renders these controls and cards directly rather than
+  through Markout; source semantics and typed rows remain shared.
+- **Inspection facet rail**: derived from `PackageQuery.Facets`, not from a browser-owned
   vocabulary or open grammar. Selecting a facet restarts source work; it never
   client-side-filters stale rows. Product-issued selection groups make
   mutually exclusive facets, such as has-dependencies and no-dependencies,
@@ -158,15 +172,15 @@ and
 
 | State | Trigger | UI |
 |---|---|---|
-| Composing | Query surface opened with no request yet | Prefix form and facet rail stay visible; the result pane explains how to start |
+| Composing | Query surface opened with no request yet | Optional search, Gallery filters, and inspection facets stay visible; the result pane explains termless browsing |
 | Streaming | Request dispatched | Source, manifest, and package-content progress updates as bounded work advances; the first 20 matches fill the initial Browser window and near-end scroll pressure requests 10 more at a time; running count and cancel affordance remain visible; facets stay interactive and re-scope the live stream |
 | Partial failure | One source/page fails | Rows already fetched stay visible; a persistent banner names the failed producer or package, matching `NuGetSearchOutcome.Failures` — never silently drop to a smaller "complete" count |
-| Bounded-complete | Stream reaches the declared cap or the source is exhausted | Footer states which one explicitly: `"first 1,500 relevance-ranked ids"` vs. `"all 340 matches"` — the exhaustiveness claim from the funnel-feasibility analysis is rendered, not just known internally; if a source also failed partway *and the cap was reached via exhaustion*, the footer says so ("all matches from sources that succeeded") rather than overclaiming completeness — a stream stopped by hitting the declared cap keeps its `bounded: <reason>` label regardless, since a cap-reached outcome never claimed exhaustiveness to begin with |
+| Bounded-complete | The local match limit or the finite Gallery response is finished | State the acquired response size, its capacity, and the match limit when reached. Any Gallery total is explicitly an estimate. Even an empty or short response is bounded, never "all matches" or population exhaustion; item failures remain visible. |
 | Failed | The request itself never reached a completion (a rejected/thrown source, not just a per-page failure) | A distinct "query failed" state naming the error, never rendered as a confirmed empty or still-streaming result |
 | Cancelled with no rows yet | The user cancels before any page arrived | A distinct "cancelled before any matches" state, never rendered as a confirmed empty result |
 | Empty | Predicate matches nothing *and* the search actually finished with no failures | Empty-state card suggesting a broader facet, not a bare blank pane |
 
-Changing the prefix, toggling a facet, cancelling, leaving the route, or
+Changing the search text, changing a source selector, toggling a facet, cancelling, leaving the route, or
 starting another run aborts or supersedes the active source operation. Rows
 already received remain visible after explicit cancellation, while events from
 an older generation cannot enter a replacement outcome.
@@ -236,7 +250,7 @@ authority path rather than copy the Package Query generation guard.
 ## Sharing and URL shape
 
 The first production route stores no query request or outcome in the URL.
-Directly loading or refreshing `/query` starts with an empty prefix and no
+Directly loading or refreshing `/query` starts with empty search text and no
 selected facets. Browser Back and Forward retain in-memory query state for the
 session; the request and outcome remain absent from URL and history metadata. A
 future sharing design may define a product-issued query record, but it must not
@@ -408,12 +422,12 @@ and browser-history and focus-return outcomes are proved by
 2. Toggle two product-issued facets and confirm that each change starts
    a fresh engine request with opaque IDs, cancels the prior request, and
    suppresses its late rows and failures.
-3. Confirm that product rows, evidence, partial failures, and exhausted,
+3. Confirm that product rows, evidence, partial failures, and finite-response,
    bounded, failed, cancelled, and zero-row completion states remain distinct
    per the [States](#states) table.
 4. Cancel after rows arrive and confirm that the rows remain visible, the state
    reads as cancelled, and the Browser source operation stops.
-5. Change the prefix, leave the route, and start another run; confirm each
+5. Change the search text, leave the route, and start another run; confirm each
    aborts or supersedes the active source operation and that events from an
    older generation cannot enter a replacement outcome.
 6. Open a row in Workspace and confirm one typed package transition using its
@@ -431,8 +445,11 @@ and browser-history and focus-return outcomes are proved by
    to 20 candidates, archive acquisition uses the Browser package store and
    deadline, and acquisition/evaluation failures remain visible. Remove the
    final package-content facet and confirm the default returns to 200.
-10. Enter `System.*` and confirm it lowers to the literal `System.` source
-    prefix rather than treating `*` as a package-ID character.
+10. Browse with no text, select tools and templates from the source catalog,
+    then search with text. Confirm source requests preserve the text and K,
+    use the source-owned order defaults or explicit override, and acquire no
+    manifests or archives without inspection facets. Confirm lifetime-download
+    counts, unavailable metadata, and estimated totals remain distinct.
 11. Confirm that no assembly/IL promoted facet, selection checkbox, or `Deepen`
    control is rendered.
 12. Confirm that a query publishes no more than 20 matches before Browser
@@ -469,6 +486,11 @@ and browser-history and focus-return outcomes are proved by
    package-ID/version handoff to a result whose selection target may differ
    from its acquisition coordinate. This contract does not reserve controls
    for it.
+7. **#6019** makes the website the first Gallery discovery consumer, using
+   ordinary shared acquisition and local evaluation before the general Source
+   Delegation protocol. [#5919](https://github.com/richlander/dotnet-inspect/issues/5919)
+   retains the counted path through delegation and CLI adoption; CLI query
+   discovery belongs to [PR #6004](https://github.com/richlander/dotnet-inspect/pull/6004).
 
 The TypeScript state and renderer (`src/package-query.ts` and
 `src/package-query-view.ts`) retain their source-independent controller seam.

--- a/eng/generate-inspect-web-engine-facade.sh
+++ b/eng/generate-inspect-web-engine-facade.sh
@@ -132,7 +132,7 @@ fi
 "$dotnet" run \
   --project "$repo_root/src/ts-jsexport" \
   -c Release \
-  "${generator_build_properties[@]}" \
+  ${generator_build_properties[@]+"${generator_build_properties[@]}"} \
   -- \
   "$source_assembly" \
   --context "$context_type" \
@@ -167,7 +167,7 @@ for index in "${!context_artifacts[@]}"; do
     --project "$repo_root/src/ts-jsexport" \
     -c Release \
     --no-build \
-    "${generator_build_properties[@]}" \
+    ${generator_build_properties[@]+"${generator_build_properties[@]}"} \
     -- \
     "$root_assembly" \
     --runtime-module ./runtime-loader.js \

--- a/eng/inspect-web-gate-projects.txt
+++ b/eng/inspect-web-gate-projects.txt
@@ -9,6 +9,7 @@ src/DotnetInspector.PackageQueries
 src/DotnetInspector.Packages
 src/DotnetInspector.Queries
 src/DotnetInspector.ResearchQueries
+src/DotnetInspector.RowSelection
 src/DotnetInspector.Services
 src/DotnetInspector.Vocabulary
 src/ILInspector.Analysis

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1045,16 +1045,33 @@ routes use the navigation fallback, while API, asset, and framework requests
 remain excluded.
 
 Search also exposes a `Package query` action that opens the routed `/query`
-surface. It runs the product-issued nuspec-only facet catalog against
-nuget.org, streams rows and visible partial failures from Browser Wasm, and
-hands an exact result coordinate to the normal Workspace package-opening path.
+surface. Leave search text empty to browse, then select a package type or
+source order from NuGetFetch's Gallery catalog. Basic discovery uses search
+metadata only; the separate inspection facets explicitly add manifest or
+bounded package-content evaluation. Browser Wasm streams shared product rows
+and visible failures, then hands an exact result coordinate to the normal
+Workspace package-opening path. Results disclose one bounded Gallery response,
+not a globally exhaustive or exact top-N result; provider totals are estimates.
 The route keeps request and result state in the current session rather than in
-the URL; a direct load starts with an empty prefix.
+the URL; a direct load starts with empty search text.
+
+The Gallery scenarios in `browser/package-adoption.spec.ts` drive the published
+production page through the existing real-Wasm package-adoption harness.
+Deterministic search responses cover blank tool/template browse, text search,
+source ordering, metadata-only acquisition, and bounded completion. Set
+`INSPECT_WEB_GALLERY_LIVE=1` when running
+`eng/test-inspect-web-package-adoption-gate.sh` to include the opt-in live Gallery
+CORS observation and capture the tool-browse page. Live provider availability
+is point-in-time evidence, not a permanent guarantee.
 
 The .NET 11 preview Emscripten wrapper currently mishandles an SDK packs path
 that contains whitespace. If that applies to the local SDK installation, pass
-`EmscriptenSdkToolsPath` pointing to a no-whitespace link to the installed
-Emscripten `tools` directory.
+`-p:EmscriptenSdkToolsPath=/absolute/no-whitespace/link/` pointing to a link to
+the installed Emscripten `tools` directory. The trailing slash is required,
+and an environment variable alone is overwritten by the SDK's property file.
+For the facade-generation script, its `DOTNET` executable override can name a
+worktree-local wrapper that supplies this property without changing `PATH` or
+the installed SDK.
 
 ## Static analysis
 

--- a/prototypes/inspect-web/browser/package-adoption.spec.ts
+++ b/prototypes/inspect-web/browser/package-adoption.spec.ts
@@ -348,6 +348,106 @@ function firstOccurrence(view: OccurrenceView): OccurrenceRow {
   return row;
 }
 
+test.describe("Gallery Package Query website over real Wasm", () => {
+  test("browses by source type and searches without implicit enrichment", async ({
+    page,
+    context,
+  }) => {
+    const requests: URL[] = [];
+    const enrichment: string[] = [];
+    context.on("request", request => {
+      if (new URL(request.url()).hostname === "globalcdn.nuget.org") {
+        enrichment.push(request.url());
+      }
+    });
+    const row = (id: string, downloads?: number) => ({
+      PackageRegistration: {
+        Id: id,
+        ...(downloads === undefined ? {} : { DownloadCount: downloads }),
+        Verified: true,
+        Owners: ["Contoso"],
+      },
+      Version: "1.0.0",
+      NormalizedVersion: "1.0.0",
+      Listed: true,
+      Description: "Gallery website fixture.",
+      DownloadCount: 3,
+    });
+    await context.route("https://azuresearch-usnc.nuget.org/**", async route => {
+      const url = new URL(route.request().url());
+      expect(url.pathname).toBe("/search/query");
+      requests.push(url);
+      const type = url.searchParams.get("packageType")?.toLowerCase();
+      const data = url.searchParams.get("q")
+        ? [row("Contoso.Parser")]
+        : type === "dotnettool"
+          ? [
+            row("Contoso.ToolA", 1_000),
+            row("Contoso.ToolB", 500),
+            ...Array.from({ length: 18 }, (_, index) =>
+              row(`Contoso.Tool${index + 3}`, 100 - index)),
+          ]
+          : type === "template"
+            ? [row("Contoso.Template", 400)]
+            : [row("Contoso.Package", 2_000)];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: corsHeaders,
+        body: JSON.stringify({ totalHits: data.length, data }),
+      });
+    });
+
+    await page.goto("/query");
+    await expect(page.locator("#package-query-type")).toBeVisible({ timeout: 120_000 });
+    await expect(page.locator("#package-query-prefix")).toHaveValue("");
+    expect(requests).toHaveLength(0);
+
+    await page.locator("#package-query-type").selectOption({ label: ".NET tools" });
+    await expect(page.locator(".query-row")).toHaveCount(20);
+    await expect(page.locator(".query-row h2")).toContainText(["Contoso.ToolA", "Contoso.ToolB"]);
+    await expect(page.locator(".query-row").first()).toContainText("1,000");
+    await expect(page.locator(".query-row-description").first()).toHaveText("Gallery website fixture.");
+    await expect(page.locator(".query-footer")).toContainText("200");
+    await expect(page.locator(".query-footer")).not.toContainText("all matches");
+    expect(requests.at(-1)?.searchParams.get("take")).toBe("200");
+    expect(requests.at(-1)?.searchParams.get("sortBy")).toBe("totalDownloads-desc");
+    const lastFacet = page.locator("[data-query-facet]").last();
+    await lastFacet.focus();
+    await expect(lastFacet).toBeInViewport();
+
+    await page.locator("#package-query-type").selectOption({ label: "Templates" });
+    await expect(page.locator(".query-row h2")).toHaveText(["Contoso.Template"]);
+    await page.locator("#package-query-order").selectOption({ label: "Relevance" });
+    await expect.poll(() => requests.at(-1)?.searchParams.get("sortBy")).toBe("relevance");
+
+    await page.locator("#package-query-type").selectOption("");
+    await expect(page.locator(".query-row h2")).toHaveText(["Contoso.Package"]);
+    await page.locator("#package-query-order").selectOption("");
+    await expect.poll(() => requests.at(-1)?.searchParams.get("sortBy")).toBe("totalDownloads-desc");
+    await page.locator("#package-query-prefix").fill("json parser");
+    await page.locator("#package-query-run").click();
+    await expect(page.locator(".query-row h2")).toHaveText(["Contoso.Parser"]);
+    await expect(page.locator(".query-row")).toContainText("unavailable");
+    expect(requests.at(-1)?.searchParams.get("q")).toBe("json parser");
+    expect(requests.at(-1)?.searchParams.get("sortBy")).toBe("relevance");
+    expect(requests.every(request => request.searchParams.get("take") === "200")).toBe(true);
+    expect(enrichment).toEqual([]);
+  });
+
+  test("live Gallery tool browse uses the production page and CORS path", async ({ page }) => {
+    test.skip(process.env.INSPECT_WEB_GALLERY_LIVE !== "1", "Opt-in live provider observation.");
+    await page.goto("/query");
+    await expect(page.locator("#package-query-type")).toBeVisible({ timeout: 120_000 });
+    await page.locator("#package-query-type").selectOption({ label: ".NET tools" });
+    await expect(page.locator(".query-row").first()).toBeVisible({ timeout: 60_000 });
+    await expect(page.locator(".query-row").first()).toContainText("Open in workspace");
+    await expect(page.locator(".query-failures")).toHaveCount(0);
+    await page.screenshot({ path: test.info().outputPath("gallery-tools.png"), fullPage: true });
+    await page.locator("[data-query-cancel]").first().click();
+  });
+});
+
 test.describe("artifact-backed package scope adoption over real Wasm", () => {
   test.describe.configure({ timeout: 240_000 });
 

--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -1141,7 +1141,7 @@ internal static class BrowserPackageWorkspace
 
     internal static ValueTask<PackageQueryContentResult>
         AcquirePackageQueryContentAsync(
-            PackageProfileMatch package,
+            PackageQueryPackage package,
             IPackageSourceClient source,
             BrowserPackageOperationDeadline deadline) =>
         AcquirePackageQueryContentAsync(
@@ -1152,7 +1152,7 @@ internal static class BrowserPackageWorkspace
 
     internal static async ValueTask<PackageQueryContentResult>
         AcquirePackageQueryContentAsync(
-            PackageProfileMatch package,
+            PackageQueryPackage package,
             IPackageSourceClient source,
             PackageSourceIdentity configuredSourceIdentity,
             BrowserPackageOperationDeadline deadline)

--- a/prototypes/inspect-web/engine.PackageExports/BrowserPackageContracts.cs
+++ b/prototypes/inspect-web/engine.PackageExports/BrowserPackageContracts.cs
@@ -231,6 +231,7 @@ public enum BrowserPackageQueryFacetTier
 {
     Nuspec,
     PackageContent,
+    SearchMetadata,
 }
 
 public sealed record BrowserPackageQueryFacetDescriptor(
@@ -247,6 +248,25 @@ public sealed record BrowserPackageQueryFacetDescriptor(
 public sealed record BrowserPackageQueryFacetCatalog(
     BrowserPackageQueryFacetDescriptor[] Facets);
 
+public sealed record BrowserGalleryPackageTypeSuggestion(
+    string Value,
+    string Label);
+
+public sealed record BrowserGalleryPackageTypeFacet(
+    string Id,
+    string Label,
+    string Summary,
+    BrowserGalleryPackageTypeSuggestion[] Suggestions);
+
+public sealed record BrowserGalleryDiscoveryOrder(
+    string Id,
+    string Label,
+    string Summary);
+
+public sealed record BrowserGalleryDiscoveryCatalog(
+    BrowserGalleryPackageTypeFacet PackageType,
+    BrowserGalleryDiscoveryOrder[] Orders);
+
 public sealed record BrowserPackageQueryEvidence(
     string Id,
     string Text);
@@ -256,9 +276,10 @@ public sealed record BrowserPackageQueryRow(
     string Version,
     BrowserPackageQueryFacetTier Tier,
     BrowserPackageQueryEvidence[] Evidence,
-    long TotalDownloads,
-    bool Verified,
-    string Producer);
+    long? TotalDownloads,
+    bool? Verified,
+    string Producer,
+    string? Description = null);
 
 [JsonConverter(typeof(JsonStringEnumConverter<BrowserPackageQueryFailureKind>))]
 public enum BrowserPackageQueryFailureKind
@@ -301,6 +322,7 @@ public enum BrowserPackageQueryCompletionKind
     SourcePageLimitReached,
     ClientPageLimitReached,
     Failed,
+    GalleryResponseComplete,
 }
 
 public sealed record BrowserPackageQueryCompletion(
@@ -311,7 +333,9 @@ public sealed record BrowserPackageQueryCompletion(
     int Candidates,
     int Matches,
     int Failures,
-    BrowserPackageQueryCompletionKind Kind);
+    BrowserPackageQueryCompletionKind Kind,
+    int? SourceCandidates = null,
+    long? EstimatedTotalHits = null);
 
 [JsonConverter(typeof(JsonStringEnumConverter<BrowserPackageQueryEventKind>))]
 public enum BrowserPackageQueryEventKind
@@ -393,6 +417,7 @@ public sealed record BrowserDependencyCoordinateMatch(
 [JsonSerializable(typeof(BrowserMemberDocumentation))]
 [JsonSerializable(typeof(BrowserPackageCacheStats))]
 [JsonSerializable(typeof(BrowserPackageQueryFacetCatalog))]
+[JsonSerializable(typeof(BrowserGalleryDiscoveryCatalog))]
 [JsonSerializable(typeof(BrowserPackageQueryEvent))]
 [JsonSerializable(typeof(BrowserPackageDependencies))]
 [JsonSerializable(typeof(BrowserWorkspacePackage[]))]

--- a/prototypes/inspect-web/engine.PackageExports/PackageQueryExports.cs
+++ b/prototypes/inspect-web/engine.PackageExports/PackageQueryExports.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using DotnetInspector.Queries;
 using InspectWeb.Engine;
 using InspectWeb.Engine.PackageFacade;
+using NuGetFetch;
 
 namespace InspectWeb.Engine.PackageFacade
 {
@@ -34,6 +35,49 @@ namespace InspectWeb.Engine.PackageFacade
                             facet.DisplayGroupLabel)),
                 ]);
 
+        internal static BrowserGalleryDiscoveryCatalog GalleryCatalog() =>
+            new(
+                new BrowserGalleryPackageTypeFacet(
+                    NuGetGalleryDiscoveryCatalog.PackageType.Id,
+                    NuGetGalleryDiscoveryCatalog.PackageType.Label,
+                    NuGetGalleryDiscoveryCatalog.PackageType.Summary,
+                    [
+                        .. NuGetGalleryDiscoveryCatalog.PackageType.Suggestions
+                            .Select(suggestion => new BrowserGalleryPackageTypeSuggestion(
+                                suggestion.Value.Name,
+                                suggestion.Label)),
+                    ]),
+                [
+                    .. NuGetGalleryDiscoveryCatalog.Orders.Select(order =>
+                        new BrowserGalleryDiscoveryOrder(
+                            order.Id,
+                            order.Label,
+                            order.Summary)),
+                ]);
+
+        internal static PackageQueryPlanResult Plan(
+            string text,
+            string[] facetIds,
+            int maximumCandidates,
+            int maximumMatches,
+            bool includePrerelease,
+            string? packageType = null,
+            string? sourceOrderId = null) =>
+            PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(
+                    PackageSourceDescriptor.NuGetGallery,
+                    maximumCandidates,
+                    text,
+                    packageType is null
+                        ? null
+                        : NuGetGalleryDiscoveryCatalog.PackageType.Select(packageType),
+                    sourceOrderId is null
+                        ? null
+                        : NuGetGalleryDiscoveryCatalog.GetOrder(sourceOrderId).Order,
+                    includePrerelease),
+                facetIds,
+                maximumMatches);
+
         internal static async Task<BrowserPackageQueryEvent> ExecuteAsync(
             string prefix,
             string[] facetIds,
@@ -43,7 +87,9 @@ namespace InspectWeb.Engine.PackageFacade
             BrowserPackageQueryMatchCredit? matchCredit,
             Action<BrowserPackageQueryEvent> emit,
             CancellationToken cancellationToken,
-            BrowserPackageWorkspace.BrowserPackageOperationDeadline? deadline = null)
+            BrowserPackageWorkspace.BrowserPackageOperationDeadline? deadline = null,
+            string? packageType = null,
+            string? sourceOrderId = null)
             => await ExecuteAsync(
                 prefix,
                 facetIds,
@@ -54,7 +100,9 @@ namespace InspectWeb.Engine.PackageFacade
                 matchCredit,
                 emit,
                 cancellationToken,
-                deadline).ConfigureAwait(false);
+                deadline,
+                packageType,
+                sourceOrderId).ConfigureAwait(false);
 
         internal static async Task<BrowserPackageQueryEvent> ExecuteAsync(
             string prefix,
@@ -66,18 +114,21 @@ namespace InspectWeb.Engine.PackageFacade
             BrowserPackageQueryMatchCredit? matchCredit,
             Action<BrowserPackageQueryEvent> emit,
             CancellationToken cancellationToken,
-            BrowserPackageWorkspace.BrowserPackageOperationDeadline? deadline = null)
+            BrowserPackageWorkspace.BrowserPackageOperationDeadline? deadline = null,
+            string? packageType = null,
+            string? sourceOrderId = null)
         {
             ArgumentNullException.ThrowIfNull(facetIds);
             ArgumentNullException.ThrowIfNull(emit);
 
-            PackageQueryPlanResult planResult = PackageQuery.Plan(
-                new PackageQueryRequest(
-                    prefix,
-                    facetIds,
-                    maximumCandidates,
-                    maximumMatches,
-                    includePrerelease));
+            PackageQueryPlanResult planResult = Plan(
+                prefix,
+                facetIds,
+                maximumCandidates,
+                maximumMatches,
+                includePrerelease,
+                packageType,
+                sourceOrderId);
             if (planResult is PackageQueryPlanResult.Rejected rejected)
                 throw new InvalidOperationException(rejected.Failure.Message);
 
@@ -190,6 +241,8 @@ namespace InspectWeb.Engine.PackageFacade
                         match.Value.Package.Version,
                         match.Value.Tier switch
                         {
+                            PackageQueryFacetTier.SearchMetadata =>
+                                BrowserPackageQueryFacetTier.SearchMetadata,
                             PackageQueryFacetTier.Nuspec =>
                                 BrowserPackageQueryFacetTier.Nuspec,
                             PackageQueryFacetTier.PackageContent =>
@@ -205,7 +258,8 @@ namespace InspectWeb.Engine.PackageFacade
                         ],
                         match.Value.Package.TotalDownloads,
                         match.Value.Package.Verified,
-                        match.Value.Package.Source.Producer.Display.ToString()),
+                        match.Value.Package.Source.Producer.Display.ToString(),
+                        match.Value.Package.Description),
                     Failure: null,
                     Completion: null),
             PackageQueryEvent.Failure failure =>
@@ -264,9 +318,13 @@ namespace InspectWeb.Engine.PackageFacade
                                 BrowserPackageQueryCompletionKind.ClientPageLimitReached,
                             PackageQueryCompletionKind.Failed =>
                                 BrowserPackageQueryCompletionKind.Failed,
+                            PackageQueryCompletionKind.GalleryResponseComplete =>
+                                BrowserPackageQueryCompletionKind.GalleryResponseComplete,
                             _ => throw new InvalidOperationException(
                                 "Unknown package-query completion kind."),
-                        })),
+                        },
+                        completed.Value.SourceCandidates,
+                        completed.Value.EstimatedTotalHits)),
                 _ => throw new InvalidOperationException(
                     "Unknown package-query event."),
             };
@@ -288,6 +346,12 @@ public static partial class PackageExports
             BrowserPackageJsonContext.Default.BrowserPackageQueryFacetCatalog);
 
     [JSExport]
+    public static string ListGalleryDiscoveryCatalog() =>
+        JsonSerializer.Serialize(
+            BrowserPackageQueryOperations.GalleryCatalog(),
+            BrowserPackageJsonContext.Default.BrowserGalleryDiscoveryCatalog);
+
+    [JSExport]
     public static void CancelPackageQuery() =>
         BrowserPackageQueryOperationCoordinator.CancelCurrent();
 
@@ -304,7 +368,9 @@ public static partial class PackageExports
         int maximumMatches,
         bool includePrerelease,
         int initialMatchCredit,
-        JSObject eventSink)
+        JSObject eventSink,
+        string? packageType,
+        string? sourceOrderId)
     {
         ArgumentNullException.ThrowIfNull(eventSink);
         string[] facetIds = JsonSerializer.Deserialize(
@@ -332,7 +398,9 @@ public static partial class PackageExports
                         "event",
                         BrowserPackageQueryOperations.Serialize(queryEvent)),
                     deadline.Token,
-                    deadline);
+                    deadline,
+                    packageType,
+                    sourceOrderId);
             },
             BrowserPackageWorkspace.PackageOperationTimeout,
             operation.CancellationToken);
@@ -350,7 +418,7 @@ namespace InspectWeb.Engine.PackageFacade
         : IPackageQueryContentProvider
     {
         public ValueTask<PackageQueryContentResult> GetContentAsync(
-            PackageProfileMatch package,
+            PackageQueryPackage package,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -5388,7 +5388,7 @@ public sealed class BrowserEngineBoundaryTests
                     Encoding.UTF8.GetBytes(
                         Nuspec(packageId, version)),
                     PackageSourceCoordinate.Create(packageId, version))).Value;
-        var package = new PackageProfileMatch(
+        var package = new PackageQueryPackage(
             packageId,
             version,
             [],
@@ -5436,7 +5436,7 @@ public sealed class BrowserEngineBoundaryTests
                     Encoding.UTF8.GetBytes(
                         Nuspec(packageId, version)),
                     PackageSourceCoordinate.Create(packageId, version))).Value;
-        var package = new PackageProfileMatch(
+        var package = new PackageQueryPackage(
             packageId,
             version,
             [],

--- a/prototypes/inspect-web/engine.Tests/BrowserPackageQueryOperationsTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserPackageQueryOperationsTests.cs
@@ -12,6 +12,102 @@ namespace InspectWeb.Engine.Tests;
 public sealed class BrowserPackageQueryOperationsTests
 {
     [Fact]
+    public void GalleryCatalog_PreservesSourceOwnedSuggestionsAndOrders()
+    {
+        BrowserGalleryDiscoveryCatalog catalog =
+            BrowserPackageQueryOperations.GalleryCatalog();
+
+        Assert.Equal(NuGetGalleryDiscoveryCatalog.PackageType.Id, catalog.PackageType.Id);
+        Assert.Equal(NuGetGalleryDiscoveryCatalog.PackageType.Label, catalog.PackageType.Label);
+        Assert.Equal(NuGetGalleryDiscoveryCatalog.PackageType.Summary, catalog.PackageType.Summary);
+        Assert.Equal(
+            NuGetGalleryDiscoveryCatalog.PackageType.Suggestions.Select(value =>
+                (value.Value.Name, value.Label)),
+            catalog.PackageType.Suggestions.Select(value =>
+                (value.Value, value.Label)));
+        Assert.Equal(
+            NuGetGalleryDiscoveryCatalog.Orders.Select(order =>
+                (order.Id, order.Label, order.Summary)),
+            catalog.Orders.Select(order =>
+                (order.Id, order.Label, order.Summary)));
+    }
+
+    [Theory]
+    [InlineData("", NuGetGalleryDiscoveryOrder.MostDownloaded)]
+    [InlineData("  ", NuGetGalleryDiscoveryOrder.MostDownloaded)]
+    [InlineData("json parser", NuGetGalleryDiscoveryOrder.Relevance)]
+    public void GalleryPlan_PreservesInputCapacityAndLocalMatchLimit(
+        string text,
+        NuGetGalleryDiscoveryOrder expectedOrder)
+    {
+        var accepted = Assert.IsType<PackageQueryPlanResult.Accepted>(
+            BrowserPackageQueryOperations.Plan(
+                text,
+                [],
+                maximumCandidates: 200,
+                maximumMatches: 10,
+                includePrerelease: false,
+                packageType: NuGetGalleryPackageType.DotnetTool.Name));
+
+        Assert.NotNull(accepted.Plan.GalleryRequest);
+        Assert.Equal(200, accepted.Plan.GalleryRequest.Capacity);
+        Assert.Equal(10, accepted.Plan.MaximumMatches);
+        Assert.Equal(expectedOrder, accepted.Plan.GalleryRequest.Order);
+        Assert.Equal(NuGetGalleryPackageType.DotnetTool, accepted.Plan.GalleryRequest.PackageType);
+        Assert.Empty(accepted.Plan.Facets);
+    }
+
+    [Fact]
+    public void GalleryPlan_UsesOpaqueOrderIdentityWithoutRewritingInspectionFacets()
+    {
+        var accepted = Assert.IsType<PackageQueryPlanResult.Accepted>(
+            BrowserPackageQueryOperations.Plan(
+                "",
+                [PackageQuery.ToolFacetId],
+                maximumCandidates: 200,
+                maximumMatches: 10,
+                includePrerelease: true,
+                sourceOrderId: NuGetGalleryDiscoveryCatalog.Relevance.Id));
+
+        Assert.NotNull(accepted.Plan.GalleryRequest);
+        Assert.Null(accepted.Plan.GalleryRequest.PackageType);
+        Assert.True(accepted.Plan.GalleryRequest.IncludePrerelease);
+        Assert.Equal(NuGetGalleryDiscoveryOrder.Relevance, accepted.Plan.GalleryRequest.Order);
+        Assert.Equal(PackageQuery.ToolFacetId, Assert.Single(accepted.Plan.Facets).Id);
+        Assert.Throws<ArgumentException>(() =>
+            BrowserPackageQueryOperations.Plan("", [], 200, 10, false, sourceOrderId: "relevance"));
+    }
+
+    [Fact]
+    public void Project_GalleryCompletionRetainsFiniteInputAndEstimatedPopulation()
+    {
+        using IPackageSourceClient source =
+            PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create());
+        var summary = new PackageQuerySummary(
+            new InertString(TextPolicy.Prose, ""),
+            source.Source,
+            CandidateLimit: 200,
+            MatchLimit: 100,
+            Candidates: 3,
+            Matches: 3,
+            Failures: 0,
+            PackageQueryCompletionKind.GalleryResponseComplete)
+        {
+            SourceCandidates = 3,
+            EstimatedTotalHits = 8_000,
+        };
+
+        BrowserPackageQueryCompletion completion =
+            BrowserPackageQueryOperations.Project(
+                new PackageQueryEvent.Completed(summary)).Completion!;
+
+        Assert.Equal(BrowserPackageQueryCompletionKind.GalleryResponseComplete, completion.Kind);
+        Assert.Equal(200, completion.CandidateLimit);
+        Assert.Equal(3, completion.SourceCandidates);
+        Assert.Equal(8_000, completion.EstimatedTotalHits);
+    }
+
+    [Fact]
     public void Facets_MatchProductCatalogOrderAndMetadata()
     {
         BrowserPackageQueryFacetCatalog catalog =

--- a/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
+++ b/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
@@ -56,6 +56,7 @@ public sealed class ProductionFacadeContextTests
             "CancelPackageQuery",
             "ClearWorkspacePackageOccurrences",
             "GetPackageDocument",
+            "ListGalleryDiscoveryCatalog",
             "ListPackageQueryFacets",
             "LoadRuntimePack",
             "LoadRuntimePackAssembly",
@@ -158,10 +159,10 @@ public sealed class ProductionFacadeContextTests
                 actual[assembly]);
         }
 
-        // 50 operations, and no operation name in two modules: a move that forgot to delete its
+        // 51 operations, and no operation name in two modules: a move that forgot to delete its
         // origin, or a name published twice, fails here rather than in the browser.
         string[] everyExport = [.. actual.Values.SelectMany(names => names)];
-        Assert.Equal(50, everyExport.Length);
+        Assert.Equal(51, everyExport.Length);
         Assert.Equal(
             everyExport.Length,
             everyExport.Distinct(StringComparer.Ordinal).Count());

--- a/prototypes/inspect-web/engine/facades/inspect-web-package.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-package.ts
@@ -6,11 +6,11 @@ export type BrowserDependencyCoordinateMatchOutcome = "NoMatch" | "Unique" | "Am
 
 export type BrowserDependencyCoordinateProvenance = "NuGetPackage" | "PlatformRuntime" | number;
 
-export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached" | "CandidateLimitReached" | "SourcePageLimitReached" | "ClientPageLimitReached" | "Failed" | number;
+export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached" | "CandidateLimitReached" | "SourcePageLimitReached" | "ClientPageLimitReached" | "Failed" | "GalleryResponseComplete" | number;
 
 export type BrowserPackageQueryEventKind = "Progress" | "Match" | "Failure" | "Completed" | number;
 
-export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | number;
+export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | "SearchMetadata" | number;
 
 export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | "PackageContentAcquisition" | "PackageContentEvaluation" | number;
 
@@ -65,6 +65,29 @@ export interface BrowserDependencyCoordinateMatch {
 export interface BrowserExceptionSurface {
   readonly type: string;
   readonly description: string;
+}
+
+export interface BrowserGalleryDiscoveryCatalog {
+  readonly packageType: BrowserGalleryPackageTypeFacet;
+  readonly orders: ReadonlyArray<BrowserGalleryDiscoveryOrder>;
+}
+
+export interface BrowserGalleryDiscoveryOrder {
+  readonly id: string;
+  readonly label: string;
+  readonly summary: string;
+}
+
+export interface BrowserGalleryPackageTypeFacet {
+  readonly id: string;
+  readonly label: string;
+  readonly summary: string;
+  readonly suggestions: ReadonlyArray<BrowserGalleryPackageTypeSuggestion>;
+}
+
+export interface BrowserGalleryPackageTypeSuggestion {
+  readonly value: string;
+  readonly label: string;
 }
 
 export interface BrowserMemberBodySelector {
@@ -166,6 +189,8 @@ export interface BrowserPackageQueryCompletion {
   readonly matches: number;
   readonly failures: number;
   readonly kind: BrowserPackageQueryCompletionKind;
+  readonly sourceCandidates: number | null;
+  readonly estimatedTotalHits: number | null;
 }
 
 export interface BrowserPackageQueryEvent {
@@ -216,9 +241,10 @@ export interface BrowserPackageQueryRow {
   readonly version: string;
   readonly tier: BrowserPackageQueryFacetTier;
   readonly evidence: ReadonlyArray<BrowserPackageQueryEvidence>;
-  readonly totalDownloads: number;
-  readonly verified: boolean;
+  readonly totalDownloads: number | null;
+  readonly verified: boolean | null;
   readonly producer: string;
+  readonly description: string | null;
 }
 
 export interface BrowserPackageSurface {
@@ -308,6 +334,7 @@ type $ManagedExports = {
     readonly "CancelPackageQuery.19325221": () => void;
     readonly "ClearWorkspacePackageOccurrences.19325221": () => void;
     readonly "GetPackageDocument.1001223652": (packageId: string, version: string, path: string) => Promise<string>;
+    readonly "ListGalleryDiscoveryCatalog.1310674786": () => string;
     readonly "ListPackageQueryFacets.1310674786": () => string;
     readonly "LoadRuntimePack.451505237": (targetFramework: string, platformVersion: string) => Promise<string>;
     readonly "LoadRuntimePackAssembly.1579276339": (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string) => Promise<string>;
@@ -320,7 +347,7 @@ type $ManagedExports = {
     readonly "QueryWorkspacePackageOccurrences.976702342": (workspaceJson: string) => Promise<string>;
     readonly "RequestPackageQueryMatches.1520975400": (additionalMatchCredit: number) => boolean;
     readonly "ResolvePackageDependencyVersion.451505237": (packageId: string, declaredRange: string | null) => Promise<string>;
-    readonly "RunPackageQuery.1079207954": (prefix: string, facetIdsJson: string, maximumCandidates: number, maximumMatches: number, includePrerelease: boolean, initialMatchCredit: number, eventSink: unknown) => Promise<string>;
+    readonly "RunPackageQuery.1009197168": (prefix: string, facetIdsJson: string, maximumCandidates: number, maximumMatches: number, includePrerelease: boolean, initialMatchCredit: number, eventSink: unknown, packageType: string | null, sourceOrderId: string | null) => Promise<string>;
     readonly "SearchTypes.271973316": (query: string, candidatesJson: string) => string;
   };
 };
@@ -397,6 +424,14 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
     value = $ownDataProperty(value, "GetPackageDocument.1001223652");
     if (typeof value !== "function") {
       throw new Error("Managed export \u0027PackageExports.GetPackageDocument.1001223652\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "PackageExports");
+    value = $ownDataProperty(value, "ListGalleryDiscoveryCatalog.1310674786");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027PackageExports.ListGalleryDiscoveryCatalog.1310674786\u0027 is not callable.");
     }
   }
   {
@@ -498,9 +533,9 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
   {
     let value: unknown = exports;
     value = $ownDataProperty(value, "PackageExports");
-    value = $ownDataProperty(value, "RunPackageQuery.1079207954");
+    value = $ownDataProperty(value, "RunPackageQuery.1009197168");
     if (typeof value !== "function") {
-      throw new Error("Managed export \u0027PackageExports.RunPackageQuery.1079207954\u0027 is not callable.");
+      throw new Error("Managed export \u0027PackageExports.RunPackageQuery.1009197168\u0027 is not callable.");
     }
   }
   {
@@ -568,6 +603,12 @@ export async function getPackageDocument(packageId: string, version: string, pat
   return $parsed as BrowserPackageDocumentContent;
 }
 
+export function listGalleryDiscoveryCatalog(): BrowserGalleryDiscoveryCatalog {
+  const $result = $requireManagedExports()["PackageExports"]["ListGalleryDiscoveryCatalog.1310674786"]();
+  const $parsed: unknown = JSON.parse($result);
+  return $parsed as BrowserGalleryDiscoveryCatalog;
+}
+
 export function listPackageQueryFacets(): BrowserPackageQueryFacetCatalog {
   const $result = $requireManagedExports()["PackageExports"]["ListPackageQueryFacets.1310674786"]();
   const $parsed: unknown = JSON.parse($result);
@@ -632,8 +673,8 @@ export async function resolvePackageDependencyVersion(packageId: string, declare
   return await $requireManagedExports()["PackageExports"]["ResolvePackageDependencyVersion.451505237"](packageId, declaredRange);
 }
 
-export async function runPackageQuery(prefix: string, facetIdsJson: string, maximumCandidates: number, maximumMatches: number, includePrerelease: boolean, initialMatchCredit: number, eventSink: unknown): Promise<BrowserPackageQueryEvent> {
-  const $result = await $requireManagedExports()["PackageExports"]["RunPackageQuery.1079207954"](prefix, facetIdsJson, maximumCandidates, maximumMatches, includePrerelease, initialMatchCredit, eventSink);
+export async function runPackageQuery(prefix: string, facetIdsJson: string, maximumCandidates: number, maximumMatches: number, includePrerelease: boolean, initialMatchCredit: number, eventSink: unknown, packageType: string | null, sourceOrderId: string | null): Promise<BrowserPackageQueryEvent> {
+  const $result = await $requireManagedExports()["PackageExports"]["RunPackageQuery.1009197168"](prefix, facetIdsJson, maximumCandidates, maximumMatches, includePrerelease, initialMatchCredit, eventSink, packageType, sourceOrderId);
   const $parsed: unknown = JSON.parse($result);
   return $parsed as BrowserPackageQueryEvent;
 }

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-package.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-package.js
@@ -66,6 +66,14 @@ function $validateManagedExports(exports) {
     {
         let value = exports;
         value = $ownDataProperty(value, "PackageExports");
+        value = $ownDataProperty(value, "ListGalleryDiscoveryCatalog.1310674786");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027PackageExports.ListGalleryDiscoveryCatalog.1310674786\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "PackageExports");
         value = $ownDataProperty(value, "ListPackageQueryFacets.1310674786");
         if (typeof value !== "function") {
             throw new Error("Managed export \u0027PackageExports.ListPackageQueryFacets.1310674786\u0027 is not callable.");
@@ -162,9 +170,9 @@ function $validateManagedExports(exports) {
     {
         let value = exports;
         value = $ownDataProperty(value, "PackageExports");
-        value = $ownDataProperty(value, "RunPackageQuery.1079207954");
+        value = $ownDataProperty(value, "RunPackageQuery.1009197168");
         if (typeof value !== "function") {
-            throw new Error("Managed export \u0027PackageExports.RunPackageQuery.1079207954\u0027 is not callable.");
+            throw new Error("Managed export \u0027PackageExports.RunPackageQuery.1009197168\u0027 is not callable.");
         }
     }
     {
@@ -213,6 +221,11 @@ export function clearWorkspacePackageOccurrences() {
 }
 export async function getPackageDocument(packageId, version, path) {
     const $result = await $requireManagedExports()["PackageExports"]["GetPackageDocument.1001223652"](packageId, version, path);
+    const $parsed = JSON.parse($result);
+    return $parsed;
+}
+export function listGalleryDiscoveryCatalog() {
+    const $result = $requireManagedExports()["PackageExports"]["ListGalleryDiscoveryCatalog.1310674786"]();
     const $parsed = JSON.parse($result);
     return $parsed;
 }
@@ -268,8 +281,8 @@ export function requestPackageQueryMatches(additionalMatchCredit) {
 export async function resolvePackageDependencyVersion(packageId, declaredRange) {
     return await $requireManagedExports()["PackageExports"]["ResolvePackageDependencyVersion.451505237"](packageId, declaredRange);
 }
-export async function runPackageQuery(prefix, facetIdsJson, maximumCandidates, maximumMatches, includePrerelease, initialMatchCredit, eventSink) {
-    const $result = await $requireManagedExports()["PackageExports"]["RunPackageQuery.1079207954"](prefix, facetIdsJson, maximumCandidates, maximumMatches, includePrerelease, initialMatchCredit, eventSink);
+export async function runPackageQuery(prefix, facetIdsJson, maximumCandidates, maximumMatches, includePrerelease, initialMatchCredit, eventSink, packageType, sourceOrderId) {
+    const $result = await $requireManagedExports()["PackageExports"]["RunPackageQuery.1009197168"](prefix, facetIdsJson, maximumCandidates, maximumMatches, includePrerelease, initialMatchCredit, eventSink, packageType, sourceOrderId);
     const $parsed = JSON.parse($result);
     return $parsed;
 }

--- a/prototypes/inspect-web/scripts/serve-package-adoption-gate.ts
+++ b/prototypes/inspect-web/scripts/serve-package-adoption-gate.ts
@@ -36,7 +36,12 @@ createServer((request, response) => {
     );
     return;
   }
-  const file = resolve(site, `.${pathname}`);
+  const file = resolve(
+    site,
+    pathname === "/query" || pathname === "/query/"
+      ? "index.html"
+      : `.${pathname}`,
+  );
   if (!file.startsWith(`${site}${sep}`)) {
     response.writeHead(404);
     response.end();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -378,6 +378,9 @@ import {
   withScopeQuery,
   type PackageQueryState,
   type QueryFacetTerm,
+  type QueryRequest,
+  type QuerySourceCatalog,
+  type QuerySourceSelection,
 } from "./package-query.ts";
 import {
   createPackageQueryLiveAnnouncer,
@@ -404,7 +407,7 @@ import {
   packageQueryHistoryState,
   readPackageQueryHistory,
   resolvePackageQueryWorkspaceSuccessor,
-  validPackageQueryPrefix,
+  validPackageQuerySearchText,
   withHistoryEntryId,
   type PackageQueryReturnFocus,
 } from "./package-query-route.ts";
@@ -446,6 +449,7 @@ let inspectBuildIdentity: HostFacade["buildIdentity"];
 let cancelPackageQuery: PackageFacade["cancelPackageQuery"];
 let inspectPackageDocument: PackageFacade["getPackageDocument"];
 let inspectListPackageQueryFacets: PackageFacade["listPackageQueryFacets"];
+let inspectListGalleryDiscoveryCatalog: PackageFacade["listGalleryDiscoveryCatalog"];
 let inspectLoadRuntimePack: PackageFacade["loadRuntimePack"];
 let inspectLoadRuntimePackAssembly: PackageFacade["loadRuntimePackAssembly"];
 let matchPackageDependencyCoordinate:
@@ -526,6 +530,7 @@ async function loadEngineModule() {
     cancelPackageQuery,
     getPackageDocument: inspectPackageDocument,
     listPackageQueryFacets: inspectListPackageQueryFacets,
+    listGalleryDiscoveryCatalog: inspectListGalleryDiscoveryCatalog,
     loadRuntimePack: inspectLoadRuntimePack,
     loadRuntimePackAssembly: inspectLoadRuntimePackAssembly,
     matchPackageDependencyCoordinate,
@@ -765,6 +770,7 @@ const initialState = {
   packageQueryReturnFocusPending: false,
   packageQueryState: initialQueryState(),
   packageQueryFacets: [],
+  packageQuerySourceCatalog: null,
   platformIndex: null,
   queryNotice: "",
   queryNoticeRetryAction: null,
@@ -972,6 +978,7 @@ interface StateOverrides {
   packageCacheStats: BrowserPackageCacheStats | null;
   packageQueryState: PackageQueryState;
   packageQueryFacets: QueryFacetTerm[];
+  packageQuerySourceCatalog: QuerySourceCatalog | null;
   packageQueryPredecessorEntryId: string | null;
   packageQueryReturnFocus: PackageQueryReturnFocus | null;
 }
@@ -1130,6 +1137,8 @@ const packageQueryController = createPackageQueryController(
       includePrerelease,
       initialMatchCredit,
       eventSink,
+      packageType,
+      sourceOrderId,
     ) => inspectRunPackageQuery(
       prefix,
       facetIdsJson,
@@ -1137,7 +1146,9 @@ const packageQueryController = createPackageQueryController(
       maximumMatches,
       includePrerelease,
       initialMatchCredit,
-      eventSink),
+      eventSink,
+      packageType,
+      sourceOrderId),
   }),
   updateKind => {
     if (!state.packageQueryOpen) return;
@@ -6873,7 +6884,7 @@ function spotlightResults(): SpotlightResult[] {
     }
     results.push({
       kind: "package-query",
-      prefix: validPackageQueryPrefix(query),
+      prefix: validPackageQuerySearchText(query) ?? "",
     });
   }
   if ((all || spotlightScope === "types") && query) {
@@ -8914,7 +8925,7 @@ function openPackageQueryRoute(
   }
   resetPackageQueryAnnouncements();
   if (!options.preserveState || seed) {
-    state.packageQueryPrefix = validPackageQueryPrefix(seed);
+    state.packageQueryPrefix = validPackageQuerySearchText(seed) ?? "";
   }
   state.packageQueryNavigationError = "";
   const returnFocus: PackageQueryReturnFocus = options.returnFocus
@@ -8994,45 +9005,54 @@ function closePackageQueryRoute() {
   render();
 }
 
-function runPackageQuery(prefix: string) {
-  const validPrefix = validPackageQueryPrefix(prefix);
-  state.packageQueryPrefix = prefix;
-  if (!validPrefix) {
+function preparePackageQueryRequest(text: string): QueryRequest | null {
+  const validText = validPackageQuerySearchText(text);
+  state.packageQueryPrefix = text;
+  if (validText === null) {
     state.packageQueryNavigationError =
-      "Enter a non-empty package ID prefix of at most 100 characters.";
+      "Search text must be at most 100 characters without control characters.";
     render();
     focusPackageQueryInput();
-    return;
+    return null;
   }
 
-  state.packageQueryPrefix = validPrefix;
+  state.packageQueryPrefix = validText;
   state.packageQueryNavigationError = "";
-  const request = state.packageQueryState.request
-    ? withScopeQuery(state.packageQueryState.request, validPrefix)
-    : createQueryRequest(validPrefix);
+  return state.packageQueryState.request
+    ? withScopeQuery(state.packageQueryState.request, validText)
+    : createQueryRequest(validText);
+}
+
+function runPackageQuery(text: string) {
+  const request = preparePackageQueryRequest(text);
+  if (!request) return;
   packageQueryLiveAnnouncer.reset();
   void packageQueryController.run(request);
 }
 
-function togglePackageQueryFacet(facetKey: string, prefix: string) {
+function changePackageQuerySource(
+  selection: QuerySourceSelection,
+  text: string,
+) {
+  const request = preparePackageQueryRequest(text);
+  if (!request) return;
+  packageQueryLiveAnnouncer.reset();
+  void packageQueryController.run({ ...request, ...selection });
+}
+
+function togglePackageQueryFacet(facetKey: string, text: string) {
   const facet = state.packageQueryFacets.find(
     candidate => candidate.key === facetKey);
-  const validPrefix = validPackageQueryPrefix(prefix);
-  state.packageQueryPrefix = prefix;
-  if (!facet || !validPrefix) {
-    state.packageQueryNavigationError = facet
-      ? "Enter a package ID prefix before selecting facets."
-      : "The selected package-query facet is unavailable.";
+  if (!facet) {
+    state.packageQueryNavigationError =
+      "The selected package-query facet is unavailable.";
     render();
     focusPackageQueryInput();
     return;
   }
 
-  state.packageQueryPrefix = validPrefix;
-  state.packageQueryNavigationError = "";
-  const current = state.packageQueryState.request
-    ? withScopeQuery(state.packageQueryState.request, validPrefix)
-    : createQueryRequest(validPrefix);
+  const current = preparePackageQueryRequest(text);
+  if (!current) return;
   packageQueryLiveAnnouncer.reset();
   void packageQueryController.run(toggleFacet(current, facet));
 }
@@ -9088,6 +9108,7 @@ const packageQueryActions: PackageQueryBindingActions = {
   onBack: closePackageQueryRoute,
   onCancel: () => packageQueryController.cancel(),
   onFacetToggle: togglePackageQueryFacet,
+  onSourceChange: changePackageQuerySource,
   onPrefixInput: prefix => {
     state.packageQueryPrefix = prefix;
     if (state.packageQueryState.request
@@ -9153,6 +9174,7 @@ function renderPackageQueryPage() {
     state: state.packageQueryState,
     prefix: state.packageQueryPrefix,
     availableFacets: state.packageQueryFacets,
+    sourceCatalog: state.packageQuerySourceCatalog,
     navigationError: [
       state.packageQueryCatalogError,
       state.packageQueryNavigationError,
@@ -12309,10 +12331,12 @@ async function bootstrap() {
     try {
       state.packageQueryFacets =
         packageQueryFacets(inspectListPackageQueryFacets());
+      state.packageQuerySourceCatalog = inspectListGalleryDiscoveryCatalog();
     } catch (error) {
       state.packageQueryFacets = [];
+      state.packageQuerySourceCatalog = null;
       state.packageQueryCatalogError =
-        `Package-query facets are unavailable: ${errorMessage(error) || "Unknown error."}`;
+        `Package-query catalogs are unavailable: ${errorMessage(error) || "Unknown error."}`;
     }
     state.engineReady = true;
     state.engineStatus = "";

--- a/prototypes/inspect-web/src/facades/inspect-web-package.d.ts
+++ b/prototypes/inspect-web/src/facades/inspect-web-package.d.ts
@@ -1,9 +1,9 @@
 export type BrowserCompileLibraryStatus = "Selected" | "NoCompileAssets" | "NoMatchingTargetFramework" | "EmptyCompileGroup" | "InvalidImplementationAssets" | number;
 export type BrowserDependencyCoordinateMatchOutcome = "NoMatch" | "Unique" | "Ambiguous" | number;
 export type BrowserDependencyCoordinateProvenance = "NuGetPackage" | "PlatformRuntime" | number;
-export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached" | "CandidateLimitReached" | "SourcePageLimitReached" | "ClientPageLimitReached" | "Failed" | number;
+export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached" | "CandidateLimitReached" | "SourcePageLimitReached" | "ClientPageLimitReached" | "Failed" | "GalleryResponseComplete" | number;
 export type BrowserPackageQueryEventKind = "Progress" | "Match" | "Failure" | "Completed" | number;
-export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | number;
+export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | "SearchMetadata" | number;
 export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | "PackageContentAcquisition" | "PackageContentEvaluation" | number;
 export type BrowserPackageQueryProgressPhase = "Search" | "Manifest" | "PackageContent" | number;
 export interface BrowserAccessibilityDescriptor {
@@ -49,6 +49,25 @@ export interface BrowserDependencyCoordinateMatch {
 export interface BrowserExceptionSurface {
     readonly type: string;
     readonly description: string;
+}
+export interface BrowserGalleryDiscoveryCatalog {
+    readonly packageType: BrowserGalleryPackageTypeFacet;
+    readonly orders: ReadonlyArray<BrowserGalleryDiscoveryOrder>;
+}
+export interface BrowserGalleryDiscoveryOrder {
+    readonly id: string;
+    readonly label: string;
+    readonly summary: string;
+}
+export interface BrowserGalleryPackageTypeFacet {
+    readonly id: string;
+    readonly label: string;
+    readonly summary: string;
+    readonly suggestions: ReadonlyArray<BrowserGalleryPackageTypeSuggestion>;
+}
+export interface BrowserGalleryPackageTypeSuggestion {
+    readonly value: string;
+    readonly label: string;
 }
 export interface BrowserMemberBodySelector {
     readonly token: number;
@@ -139,6 +158,8 @@ export interface BrowserPackageQueryCompletion {
     readonly matches: number;
     readonly failures: number;
     readonly kind: BrowserPackageQueryCompletionKind;
+    readonly sourceCandidates: number | null;
+    readonly estimatedTotalHits: number | null;
 }
 export interface BrowserPackageQueryEvent {
     readonly kind: BrowserPackageQueryEventKind;
@@ -182,9 +203,10 @@ export interface BrowserPackageQueryRow {
     readonly version: string;
     readonly tier: BrowserPackageQueryFacetTier;
     readonly evidence: ReadonlyArray<BrowserPackageQueryEvidence>;
-    readonly totalDownloads: number;
-    readonly verified: boolean;
+    readonly totalDownloads: number | null;
+    readonly verified: boolean | null;
     readonly producer: string;
+    readonly description: string | null;
 }
 export interface BrowserPackageSurface {
     readonly package: string;
@@ -269,6 +291,7 @@ export declare function activateWorkspacePackageOccurrence(action: string): Prom
 export declare function cancelPackageQuery(): void;
 export declare function clearWorkspacePackageOccurrences(): void;
 export declare function getPackageDocument(packageId: string, version: string, path: string): Promise<BrowserPackageDocumentContent>;
+export declare function listGalleryDiscoveryCatalog(): BrowserGalleryDiscoveryCatalog;
 export declare function listPackageQueryFacets(): BrowserPackageQueryFacetCatalog;
 export declare function loadRuntimePack(targetFramework: string, platformVersion: string): Promise<string>;
 export declare function loadRuntimePackAssembly(targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string): Promise<string>;
@@ -281,5 +304,5 @@ export declare function queryPackageVersions(packageId: string): Promise<Readonl
 export declare function queryWorkspacePackageOccurrences(workspaceJson: string): Promise<BrowserWorkspacePackageOccurrenceView>;
 export declare function requestPackageQueryMatches(additionalMatchCredit: number): boolean;
 export declare function resolvePackageDependencyVersion(packageId: string, declaredRange: string | null): Promise<string>;
-export declare function runPackageQuery(prefix: string, facetIdsJson: string, maximumCandidates: number, maximumMatches: number, includePrerelease: boolean, initialMatchCredit: number, eventSink: unknown): Promise<BrowserPackageQueryEvent>;
+export declare function runPackageQuery(prefix: string, facetIdsJson: string, maximumCandidates: number, maximumMatches: number, includePrerelease: boolean, initialMatchCredit: number, eventSink: unknown, packageType: string | null, sourceOrderId: string | null): Promise<BrowserPackageQueryEvent>;
 export declare function searchTypes(query: string, candidatesJson: string): ReadonlyArray<BrowserTypeSearchHit>;

--- a/prototypes/inspect-web/src/package-query-route.ts
+++ b/prototypes/inspect-web/src/package-query-route.ts
@@ -106,12 +106,7 @@ export function resolvePackageQueryWorkspaceSuccessor(
   }
 }
 
-export function validPackageQueryPrefix(value: string): string {
-  const prefix = value.trim();
-  return prefix.length > 0
-    && prefix.length <= 100
-    && !Array.from(prefix).some(character =>
-      character.codePointAt(0)! < 0x20 || character.codePointAt(0) === 0x7f)
-    ? prefix
-    : "";
+export function validPackageQuerySearchText(value: string): string | null {
+  if (value.length > 100 || /\p{Cc}/u.test(value)) return null;
+  return value.trim().length === 0 ? "" : value;
 }

--- a/prototypes/inspect-web/src/package-query-source.ts
+++ b/prototypes/inspect-web/src/package-query-source.ts
@@ -20,13 +20,15 @@ export interface BrowserPackageQueryEngine {
   cancel(): void;
   requestMatches(additionalMatchCredit: number): boolean;
   run(
-    prefix: string,
+    searchText: string,
     facetIdsJson: string,
     maximumCandidates: number,
     maximumMatches: number,
     includePrerelease: boolean,
     initialMatchCredit: number,
     eventSink: unknown,
+    packageType: string | null,
+    sourceOrderId: string | null,
   ): Promise<BrowserPackageQueryEvent>;
 }
 
@@ -44,7 +46,7 @@ function toQueryFacet(
     label: descriptor.label,
     summary: descriptor.summary,
     weight: descriptor.weight,
-    tier: toQueryTier(descriptor.tier),
+    tier: toInspectionTier(descriptor.tier),
     selectionGroupId: descriptor.selectionGroupId,
     combinesWithinSelectionGroup: descriptor.combinesWithinSelectionGroup,
     displayGroupId: descriptor.displayGroupId,
@@ -138,9 +140,11 @@ export function createBrowserPackageQueryDataSource(
           JSON.stringify(request.facets.map(facet => facet.key)),
           request.requestedLimit,
           request.requestedMatchLimit,
-          false,
+          request.includePrerelease,
           PACKAGE_QUERY_INITIAL_MATCH_CREDIT,
-          eventSink);
+          eventSink,
+          request.packageType,
+          request.sourceOrderId);
         flushEvents();
         if (flushState.failed) throw flushState.error;
         if (abortSignal.aborted) return { kind: "cancelled" };
@@ -245,6 +249,13 @@ function numberValue(value: unknown, description: string): number {
   return value;
 }
 
+function nullableNumberValue(
+  value: unknown,
+  description: string,
+): number | null {
+  return value === null ? null : numberValue(value, description);
+}
+
 function booleanValue(value: unknown, description: string): boolean {
   if (typeof value !== "boolean") {
     throw new TypeError(`The Browser ${description} was not a boolean.`);
@@ -261,7 +272,10 @@ function parseRow(value: unknown): BrowserPackageQueryRow {
   return {
     packageId: stringValue(row.packageId, "package-query package ID"),
     version: stringValue(row.version, "package-query version"),
-    tier: facetTierValue(row.tier),
+    description: nullableStringValue(
+      row.description,
+      "package-query description"),
+    tier: rowTierValue(row.tier),
     evidence: row.evidence.map(item => {
       const evidence = objectValue(item, "package-query evidence");
       return {
@@ -269,10 +283,12 @@ function parseRow(value: unknown): BrowserPackageQueryRow {
         text: stringValue(evidence.text, "package-query evidence text"),
       };
     }),
-    totalDownloads: numberValue(
+    totalDownloads: nullableNumberValue(
       row.totalDownloads,
       "package-query download count"),
-    verified: booleanValue(row.verified, "package-query verification flag"),
+    verified: row.verified === null
+      ? null
+      : booleanValue(row.verified, "package-query verification flag"),
     producer: stringValue(row.producer, "package-query producer"),
   };
 }
@@ -321,14 +337,22 @@ function parseCompletion(value: unknown): BrowserPackageQueryCompletion {
       "package-query candidate count"),
     matches: numberValue(completion.matches, "package-query match count"),
     failures: numberValue(completion.failures, "package-query failure count"),
+    sourceCandidates: nullableNumberValue(
+      completion.sourceCandidates,
+      "package-query source candidate count"),
+    estimatedTotalHits: nullableNumberValue(
+      completion.estimatedTotalHits,
+      "package-query estimated total hits"),
     kind: completionKindValue(completion.kind),
   };
 }
 
-function facetTierValue(
+function rowTierValue(
   value: unknown,
 ): BrowserPackageQueryRow["tier"] {
-  if (value === "Nuspec" || value === "PackageContent") return value;
+  if (value === "SearchMetadata"
+    || value === "Nuspec"
+    || value === "PackageContent") return value;
   throw new TypeError(
     `Unsupported package-query row tier '${String(value)}'.`);
 }
@@ -360,6 +384,7 @@ function completionKindValue(
     case "CandidateLimitReached":
     case "SourcePageLimitReached":
     case "ClientPageLimitReached":
+    case "GalleryResponseComplete":
     case "Failed":
       return value;
     default:
@@ -415,7 +440,7 @@ function dispatchEvent(
         throw new TypeError(
           "A package-query completion event contained no summary.");
       }
-      onCompleted(toTerminalCompletion(queryEvent.completion));
+      onCompleted(toTerminalCompletion(parseCompletion(queryEvent.completion)));
       return;
     default:
       throw new TypeError(
@@ -452,7 +477,7 @@ function toQueryRow(
   row: NonNullable<BrowserPackageQueryEvent["row"]>,
 ): QueryResultRow {
   const evidence = row.evidence.map(item => item.text);
-  if (!evidence.length) {
+  if (!evidence.length || evidence.some(item => item.trim().length === 0)) {
     throw new TypeError("A package-query row contained no evidence.");
   }
   return {
@@ -461,6 +486,7 @@ function toQueryRow(
     tier: toQueryTier(row.tier),
     evidence: [evidence[0]!, ...evidence.slice(1)],
     totalDownloads: row.totalDownloads,
+    description: row.description,
     producer: row.producer,
   };
 }
@@ -468,6 +494,12 @@ function toQueryRow(
 function toQueryTier(
   tier: BrowserPackageQueryRow["tier"],
 ): QueryResultRow["tier"] {
+  return tier === "SearchMetadata" ? "search-metadata" : toInspectionTier(tier);
+}
+
+function toInspectionTier(
+  tier: BrowserPackageQueryFacetDescriptor["tier"],
+): QueryFacetTerm["tier"] {
   switch (tier) {
     case "Nuspec":
       return "nuspec";
@@ -493,6 +525,12 @@ function toTerminalCompletion(
     case "Exhausted":
       return { kind: "exhausted" };
     case "MatchLimitReached":
+      if (completion.sourceCandidates !== null) {
+        return {
+          kind: "bounded",
+          reason: galleryCompletionReason(completion),
+        };
+      }
       return {
         kind: "bounded",
         reason: `first ${completion.matchLimit.toLocaleString()} matches`,
@@ -513,13 +551,34 @@ function toTerminalCompletion(
         kind: "bounded",
         reason: "the client page limit",
       };
+    case "GalleryResponseComplete":
+      return {
+        kind: "bounded",
+        reason: galleryCompletionReason(completion),
+      };
     case "Failed":
       return {
         kind: "failed",
-        reason: "The package source failed before returning a usable profile.",
+        reason: "The package source failed before returning usable package input.",
       };
     default:
       throw new TypeError(
         `Unknown package-query completion '${String(completion.kind)}'.`);
   }
+}
+
+function galleryCompletionReason(
+  completion: BrowserPackageQueryCompletion,
+): string {
+  if (completion.sourceCandidates === null) {
+    throw new TypeError(
+      "A Gallery package-query completion contained no source candidate count.");
+  }
+  const matchLimit = completion.kind === "MatchLimitReached"
+    ? `; local match limit ${completion.matchLimit.toLocaleString()} reached`
+    : "";
+  const estimate = completion.estimatedTotalHits === null
+    ? "unavailable"
+    : `${completion.estimatedTotalHits.toLocaleString()} (estimate only)`;
+  return `one finite Gallery response (capacity ${completion.candidateLimit.toLocaleString()} candidates); acquired ${completion.sourceCandidates.toLocaleString()} candidates${matchLimit}; estimated total hits: ${estimate}`;
 }

--- a/prototypes/inspect-web/src/package-query-view.ts
+++ b/prototypes/inspect-web/src/package-query-view.ts
@@ -2,7 +2,10 @@ import type {
   PackageQueryState,
   QueryFacetTerm,
   QueryResultRow,
+  QuerySourceCatalog,
+  QuerySourceSelection,
 } from "./package-query.ts";
+import { createQueryRequest } from "./package-query.ts";
 import { renderBrand } from "./brand.ts";
 import { focusRenderedElement } from "./scope-bar.ts";
 
@@ -16,6 +19,7 @@ export interface PackageQueryBindingActions {
   onResultPressure: () => void;
   onRowOpen: (packageId: string, version: string) => void;
   onRun: (prefix: string) => void;
+  onSourceChange: (selection: QuerySourceSelection, searchText: string) => void;
 }
 
 export type PackageQueryFocusSnapshot =
@@ -27,6 +31,7 @@ export type PackageQueryFocusSnapshot =
   | { kind: "product" }
   | { kind: "back" }
   | { kind: "run" }
+  | { kind: "type" | "order" | "prerelease" }
   | { kind: "facet"; facetKey: string }
   | { kind: "row"; packageId: string; version: string }
   | { kind: "cancel"; index: number }
@@ -74,6 +79,9 @@ export function capturePackageQueryFocus(
   if (active.id === "package-query-product") return { kind: "product" };
   if (active.id === "package-query-back") return { kind: "back" };
   if (active.id === "package-query-run") return { kind: "run" };
+  if (active.id === "package-query-type") return { kind: "type" };
+  if (active.id === "package-query-order") return { kind: "order" };
+  if (active.id === "package-query-prerelease") return { kind: "prerelease" };
   if (active.dataset.queryFacet) {
     return { kind: "facet", facetKey: active.dataset.queryFacet };
   }
@@ -111,6 +119,11 @@ export function restorePackageQueryFocus(
       break;
     case "run":
       target = root.querySelector("#package-query-run");
+      break;
+    case "type":
+    case "order":
+    case "prerelease":
+      target = root.querySelector(`#package-query-${snapshot.kind}`);
       break;
     case "facet":
       target = [...root.querySelectorAll<HTMLElement>("[data-query-facet]")]
@@ -183,6 +196,22 @@ export function bindPackageQueryView(
     button.addEventListener("click", () => actions.onFacetToggle(
       button.dataset.queryFacet ?? "",
       prefixInput()?.value ?? "")));
+  const packageType = root.querySelector<HTMLSelectElement>(
+    "#package-query-type");
+  const sourceOrder = root.querySelector<HTMLSelectElement>(
+    "#package-query-order");
+  const prerelease = root.querySelector<HTMLInputElement>(
+    "#package-query-prerelease");
+  if (packageType && sourceOrder && prerelease) {
+    const sourceChanged = () => actions.onSourceChange({
+      packageType: packageType.value || null,
+      sourceOrderId: sourceOrder.value || null,
+      includePrerelease: prerelease.checked,
+    }, prefixInput()?.value ?? "");
+    packageType.addEventListener("change", sourceChanged);
+    sourceOrder.addEventListener("change", sourceChanged);
+    prerelease.addEventListener("change", sourceChanged);
+  }
   bindPackageQueryStreamControls(root, actions);
   const queryMain = root.querySelector<HTMLElement>(".query-main");
   const reportResultPressure = () => {
@@ -234,9 +263,14 @@ function renderRow(
         </div>
         <span class="query-tier query-tier-${escapeHtml(row.tier)}">${escapeHtml(row.tier)}</span>
       </div>
+      ${row.description?.trim()
+        ? `<p class="query-row-description">${escapeHtml(row.description)}</p>`
+        : ""}
       <ul class="query-evidence">${evidence}</ul>
       <div class="query-row-meta">
-        <span>${row.totalDownloads.toLocaleString()} downloads</span>
+        <span>${row.totalDownloads === null
+          ? "Lifetime downloads unavailable"
+          : `${row.totalDownloads.toLocaleString()} lifetime downloads`}</span>
         ${row.producer
           ? `<span>${escapeHtml(row.producer)}</span>`
           : ""}
@@ -319,6 +353,53 @@ function renderCompletionFooter(
     </div>`;
 }
 
+function renderSourceControls(
+  catalog: QuerySourceCatalog | null,
+  selection: QuerySourceSelection,
+  escapeHtml: (value: unknown) => string,
+): string {
+  if (!catalog) return "";
+  const packageTypes = catalog.packageType.suggestions.map(suggestion => `
+    <option value="${escapeHtml(suggestion.value)}"${selection.packageType === suggestion.value ? " selected" : ""}>${escapeHtml(suggestion.label)}</option>`).join("");
+  const customType = selection.packageType !== null
+    && !catalog.packageType.suggestions.some(
+      suggestion => suggestion.value === selection.packageType)
+    ? `<option value="${escapeHtml(selection.packageType)}" selected>${escapeHtml(selection.packageType)}</option>`
+    : "";
+  const orders = catalog.orders.map(order => `
+    <option value="${escapeHtml(order.id)}" title="${escapeHtml(order.summary)}"${selection.sourceOrderId === order.id ? " selected" : ""}>${escapeHtml(order.label)}</option>`).join("");
+  const orderSummary = selection.sourceOrderId === null
+    ? "Automatic uses the source default for this search."
+    : catalog.orders.find(order => order.id === selection.sourceOrderId)?.summary
+      ?? `Unavailable source order: ${selection.sourceOrderId}`;
+  const unavailableOrder = selection.sourceOrderId !== null
+    && !catalog.orders.some(order => order.id === selection.sourceOrderId)
+    ? `<option value="${escapeHtml(selection.sourceOrderId)}" selected>${escapeHtml(selection.sourceOrderId)} (unavailable)</option>`
+    : "";
+  return `
+    <div class="query-source-controls" role="group" aria-label="Gallery filters">
+      <h2>Gallery filters</h2>
+      <label for="package-query-type">${escapeHtml(catalog.packageType.label)}
+        <select id="package-query-type" aria-describedby="package-query-type-description">
+          <option value=""${selection.packageType === null ? " selected" : ""}>All package types</option>
+          ${packageTypes}${customType}
+        </select>
+      </label>
+      <p id="package-query-type-description">${escapeHtml(catalog.packageType.summary)}</p>
+      <label for="package-query-order">Source order
+        <select id="package-query-order" aria-describedby="package-query-order-description">
+          <option value=""${selection.sourceOrderId === null ? " selected" : ""}>Automatic</option>
+          ${orders}${unavailableOrder}
+        </select>
+      </label>
+      <p id="package-query-order-description">${escapeHtml(orderSummary)}</p>
+      <label for="package-query-prerelease">
+        <input id="package-query-prerelease" type="checkbox"${selection.includePrerelease ? " checked" : ""} />
+        Include prerelease
+      </label>
+    </div>`;
+}
+
 function renderStreamingCancel(
   state: PackageQueryState,
 ): string {
@@ -365,7 +446,7 @@ function renderEmptyState(
       <section class="query-empty">
         <span class="large-glyph">⌕</span>
         <h2>Query nuget.org</h2>
-        <p>Enter a package ID prefix, then narrow the live result stream with product facets.</p>
+        <p>Leave search blank to browse, or enter Gallery search text. Narrow the source with Gallery filters; add inspection facets only when needed.</p>
       </section>`;
   }
   if (completion.kind === "cancelled") {
@@ -389,7 +470,7 @@ function renderEmptyState(
       <section class="query-empty">
         <span class="large-glyph">◇</span>
         <h2>No matches within the bound</h2>
-        <p>Searched ${escapeHtml(completion.reason)}, not the whole source.${state.outcome.failures.length ? " Some source work also failed, so this is not a confirmed empty result within that bound." : ""}</p>
+        <p>Scope: ${escapeHtml(completion.reason)}. This is not the whole source.${state.outcome.failures.length ? " Some source work also failed, so this is not a confirmed empty result within that bound." : ""}</p>
       </section>`;
   }
   if (state.outcome.failures.length) {
@@ -404,7 +485,7 @@ function renderEmptyState(
     <section class="query-empty">
       <span class="large-glyph">◇</span>
       <h2>No matches</h2>
-      <p>Try a broader prefix or fewer facets.</p>
+      <p>Try a broader search, browse without search text, or select fewer inspection facets.</p>
     </section>`;
 }
 
@@ -412,6 +493,7 @@ export interface RenderPackageQueryOptions {
   state: PackageQueryState;
   prefix?: string;
   availableFacets: readonly QueryFacetTerm[];
+  sourceCatalog?: QuerySourceCatalog | null;
   navigationError?: string;
   escapeHtml: (value: unknown) => string;
 }
@@ -477,6 +559,7 @@ export function renderPackageQueryView(
     state,
     prefix = state.request?.scopeQuery ?? "",
     availableFacets,
+    sourceCatalog = null,
     navigationError = "",
     escapeHtml,
   } = options;
@@ -484,6 +567,7 @@ export function renderPackageQueryView(
   const facets = renderFacets(availableFacets, activeKeys, escapeHtml);
   const failures = renderFailures(state, escapeHtml);
   const results = renderResults(state, escapeHtml);
+  const request = state.request ?? createQueryRequest("");
 
   return `
     <div class="query-page">
@@ -495,13 +579,13 @@ export function renderPackageQueryView(
       </header>
       <main class="query-main">
         <div class="query-heading">
-          <p class="query-kicker">manifest + bounded package content · nuget.org</p>
+          <p class="query-kicker">Gallery discovery + optional inspection · nuget.org</p>
           <h1 id="package-query-heading" tabindex="-1">Package query</h1>
-          <p>Find packages by product-owned source, manifest, and package-content facets.</p>
+          <p>Browse or search using basic search metadata. Manifests and package content are acquired only with explicit inspection facets.</p>
         </div>
         <form id="package-query-form" class="query-bar" role="search">
-          <label for="package-query-prefix">Package ID prefix (<code>*</code> optional)</label>
-          <input id="package-query-prefix" name="prefix" value="${escapeHtml(prefix)}" autocomplete="off" spellcheck="false" placeholder="System.*" required maxlength="100" />
+          <label for="package-query-prefix">Search (optional)</label>
+          <input id="package-query-prefix" name="search" value="${escapeHtml(prefix)}" autocomplete="off" spellcheck="false" placeholder="Search packages or leave blank to browse" maxlength="100" />
           <button id="package-query-run" type="submit">Run query</button>
           <span id="package-query-cancel-region">${renderStreamingCancel(state)}</span>
         </form>
@@ -510,11 +594,14 @@ export function renderPackageQueryView(
           : ""}
         <div id="package-query-failure-region">${failures}</div>
         <div class="query-layout">
-          <aside class="query-facet-rail" aria-label="Package query facets">
-            <h2>Facets</h2>
+          <aside class="query-facet-rail" aria-label="Package query controls">
+            ${renderSourceControls(sourceCatalog, request, escapeHtml)}
+            <h2>Inspection facets</h2>
             <p>Every change starts a fresh request.</p>
             <div class="query-facets">${facets}</div>
             <p class="query-facet-disclosure">Content facets download up to 20 candidate package archives.</p>
+            <p class="query-facet-disclosure">Source capacity K: ${request.requestedLimit.toLocaleString()} candidates. Maximum matches N: ${request.requestedMatchLimit.toLocaleString()}. The match limit does not change source capacity.</p>
+            <p class="query-facet-disclosure">Match counts and lifetime downloads describe a bounded response, not global top-N.</p>
           </aside>
           <section id="package-query-results" class="query-results" aria-label="Package query results">
             ${results}

--- a/prototypes/inspect-web/src/package-query.ts
+++ b/prototypes/inspect-web/src/package-query.ts
@@ -27,8 +27,24 @@ export const PACKAGE_QUERY_INITIAL_MATCH_CREDIT = 20;
 const PACKAGE_QUERY_MATCH_CREDIT_BATCH = 10;
 const PACKAGE_QUERY_MATCH_CREDIT_THRESHOLD = 5;
 
+export interface QuerySourceSelection {
+  packageType: string | null;
+  sourceOrderId: string | null;
+  includePrerelease: boolean;
+}
+
+export interface QuerySourceCatalog {
+  packageType: {
+    id: string;
+    label: string;
+    summary: string;
+    suggestions: readonly { value: string; label: string }[];
+  };
+  orders: readonly { id: string; label: string; summary: string }[];
+}
+
 /** One rerunnable in-memory request. Never encodes a resolved outcome. */
-export interface QueryRequest {
+export interface QueryRequest extends QuerySourceSelection {
   scopeQuery: string;
   facets: readonly QueryFacetTerm[];
   /** Declared cap communicated to the source. The bounded-complete footer
@@ -45,6 +61,9 @@ export function createQueryRequest(
 ): QueryRequest {
   return {
     scopeQuery,
+    packageType: null,
+    sourceOrderId: null,
+    includePrerelease: false,
     facets: [],
     requestedLimit: DEFAULT_QUERY_CANDIDATE_LIMIT,
     requestedMatchLimit: 100,
@@ -117,9 +136,10 @@ export function toggleFacet(
 export interface QueryResultRow {
   packageId: string;
   version: string;
-  tier: "nuspec" | "package-content";
+  tier: "search-metadata" | "nuspec" | "package-content";
   evidence: readonly [string, ...string[]];
-  totalDownloads: number;
+  totalDownloads: number | null;
+  description?: string | null;
   producer?: string;
 }
 

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -2846,7 +2846,8 @@ kbd {
   color: var(--muted);
   font: 11px var(--mono);
 }
-.query-bar input {
+.query-bar input,
+.query-source-controls select {
   min-width: 0;
   border: 1px solid var(--line-strong);
   border-radius: 5px;
@@ -2856,6 +2857,8 @@ kbd {
   padding: 8px 10px;
 }
 .query-bar input:focus-visible,
+.query-source-controls select:focus-visible,
+.query-source-controls input:focus-visible,
 .query-facet:focus-visible,
 .query-page button:focus-visible {
   outline: 2px solid var(--blue);
@@ -2900,6 +2903,34 @@ kbd {
 }
 .query-facet-rail .query-facet-disclosure {
   margin: 12px 0 0;
+}
+.query-source-controls {
+  display: grid;
+  gap: 9px;
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+}
+.query-source-controls label {
+  display: grid;
+  gap: 5px;
+  color: var(--muted);
+  font: 11px var(--mono);
+}
+.query-source-controls label:has(input[type="checkbox"]) {
+  display: flex;
+  align-items: center;
+}
+.query-source-controls select { width: 100%; }
+.query-row-description {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  margin: 8px 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
 }
 .query-facets { display: flex; flex-direction: column; gap: 7px; }
 .query-facet-group {

--- a/prototypes/inspect-web/test/package-query-route.test.ts
+++ b/prototypes/inspect-web/test/package-query-route.test.ts
@@ -8,7 +8,7 @@ import {
   packageQueryHistoryState,
   readPackageQueryHistory,
   resolvePackageQueryWorkspaceSuccessor,
-  validPackageQueryPrefix,
+  validPackageQuerySearchText,
   withHistoryEntryId,
 } from "../src/package-query-route.ts";
 
@@ -18,13 +18,37 @@ test("package query route recognizes only its canonical path", () => {
   assert.equal(isPackageQueryPath("/packages/query"), false);
 });
 
-test("package query prefix validation trims useful input and rejects invalid shapes", () => {
-  assert.equal(validPackageQueryPrefix(" Microsoft.Extensions. "), "Microsoft.Extensions.");
-  assert.equal(validPackageQueryPrefix("Microsoft-*"), "Microsoft-*");
-  assert.equal(validPackageQueryPrefix(""), "");
-  assert.equal(validPackageQueryPrefix("contains space"), "contains space");
-  assert.equal(validPackageQueryPrefix("../escape"), "../escape");
-  assert.equal(validPackageQueryPrefix("a".repeat(101)), "");
+test("package query search validation preserves nonempty Gallery text exactly", () => {
+  for (const text of [
+    " Microsoft.Extensions. ",
+    "Microsoft-*",
+    "hosting dependency injection",
+    ' tags:"web api" ',
+    "a".repeat(100),
+  ]) {
+    assert.equal(validPackageQuerySearchText(text), text);
+  }
+});
+
+test("package query blank search normalizes to browse without fabricating a wildcard", () => {
+  for (const text of ["", " ", " ".repeat(100), "\u00a0\u2003"]) {
+    assert.equal(validPackageQuerySearchText(text), "");
+  }
+});
+
+test("package query invalid search is distinct from blank browse", () => {
+  for (const text of [
+    "a".repeat(101),
+    " ".repeat(101),
+    "contains\nnewline",
+    "\t",
+    "\rtext",
+    "text\u0000",
+    "text\u007f",
+    "text\u0085",
+  ]) {
+    assert.equal(validPackageQuerySearchText(text), null);
+  }
 });
 
 test("package query history scopes predecessor identity to one entry", () => {

--- a/prototypes/inspect-web/test/package-query-source.test.ts
+++ b/prototypes/inspect-web/test/package-query-source.test.ts
@@ -6,8 +6,13 @@ import {
   packageQueryFacets,
   type BrowserPackageQueryEngine,
 } from "../src/package-query-source.ts";
-import { createQueryRequest, withFacet } from "../src/package-query.ts";
+import {
+  createQueryRequest,
+  withFacet,
+  type QueryResultRow,
+} from "../src/package-query.ts";
 import type {
+  BrowserPackageQueryCompletion,
   BrowserPackageQueryEvent,
   BrowserPackageQueryFacetCatalog,
 } from "../src/facades/inspect-web-package.d.ts";
@@ -25,9 +30,259 @@ const completionEvent: BrowserPackageQueryEvent = {
     candidates: 1,
     matches: 1,
     failures: 1,
+    sourceCandidates: null,
+    estimatedTotalHits: null,
     kind: "Exhausted",
   },
 };
+
+async function runCompletion(completion: BrowserPackageQueryCompletion) {
+  const engine: BrowserPackageQueryEngine = {
+    cancel() {},
+    requestMatches() { return true; },
+    async run() {
+      return { ...completionEvent, completion };
+    },
+  };
+  return createBrowserPackageQueryDataSource(engine).run(
+    createQueryRequest(""),
+    () => {},
+    () => {},
+    () => {},
+    new AbortController().signal);
+}
+
+test("Browser source forwards browse and free text with opaque selections and unchanged K", async () => {
+  for (const searchText of ["", "  hosting dependency injection  ", "System.*"]) {
+    for (const matchLimit of [100, 7]) {
+      const request = {
+        ...withFacet(createQueryRequest(searchText), {
+          key: "producer.inspection.facet",
+          label: "Producer inspection",
+          tier: "nuspec",
+        }),
+        packageType: "Producer.CustomType",
+        sourceOrderId: "producer.order.custom",
+        includePrerelease: true,
+        requestedMatchLimit: matchLimit,
+      };
+      const engine: BrowserPackageQueryEngine = {
+        cancel() {},
+        requestMatches() { return true; },
+        async run(...args) {
+          assert.deepEqual(args.slice(0, 6), [
+            searchText, '["producer.inspection.facet"]', 200, matchLimit, true, 20,
+          ]);
+          assert.ok(typeof args[6] === "object" && args[6] !== null);
+          assert.deepEqual(args.slice(7), [
+            "Producer.CustomType", "producer.order.custom",
+          ]);
+          return completionEvent;
+        },
+      };
+      await createBrowserPackageQueryDataSource(engine).run(
+        request, () => {}, () => {}, () => {}, new AbortController().signal);
+    }
+  }
+});
+
+test("Browser source leaves automatic source order and package type unresolved", async () => {
+  for (const searchText of ["", "hosting"]) {
+    const engine: BrowserPackageQueryEngine = {
+      cancel() {},
+      requestMatches() { return true; },
+      async run(...args) {
+        assert.equal(args[0], searchText);
+        assert.equal(args[4], false);
+        assert.deepEqual(args.slice(7), [null, null]);
+        return completionEvent;
+      },
+    };
+    await createBrowserPackageQueryDataSource(engine).run(
+      createQueryRequest(searchText),
+      () => {}, () => {}, () => {}, new AbortController().signal);
+  }
+});
+
+test("Gallery metadata rows preserve unknown downloads and source-authored evidence", async () => {
+  for (const totalDownloads of [null, 0, 9876]) {
+    for (const verified of [null, false, true]) {
+      const event: BrowserPackageQueryEvent = {
+        ...toolMatchEvent,
+        row: {
+          ...toolMatchEvent.row!,
+          tier: "SearchMetadata",
+          totalDownloads,
+          verified,
+          evidence: [{
+            id: "producer.source-selection",
+            text: "Source order: producer ranking; package type: Producer.Type",
+          }],
+        },
+      };
+      const rows: QueryResultRow[] = [];
+      const engine: BrowserPackageQueryEngine = {
+        cancel() {},
+        requestMatches() { return true; },
+        async run(...args) {
+          assert.ok(typeof args[6] === "object" && args[6] !== null);
+          Reflect.set(args[6], "event", JSON.stringify(event));
+          return completionEvent;
+        },
+      };
+      await createBrowserPackageQueryDataSource(engine).run(
+        createQueryRequest(""),
+        page => rows.push(...page),
+        () => {}, () => {}, new AbortController().signal);
+      assert.deepEqual(rows, [{
+        packageId: "Contoso.Tool",
+        version: "2.0.0",
+        tier: "search-metadata",
+        totalDownloads,
+        description: null,
+        producer: "nuget.org",
+        evidence: ["Source order: producer ranking; package type: Producer.Type"],
+      }]);
+    }
+  }
+});
+
+test("Gallery row descriptions are projected unchanged from the producer", async () => {
+  const description = "  Tools for <format> packages & templates.  ";
+  const rows: QueryResultRow[] = [];
+  const engine: BrowserPackageQueryEngine = {
+    cancel() {},
+    requestMatches() { return true; },
+    async run(...args) {
+      assert.ok(typeof args[6] === "object" && args[6] !== null);
+      Reflect.set(args[6], "event", JSON.stringify({
+        ...toolMatchEvent,
+        row: {
+          ...toolMatchEvent.row!,
+          tier: "SearchMetadata",
+          description,
+        },
+      } satisfies BrowserPackageQueryEvent));
+      return completionEvent;
+    },
+  };
+
+  await createBrowserPackageQueryDataSource(engine).run(
+    createQueryRequest(""),
+    page => rows.push(...page),
+    () => {}, () => {}, new AbortController().signal);
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.description, description);
+});
+
+test("Gallery completions retain capacity and full acquired response independently of local matches", async () => {
+  const completion = await runCompletion({
+    ...completionEvent.completion!,
+    kind: "MatchLimitReached",
+    candidateLimit: 200,
+    matchLimit: 7,
+    candidates: 7,
+    matches: 7,
+    sourceCandidates: 200,
+    estimatedTotalHits: 42000,
+  });
+
+  assert.deepEqual(completion, {
+    kind: "bounded",
+    reason: "one finite Gallery response (capacity 200 candidates); acquired 200 candidates; local match limit 7 reached; estimated total hits: 42,000 (estimate only)",
+  });
+});
+
+test("empty and short Gallery responses stay finite even with absent or zero estimates", async () => {
+  for (const sourceCandidates of [0, 3]) {
+    for (const estimatedTotalHits of [null, 0, 400]) {
+      const completion = await runCompletion({
+        ...completionEvent.completion!,
+        kind: "GalleryResponseComplete",
+        candidateLimit: 200,
+        sourceCandidates,
+        estimatedTotalHits,
+        candidates: sourceCandidates,
+        matches: 0,
+        failures: 0,
+      });
+      assert.equal(completion.kind, "bounded");
+      assert.ok(completion.kind === "bounded");
+      assert.match(completion.reason, /one finite Gallery response/);
+      assert.match(completion.reason, /capacity 200 candidates/);
+      assert.ok(completion.reason.includes(`acquired ${sourceCandidates} candidates`));
+      assert.ok(completion.reason.includes(estimatedTotalHits === null
+        ? "estimated total hits: unavailable"
+        : `estimated total hits: ${estimatedTotalHits} (estimate only)`));
+      assert.doesNotMatch(completion.reason, /exhausted|all matches|local match limit/);
+    }
+  }
+});
+
+test("Gallery completion requires received-count evidence and known completion kind", async () => {
+  await assert.rejects(runCompletion({
+    ...completionEvent.completion!,
+    kind: "GalleryResponseComplete",
+  }), /no source candidate count/);
+  await assert.rejects(runCompletion({
+    ...completionEvent.completion!,
+    kind: 99,
+  }), /Unknown package-query completion/);
+  for (const property of ["sourceCandidates", "estimatedTotalHits"]) {
+    const incomplete = { ...completionEvent.completion! };
+    Reflect.deleteProperty(incomplete, property);
+    await assert.rejects(runCompletion(incomplete), /not a finite number/);
+  }
+});
+
+test("legacy match completion and failed package input retain distinct outcomes", async () => {
+  assert.deepEqual(await runCompletion({
+    ...completionEvent.completion!,
+    kind: "MatchLimitReached",
+  }), { kind: "bounded", reason: "first 100 matches" });
+  assert.deepEqual(await runCompletion({
+    ...completionEvent.completion!,
+    kind: "Failed",
+  }), {
+    kind: "failed",
+    reason: "The package source failed before returning usable package input.",
+  });
+});
+
+test("streamed metadata admission rejects unknown tiers, malformed metadata, and empty evidence", async () => {
+  const invalidRows = [
+    { ...toolMatchEvent.row!, tier: "UnknownTier" },
+    { ...toolMatchEvent.row!, totalDownloads: "unavailable" },
+    { ...toolMatchEvent.row!, verified: "unknown" },
+    { ...toolMatchEvent.row!, totalDownloads: undefined },
+    { ...toolMatchEvent.row!, verified: undefined },
+    { ...toolMatchEvent.row!, description: undefined },
+    { ...toolMatchEvent.row!, description: 123 },
+    { ...toolMatchEvent.row!, tier: "SearchMetadata", evidence: [] },
+    {
+      ...toolMatchEvent.row!,
+      tier: "SearchMetadata",
+      evidence: [{ id: "producer.source", text: " " }],
+    },
+  ];
+  for (const row of invalidRows) {
+    const engine: BrowserPackageQueryEngine = {
+      cancel() {},
+      requestMatches() { return true; },
+      async run(...args) {
+        assert.ok(typeof args[6] === "object" && args[6] !== null);
+        Reflect.set(args[6], "event", JSON.stringify({ ...toolMatchEvent, row }));
+        return completionEvent;
+      },
+    };
+    await assert.rejects(
+      createBrowserPackageQueryDataSource(engine).run(
+        createQueryRequest(""),
+        () => {}, () => {}, () => {}, new AbortController().signal),
+      /Unsupported package-query row tier|not a finite number|not a boolean|not text|no evidence/);
+  }
+});
 
 const toolMatchEvent: BrowserPackageQueryEvent = {
   kind: "Match",
@@ -43,6 +298,7 @@ const toolMatchEvent: BrowserPackageQueryEvent = {
       text: "DotnetToolSettings.xml declares v2.",
     }],
     totalDownloads: 12,
+    description: null,
     verified: false,
     producer: "nuget.org",
   },
@@ -210,6 +466,7 @@ test("Browser data source streams matches and failures before terminal completio
       tier: "Nuspec",
       evidence: [{ id: "package.query.source-verified", text: "Verified source" }],
       totalDownloads: 1234,
+      description: null,
       verified: true,
       producer: "nuget.org",
     },

--- a/prototypes/inspect-web/test/package-query-view.test.ts
+++ b/prototypes/inspect-web/test/package-query-view.test.ts
@@ -24,6 +24,8 @@ import {
   type PackageQueryState,
   type QueryFacetTerm,
   type QueryResultRow,
+  type QuerySourceCatalog,
+  type QuerySourceSelection,
 } from "../src/package-query.ts";
 import { fakeDom } from "./fake-dom.ts";
 
@@ -73,6 +75,30 @@ const FACETS: readonly QueryFacetTerm[] = [
   SKILL_FACET,
 ];
 
+const SOURCE_CATALOG: QuerySourceCatalog = {
+  packageType: {
+    id: "producer.package-type",
+    label: "Producer package type",
+    summary: "Select a type from source metadata.",
+    suggestions: [
+      { value: "Producer.Tool", label: "Producer tools" },
+      { value: "Producer.Template", label: "Producer templates" },
+    ],
+  },
+  orders: [
+    {
+      id: "producer.order.first",
+      label: "Producer first order",
+      summary: "First producer ordering description.",
+    },
+    {
+      id: "producer.order.second",
+      label: "Producer second order",
+      summary: "Second producer ordering description.",
+    },
+  ],
+};
+
 function row(packageId: string): QueryResultRow {
   return {
     packageId,
@@ -91,6 +117,176 @@ test("an unstarted query renders the composing empty state", () => {
   });
 
   assert.match(html, /Query nuget\.org/);
+  assert.match(html, /Search \(optional\)/);
+  assert.match(html, /Leave search blank to browse/);
+  assert.doesNotMatch(html, /required|Package ID prefix|<code>\*<\/code>/);
+});
+
+test("source controls render only from an available catalog, separate from inspection facets", () => {
+  for (const sourceCatalog of [undefined, null]) {
+    const html = renderPackageQueryView({
+      state: initialQueryState(),
+      availableFacets: FACETS,
+      ...(sourceCatalog === undefined ? {} : { sourceCatalog }),
+      escapeHtml,
+    });
+    assert.doesNotMatch(html, /id="package-query-(type|order|prerelease)"/);
+    assert.match(html, /<h2>Inspection facets<\/h2>/);
+  }
+  const html = renderPackageQueryView({
+    state: initialQueryState(),
+    availableFacets: FACETS,
+    sourceCatalog: SOURCE_CATALOG,
+    escapeHtml,
+  });
+
+  assert.match(html, /aria-label="Gallery filters"/);
+  assert.match(html, /Producer package type/);
+  assert.match(html, /Select a type from source metadata/);
+  assert.match(html, /<option value="" selected>All package types<\/option>/);
+  assert.match(html, /<option value="" selected>Automatic<\/option>/);
+  assert.match(html, /value="Producer.Tool">Producer tools<\/option>/);
+  assert.match(html, /value="producer.order.second" title="Second producer ordering description.">Producer second order<\/option>/);
+  assert.match(html, /id="package-query-prerelease" type="checkbox" \/>/);
+  assert.match(html, /basic search metadata/);
+  assert.match(html, /Manifests and package content are acquired only with explicit inspection facets/);
+  assert.ok(html.indexOf('aria-label="Gallery filters"') < html.indexOf("<h2>Inspection facets</h2>"));
+});
+
+test("source selections render from request identity without changing inspection facets", () => {
+  const state: PackageQueryState = {
+    request: {
+      ...withFacet(createQueryRequest(" hosting libraries "), NUSPEC_FACET),
+      packageType: "Producer.Template",
+      sourceOrderId: "producer.order.second",
+      includePrerelease: true,
+    },
+    outcome: emptyOutcome(),
+  };
+  const html = renderPackageQueryView({
+    state,
+    availableFacets: FACETS,
+    sourceCatalog: SOURCE_CATALOG,
+    escapeHtml,
+  });
+
+  assert.match(html, /value=" hosting libraries "/);
+  assert.match(html, /value="Producer.Template" selected>Producer templates<\/option>/);
+  assert.match(html, /value="producer.order.second"[^>]* selected>Producer second order<\/option>/);
+  assert.match(html, /id="package-query-prerelease" type="checkbox" checked/);
+  assert.match(html, /data-query-facet="tfm-out-of-support"[\s\S]*aria-pressed="true"/);
+  assert.match(html, /id="package-query-order-description">Second producer ordering description./);
+});
+
+test("existing custom type and unavailable order stay visible rather than silently resetting", () => {
+  const html = renderPackageQueryView({
+    state: {
+      request: {
+        ...createQueryRequest(""),
+        packageType: "Producer.Custom",
+        sourceOrderId: "producer.order.unavailable",
+      },
+      outcome: emptyOutcome(),
+    },
+    availableFacets: FACETS,
+    sourceCatalog: SOURCE_CATALOG,
+    escapeHtml,
+  });
+
+  assert.match(html, /value="Producer.Custom" selected>Producer.Custom<\/option>/);
+  assert.match(html, /value="producer.order.unavailable" selected>producer.order.unavailable \(unavailable\)<\/option>/);
+  assert.match(html, /Unavailable source order: producer.order.unavailable/);
+  assert.doesNotMatch(html, /value="" selected>/);
+});
+
+test("source capacity and local match limit are independently disclosed before and during inspection", () => {
+  for (const request of [
+    null,
+    withFacet(createQueryRequest(""), NUSPEC_FACET),
+    withFacet(createQueryRequest(""), SKILL_FACET),
+    { ...createQueryRequest(""), requestedMatchLimit: 7 },
+  ]) {
+    const html = renderPackageQueryView({
+      state: { request, outcome: emptyOutcome() },
+      availableFacets: FACETS,
+      escapeHtml,
+    });
+    assert.ok(html.includes(`Source capacity K: ${request?.requestedLimit ?? 200} candidates`));
+    assert.ok(html.includes(`Maximum matches N: ${request?.requestedMatchLimit ?? 100}`));
+    assert.match(html, /The match limit does not change source capacity/);
+    assert.match(html, /Content facets download up to 20 candidate package archives/);
+    assert.match(html, /Match counts and lifetime downloads describe a bounded response, not global top-N/);
+  }
+});
+
+test("basic metadata rows show producer evidence and unavailable lifetime downloads distinctly from zero", () => {
+  for (const totalDownloads of [null, 0, 1234]) {
+    const html = renderPackageQueryView({
+      state: {
+        request: createQueryRequest(""),
+        outcome: appendRows(emptyOutcome(), [{
+          ...row("Producer.Result"),
+          tier: "search-metadata",
+          totalDownloads,
+          evidence: ["Source selection and order from the producer"],
+        }]),
+      },
+      availableFacets: [],
+      escapeHtml,
+    });
+    assert.match(html, /query-tier-search-metadata">search-metadata</);
+    assert.match(html, /Source selection and order from the producer/);
+    if (totalDownloads === null) {
+      assert.match(html, /Lifetime downloads unavailable/);
+      assert.doesNotMatch(html, /0 lifetime downloads/);
+    } else {
+      assert.ok(html.includes(`${totalDownloads.toLocaleString()} lifetime downloads`));
+      assert.doesNotMatch(html, /Lifetime downloads unavailable/);
+    }
+  }
+});
+
+test("Gallery completion text retains the finite bound and estimate with or without rows", () => {
+  for (const rows of [[], [row("Producer.Result")]]) {
+    const reason = "one finite Gallery response (capacity 200 candidates); acquired 3 candidates; estimated total hits: 0 (estimate only)";
+    const html = renderPackageQueryView({
+      state: {
+        request: createQueryRequest(""),
+        outcome: withCompletion(appendRows(emptyOutcome(), rows), {
+          kind: "bounded",
+          reason,
+        }),
+      },
+      availableFacets: [],
+      escapeHtml,
+    });
+    assert.ok(html.includes(reason));
+    assert.doesNotMatch(html, /all matches|exhausted|<h2>No matches<\/h2>/);
+    assert.doesNotMatch(html, /data-query-cancel/);
+  }
+});
+
+test("row descriptions render as escaped text only when available", () => {
+  for (const description of [undefined, null, "", "   ", "Tools for <format> packages & templates."]) {
+    const html = renderPackageQueryView({
+      state: {
+        request: createQueryRequest(""),
+        outcome: appendRows(emptyOutcome(), [{
+          ...row("Producer.Result"),
+          tier: "search-metadata",
+          ...(description === undefined ? {} : { description }),
+        }]),
+      },
+      availableFacets: [],
+      escapeHtml,
+    });
+    if (description?.trim()) {
+      assert.match(html, /<p class="query-row-description">Tools for &lt;format&gt; packages &amp; templates.<\/p>/);
+      assert.doesNotMatch(html, /<format>/);
+    } else {
+      assert.doesNotMatch(html, /query-row-description/);
+    }
+  }
 });
 
 test("the query header keeps home and Back without Query or Workspace buttons", () => {
@@ -460,6 +656,8 @@ class FakeElement {
   scrollHeight = 0;
   clientHeight = 0;
   innerHTML = "";
+  value = "";
+  checked = false;
   selectionStart: number | null = null;
   selectionEnd: number | null = null;
   selectionRange: readonly [number, number] | null = null;
@@ -486,8 +684,8 @@ class FakeElement {
       listeners.filter(candidate => candidate !== listener));
   }
 
-  dispatch(type: string) {
-    for (const listener of this.listeners.get(type) ?? []) listener(fakeDom.event());
+  dispatch(type: string, event = fakeDom.event()) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
   }
 
   focus() {
@@ -553,6 +751,11 @@ test("query focus snapshots restore semantic controls after a full render", () =
       selector: "#package-query-back",
       replacement: new FakeElement({}, "package-query-back"),
     },
+    ...["type", "order", "prerelease"].map(control => ({
+      active: new FakeElement({}, `package-query-${control}`),
+      selector: `#package-query-${control}`,
+      replacement: new FakeElement({}, `package-query-${control}`),
+    })),
     {
       active: new FakeElement({ queryFacet: "downloads-1m" }),
       selector: "[data-query-facet]",
@@ -621,10 +824,14 @@ test("query scroll position survives streamed full renders", () => {
 });
 
 test("a vanished query control reports prefix fallback", () => {
-  const cases = [new FakeElement({
-    queryRowOpen: "Vanished.Package",
-    queryRowVersion: "1.0.0",
-  })];
+  const cases = [
+    new FakeElement({
+      queryRowOpen: "Vanished.Package",
+      queryRowVersion: "1.0.0",
+    }),
+    ...["type", "order", "prerelease"].map(
+      control => new FakeElement({}, `package-query-${control}`)),
+  ];
 
   for (const active of cases) {
     const prefix = new FakeElement({}, "package-query-prefix");
@@ -713,6 +920,7 @@ test("bindPackageQueryView wires back, row-open, facet, and cancel", () => {
     onResultPressure: () => calls.push("pressure"),
     onRowOpen: (id, version) => calls.push(`open:${id}:${version}`),
     onRun: () => {},
+    onSourceChange: () => {},
   };
 
   bindPackageQueryView(fakeDom.parentNode(root), actions);
@@ -728,6 +936,97 @@ test("bindPackageQueryView wires back, row-open, facet, and cancel", () => {
     "facet:tfm-out-of-support",
     "cancel",
   ]);
+});
+
+test("source control changes forward the complete selection and current unmodified search text", () => {
+  const root = new FakeRoot();
+  const input = new FakeElement({}, "package-query-prefix");
+  const packageType = new FakeElement({}, "package-query-type");
+  const order = new FakeElement({}, "package-query-order");
+  const prerelease = new FakeElement({}, "package-query-prerelease");
+  root.add("#package-query-prefix", input);
+  root.add("#package-query-type", packageType);
+  root.add("#package-query-order", order);
+  root.add("#package-query-prerelease", prerelease);
+  const calls: { selection: QuerySourceSelection; searchText: string }[] = [];
+  bindPackageQueryView(fakeDom.parentNode(root), {
+    onBack: () => {},
+    onCancel: () => {},
+    onFacetToggle: () => assert.fail("source controls are not inspection facets"),
+    onPrefixInput: () => {},
+    onResultPressure: () => {},
+    onRowOpen: () => {},
+    onRun: () => assert.fail("source changes use their own action"),
+    onSourceChange: (selection, searchText) => calls.push({ selection, searchText }),
+  });
+
+  packageType.value = "Producer.CustomType";
+  packageType.dispatch("change");
+  input.value = " hosting libraries * ";
+  order.value = "producer.order.custom";
+  order.dispatch("change");
+  prerelease.checked = true;
+  prerelease.dispatch("change");
+  packageType.value = "";
+  order.value = "";
+  prerelease.checked = false;
+  order.dispatch("change");
+
+  assert.deepEqual(calls, [
+    {
+      selection: {
+        packageType: "Producer.CustomType", sourceOrderId: null, includePrerelease: false,
+      },
+      searchText: "",
+    },
+    {
+      selection: {
+        packageType: "Producer.CustomType", sourceOrderId: "producer.order.custom", includePrerelease: false,
+      },
+      searchText: " hosting libraries * ",
+    },
+    {
+      selection: {
+        packageType: "Producer.CustomType", sourceOrderId: "producer.order.custom", includePrerelease: true,
+      },
+      searchText: " hosting libraries * ",
+    },
+    {
+      selection: {
+        packageType: null, sourceOrderId: null, includePrerelease: false,
+      },
+      searchText: " hosting libraries * ",
+    },
+  ]);
+});
+
+test("query form submits blank browse and unchanged text without requiring source controls", () => {
+  const root = new FakeRoot();
+  const form = new FakeElement({}, "package-query-form");
+  const input = new FakeElement({}, "package-query-prefix");
+  root.add("#package-query-form", form);
+  root.add("#package-query-prefix", input);
+  const calls: string[] = [];
+  let prevented = 0;
+  bindPackageQueryView(fakeDom.parentNode(root), {
+    onBack: () => {},
+    onCancel: () => {},
+    onFacetToggle: () => {},
+    onPrefixInput: () => {},
+    onResultPressure: () => {},
+    onRowOpen: () => {},
+    onRun: text => calls.push(text),
+    onSourceChange: () => assert.fail("source controls are absent"),
+  });
+  for (const text of ["", " hosting libraries ", "System.*"]) {
+    input.value = text;
+    form.dispatch("submit", fakeDom.event({
+      preventDefault() { prevented++; },
+    }));
+  }
+
+  assert.deepEqual(calls, ["", " hosting libraries ", "System.*"]);
+  assert.equal(prevented, 3);
 });
 
 test("query result pressure starts within 600 pixels of the current end", () => {
@@ -758,6 +1057,7 @@ test("bindPackageQueryView reports near-end scroll pressure and disconnects it",
     onResultPressure: () => { pressure++; },
     onRowOpen: () => {},
     onRun: () => {},
+    onSourceChange: () => {},
   });
 
   main.scrollTop = 401;
@@ -799,6 +1099,7 @@ test("patchPackageQueryStream updates only dynamic query regions", () => {
       onResultPressure: () => { pressure++; },
       onRowOpen: () => {},
       onRun: () => {},
+      onSourceChange: () => {},
     });
 
   assert.equal(patched, true);

--- a/prototypes/inspect-web/test/package-query.test.ts
+++ b/prototypes/inspect-web/test/package-query.test.ts
@@ -96,6 +96,40 @@ test("createQueryRequest gives candidate and match limits independent defaults",
   assert.equal(defaults.requestedLimit, 200);
   assert.equal(defaults.requestedMatchLimit, 100);
   assert.notEqual(defaults.requestedLimit, defaults.requestedMatchLimit);
+  assert.equal(defaults.packageType, null);
+  assert.equal(defaults.sourceOrderId, null);
+  assert.equal(defaults.includePrerelease, false);
+});
+
+test("browse and free-text requests preserve source intent without resolving source defaults", () => {
+  for (const text of ["", "  hosting dependency injection  ", "System.*"]) {
+    assert.equal(createQueryRequest(text).scopeQuery, text);
+    assert.equal(createQueryRequest(text).sourceOrderId, null);
+  }
+});
+
+test("inspection changes retain opaque source selections and independent match limits", () => {
+  const request = {
+    ...createQueryRequest(" hosting libraries "),
+    packageType: "Producer.CustomType",
+    sourceOrderId: "producer.order.custom",
+    includePrerelease: true,
+    requestedMatchLimit: 7,
+  };
+  const content = toggleFacet(request, SKILL_FACET);
+  const manifest = toggleFacet(toggleFacet(content, TFM_FACET), SKILL_FACET);
+  const browse = withScopeQuery(manifest, "");
+
+  assert.equal(content.requestedLimit, 20);
+  assert.equal(manifest.requestedLimit, 200);
+  for (const changed of [content, manifest, browse]) {
+    assert.equal(changed.packageType, request.packageType);
+    assert.equal(changed.sourceOrderId, request.sourceOrderId);
+    assert.equal(changed.includePrerelease, true);
+    assert.equal(changed.requestedMatchLimit, 7);
+  }
+  assert.deepEqual(browse.facets, [TFM_FACET]);
+  assert.equal(browse.scopeQuery, "");
 });
 
 test("package-content facets lower the candidate bound until the last one is removed", () => {
@@ -109,9 +143,12 @@ test("package-content facets lower the candidate bound until the last one is rem
   assert.equal(withSkill.requestedLimit, 20);
   assert.equal(withSkillAndManifest.requestedLimit, 20);
   assert.equal(manifestOnly.requestedLimit, 200);
+  assert.equal(withSkill.requestedMatchLimit, 100);
+  assert.equal(withSkillAndManifest.requestedMatchLimit, 100);
+  assert.equal(manifestOnly.requestedMatchLimit, 100);
 });
 
-test("withScopeQuery preserves facets and bounds while changing the prefix", () => {
+test("withScopeQuery preserves facets and bounds while changing search text", () => {
   const request = {
     ...withFacet(createQueryRequest("Microsoft."), TFM_FACET),
     requestedLimit: 25,
@@ -122,6 +159,36 @@ test("withScopeQuery preserves facets and bounds while changing the prefix", () 
     ...request,
     scopeQuery: "System.",
   });
+});
+
+test("controller runs blank browse with source selection and nullable metadata", async () => {
+  const state = initialQueryState();
+  const request = {
+    ...createQueryRequest(""),
+    packageType: "Producer.Type",
+    sourceOrderId: "producer.order",
+    includePrerelease: true,
+  };
+  const source: PackageQueryDataSource = {
+    async run(received, onPage) {
+      assert.deepEqual(received, request);
+      onPage([{
+        ...row("Browse.Result"),
+        tier: "search-metadata",
+        evidence: ["Producer source selection and order"],
+        totalDownloads: null,
+      }]);
+      return { kind: "bounded", reason: "one finite Gallery response" };
+    },
+  };
+  const controller = createPackageQueryController(state, source, () => {});
+
+  await controller.run(request);
+
+  assert.equal(state.request?.scopeQuery, "");
+  assert.equal(state.outcome.rows[0]?.tier, "search-metadata");
+  assert.equal(state.outcome.rows[0]?.totalDownloads, null);
+  assert.equal(state.outcome.completion.kind, "bounded");
 });
 
 test("toggleFacet replaces an active facet in the same producer-owned selection group", () => {
@@ -438,6 +505,45 @@ test("a superseded run's late pages never land in the newer outcome", async () =
 
   assert.deepEqual(state.outcome.rows.map(r => r.packageId), ["fresh"]);
   assert.equal(state.outcome.completion.kind, "exhausted");
+});
+
+test("changing only source selection supersedes browse work without changing search text", async () => {
+  const state = initialQueryState();
+  let firstSignal: AbortSignal | undefined;
+  let releaseFirst!: () => void;
+  const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+  const source: PackageQueryDataSource = {
+    async run(request, onPage, onFailure, onProgress, signal) {
+      assert.equal(request.scopeQuery, "");
+      if (request.sourceOrderId === null) {
+        firstSignal = signal;
+        await firstGate;
+        onPage([row("Stale")]);
+        onFailure("Stale failure");
+        onProgress({ phase: "search", completed: 1, limit: 1 });
+        return { kind: "exhausted" };
+      }
+      onPage([row("Current")]);
+      return { kind: "bounded", reason: "one finite Gallery response" };
+    },
+  };
+  const controller = createPackageQueryController(state, source, () => {});
+  const first = controller.run(createQueryRequest(""));
+  await controller.run({
+    ...createQueryRequest(""),
+    sourceOrderId: "producer.order.custom",
+  });
+  assert.equal(firstSignal?.aborted, true);
+  releaseFirst();
+  await first;
+
+  assert.deepEqual(state.outcome.rows.map(item => item.packageId), ["Current"]);
+  assert.deepEqual(state.outcome.failures, []);
+  assert.deepEqual(state.outcome.progress, []);
+  assert.deepEqual(state.outcome.completion, {
+    kind: "bounded",
+    reason: "one finite Gallery response",
+  });
 });
 
 test("a superseded run's late rejection never overwrites the newer outcome", async () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3200,7 +3200,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
 
   assert.match(
     results,
-    /kind: "package-query",[\s\S]*prefix: validPackageQueryPrefix\(query\),/);
+    /kind: "package-query",[\s\S]*prefix: validPackageQuerySearchText\(query\) \?\? "",/);
   assert.match(
     appSource,
     /case "package-query":\s*openPackageQueryRoute\(result\.prefix\);\s*break;/);
@@ -3300,17 +3300,17 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /workspaceLocation\.sync\(snapshot, history\.state\)/);
   assert.equal(
     appSource.match(
-      /\? withScopeQuery\(state\.packageQueryState\.request, validPrefix\)/g)
+      /\? withScopeQuery\(state\.packageQueryState\.request, validText\)/g)
       ?.length,
-    2);
+    1);
   assert.equal(
     appSource.match(
       /packageQueryLiveAnnouncer\.reset\(\);\s*void packageQueryController\.run/g)
       ?.length,
-    2);
+    3);
   assert.match(
     appSource,
-    /state\.packageQueryCatalogError =\s*`Package-query facets are unavailable/);
+    /state\.packageQueryCatalogError =\s*`Package-query catalogs are unavailable/);
   assert.match(
     appSource,
     /navigationError: \[\s*state\.packageQueryCatalogError,\s*state\.packageQueryNavigationError/);

--- a/src/DotnetInspector.Queries.Tests/PackageQueryGalleryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryGalleryTests.cs
@@ -1,0 +1,424 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+using DotnetInspector.Packages;
+using DotnetInspector.RowSelection;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class PackageQueryGalleryTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("json")]
+    [InlineData(" owner:somebody tags:\"a b\" ")]
+    [InlineData("System.*")]
+    public void PlanGalleryPreservesSourceInputAndDoesNotInterpretPrefixes(string? text)
+    {
+        var request = new NuGetGalleryDiscoveryRequest(
+            PackageSourceDescriptor.NuGetGallery, 200, text);
+        PackageQueryPlan plan = Accepted(PackageQuery.PlanGallery(request, maximumMatches: 7));
+        Assert.Same(request, plan.GalleryRequest);
+        Assert.Equal(text, plan.GalleryRequest!.Text);
+        Assert.Equal("", plan.Prefix.ToString());
+        Assert.Equal(200, plan.MaximumCandidates);
+        Assert.Equal(7, plan.MaximumMatches);
+        Assert.Empty(plan.Facets);
+        Assert.Null(Accepted(PackageQuery.Plan(new PackageQueryRequest("System."))).GalleryRequest);
+    }
+
+    [Theory]
+    [InlineData("\u202Ehidden")]
+    [InlineData("json\u001b[2J")]
+    [InlineData("json\0")]
+    public void PlanGalleryRejectsNonInertTextWithoutEchoingIt(string text)
+    {
+        var result = PackageQuery.PlanGallery(
+            new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 20, text));
+        var failure = Assert.IsType<PackageQueryPlanResult.Rejected>(result).Failure;
+        Assert.Equal(PackageQueryRequestFailureReason.InvalidSearchText, failure.Reason);
+        Assert.DoesNotContain(text, failure.Message);
+    }
+
+    [Fact]
+    public void GalleryAndPrefixReuseTheFacetAndMatchBoundPlanner()
+    {
+        string[][] selections =
+        [
+            [""],
+            ["unknown"],
+            [PackageQuery.ToolFacetId, PackageQuery.ToolFacetId],
+            [PackageQuery.HasDependenciesFacetId, PackageQuery.NoDependenciesFacetId],
+            [PackageQuery.ToolFacetId, PackageQuery.ToolV2FacetId],
+            [PackageQuery.EmbeddedSkillFacetId],
+            [.. Enumerable.Repeat(PackageQuery.ToolFacetId, 10)],
+        ];
+        foreach (string[] selected in selections)
+        {
+            var prefix = Assert.IsType<PackageQueryPlanResult.Rejected>(PackageQuery.Plan(
+                new PackageQueryRequest("System.", selected, MaximumCandidates: 21)));
+            var gallery = Assert.IsType<PackageQueryPlanResult.Rejected>(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 21), selected));
+            Assert.Equal(prefix.Failure.Reason, gallery.Failure.Reason);
+            Assert.Equal(prefix.Failure.FacetIds, gallery.Failure.FacetIds);
+        }
+        Assert.Equal(
+            PackageQueryRequestFailureReason.InvalidMatchLimit,
+            Assert.IsType<PackageQueryPlanResult.Rejected>(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 20),
+                maximumMatches: 0)).Failure.Reason);
+        Assert.Equal(20, Accepted(PackageQuery.PlanGallery(
+            new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 20),
+            [PackageQuery.ToolV1FacetId, PackageQuery.ToolV2FacetId])).MaximumCandidates);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(2, 1)]
+    [InlineData(5, 3)]
+    [InlineData(3, 10)]
+    [InlineData(5, 5)]
+    public async Task MetadataSelectionEqualsHeadOverTheFullResponseIncludingTies(
+        int count, int maximumMatches)
+    {
+        string[] ids = [.. Enumerable.Range(0, count).Select(i => $"Sample.{i}")];
+        string[] rows = [.. ids.Select(id => Row(id, downloads: 10))];
+        using var handler = new GalleryHandler(Envelope(rows));
+        using var source = Source(handler);
+        var request = new NuGetGalleryDiscoveryRequest(
+            PackageSourceDescriptor.NuGetGallery, 5,
+            packageType: NuGetGalleryPackageType.DotnetTool);
+        var events = await PackageQuery.ExecuteToArrayAsync(
+            source, Accepted(PackageQuery.PlanGallery(request, maximumMatches: maximumMatches)),
+            TestContext.Current.CancellationToken);
+
+        var expected = RowSelectionExecutor.Apply(
+            ids,
+            RowSelectionPlan<string>.Create([RowSelectionStage<string>.Head(maximumMatches)]));
+        var matches = events.OfType<PackageQueryEvent.Match>().Select(e => e.Value).ToArray();
+        Assert.Equal(expected.Values, matches.Select(match => match.Package.PackageId));
+        Assert.All(matches, match =>
+        {
+            Assert.Equal(PackageQueryFacetTier.SearchMetadata, match.Tier);
+            Assert.Null(match.Package.Manifest);
+            Assert.Null(match.Package.Verified);
+            Assert.Equal(10, match.Package.TotalDownloads);
+            Assert.Same(source.Source, match.Package.Source);
+            Assert.DoesNotContain(match.Evidence, item => item.Id == PackageQuery.PrefixEvidenceId);
+            Assert.Contains(match.Evidence, item => item.Id == PackageQuery.GalleryPackageTypeEvidenceId);
+            Assert.Contains(match.Evidence, item => item.Id == PackageQuery.GalleryOrderEvidenceId);
+            Assert.DoesNotContain(match.Evidence, item => item.Id == PackageQuery.ToolFacetId);
+        });
+        var summary = Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(count, summary.SourceCandidates);
+        Assert.Equal(5, summary.CandidateLimit);
+        Assert.Equal(maximumMatches, summary.MatchLimit);
+        Assert.Equal(Math.Min(count, maximumMatches), summary.Candidates);
+        Assert.Equal(Math.Min(count, maximumMatches), summary.Matches);
+        Assert.Equal(500, summary.EstimatedTotalHits);
+        Assert.Equal(
+            count > maximumMatches
+                ? PackageQueryCompletionKind.MatchLimitReached
+                : PackageQueryCompletionKind.GalleryResponseComplete,
+            summary.Completion);
+        Assert.Contains("take=5", Assert.Single(handler.Requests));
+        Assert.Equal([PackageQueryProgressPhase.Search],
+            events.OfType<PackageQueryEvent.Progress>().Select(e => e.Value.Phase).Distinct());
+    }
+
+    [Fact]
+    public async Task CapacityDependentRankingDoesNotReplaceHeadWithSmallerAcquisition()
+    {
+        // Indexed membership is A, B, C; auxiliary lifetime order within K=3 is B, C, A.
+        string fullResponse = Envelope(
+            Row("B", 600), Row("C", 500), Row("A", 10));
+        using var fullHandler = new GalleryHandler(fullResponse);
+        using var fullSource = Source(fullHandler);
+        var fullEvents = await PackageQuery.ExecuteToArrayAsync(
+            fullSource,
+            Accepted(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 3),
+                maximumMatches: 1)),
+            TestContext.Current.CancellationToken);
+        using var smallerHandler = new GalleryHandler(Envelope(Row("A", 10)));
+        using var smallerSource = Source(smallerHandler);
+        var smallerEvents = await PackageQuery.ExecuteToArrayAsync(
+            smallerSource,
+            Accepted(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 1),
+                maximumMatches: 1)),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("B", Assert.Single(fullEvents.OfType<PackageQueryEvent.Match>()).Value.Package.PackageId);
+        Assert.Equal("A", Assert.Single(smallerEvents.OfType<PackageQueryEvent.Match>()).Value.Package.PackageId);
+        Assert.Contains("take=3", Assert.Single(fullHandler.Requests));
+        Assert.Contains("take=1", Assert.Single(smallerHandler.Requests));
+        Assert.Equal(3, Assert.IsType<PackageQueryEvent.Completed>(fullEvents[^1]).Value.SourceCandidates);
+    }
+
+    [Fact]
+    public async Task ManifestSelectionIsLocalAndStopsEnrichmentAfterHeadOfMatches()
+    {
+        string response = Envelope(Row("Library", 30), Row("Tool", 20), Row("AnotherTool", 10));
+        var manifests = new Dictionary<string, string>
+        {
+            ["library"] = Manifest("Library"),
+            ["tool"] = Manifest("Tool", tool: true),
+            ["anothertool"] = Manifest("AnotherTool", tool: true),
+        };
+        using var handler = new GalleryHandler(response, manifests);
+        using var source = Source(handler);
+        var request = new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 3);
+        var events = await PackageQuery.ExecuteToArrayAsync(source,
+            Accepted(PackageQuery.PlanGallery(request, [PackageQuery.ToolFacetId], maximumMatches: 1)),
+            TestContext.Current.CancellationToken);
+        using var allHandler = new GalleryHandler(response, manifests);
+        using var allSource = Source(allHandler);
+        var allEvents = await PackageQuery.ExecuteToArrayAsync(allSource,
+            Accepted(PackageQuery.PlanGallery(request, [PackageQuery.ToolFacetId])),
+            TestContext.Current.CancellationToken);
+        var reference = RowSelectionExecutor.Apply(
+            allEvents.OfType<PackageQueryEvent.Match>().Select(e => e.Value.Package.PackageId).ToArray(),
+            RowSelectionPlan<string>.Create([RowSelectionStage<string>.Head(1)]));
+
+        PackageQueryMatch match = Assert.Single(events.OfType<PackageQueryEvent.Match>()).Value;
+        Assert.Equal(reference.Values, [match.Package.PackageId]);
+        Assert.Equal("Tool", match.Package.PackageId);
+        Assert.True(match.Package.Manifest!.IsToolPackage);
+        Assert.Null(match.Package.Verified);
+        Assert.Equal(PackageQueryFacetTier.Nuspec, match.Tier);
+        Assert.Contains(match.Evidence, e => e.Id == PackageQuery.ToolFacetId);
+        Assert.DoesNotContain("packageType=", handler.Requests[0]);
+        Assert.Contains("take=3", handler.Requests[0]);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.DoesNotContain(handler.Requests, r => r.Contains("anothertool"));
+        PackageQuerySummary summary = Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(3, summary.SourceCandidates);
+        Assert.Equal(2, summary.Candidates);
+        Assert.Equal(PackageQueryCompletionKind.MatchLimitReached, summary.Completion);
+    }
+
+    [Theory]
+    [InlineData(PackageQuery.VerifiedFacetId)]
+    [InlineData(PackageQuery.MillionDownloadsFacetId)]
+    public async Task UnavailableMetadataDoesNotSatisfySourceFactFacets(string facet)
+    {
+        using var handler = new GalleryHandler(Envelope(Row("Sample")), new()
+        {
+            ["sample"] = Manifest("Sample"),
+        });
+        using var source = Source(handler);
+        var events = await PackageQuery.ExecuteToArrayAsync(source,
+            Accepted(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 10, "sample"),
+                [facet])),
+            TestContext.Current.CancellationToken);
+        Assert.Empty(events.OfType<PackageQueryEvent.Match>());
+        Assert.Empty(events.OfType<PackageQueryEvent.Failure>());
+        Assert.Equal(PackageQueryCompletionKind.GalleryResponseComplete,
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value.Completion);
+    }
+
+    [Fact]
+    public async Task ExplicitManifestEnrichmentRetainsAbsentSourceMetadata()
+    {
+        using var handler = new GalleryHandler(Envelope(Row("Sample")), new()
+        {
+            ["sample"] = Manifest("Sample"),
+        });
+        using var source = Source(handler);
+        var events = await PackageQuery.ExecuteToArrayAsync(source,
+            Accepted(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 10, "sample"),
+                [PackageQuery.NoDependenciesFacetId])),
+            TestContext.Current.CancellationToken);
+        var match = Assert.Single(events.OfType<PackageQueryEvent.Match>()).Value;
+        Assert.NotNull(match.Package.Manifest);
+        Assert.Null(match.Package.TotalDownloads);
+        Assert.Null(match.Package.Verified);
+        Assert.Empty(match.Package.Owners);
+        Assert.Equal(PackageQueryFacetTier.Nuspec, match.Tier);
+    }
+
+    [Fact]
+    public async Task ContentProviderIsExplicitAndReceivesRealManifestWithOptionalMetadata()
+    {
+        using var handler = new GalleryHandler(Envelope(Row("Tool")), new()
+        {
+            ["tool"] = Manifest("Tool", tool: true),
+        });
+        using var source = Source(handler);
+        PackageQueryPlan plan = Accepted(PackageQuery.PlanGallery(
+            new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 20, "tool"),
+            [PackageQuery.ToolV2FacetId]));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await PackageQuery.ExecuteToArrayAsync(source, plan, TestContext.Current.CancellationToken));
+        Assert.Empty(handler.Requests);
+        var provider = new ContentProvider();
+
+        var events = await PackageQuery.ExecuteToArrayAsync(source, plan, provider,
+            TestContext.Current.CancellationToken);
+
+        var match = Assert.Single(events.OfType<PackageQueryEvent.Match>()).Value;
+        Assert.Equal(PackageQueryFacetTier.PackageContent, match.Tier);
+        Assert.Contains(match.Evidence, e => e.Id == PackageQuery.ToolV2FacetId);
+        var package = Assert.Single(provider.Requests);
+        Assert.True(package.Manifest!.IsToolPackage);
+        Assert.Null(package.TotalDownloads);
+        Assert.Null(package.Verified);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task AcquisitionFailureIsVisibleAndPublishesNoPartialInput()
+    {
+        using var handler = new GalleryHandler($$"""{"data":[{{Row("Good", 10)}},null]}""");
+        using var source = Source(handler);
+        var events = await PackageQuery.ExecuteToArrayAsync(source,
+            Accepted(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 10))),
+            TestContext.Current.CancellationToken);
+        Assert.Empty(events.OfType<PackageQueryEvent.Match>());
+        Assert.Equal(PackageQueryFailureKind.Search,
+            Assert.Single(events.OfType<PackageQueryEvent.Failure>()).Value.Kind);
+        var summary = Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(0, summary.Candidates);
+        Assert.Null(summary.SourceCandidates);
+        Assert.Null(summary.EstimatedTotalHits);
+        Assert.Equal(PackageQueryCompletionKind.Failed, summary.Completion);
+    }
+
+    [Fact]
+    public async Task ManifestFailureKeepsFiniteInputAccountingAndContinues()
+    {
+        using var handler = new GalleryHandler(Envelope(Row("Missing", 20), Row("Good", 10)), new()
+        {
+            ["good"] = Manifest("Good", tool: true),
+        });
+        using var source = Source(handler);
+        var events = await PackageQuery.ExecuteToArrayAsync(source,
+            Accepted(PackageQuery.PlanGallery(
+                new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 10),
+                [PackageQuery.ToolFacetId])),
+            TestContext.Current.CancellationToken);
+        Assert.Single(events.OfType<PackageQueryEvent.Match>());
+        Assert.Equal(PackageQueryFailureKind.ManifestAcquisition,
+            Assert.Single(events.OfType<PackageQueryEvent.Failure>()).Value.Kind);
+        var summary = Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(2, summary.SourceCandidates);
+        Assert.Equal(2, summary.Candidates);
+        Assert.Equal(1, summary.Failures);
+        Assert.Equal(PackageQueryCompletionKind.GalleryResponseComplete, summary.Completion);
+    }
+
+    [Fact]
+    public async Task CancellationBetweenMatchesStopsFurtherEnrichment()
+    {
+        using var handler = new GalleryHandler(Envelope(Row("First", 20), Row("Second", 10)), new()
+        {
+            ["first"] = Manifest("First", tool: true),
+            ["second"] = Manifest("Second", tool: true),
+        });
+        using var source = Source(handler);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        var plan = Accepted(PackageQuery.PlanGallery(
+            new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 10),
+            [PackageQuery.ToolFacetId]));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var item in PackageQuery.ExecuteAsync(source, plan, cancellation.Token))
+                if (item is PackageQueryEvent.Match)
+                    cancellation.Cancel();
+        });
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    private static PackageQueryPlan Accepted(PackageQueryPlanResult result) =>
+        Assert.IsType<PackageQueryPlanResult.Accepted>(result).Plan;
+
+    private static INuGetGalleryPackageSourceClient Source(HttpMessageHandler handler) =>
+        PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+
+    private static string Row(string id, long? downloads = null) => $$"""
+        {"PackageRegistration":{"Id":"{{id}}"{{(downloads is null ? "" : $",\"DownloadCount\":{downloads}")}}},
+        "Version":"1.0.0","NormalizedVersion":"1.0.0"}
+        """;
+
+    private static string Envelope(params string[] rows) =>
+        $$"""{"totalHits":500,"data":[{{string.Join(',', rows)}}]}""";
+
+    private static string Manifest(string id, bool tool = false) => $$"""
+        <package><metadata><id>{{id}}</id><version>1.0.0</version>
+        <authors>Example</authors><description>Example</description>
+        {{(tool ? """<packageTypes><packageType name="DotnetTool" /></packageTypes>""" : "")}}
+        </metadata></package>
+        """;
+
+    private sealed class GalleryHandler(
+        string response,
+        Dictionary<string, string>? manifests = null) : HttpMessageHandler
+    {
+        public List<string> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Uri uri = request.RequestUri!;
+            Requests.Add(uri.AbsoluteUri);
+            string? body = null;
+            if (uri.AbsolutePath == "/search/query")
+                body = response;
+            else if (uri.AbsolutePath.EndsWith(".nuspec", StringComparison.Ordinal))
+                manifests?.TryGetValue(uri.AbsolutePath.Split('/')[2], out body);
+            else
+                Assert.Fail($"Unexpected acquisition: {uri}");
+            return Task.FromResult(new HttpResponseMessage(
+                body is null ? HttpStatusCode.NotFound : HttpStatusCode.OK)
+            {
+                Content = new StringContent(body ?? "", Encoding.UTF8),
+            });
+        }
+    }
+
+    private sealed class ContentProvider : IPackageQueryContentProvider
+    {
+        public List<PackageQueryPackage> Requests { get; } = [];
+
+        public ValueTask<PackageQueryContentResult> GetContentAsync(
+            PackageQueryPackage package, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(package);
+            return ValueTask.FromResult<PackageQueryContentResult>(
+                new PackageQueryContentResult.Available(new ToolContent()));
+        }
+    }
+
+    private sealed class ToolContent : IPackageContent
+    {
+        public string? RootPath => null;
+        public string? NupkgPath => null;
+        public bool FromCache => false;
+        public string ProducerKey => "nuget.org";
+        public bool RequiresArchiveTreeMatch => false;
+        public IEnumerable<string> EnumerateEntries() => ["tools/DotnetToolSettings.xml"];
+        public bool TryOpenArchive([NotNullWhen(true)] out Stream? stream)
+        {
+            stream = null;
+            return false;
+        }
+        public bool TryOpenEntry(string relativePath, [NotNullWhen(true)] out Stream? stream) =>
+            TryOpenEntry(relativePath, long.MaxValue, out stream);
+        public bool TryOpenEntry(
+            string relativePath, long maxExpandedBytes, [NotNullWhen(true)] out Stream? stream)
+        {
+            stream = new MemoryStream(Encoding.UTF8.GetBytes(
+                """<DotNetCliTool Version="2"><Commands /></DotNetCliTool>"""));
+            return true;
+        }
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
@@ -1622,7 +1622,7 @@ public sealed class PackageQueryTests
         public List<string> Requests { get; } = [];
 
         public ValueTask<PackageQueryContentResult> GetContentAsync(
-            PackageProfileMatch package,
+            PackageQueryPackage package,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
+++ b/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\DotnetInspector.Packages\DotnetInspector.Packages.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\NuGetFetch\NuGetFetch.csproj" />
+    <ProjectReference Include="..\DotnetInspector.RowSelection\DotnetInspector.RowSelection.csproj" />
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
     <ProjectReference Include="..\ILInspector.CallGraph\ILInspector.CallGraph.csproj" />

--- a/src/DotnetInspector.Queries/PackageProfileQuery.cs
+++ b/src/DotnetInspector.Queries/PackageProfileQuery.cs
@@ -243,57 +243,17 @@ public static class PackageProfileQuery
                 continue;
             }
 
-            PackageSourceCoordinate coordinate = expectedCoordinate;
-            PackageSourceOperationResult<PackageSourceManifest> manifestResult =
-                await source.GetManifestAsync(
-                    coordinate.PackageId,
-                    coordinate.Version,
-                    cancellationToken,
-                    operationContext).ConfigureAwait(false);
-            if (manifestResult.Failure is { } manifestFailure)
+            var (manifestFacts, manifestFailure) = await AcquireManifestAsync(
+                source,
+                candidate.Candidate,
+                candidate.Metadata.Id,
+                candidate.Metadata.Version,
+                cancellationToken,
+                operationContext).ConfigureAwait(false);
+            if (manifestFailure is not null)
             {
                 failures++;
-                yield return new PackageProfileEvent.Failure(
-                    new PackageProfileFailure(
-                        candidate.Metadata.Id,
-                        candidate.Metadata.Version,
-                        manifestFailure.Source,
-                        PackageProfileFailureKind.ManifestAcquisition,
-                        manifestFailure.Message));
-                continue;
-            }
-
-            PackageSourceManifest manifest =
-                manifestResult.Value
-                ?? throw new InvalidOperationException(
-                    "The package source manifest operation completed without a value or failure.");
-            if (manifest.Coordinate != coordinate
-                || !ReferenceEquals(
-                    manifest.Source,
-                    candidate.Candidate.Source)
-                || !ReferenceEquals(manifest.Source, source.Source))
-            {
-                failures++;
-                yield return Failure(
-                    candidate,
-                    PackageProfileFailureKind.ManifestContract,
-                    "The package source returned a manifest with mismatched coordinate or provenance.");
-                continue;
-            }
-
-            PackageManifestFactsResult manifestFacts =
-                PackageManifestFactsQuery.Execute(
-                    manifest.Content.ToArray(),
-                    coordinate);
-            if (manifestFacts is PackageManifestFactsResult.Failed
-                manifestFailureResult)
-            {
-                failures++;
-                yield return Failure(
-                    candidate,
-                    PackageProfileFailureKind.InvalidManifest,
-                    manifestFailureResult.Failure.Message,
-                    manifestFailureResult.Failure.Reason);
+                yield return new PackageProfileEvent.Failure(manifestFailure);
                 continue;
             }
 
@@ -310,8 +270,9 @@ public static class PackageProfileQuery
                     candidate.Metadata.TotalDownloads,
                     candidate.Metadata.Verified,
                     candidate.Candidate.Source,
-                    ((PackageManifestFactsResult.Available)manifestFacts)
-                        .Value));
+                    manifestFacts
+                        ?? throw new InvalidOperationException(
+                            "Manifest acquisition returned no facts or failure.")));
         }
 
         yield return new PackageProfileEvent.Completed(
@@ -322,6 +283,59 @@ public static class PackageProfileQuery
                 matches,
                 failures,
                 searchResult.TruncationReason));
+    }
+
+    internal static async ValueTask<(
+        PackageManifestFacts? Facts,
+        PackageProfileFailure? Failure)> AcquireManifestAsync(
+            IPackageSourceClient source,
+            PackageCandidateObservation candidate,
+            string packageId,
+            string version,
+            CancellationToken cancellationToken,
+            NuGetOperationContext? operationContext = null)
+    {
+        PackageSourceCoordinate coordinate = candidate.Coordinate;
+        PackageSourceOperationResult<PackageSourceManifest> result =
+            await source.GetManifestAsync(
+                coordinate.PackageId,
+                coordinate.Version,
+                cancellationToken,
+                operationContext).ConfigureAwait(false);
+        if (result.Failure is { } failure)
+        {
+            return (null, new PackageProfileFailure(
+                packageId, version, failure.Source,
+                PackageProfileFailureKind.ManifestAcquisition,
+                failure.Message));
+        }
+
+        PackageSourceManifest manifest = result.Value
+            ?? throw new InvalidOperationException(
+                "The package source manifest operation completed without a value or failure.");
+        if (manifest.Coordinate != coordinate
+            || !ReferenceEquals(manifest.Source, candidate.Source)
+            || !ReferenceEquals(manifest.Source, source.Source))
+        {
+            return (null, new PackageProfileFailure(
+                packageId, version, candidate.Source,
+                PackageProfileFailureKind.ManifestContract,
+                "The package source returned a manifest with mismatched coordinate or provenance."));
+        }
+
+        PackageManifestFactsResult facts = PackageManifestFactsQuery.Execute(
+            manifest.Content.ToArray(), coordinate);
+        return facts switch
+        {
+            PackageManifestFactsResult.Available available => (available.Value, null),
+            PackageManifestFactsResult.Failed failed => (null,
+                new PackageProfileFailure(
+                    packageId, version, candidate.Source,
+                    PackageProfileFailureKind.InvalidManifest,
+                    failed.Failure.Message,
+                    failed.Failure.Reason)),
+            _ => throw new InvalidOperationException("Unknown manifest facts result."),
+        };
     }
 
     private static PackageProfileEvent.Failure Failure(

--- a/src/DotnetInspector.Queries/PackageQuery.Gallery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.Gallery.cs
@@ -1,0 +1,210 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using DotnetInspector.RowSelection;
+using InertText;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries;
+
+internal abstract record PackageQueryInputEvent
+{
+    internal sealed record Acquired(int Count, long? EstimatedTotalHits)
+        : PackageQueryInputEvent;
+    internal sealed record Match(PackageQueryPackage Value) : PackageQueryInputEvent;
+    internal sealed record Failure(PackageQueryFailure Value) : PackageQueryInputEvent;
+    internal sealed record Completed(int Candidates, PackageQueryCompletionKind Completion)
+        : PackageQueryInputEvent;
+}
+
+public static partial class PackageQuery
+{
+    public const string GalleryScopeEvidenceId = "package.query.scope.gallery";
+    public const string GalleryOrderEvidenceId = "package.query.source.gallery-order";
+    public const string GalleryPackageTypeEvidenceId = "package.query.source.gallery-package-type";
+    public const string GalleryPrereleaseEvidenceId = "package.query.source.gallery-prerelease";
+
+    /// <summary>
+    /// Plans local selection over one bounded Gallery response. Match selection
+    /// does not change the capacity, text, type, or order of that source input.
+    /// </summary>
+    public static PackageQueryPlanResult PlanGallery(
+        NuGetGalleryDiscoveryRequest request,
+        IReadOnlyCollection<string>? facetIds = null,
+        int maximumMatches = DefaultMaximumMatches)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        string scopeEvidence = request.IsBrowse
+            ? "Package belongs to the acquired Gallery browse response."
+            : $"Package belongs to the Gallery response for \"{request.Text}\".";
+        if (!InertString.IsPermitted(TextPolicy.Prose, request.Text ?? "")
+            || !InertString.IsPermitted(TextPolicy.Prose, scopeEvidence))
+        {
+            return Rejected(PackageQueryRequestFailureReason.InvalidSearchText);
+        }
+
+        return PlanCore(
+            Evidence(""),
+            Evidence(scopeEvidence),
+            facetIds,
+            request.Capacity,
+            maximumMatches,
+            request.IncludePrerelease,
+            request);
+    }
+
+    static void AddScopeEvidence(
+        PackageQueryPlan plan,
+        ImmutableArray<PackageQueryEvidence>.Builder evidence)
+    {
+        if (plan.GalleryRequest is not { } request)
+        {
+            evidence.Add(new PackageQueryEvidence(PrefixEvidenceId, plan.PrefixEvidence));
+            return;
+        }
+
+        evidence.Add(new PackageQueryEvidence(GalleryScopeEvidenceId, plan.PrefixEvidence));
+        evidence.Add(new PackageQueryEvidence(
+            GalleryOrderEvidenceId,
+            Evidence(request.Order == NuGetGalleryDiscoveryOrder.MostDownloaded
+                ? "Gallery download-ranked response order; not a global top-N."
+                : "Gallery relevance response order.")));
+        evidence.Add(new PackageQueryEvidence(
+            GalleryPrereleaseEvidenceId,
+            Evidence(request.IncludePrerelease
+                ? "Gallery source selection permits prerelease versions."
+                : "Gallery source selection permits stable versions only.")));
+        if (request.PackageType is { } packageType)
+        {
+            evidence.Add(new PackageQueryEvidence(
+                GalleryPackageTypeEvidenceId,
+                Evidence($"Gallery applied package type \"{packageType.Name}\"; this is index evidence.")));
+        }
+    }
+
+    static async IAsyncEnumerable<PackageQueryInputEvent> AcquireInputAsync(
+        IPackageSourceClient source,
+        PackageQueryPlan plan,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (plan.GalleryRequest is not null)
+        {
+            await foreach (PackageQueryInputEvent item in AcquireGalleryInputAsync(
+                source, plan, cancellationToken).ConfigureAwait(false))
+                yield return item;
+            yield break;
+        }
+
+        await foreach (PackageProfileEvent item in PackageProfileQuery.ExecuteAsync(
+            source,
+            new PackagePrefixProfileRequest(
+                plan.Prefix.ToString(), plan.MaximumCandidates, plan.IncludePrerelease),
+            cancellationToken).ConfigureAwait(false))
+        {
+            yield return item switch
+            {
+                PackageProfileEvent.Match match =>
+                    new PackageQueryInputEvent.Match(new PackageQueryPackage(match.Value)),
+                PackageProfileEvent.Failure failure =>
+                    new PackageQueryInputEvent.Failure(FromProfileFailure(failure.Value)),
+                PackageProfileEvent.Completed completed =>
+                    new PackageQueryInputEvent.Completed(
+                        completed.Value.Candidates,
+                        completed.Value.Candidates == 0 && completed.Value.Failures > 0
+                            ? PackageQueryCompletionKind.Failed
+                            : MapCompletion(completed.Value.TruncationReason)),
+                _ => throw new InvalidOperationException("Unknown package-profile event."),
+            };
+        }
+    }
+
+    static async IAsyncEnumerable<PackageQueryInputEvent> AcquireGalleryInputAsync(
+        IPackageSourceClient source,
+        PackageQueryPlan plan,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        NuGetGalleryDiscoveryRequest request = plan.GalleryRequest
+            ?? throw new InvalidOperationException("A Gallery input requires a Gallery request.");
+        if (source is not INuGetGalleryPackageSourceClient gallery)
+        {
+            yield return SearchFailure(
+                "The package source does not support Gallery discovery.",
+                PackageQueryFailureKind.Search);
+            yield return new PackageQueryInputEvent.Completed(0, PackageQueryCompletionKind.Failed);
+            yield break;
+        }
+
+        PackageSourceOperationResult<NuGetGalleryDiscoveryResult> operation =
+            await gallery.DiscoverAsync(request, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (operation.Failure is { } failure)
+        {
+            yield return SearchFailure(failure.Message, PackageQueryFailureKind.Search);
+            yield return new PackageQueryInputEvent.Completed(0, PackageQueryCompletionKind.Failed);
+            yield break;
+        }
+
+        NuGetGalleryDiscoveryResult response = operation.Value
+            ?? throw new InvalidOperationException("Gallery discovery returned no value or failure.");
+        if (response.Request != request || !ReferenceEquals(response.Source, source.Source))
+        {
+            yield return SearchFailure(
+                "Gallery discovery returned a different source input.",
+                PackageQueryFailureKind.SearchContract);
+            yield return new PackageQueryInputEvent.Completed(0, PackageQueryCompletionKind.Failed);
+            yield break;
+        }
+
+        yield return new PackageQueryInputEvent.Acquired(
+            response.Matches.Length, response.EstimatedTotalHits);
+        bool needsManifest = !plan.Definitions.IsEmpty;
+        IReadOnlyList<NuGetGalleryDiscoveryMatch> input = response.Matches;
+        if (!needsManifest)
+        {
+            // Selection applies only after acquisition of the exact K-sized input.
+            input = RowSelectionExecutor.Apply(
+                input,
+                RowSelectionPlan<string>.Create(
+                    [RowSelectionStage<string>.Head(plan.MaximumMatches)])).Values;
+        }
+
+        int candidates = 0;
+        foreach (NuGetGalleryDiscoveryMatch match in input)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            candidates++;
+            PackageManifestFacts? manifest = null;
+            if (needsManifest)
+            {
+                var (facts, manifestFailure) = await PackageProfileQuery.AcquireManifestAsync(
+                    source, match.Candidate, match.PackageId, match.Version,
+                    cancellationToken).ConfigureAwait(false);
+                if (manifestFailure is not null)
+                {
+                    yield return new PackageQueryInputEvent.Failure(
+                        FromProfileFailure(manifestFailure));
+                    continue;
+                }
+                manifest = facts ?? throw new InvalidOperationException(
+                    "Manifest acquisition returned no facts or failure.");
+            }
+
+            yield return new PackageQueryInputEvent.Match(new PackageQueryPackage(
+                match.PackageId,
+                match.Version,
+                match.Owners,
+                match.TotalDownloads,
+                match.Verified,
+                match.Candidate.Source,
+                manifest,
+                match.Description));
+        }
+
+        yield return new PackageQueryInputEvent.Completed(
+            candidates, PackageQueryCompletionKind.GalleryResponseComplete);
+
+        PackageQueryInputEvent.Failure SearchFailure(
+            string message,
+            PackageQueryFailureKind kind) =>
+            new(new PackageQueryFailure(null, null, source.Source, kind, message));
+    }
+}

--- a/src/DotnetInspector.Queries/PackageQuery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.cs
@@ -15,6 +15,7 @@ public enum PackageQueryFacetTier
 {
     Nuspec,
     PackageContent,
+    SearchMetadata,
 }
 
 /// <summary>One product-owned package-query facet.</summary>
@@ -68,6 +69,7 @@ public enum PackageQueryRequestFailureReason
     DuplicateFacet,
     IncompatibleFacets,
     PackageContentCandidateLimitExceeded,
+    InvalidSearchText,
 }
 
 /// <summary>
@@ -94,6 +96,8 @@ public sealed record PackageQueryRequestFailure
     {
         PackageQueryRequestFailureReason.InvalidPrefix =>
             "The package-query prefix is invalid.",
+        PackageQueryRequestFailureReason.InvalidSearchText =>
+            "The Gallery search text is invalid.",
         PackageQueryRequestFailureReason.InvalidCandidateLimit =>
             $"The package-query candidate limit must be between 1 and {PackageProfileQuery.MaximumPackageLimit}.",
         PackageQueryRequestFailureReason.InvalidMatchLimit =>
@@ -137,7 +141,8 @@ public sealed class PackageQueryPlan
         ImmutableArray<PackageQueryFacetDefinition> definitions,
         int maximumCandidates,
         int maximumMatches,
-        bool includePrerelease)
+        bool includePrerelease,
+        NuGetGalleryDiscoveryRequest? galleryRequest = null)
     {
         Prefix = prefix;
         PrefixEvidence = prefixEvidence;
@@ -146,6 +151,7 @@ public sealed class PackageQueryPlan
         MaximumCandidates = maximumCandidates;
         MaximumMatches = maximumMatches;
         IncludePrerelease = includePrerelease;
+        GalleryRequest = galleryRequest;
     }
 
     public InertString Prefix { get; }
@@ -153,6 +159,7 @@ public sealed class PackageQueryPlan
     public int MaximumCandidates { get; }
     public int MaximumMatches { get; }
     public bool IncludePrerelease { get; }
+    public NuGetGalleryDiscoveryRequest? GalleryRequest { get; }
 
     internal InertString PrefixEvidence { get; }
     internal ImmutableArray<PackageQueryFacetDefinition> Definitions { get; }
@@ -168,9 +175,18 @@ public sealed record PackageQueryEvidence(
 
 /// <summary>One package that satisfied every selected package-query facet.</summary>
 public sealed record PackageQueryMatch(
-    PackageProfileMatch Package,
+    PackageQueryPackage Package,
     PackageQueryFacetTier Tier,
-    ImmutableArray<PackageQueryEvidence> Evidence);
+    ImmutableArray<PackageQueryEvidence> Evidence)
+{
+    public PackageQueryMatch(
+        PackageProfileMatch Package,
+        PackageQueryFacetTier Tier,
+        ImmutableArray<PackageQueryEvidence> Evidence)
+        : this(new PackageQueryPackage(Package), Tier, Evidence)
+    {
+    }
+}
 
 /// <summary>The stage at which one package-query item failed.</summary>
 public enum PackageQueryFailureKind
@@ -202,6 +218,7 @@ public enum PackageQueryCompletionKind
     SourcePageLimitReached,
     ClientPageLimitReached,
     Failed,
+    GalleryResponseComplete,
 }
 
 /// <summary>Terminal accounting for one package-query stream.</summary>
@@ -213,7 +230,11 @@ public sealed record PackageQuerySummary(
     int Candidates,
     int Matches,
     int Failures,
-    PackageQueryCompletionKind Completion);
+    PackageQueryCompletionKind Completion)
+{
+    public int? SourceCandidates { get; init; }
+    public long? EstimatedTotalHits { get; init; }
+}
 
 /// <summary>A bounded checkpoint in package-query work.</summary>
 public sealed record PackageQueryProgress(
@@ -264,14 +285,14 @@ public abstract record PackageQueryContentResult
 public interface IPackageQueryContentProvider
 {
     ValueTask<PackageQueryContentResult> GetContentAsync(
-        PackageProfileMatch package,
+        PackageQueryPackage package,
         CancellationToken cancellationToken);
 }
 
 internal sealed record PackageQueryFacetDefinition(
     PackageQueryFacetDescriptor Descriptor,
-    Func<PackageProfileMatch, bool> MatchesManifest,
-    Func<PackageProfileMatch, InertString> Evidence,
+    Func<PackageQueryPackage, bool> MatchesManifest,
+    Func<PackageQueryPackage, InertString> Evidence,
     Func<PackageContentFacts, bool>? MatchesPackageContent = null);
 
 internal sealed record PackageContentFacts(
@@ -282,7 +303,7 @@ internal sealed record PackageContentFacts(
 /// Plans and executes product-owned manifest and package-content facets over a
 /// bounded package profile without loading inspected assemblies.
 /// </summary>
-public static class PackageQuery
+public static partial class PackageQuery
 {
     public const int DefaultMaximumCandidates = 200;
     public const int DefaultMaximumMatches = 100;
@@ -313,7 +334,7 @@ public static class PackageQuery
                 "The package source reports a verified package identity.",
                 100,
                 PackageQueryFacetTier.Nuspec),
-            static match => match.Verified,
+            static match => match.Verified == true,
             static _ => Evidence(
                 "The package source reports this package as verified.")),
         new(
@@ -326,7 +347,7 @@ public static class PackageQuery
                 ToolSelectionGroupId,
                 ToolDisplayGroupId,
                 ".NET tool format"),
-            static match => match.Manifest.IsToolPackage,
+            static match => match.RequiredManifest.IsToolPackage,
             static _ => Evidence(
                 "The package manifest declares a .NET tool package.")),
         new(
@@ -342,7 +363,7 @@ public static class PackageQuery
             {
                 CombinesWithinSelectionGroup = true,
             },
-            static match => match.Manifest.IsToolPackage,
+            static match => match.RequiredManifest.IsToolPackage,
             static _ => Evidence(
                 "DotnetToolSettings.xml declares the portable .NET tool v1 format."),
             static content => content.ToolSettingsVersion == "1"),
@@ -359,7 +380,7 @@ public static class PackageQuery
             {
                 CombinesWithinSelectionGroup = true,
             },
-            static match => match.Manifest.IsToolPackage,
+            static match => match.RequiredManifest.IsToolPackage,
             static _ => Evidence(
                 "DotnetToolSettings.xml declares the RID-specific .NET tool v2 format."),
             static content => content.ToolSettingsVersion == "2"),
@@ -402,7 +423,7 @@ public static class PackageQuery
                 PackageQueryFacetTier.Nuspec),
             static match => match.TotalDownloads >= 1_000_000,
             static match => Evidence(
-                $"The package source reports {match.TotalDownloads.ToString("N0", CultureInfo.InvariantCulture)} total downloads.")),
+                $"The package source reports {match.TotalDownloads?.ToString("N0", CultureInfo.InvariantCulture)} total downloads.")),
         new(
             new PackageQueryFacetDescriptor(
                 EmbeddedReadmeFacetId,
@@ -411,7 +432,7 @@ public static class PackageQuery
                 600,
                 PackageQueryFacetTier.Nuspec),
             static match => !string.IsNullOrWhiteSpace(
-                match.Manifest.ReadmeFile),
+                match.RequiredManifest.ReadmeFile),
             static _ => Evidence(
                 "The package manifest declares an embedded README file.")),
         new(
@@ -468,16 +489,34 @@ public static class PackageQuery
                 value: request.MaximumCandidates);
         }
 
-        if (request.MaximumMatches
+        return PlanCore(
+            Evidence(prefix),
+            Evidence(prefixEvidence),
+            request.FacetIds,
+            request.MaximumCandidates,
+            request.MaximumMatches,
+            request.IncludePrerelease);
+    }
+
+    static PackageQueryPlanResult PlanCore(
+        InertString prefix,
+        InertString scopeEvidence,
+        IReadOnlyCollection<string>? facetIds,
+        int maximumCandidates,
+        int maximumMatches,
+        bool includePrerelease,
+        NuGetGalleryDiscoveryRequest? galleryRequest = null)
+    {
+        if (maximumMatches
             is <= 0 or > PackageProfileQuery.MaximumPackageLimit)
         {
             return Rejected(
                 PackageQueryRequestFailureReason.InvalidMatchLimit,
-                value: request.MaximumMatches);
+                value: maximumMatches);
         }
 
         IReadOnlyCollection<string> requested =
-            request.FacetIds ?? [];
+            facetIds ?? [];
         if (requested.Count > Definitions.Length)
         {
             return Rejected(PackageQueryRequestFailureReason.TooManyFacets);
@@ -537,7 +576,7 @@ public static class PackageQuery
                 incompatible.Select(definition =>
                     definition.Descriptor.Id));
         }
-        if (request.MaximumCandidates > MaximumPackageContentCandidates
+        if (maximumCandidates > MaximumPackageContentCandidates
             && selected.Any(definition =>
                 definition.Descriptor.Tier
                     == PackageQueryFacetTier.PackageContent))
@@ -545,17 +584,18 @@ public static class PackageQuery
             return Rejected(
                 PackageQueryRequestFailureReason
                     .PackageContentCandidateLimitExceeded,
-                value: request.MaximumCandidates);
+                value: maximumCandidates);
         }
 
         return new PackageQueryPlanResult.Accepted(
             new PackageQueryPlan(
-                Evidence(prefix),
-                Evidence(prefixEvidence),
+                prefix,
+                scopeEvidence,
                 selected,
-                request.MaximumCandidates,
-                request.MaximumMatches,
-                request.IncludePrerelease));
+                maximumCandidates,
+                maximumMatches,
+                includePrerelease,
+                galleryRequest));
     }
 
     /// <summary>Executes and materializes one validated package query.</summary>
@@ -634,24 +674,30 @@ public static class PackageQuery
         int matches = 0;
         int failures = 0;
         int packageContentCompleted = 0;
+        int? sourceCandidates = null;
+        long? estimatedTotalHits = null;
         bool searchOutcomeObserved = false;
         cancellationToken.ThrowIfCancellationRequested();
         yield return Progress(
             PackageQueryProgressPhase.Search,
             completed: 0,
             limit: 1);
-        await foreach (PackageProfileEvent profileEvent
-            in PackageProfileQuery.ExecuteAsync(
-                source,
-                new PackagePrefixProfileRequest(
-                    plan.Prefix.ToString(),
-                    plan.MaximumCandidates,
-                    plan.IncludePrerelease),
-                cancellationToken).ConfigureAwait(false))
+        await foreach (PackageQueryInputEvent inputEvent
+            in AcquireInputAsync(source, plan, cancellationToken)
+                .ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (inputEvent is PackageQueryInputEvent.Acquired acquired)
+            {
+                sourceCandidates = acquired.Count;
+                estimatedTotalHits = acquired.EstimatedTotalHits;
+                searchOutcomeObserved = true;
+                yield return Progress(
+                    PackageQueryProgressPhase.Search, completed: 1, limit: 1);
+                continue;
+            }
             bool sourceWideSearchFailure =
-                profileEvent is PackageProfileEvent.Failure searchFailure
+                inputEvent is PackageQueryInputEvent.Failure searchFailure
                 && IsSourceWideSearchFailure(searchFailure.Value);
             if (!searchOutcomeObserved)
             {
@@ -665,14 +711,17 @@ public static class PackageQuery
                 }
             }
 
-            switch (profileEvent)
+            switch (inputEvent)
             {
-                case PackageProfileEvent.Match match:
+                case PackageQueryInputEvent.Match match:
                     candidates++;
-                    yield return Progress(
-                        PackageQueryProgressPhase.Manifest,
-                        candidates,
-                        plan.MaximumCandidates);
+                    if (match.Value.Manifest is not null)
+                    {
+                        yield return Progress(
+                            PackageQueryProgressPhase.Manifest,
+                            candidates,
+                            plan.MaximumCandidates);
+                    }
                     if (!TryMatchManifest(
                         plan,
                         match.Value,
@@ -775,7 +824,9 @@ public static class PackageQuery
                             match.Value,
                             requiresPackageContent
                                 ? PackageQueryFacetTier.PackageContent
-                                : PackageQueryFacetTier.Nuspec,
+                                : match.Value.Manifest is not null
+                                    ? PackageQueryFacetTier.Nuspec
+                                    : PackageQueryFacetTier.SearchMetadata,
                             evidence.ToImmutable()));
                     cancellationToken.ThrowIfCancellationRequested();
                     if (matches >= plan.MaximumMatches)
@@ -786,12 +837,16 @@ public static class PackageQuery
                             candidates,
                             matches,
                             failures,
-                            PackageQueryCompletionKind.MatchLimitReached);
+                            sourceCandidates == candidates
+                                ? PackageQueryCompletionKind.GalleryResponseComplete
+                                : PackageQueryCompletionKind.MatchLimitReached,
+                            sourceCandidates,
+                            estimatedTotalHits);
                         yield break;
                     }
                     break;
 
-                case PackageProfileEvent.Failure failure:
+                case PackageQueryInputEvent.Failure failure:
                     failures++;
                     if (!sourceWideSearchFailure)
                     {
@@ -802,50 +857,44 @@ public static class PackageQuery
                             plan.MaximumCandidates);
                     }
 
-                    yield return new PackageQueryEvent.Failure(
-                        FromProfileFailure(failure.Value));
+                    yield return new PackageQueryEvent.Failure(failure.Value);
                     break;
 
-                case PackageProfileEvent.Completed completed:
+                case PackageQueryInputEvent.Completed completed:
                     yield return Completed(
                         plan,
-                        completed.Value.Source,
-                        completed.Value.Candidates,
+                        source.Source,
+                        completed.Candidates,
                         matches,
                         failures,
-                        completed.Value.Candidates == 0
-                            && completed.Value.Failures > 0
-                            ? PackageQueryCompletionKind.Failed
-                            : MapCompletion(
-                                completed.Value.TruncationReason));
+                        completed.Completion,
+                        sourceCandidates,
+                        estimatedTotalHits);
                     yield break;
             }
         }
 
         throw new InvalidOperationException(
-            "The package profile stream ended without a completion event.");
+            "The package query input ended without a completion event.");
     }
 
-    static bool IsSourceWideSearchFailure(PackageProfileFailure failure) =>
-        failure.Kind == PackageProfileFailureKind.Search
+    static bool IsSourceWideSearchFailure(PackageQueryFailure failure) =>
+        failure.Kind == PackageQueryFailureKind.Search
         || failure is
         {
-            Kind: PackageProfileFailureKind.SearchContract,
+            Kind: PackageQueryFailureKind.SearchContract,
             PackageId: null,
             Version: null,
         };
 
     static bool TryMatchManifest(
         PackageQueryPlan plan,
-        PackageProfileMatch match,
+        PackageQueryPackage match,
         out ImmutableArray<PackageQueryEvidence>.Builder evidence)
     {
         evidence = ImmutableArray.CreateBuilder<PackageQueryEvidence>(
             plan.Definitions.Length + 1);
-        evidence.Add(
-            new PackageQueryEvidence(
-                PrefixEvidenceId,
-                plan.PrefixEvidence));
+        AddScopeEvidence(plan, evidence);
         var handledGroups = new HashSet<string>(StringComparer.Ordinal);
         foreach (PackageQueryFacetDefinition definition in plan.Definitions)
         {
@@ -890,7 +939,7 @@ public static class PackageQuery
 
     static bool TryMatchPackageContent(
         PackageQueryPlan plan,
-        PackageProfileMatch match,
+        PackageQueryPackage match,
         PackageContentFacts content,
         ImmutableArray<PackageQueryEvidence>.Builder evidence)
     {
@@ -1063,12 +1112,12 @@ public static class PackageQuery
             failure.Message,
             failure.ManifestFailureReason);
 
-    static int DependencyCount(PackageProfileMatch match) =>
-        match.Manifest.DependencyGroups.Sum(group =>
+    static int DependencyCount(PackageQueryPackage match) =>
+        match.RequiredManifest.DependencyGroups.Sum(group =>
             group.Dependencies.Length);
 
-    static int NonEmptyDependencyGroupCount(PackageProfileMatch match) =>
-        match.Manifest.DependencyGroups.Count(group =>
+    static int NonEmptyDependencyGroupCount(PackageQueryPackage match) =>
+        match.RequiredManifest.DependencyGroups.Count(group =>
             !group.Dependencies.IsEmpty);
 
     static string Pluralize(int count, string singular, string plural) =>
@@ -1089,7 +1138,9 @@ public static class PackageQuery
         int candidates,
         int matches,
         int failures,
-        PackageQueryCompletionKind completion) =>
+        PackageQueryCompletionKind completion,
+        int? sourceCandidates = null,
+        long? estimatedTotalHits = null) =>
         new(
             new PackageQuerySummary(
                 plan.Prefix,
@@ -1099,7 +1150,11 @@ public static class PackageQuery
                 candidates,
                 matches,
                 failures,
-                completion));
+                completion)
+            {
+                SourceCandidates = sourceCandidates,
+                EstimatedTotalHits = estimatedTotalHits,
+            });
 
     static PackageQueryCompletionKind MapCompletion(
         PackageSearchTruncationReason reason) =>

--- a/src/DotnetInspector.Queries/PackageQueryPackage.cs
+++ b/src/DotnetInspector.Queries/PackageQueryPackage.cs
@@ -1,0 +1,35 @@
+using System.Collections.Immutable;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// A package-query row. Manifest facts exist only after explicit acquisition;
+/// unavailable source metadata is not replaced by zero or false.
+/// </summary>
+public sealed record PackageQueryPackage(
+    string PackageId,
+    string Version,
+    ImmutableArray<string> Owners,
+    long? TotalDownloads,
+    bool? Verified,
+    PackageSourceResultIdentity Source,
+    PackageManifestFacts? Manifest = null,
+    string? Description = null)
+{
+    public PackageQueryPackage(PackageProfileMatch profile)
+        : this(
+            profile.PackageId,
+            profile.Version,
+            profile.Owners,
+            profile.TotalDownloads,
+            profile.Verified,
+            profile.Source,
+            profile.Manifest)
+    {
+    }
+
+    internal PackageManifestFacts RequiredManifest =>
+        Manifest ?? throw new InvalidOperationException(
+            "Manifest facet evaluation requires acquired manifest facts.");
+}

--- a/src/NuGetFetch.Tests/GalleryDiscoveryClientTests.cs
+++ b/src/NuGetFetch.Tests/GalleryDiscoveryClientTests.cs
@@ -1,0 +1,363 @@
+using System.Net;
+using System.Text;
+
+namespace NuGetFetch.Tests;
+
+public sealed class GalleryDiscoveryClientTests
+{
+    private const string Row = """
+        {"PackageRegistration":{"Id":"Cake.Tool","DownloadCount":9000000,
+        "Verified":true,"Owners":["cake-build"]},"Version":"6.2.0",
+        "NormalizedVersion":"6.2.0","Description":"Build automation","DownloadCount":12}
+        """;
+
+    [Fact]
+    public async Task GalleryDiscoveryUsesSearchMetadataOnly()
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json(
+            $$"""{"totalHits":6000,"data":[{{Row}}]}""")));
+        var association = PackageSourceAssociation.Create();
+        using INuGetGalleryPackageSourceClient source =
+            PackageSourceClientFactory.CreateGallery(association, handler);
+        var request = new NuGetGalleryDiscoveryRequest(
+            PackageSourceDescriptor.NuGetGallery, 2,
+            packageType: NuGetGalleryPackageType.DotnetTool);
+
+        var outcome = await source.DiscoverAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Null(outcome.Failure);
+        NuGetGalleryDiscoveryResult result = Assert.IsType<NuGetGalleryDiscoveryResult>(outcome.Value);
+        Assert.Same(request, result.Request);
+        Assert.Same(source.Source, result.Source);
+        Assert.Same(association, result.Source.Association);
+        Assert.Equal(PackageProducerIdentity.NuGetOrg, result.Source.Producer);
+        Assert.Equal(6000, result.EstimatedTotalHits);
+        NuGetGalleryDiscoveryMatch match = Assert.Single(result.Matches);
+        Assert.Equal("Cake.Tool", match.PackageId);
+        Assert.Equal("6.2.0", match.Version);
+        Assert.Equal(9_000_000, match.TotalDownloads);
+        Assert.True(match.Verified);
+        Assert.Equal(["cake-build"], match.Owners);
+        Assert.Equal("Build automation", match.Description);
+        Assert.Equal(PackageSourceCoordinate.Create("cake.tool", "6.2.0"), match.Candidate.Coordinate);
+        Assert.Same(result.Source, match.Candidate.Source);
+        Assert.Equal(PackageListingState.Listed, match.Candidate.ListingState);
+        Assert.Equal(
+            "https://azuresearch-usnc.nuget.org/search/query?packageType=dotnettool&sortBy=totalDownloads-desc&prerelease=false&semVerLevel=2.0.0&skip=0&take=2",
+            Assert.Single(handler.Urls));
+    }
+
+    [Theory]
+    [InlineData(null, null, "totalDownloads-desc", false)]
+    [InlineData("json", null, "relevance", false)]
+    [InlineData("owner:someone tags:\"a b\"&take=1", NuGetGalleryDiscoveryOrder.MostDownloaded, "totalDownloads-desc", true)]
+    [InlineData(null, NuGetGalleryDiscoveryOrder.Relevance, "relevance", true)]
+    public async Task DiscoveryEncodesExactInputWithoutPrefixOrPagination(
+        string? text, NuGetGalleryDiscoveryOrder? order, string wireOrder, bool prerelease)
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json("""{"data":[]}""")));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var request = new NuGetGalleryDiscoveryRequest(
+            PackageSourceDescriptor.NuGetGallery, 1000, text,
+            NuGetGalleryPackageType.Template, order, prerelease);
+
+        Assert.NotNull((await source.DiscoverAsync(request, TestContext.Current.CancellationToken)).Value);
+
+        string url = Assert.Single(handler.Urls);
+        Assert.Contains("take=1000", url);
+        Assert.Contains("skip=0", url);
+        Assert.Contains("packageType=template", url);
+        Assert.Contains($"sortBy={wireOrder}", url);
+        Assert.Contains($"prerelease={prerelease.ToString().ToLowerInvariant()}", url);
+        if (text is null)
+            Assert.DoesNotContain("q=", url);
+        else
+            Assert.Contains($"q={Uri.EscapeDataString(text)}", url);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("\"totalHits\":null,")]
+    [InlineData("\"totalHits\":-1,")]
+    [InlineData("\"totalHits\":\"many\",")]
+    [InlineData("\"totalHits\":1.5,")]
+    [InlineData("\"totalHits\":9223372036854775808,")]
+    [InlineData("\"totalHits\":1,\"totalHits\":2,")]
+    public async Task UnusablePopulationEstimateDoesNotInvalidateRows(string estimate)
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json(
+            $$"""{ {{estimate}} "data":[{{Row}}] }""")));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var result = await source.DiscoverAsync(Request(), TestContext.Current.CancellationToken);
+        Assert.Null(result.Failure);
+        Assert.Null(result.Value!.EstimatedTotalHits);
+        Assert.Single(result.Value.Matches);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(",\"DownloadCount\":null,\"Verified\":null,\"Owners\":null")]
+    [InlineData(",\"DownloadCount\":-1,\"Verified\":\"yes\",\"Owners\":[17]")]
+    [InlineData(",\"DownloadCount\":1,\"DownloadCount\":2,\"Verified\":true,\"Verified\":false")]
+    public async Task RelevanceRetainsUnavailableMetadataWithoutInventingFacts(string optional)
+    {
+        string row = $$"""
+            {"PackageRegistration":{"Id":"Sample"{{optional}}},
+            "Version":"1.0","NormalizedVersion":"1.0.0","Description":"\u202Ehidden"}
+            """;
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json(
+            $$"""{"data":[{{row}}]}""")));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var result = await source.DiscoverAsync(
+            Request(order: NuGetGalleryDiscoveryOrder.Relevance),
+            TestContext.Current.CancellationToken);
+        NuGetGalleryDiscoveryMatch match = Assert.Single(result.Value!.Matches);
+        Assert.Null(match.TotalDownloads);
+        Assert.Null(match.Verified);
+        Assert.Empty(match.Owners);
+        Assert.Null(match.Description);
+        Assert.Equal("1.0.0", match.Candidate.Coordinate.Version);
+    }
+
+    public static IEnumerable<object[]> InvalidResponses()
+    {
+        yield return ["""{}"""];
+        yield return ["""{"data":null}"""];
+        yield return ["""{"data":[],"data":[]}"""];
+        yield return ["""{"data":[null]}"""];
+        yield return ["""{"data":[{}]}"""];
+        yield return [$$"""{"data":[{{Row}},{{Row}}]}"""];
+        yield return [$$"""{"data":[{{Row}},{{Row.Replace("Cake.Tool", "cake.tool")}}]}"""];
+        yield return [$$"""{"data":[{{Row}},null]}"""];
+        yield return [$$"""{"data":[{{Row}}]"""];
+        yield return [$$"""{"data":[{{Row}}]} trailing"""];
+        foreach (string row in new[]
+        {
+            Row.Replace("\"Id\":\"Cake.Tool\"", "\"Id\":\"../invalid\""),
+            Row.Replace("\"Id\":\"Cake.Tool\"", "\"Id\":\"Cake.Tool\",\"Id\":\"Other\""),
+            Row.Replace("\"Version\":\"6.2.0\"", "\"Version\":\"6.2.0\",\"Version\":\"6.2.0\""),
+            Row.Replace("\"Version\":\"6.2.0\"", "\"Version\":false"),
+            Row.Replace("\"NormalizedVersion\":\"6.2.0\"", "\"NormalizedVersion\":\"7.0.0\""),
+            Row.Replace("\"NormalizedVersion\":\"6.2.0\"", "\"NormalizedVersion\":\"6.2.0\",\"NormalizedVersion\":\"6.2.0\""),
+            Row.Replace("\"NormalizedVersion\":\"6.2.0\",", ""),
+            Row.Replace("\"DownloadCount\":9000000", "\"DownloadCount\":-1"),
+            Row.Replace("\"DownloadCount\":9000000", "\"DownloadCount\":9000000,\"DownloadCount\":1"),
+            Row.Replace("\"DownloadCount\":9000000,", ""),
+            Row.Replace("\"PackageRegistration\":", "\"PackageRegistration\":{},\"PackageRegistration\":"),
+            Row.Replace("6.2.0", "6.2.0-preview.1"),
+        })
+            yield return [$$"""{"data":[{{row}}]}"""];
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidResponses))]
+    public async Task InvalidResponseRejectsAtomically(string json)
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json(json)));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var outcome = await source.DiscoverAsync(Request(), TestContext.Current.CancellationToken);
+        Assert.Null(outcome.Value);
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, outcome.Failure!.Kind);
+        Assert.Single(handler.Urls);
+    }
+
+    [Fact]
+    public async Task OverCapacityIsRejectedRatherThanTruncated()
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json(
+            $$"""{"data":[{{Row}},{{Row.Replace("Cake.Tool", "Other")}}]}""")));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var result = await source.DiscoverAsync(
+            new NuGetGalleryDiscoveryRequest(PackageSourceDescriptor.NuGetGallery, 1),
+            TestContext.Current.CancellationToken);
+        Assert.Null(result.Value);
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, result.Failure!.Kind);
+    }
+
+    [Fact]
+    public async Task ProviderOrderAndTiesArePreserved()
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json(
+            $$"""{"totalHits":0,"data":[{{Row}},{{Row.Replace("Cake.Tool", "Alpha")}}]}""")));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var result = await source.DiscoverAsync(Request(), TestContext.Current.CancellationToken);
+        Assert.Equal(["Cake.Tool", "Alpha"], result.Value!.Matches.Select(match => match.PackageId));
+        Assert.Equal(0, result.Value.EstimatedTotalHits);
+    }
+
+    [Fact]
+    public async Task ExplicitPrereleasePolicyAdmitsSemVer2Versions()
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(Json(
+            $$"""{"data":[{{Row.Replace("6.2.0", "6.3.0-preview.1")}}]}""")));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var request = new NuGetGalleryDiscoveryRequest(
+            PackageSourceDescriptor.NuGetGallery, 10, includePrerelease: true);
+        var result = await source.DiscoverAsync(request, TestContext.Current.CancellationToken);
+        Assert.Equal("6.3.0-preview.1", Assert.Single(result.Value!.Matches).Version);
+        Assert.Contains("prerelease=true&semVerLevel=2.0.0", Assert.Single(handler.Urls));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MetadataBoundsRejectWholeResponse(bool advertised)
+    {
+        using var handler = new RecordingHandler((_, _) =>
+        {
+            HttpResponseMessage response = Json($$"""{"data":[{{Row}}]}""");
+            if (!advertised)
+                response.Content = new StreamContent(new NonSeekableStream(Encoding.UTF8.GetBytes(
+                    $$"""{"data":[{{Row}}]}""")));
+            return Task.FromResult(response);
+        });
+        using var source = PackageSourceClientFactory.CreateGallery(
+            PackageSourceAssociation.Create(), handler,
+            new NuGetFetchOptions { MaxMetadataResponseBytes = 32 });
+        var result = await source.DiscoverAsync(Request(), TestContext.Current.CancellationToken);
+        Assert.Null(result.Value);
+        Assert.Equal(PackageSourceFailureKind.ResponseRejected, result.Failure!.Kind);
+        Assert.Single(handler.Urls);
+    }
+
+    [Fact]
+    public async Task TransientFailureRetriesTheSameFullRequest()
+    {
+        int attempts = 0;
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(
+            ++attempts == 1
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                : Json($$"""{"data":[{{Row}}]}""")));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var result = await source.DiscoverAsync(Request(), TestContext.Current.CancellationToken);
+        Assert.NotNull(result.Value);
+        Assert.Equal(2, attempts);
+        Assert.Equal(handler.Urls[0], handler.Urls[1]);
+    }
+
+    [Fact]
+    public async Task SharedDeadlineFailureDoesNotPublishRows()
+    {
+        using var handler = new RecordingHandler(async (_, token) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return Json("""{"data":[]}""");
+        });
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        using var context = new NuGetOperationContext(
+            TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(80),
+            TestContext.Current.CancellationToken);
+        var result = await source.DiscoverAsync(
+            Request(), TestContext.Current.CancellationToken, context);
+        Assert.Null(result.Value);
+        Assert.Equal(PackageSourceFailureKind.Timeout, result.Failure!.Kind);
+        Assert.Single(handler.Urls);
+    }
+
+    [Fact]
+    public async Task CallerCancellationCannotBecomeSuccessfulRows()
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        using var handler = new RecordingHandler((_, _) =>
+        {
+            cancellation.Cancel();
+            return Task.FromResult(Json($$"""{"data":[{{Row}}]}"""));
+        });
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => source.DiscoverAsync(Request(), cancellation.Token));
+        Assert.Single(handler.Urls);
+    }
+
+    [Fact]
+    public async Task IncompleteTransportRejectsEvenApparentlyCompleteJson()
+    {
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new TruncatedTransportStream(
+                    Encoding.UTF8.GetBytes($$"""{"data":[{{Row}}]}"""))),
+            }));
+        using var source = PackageSourceClientFactory.CreateGallery(PackageSourceAssociation.Create(), handler);
+        var result = await source.DiscoverAsync(Request(), TestContext.Current.CancellationToken);
+        Assert.Null(result.Value);
+        Assert.Equal(PackageSourceFailureKind.Transport, result.Failure!.Kind);
+        Assert.Equal(4, handler.Urls.Count);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RequestAndMetadataBodyTimeoutsStayTypedAndBounded(bool stallBody)
+    {
+        using var handler = new RecordingHandler(async (_, token) =>
+        {
+            if (!stallBody)
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new StallingStream()),
+            };
+        });
+        using var source = PackageSourceClientFactory.CreateGallery(
+            PackageSourceAssociation.Create(), handler,
+            new NuGetFetchOptions
+            {
+                OperationTimeout = TimeSpan.FromSeconds(5),
+                RequestTimeout = stallBody ? TimeSpan.FromSeconds(1) : TimeSpan.FromMilliseconds(20),
+                MetadataBodyTimeout = TimeSpan.FromMilliseconds(20),
+            });
+        var result = await source.DiscoverAsync(Request(), TestContext.Current.CancellationToken);
+        Assert.Null(result.Value);
+        Assert.Equal(PackageSourceFailureKind.Timeout, result.Failure!.Kind);
+        Assert.Equal(4, handler.Urls.Count);
+    }
+
+    private static NuGetGalleryDiscoveryRequest Request(
+        NuGetGalleryDiscoveryOrder? order = null) =>
+        new(PackageSourceDescriptor.NuGetGallery, 10, order: order);
+
+    private static HttpResponseMessage Json(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class RecordingHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond)
+        : HttpMessageHandler
+    {
+        public List<string> Urls { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Urls.Add(request.RequestUri!.AbsoluteUri);
+            return respond(request, cancellationToken);
+        }
+    }
+
+    private class NonSeekableStream(byte[] bytes) : MemoryStream(bytes)
+    {
+        public override bool CanSeek => false;
+    }
+
+    private sealed class TruncatedTransportStream(byte[] bytes) : NonSeekableStream(bytes)
+    {
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (Position == Length)
+                throw new IOException("The transport ended before its advertised body completed.");
+            return base.ReadAsync(buffer, cancellationToken);
+        }
+    }
+
+    private sealed class StallingStream() : NonSeekableStream([])
+    {
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+    }
+}

--- a/src/NuGetFetch/NuGetGalleryDiscoveryReader.cs
+++ b/src/NuGetFetch/NuGetGalleryDiscoveryReader.cs
@@ -1,0 +1,188 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using InertText;
+
+namespace NuGetFetch;
+
+internal static class NuGetGalleryDiscoveryReader
+{
+    internal static string RequestUrl(NuGetGalleryDiscoveryRequest request)
+    {
+        var parameters = new List<string>();
+        if (request.Text is { } text)
+            parameters.Add($"q={Uri.EscapeDataString(text)}");
+        if (request.PackageType is { } packageType)
+            parameters.Add($"packageType={Uri.EscapeDataString(packageType.Name)}");
+        parameters.Add(request.Order == NuGetGalleryDiscoveryOrder.MostDownloaded
+            ? "sortBy=totalDownloads-desc"
+            : "sortBy=relevance");
+        parameters.Add(request.IncludePrerelease
+            ? "prerelease=true"
+            : "prerelease=false");
+        parameters.Add("semVerLevel=2.0.0");
+        parameters.Add("skip=0");
+        parameters.Add($"take={request.Capacity.ToString(CultureInfo.InvariantCulture)}");
+        return "https://azuresearch-usnc.nuget.org/search/query?"
+            + string.Join('&', parameters);
+    }
+
+    internal static async ValueTask<NuGetGalleryDiscoveryResult> ReadAsync(
+        Stream stream,
+        NuGetGalleryDiscoveryRequest request,
+        PackageSourceResultFactory results,
+        NuGetOperationDeadline operation,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await JsonDocument.ParseAsync(
+            stream,
+            new JsonDocumentOptions { MaxDepth = 64 },
+            cancellationToken).ConfigureAwait(false);
+        JsonElement root = document.RootElement;
+        JsonElement data = Required(root, "data", JsonValueKind.Array);
+        if (data.GetArrayLength() > request.Capacity)
+            throw Invalid("The Gallery response exceeded the requested capacity.");
+
+        var matches = ImmutableArray.CreateBuilder<NuGetGalleryDiscoveryMatch>(
+            data.GetArrayLength());
+        var packageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (JsonElement row in data.EnumerateArray())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            operation.ThrowIfExpired();
+            // Yield periodically so single-threaded browser cancellation can run.
+            if (OperatingSystem.IsBrowser() && matches.Count % 32 == 0)
+            {
+                await Task.Yield();
+                cancellationToken.ThrowIfCancellationRequested();
+                operation.ThrowIfExpired();
+            }
+
+            JsonElement registration = Required(
+                row, "PackageRegistration", JsonValueKind.Object);
+            string id = RequiredText(registration, "Id");
+            string version = RequiredText(row, "Version");
+            string normalizedVersion = RequiredText(row, "NormalizedVersion");
+            PackageSourceCoordinate coordinate;
+            try
+            {
+                coordinate = PackageSourceCoordinate.Create(id, version);
+                if (coordinate != PackageSourceCoordinate.Create(id, normalizedVersion))
+                    throw Invalid("The Gallery response contains inconsistent versions.");
+            }
+            catch (ArgumentException exception)
+            {
+                throw new JsonException(
+                    "The Gallery response contains an invalid coordinate.", exception);
+            }
+
+            if (!packageIds.Add(coordinate.PackageId))
+                throw Invalid("The Gallery response contains a repeated package ID.");
+            if (!request.IncludePrerelease
+                && NuGet.Versioning.NuGetVersion.Parse(coordinate.Version).IsPrerelease)
+            {
+                throw Invalid("The Gallery response contains a prerelease version for stable-only discovery.");
+            }
+
+            long? downloads = NonNegativeInteger(
+                request.Order == NuGetGalleryDiscoveryOrder.MostDownloaded
+                    ? Required(registration, "DownloadCount", JsonValueKind.Number)
+                    : Optional(registration, "DownloadCount"));
+            if (request.Order == NuGetGalleryDiscoveryOrder.MostDownloaded
+                && downloads is null)
+            {
+                throw Invalid("Download-ranked Gallery rows require lifetime downloads.");
+            }
+
+            JsonElement verified = Optional(registration, "Verified");
+            matches.Add(new NuGetGalleryDiscoveryMatch(
+                results.Candidate(
+                    coordinate,
+                    PackageDiscoveryContract.KeywordSearch,
+                    PackageListingState.Listed),
+                id,
+                version,
+                downloads,
+                verified.ValueKind switch
+                {
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    _ => null,
+                },
+                Owners(Optional(registration, "Owners")),
+                SafeText(Optional(row, "Description"), TextPolicy.Prose)));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        operation.ThrowIfExpired();
+        return results.GalleryDiscovery(
+            request,
+            matches.MoveToImmutable(),
+            NonNegativeInteger(Optional(root, "totalHits")),
+            operation);
+    }
+
+    private static JsonElement Required(
+        JsonElement parent,
+        string name,
+        JsonValueKind kind)
+    {
+        JsonElement value = Optional(parent, name);
+        if (value.ValueKind != kind)
+            throw Invalid("The Gallery response has missing, repeated, or invalid required metadata.");
+        return value;
+    }
+
+    private static JsonElement Optional(JsonElement parent, string name)
+    {
+        if (parent.ValueKind != JsonValueKind.Object)
+            return default;
+        JsonElement value = default;
+        bool found = false;
+        foreach (JsonProperty property in parent.EnumerateObject())
+        {
+            if (!property.NameEquals(name))
+                continue;
+            if (found)
+                return default;
+            found = true;
+            value = property.Value;
+        }
+        return value;
+    }
+
+    private static string RequiredText(JsonElement parent, string name) =>
+        SafeText(Required(parent, name, JsonValueKind.String), TextPolicy.Field)
+        ?? throw Invalid("The Gallery response has invalid coordinate text.");
+
+    private static string? SafeText(JsonElement value, TextPolicy policy) =>
+        value.ValueKind == JsonValueKind.String
+            && value.GetString() is { } text
+            && !string.IsNullOrWhiteSpace(text)
+            && InertString.IsPermitted(policy, text)
+                ? text
+                : null;
+
+    private static long? NonNegativeInteger(JsonElement value) =>
+        value.ValueKind == JsonValueKind.Number
+            && value.TryGetInt64(out long number)
+            && number >= 0
+                ? number
+                : null;
+
+    private static ImmutableArray<string> Owners(JsonElement value)
+    {
+        if (value.ValueKind != JsonValueKind.Array)
+            return [];
+        var owners = ImmutableArray.CreateBuilder<string>(value.GetArrayLength());
+        foreach (JsonElement owner in value.EnumerateArray())
+        {
+            if (SafeText(owner, TextPolicy.Field) is not { } text)
+                return [];
+            owners.Add(text);
+        }
+        return owners.MoveToImmutable();
+    }
+
+    private static JsonException Invalid(string message) => new(message);
+}

--- a/src/NuGetFetch/NuGetGalleryDiscoveryResult.cs
+++ b/src/NuGetFetch/NuGetGalleryDiscoveryResult.cs
@@ -1,0 +1,109 @@
+using System.Collections.Immutable;
+
+namespace NuGetFetch;
+
+/// <summary>The Gallery-specific metadata discovery capability.</summary>
+public interface INuGetGalleryPackageSourceClient : IPackageSourceClient
+{
+    Task<PackageSourceOperationResult<NuGetGalleryDiscoveryResult>> DiscoverAsync(
+        NuGetGalleryDiscoveryRequest request,
+        CancellationToken cancellationToken = default,
+        NuGetOperationContext? operationContext = null);
+}
+
+/// <summary>One admitted search-metadata observation, without manifest facts.</summary>
+public sealed class NuGetGalleryDiscoveryMatch
+{
+    internal NuGetGalleryDiscoveryMatch(
+        PackageCandidateObservation candidate,
+        string packageId,
+        string version,
+        long? totalDownloads,
+        bool? verified,
+        ImmutableArray<string> owners,
+        string? description)
+    {
+        Candidate = candidate;
+        PackageId = packageId;
+        Version = version;
+        TotalDownloads = totalDownloads;
+        Verified = verified;
+        Owners = owners;
+        Description = description;
+    }
+
+    public PackageCandidateObservation Candidate { get; }
+    public string PackageId { get; }
+    public string Version { get; }
+    public long? TotalDownloads { get; }
+    public bool? Verified { get; }
+    public ImmutableArray<string> Owners { get; }
+    public string? Description { get; }
+}
+
+/// <summary>
+/// One fully admitted finite Gallery response. Success does not establish
+/// exhaustion of the searchable population.
+/// </summary>
+public sealed class NuGetGalleryDiscoveryResult
+{
+    private readonly object _issuer;
+
+    internal NuGetGalleryDiscoveryResult(
+        object issuer,
+        PackageSourceResultIdentity source,
+        NuGetGalleryDiscoveryRequest request,
+        ImmutableArray<NuGetGalleryDiscoveryMatch> matches,
+        long? estimatedTotalHits)
+    {
+        _issuer = issuer;
+        Source = source;
+        Request = request;
+        Matches = matches;
+        EstimatedTotalHits = estimatedTotalHits;
+    }
+
+    public PackageSourceResultIdentity Source { get; }
+    public NuGetGalleryDiscoveryRequest Request { get; }
+    public ImmutableArray<NuGetGalleryDiscoveryMatch> Matches { get; }
+    public long? EstimatedTotalHits { get; }
+
+    internal bool HasIssuer(object issuer) => ReferenceEquals(_issuer, issuer);
+}
+
+public sealed partial class PackageSourceResultFactory
+{
+    internal NuGetGalleryDiscoveryResult GalleryDiscovery(
+        NuGetGalleryDiscoveryRequest request,
+        ImmutableArray<NuGetGalleryDiscoveryMatch> matches,
+        long? estimatedTotalHits,
+        NuGetOperationDeadline operation)
+    {
+        operation.ThrowIfExpired();
+        foreach (NuGetGalleryDiscoveryMatch match in matches)
+        {
+            operation.ThrowIfExpired();
+            ValidateCandidate(match.Candidate);
+        }
+
+        return new NuGetGalleryDiscoveryResult(
+            _issuer, Source, request, matches, estimatedTotalHits);
+    }
+
+    internal PackageSourceOperationResult<NuGetGalleryDiscoveryResult>
+        SucceededGalleryDiscovery(
+            NuGetGalleryDiscoveryResult value,
+            NuGetOperationDeadline operation)
+    {
+        operation.ThrowIfExpired();
+        RequireSourceAndIssuer(value.Source, value.HasIssuer(_issuer));
+        return Succeeded(value);
+    }
+
+    internal PackageSourceOperationResult<NuGetGalleryDiscoveryResult>
+        FailedGalleryDiscovery(PackageSourceFailureKind kind) =>
+        Failed<NuGetGalleryDiscoveryResult>(
+            PackageSourceCapabilities.Search,
+            coordinate: null,
+            ValidateFailureKind(kind, allowNotFound: false));
+}

--- a/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
+++ b/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
@@ -2,7 +2,7 @@ using System.Runtime.ExceptionServices;
 
 namespace NuGetFetch;
 
-internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
+internal sealed class NuGetGalleryPackageSourceClient : INuGetGalleryPackageSourceClient
 {
     private const string SearchEndpoint =
         "https://azuresearch-usnc.nuget.org/query";
@@ -49,6 +49,42 @@ internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
         | PackageSourceCapabilities.Manifest
         | PackageSourceCapabilities.PackagePayload
         | PackageSourceCapabilities.SymbolPayload;
+
+    public async Task<PackageSourceOperationResult<NuGetGalleryDiscoveryResult>>
+        DiscoverAsync(
+            NuGetGalleryDiscoveryRequest request,
+            CancellationToken cancellationToken = default,
+            NuGetOperationContext? operationContext = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using NuGetOperationDeadline operation =
+            CreateOperation(cancellationToken, operationContext);
+        return await PackageSourceOperation.CaptureGalleryDiscoveryAsync(
+            _results,
+            () => NuGetHttpRetry.RunRequestAsync(
+                operation,
+                async requestToken =>
+                {
+                    using HttpRequestMessage message =
+                        NuGetHttpRequest.CreateGet(
+                            NuGetGalleryDiscoveryReader.RequestUrl(request));
+                    using HttpResponseMessage response = await _client.SendAsync(
+                        message,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        requestToken).ConfigureAwait(false);
+                    response.EnsureSuccessStatusCode();
+                    return await NuGetMetadataReader.ReadResponseAsync(
+                        response,
+                        (stream, token) => NuGetGalleryDiscoveryReader.ReadAsync(
+                            stream, request, _results, operation, token),
+                        _options,
+                        operation.RequestTimeout,
+                        requestToken).ConfigureAwait(false);
+                }),
+            cancellationToken,
+            operationContext,
+            operation).ConfigureAwait(false);
+    }
 
     public async Task<PackageSourceOperationResult<PackageSearchResult>> SearchAsync(
         string query,

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -543,7 +543,7 @@ public static partial class PackageSourceClientFactory
     /// Creates the built-in Gallery client with an isolated, credential-free
     /// transport owned by the returned client.
     /// </summary>
-    public static IPackageSourceClient CreateGallery(
+    public static INuGetGalleryPackageSourceClient CreateGallery(
         PackageSourceAssociation association,
         NuGetFetchOptions? options = null) =>
         new NuGetGalleryPackageSourceClient(
@@ -558,7 +558,7 @@ public static partial class PackageSourceClientFactory
     /// Creates the built-in Gallery client over a caller-created,
     /// credential-free transport owned by the returned client.
     /// </summary>
-    public static IPackageSourceClient CreateGallery(
+    public static INuGetGalleryPackageSourceClient CreateGallery(
         PackageSourceAssociation association,
         HttpMessageHandler ownedCredentialFreeTransport,
         NuGetFetchOptions? options = null)

--- a/src/NuGetFetch/PackageSourceResults.cs
+++ b/src/NuGetFetch/PackageSourceResults.cs
@@ -669,6 +669,7 @@ public sealed class PackageSourceOperationResult<T>
     {
         PackageSourceClientFactory.RequireOwnerCapability(ownerCapability);
         if (typeof(T) != typeof(PackageSearchResult)
+            && typeof(T) != typeof(NuGetGalleryDiscoveryResult)
             && typeof(T) != typeof(PackageVersionResult)
             && typeof(T) != typeof(PackageSourceManifest)
             && typeof(T) != typeof(PackageSourcePayload))
@@ -698,7 +699,7 @@ public sealed class PackageSourceOperationResult<T>
 /// <summary>
 /// Issues immutable results for one runtime package source.
 /// </summary>
-public sealed class PackageSourceResultFactory
+public sealed partial class PackageSourceResultFactory
 {
     private readonly object _ownerCapability;
     private readonly object _issuer = new();
@@ -1400,6 +1401,21 @@ public sealed class PackageSourceResultFactory
 
 internal static class PackageSourceOperation
 {
+    public static Task<PackageSourceOperationResult<NuGetGalleryDiscoveryResult>>
+        CaptureGalleryDiscoveryAsync(
+            PackageSourceResultFactory factory,
+            Func<Task<NuGetGalleryDiscoveryResult>> operation,
+            CancellationToken cancellationToken,
+            NuGetOperationContext? operationContext,
+            NuGetOperationDeadline operationDeadline) =>
+        CaptureAsync(
+            operation,
+            value => factory.SucceededGalleryDiscovery(value, operationDeadline),
+            factory.FailedGalleryDiscovery,
+            allowNotFound: false,
+            cancellationToken,
+            operationContext);
+
     public static Task<PackageSourceOperationResult<PackageSearchResult>>
         CaptureSearchAsync(
             PackageSourceResultFactory factory,


### PR DESCRIPTION
# Browse popular NuGet packages from the website

Makes inexpensive Gallery discovery a real website capability: browse popular
packages, .NET tools, or templates without already knowing a package name.
NuGetFetch owns provider behavior, shared Package Query owns local selection,
and the website remains an interactive consumer of typed results.

Fixes #6019. Delivers milestones 3-5 of the eight-step adoption path in #5919.
CLI query-capability discovery belongs to #6004; this PR does not add CLI flags
or advertise Gallery execution through `-Q`.

## Demo

Open `/query`, leave **Search** blank, and choose **.NET tools**. The actual
published website, running its Release Wasm engine in Firefox, displayed:

```text
Gallery filters
  Package type: .NET tools
  Source order: Automatic
  Include prerelease: off

Cake.Tool   6.2.0   SEARCH-METADATA
The Cake .NET Tool.
170,787,795 lifetime downloads                 [Open in workspace]

dotnet-ef   10.0.11   SEARCH-METADATA
Entity Framework Core Tools for the .NET Command-Line Interface.
```

These are one live observation, not pinned package versions or global top-N
claims. Automatic ordering resolves to Most downloaded for blank browse.
The source acquires one metadata response with K=200; browser demand credit
delivers an initial 20 matches without changing that source request.

The neighboring real-Wasm fixture scenario changes the type to **Templates**,
overrides **Relevance**, then searches `json parser` across all types with
automatic ordering. It receives `Contoso.Parser 1.0.0`, reports its missing
lifetime count as **unavailable**, and sends the text unchanged with
`sortBy=relevance`. The 20-row browse case also exercises keyboard access to
the last inspection facet alongside a long result stream.

Before this change, the page required a literal package prefix and acquired
manifests before producing any result. Now basic discovery needs only Gallery
search metadata. Existing manifest/content facets remain explicit, separate
inspection work, and exact-version **Open in workspace** remains available.

## Design basis

**Normative owner:** `docs/design/package-query-cli.md#gallery-source-input`.
**Claim:** Package Query preserves the exact bounded Gallery input issued by
NuGetFetch while evaluating inspection facets and selecting matches locally.

The source owner (`nuget-gallery-discovery.md`) supplies request/catalog,
provider interpretation, admission, provenance, and finite-response meaning.
RowSelection supplies the Head reference semantics. Existing source and browser
owners retain authorization, transport, deadlines, containment, generation,
credit, and Workspace handoff contracts.

The user explicitly approved **website-first ordinary shared acquisition;
defer Source Delegation** in #6019. This changes adoption sequencing, not source
scope or completion meaning. Delegation, its L2 adapter, and CLI execution
adoption remain milestones 6-8 of #5919. No delegation guarantees, upstream
Count, population exhaustion, or global top-N are claimed.

## Meaningful changes

- Adds Gallery-specific metadata transport and typed finite-response results
  in NuGetFetch, reusing source provenance, retries, cancellation, byte limits,
  and operation deadlines.
- Composes those results with local Head(N) and existing explicit inspection
  predicates. K remains independent of N. A neutral package row carries
  optional source metadata and an actual manifest only when acquired.
- Wires catalog-driven package types, source orders, prerelease selection,
  optional text, descriptions, unavailable counts, and bounded completion into
  the actual website and generated package facade.
- Preserves literal-prefix profiling and existing content facets. The Gallery
  page's required-prefix assumption is retired; no parallel provider parser or
  facet registry is added in TypeScript.

The Gallery implementation is the behavioral analogue, not transferred code.
Its indexed page selection followed by auxiliary-download reordering explains
the deliberately bounded design: A(indexed/auxiliary=200/200) wins K=1, but
B(100/300),A is the K=2 response. Local Head(1) over K=2 must therefore retain B.
The query fixture preserves this counterexample.

**Rendering boundary:** existing browser controls and cards render typed rows
directly rather than through Markout. Shared source/query behavior remains
host-neutral; future CLI rendering remains with its existing Sections/Markout
owners.

The generator includes a two-line Bash 3.2 empty-array compatibility correction
that directly blocked facade generation on macOS. The README documents the
existing whitespace-containing SDK/Emscripten workaround; it does not replace
the installed SDK or change PATH.

## Validation

All managed execution used Release and the configured .NET 11 preview SDK.

| Gate | Result |
| --- | --- |
| NuGetFetch discovery transport, request/catalog, and legacy-identity migration selection | 152 passed |
| Gallery query, existing Package Query, and package profile selection | 73 passed |
| Four frontend Package Query unit files | 99 passed |
| Existing application-wiring selection | 1 passed |
| Browser Package Query operations, production facade context, and content-policy selection | 28 passed |
| Frontend typecheck and existing frontend lint | Passed |
| Full frontend build and Release browser publish | Passed |
| Generated facade `--check` | All seven facade triples current; runtime canary passed |
| Published Firefox Gallery scenarios | Deterministic browse/search and opt-in live Gallery CORS passed |
| Release change-detection self-test | Passed with RowSelection included in the browser CI project closure |
| Changed Markdown and patch whitespace | Passed |

Focused commands and the live-browser opt-in are documented in the website
README and source design. Live provider availability is an observation;
deterministic source/query/browser fixtures enforce the implementation contract.

Current-head CI succeeded. Round 1 is review-clean with independent GPT-6 Astra
and Claude Opus 5 reviews at `4f20f236ee05407e2092351008551ada2d2f9679`.
No production deployment is included.
