### PR TITLE
Enforce Content Security Policy for inspect-web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,8 @@ jobs:
           # where they ship. The toolchain test pins them in the source file; this checks
           # the copy Azure actually reads. Values are compared exactly rather than by
           # prefix -- `max-age=0` starts with `max-age=` and switches HSTS off.
-          jq -e '.globalHeaders == {
+          # CSP includes a per-publish import-map hash, checked below in Firefox.
+          jq -e '(.globalHeaders | del(."Content-Security-Policy")) == {
               "X-Content-Type-Options": "nosniff",
               "Referrer-Policy": "no-referrer",
               "X-Frame-Options": "DENY",

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1400,9 +1400,38 @@ lets the sanitization comment name a gate that is monitoring rather than
 enforcement. Run `npm audit --audit-level=info` locally to get the old answer on
 demand.
 
-A Content-Security-Policy remains separate follow-up work for browser-enforced
-resource restrictions. Bundling Prism does not establish such a policy or
-prohibit intentional package, API, or Wasm acquisition traffic.
+`staticwebapp.config.json` owns the browser's enforcing Content-Security-Policy
+on static responses. It follows the
+[standard CSP directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy)
+and [.NET's Wasm CSP guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/security/content-security-policy):
+same-origin scripts and workers, `wasm-unsafe-eval` for .NET, and a SHA-256 hash
+for the SDK-generated inline import map. It does not grant JavaScript
+`unsafe-eval` or `unsafe-inline`. Objects, frames, form submissions, and
+embedding the site are denied; the existing `<base href="/">` remains permitted.
+
+Two compatibility allowances are deliberate. `style-src 'unsafe-inline'`
+preserves application styles and Mermaid's generated style elements and
+attributes. HTTPS connections and images remain permitted for package, symbol,
+SourceLink, icon, and documentation acquisition; `data:` images remain permitted.
+This is script-execution defense in depth, not a destination allow list or a
+replacement for the existing acquisition policies and DOMPurify.
+
+After .NET fills the import map, `publish-content-security-policy.ts` substitutes
+its hash into the published hosting configuration. It hashes browser-normalized
+line endings without trimming the script text, rejects a missing, empty, or
+duplicate map, and regenerates from the source template on every publish.
+Deploy the published configuration alongside its matching `index.html`, not
+the source template or Vite's empty import map.
+
+`test/content-security-policy.test.ts` gates hash generation and republication.
+The existing published Worker Firefox gate serves the artifact's actual
+`globalHeaders`; `browser/content-security-policy.spec.ts` checks the exact
+header/hash, page startup, blocked unapproved scripts, and Mermaid rendering.
+The neighboring Worker tests cover cold/warm managed calls and restart under
+the same policy. These are bounded compatibility and enforcement checks, not
+exhaustive coverage of every route or interaction. Azure's managed `/api/*`
+responses do not inherit static `globalHeaders`; Vite development serving is
+also outside this deployment policy.
 
 Knip checks authored source, every TypeScript and JavaScript test, and
 build/verification scripts for unused files, exports, and dependencies.

--- a/prototypes/inspect-web/browser/content-security-policy.spec.ts
+++ b/prototypes/inspect-web/browser/content-security-policy.spec.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "@playwright/test";
+
+declare global {
+  interface Window {
+    cspViolations: string[];
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.cspViolations = [];
+    document.addEventListener("securitypolicyviolation", event => {
+      window.cspViolations.push(`${event.effectiveDirective}:${event.blockedURI}`);
+    });
+  });
+});
+
+test("published page boots with the exact CSP and import-map hash", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  const response = await page.goto("/index.html");
+  const map = await page.locator('script[type="importmap"]').textContent();
+  if (map === null) throw new Error("Published import map is missing.");
+  const hash = createHash("sha256").update(map).digest("base64");
+  expect(response?.headers()["content-security-policy"]).toBe(
+    `default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-${hash}'; `
+    + "style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; "
+    + "connect-src 'self' https:; worker-src 'self'; object-src 'none'; "
+    + "frame-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'",
+  );
+  await expect(page.locator(".home-search")).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
+  await expect(page.locator("#spotlight-input")).toBeEditable();
+  expect(errors).toEqual([]);
+  expect(await page.evaluate(() => window.cspViolations)).toEqual([]);
+});
+
+test("published CSP blocks unapproved inline and external scripts", async ({ page }) => {
+  await page.goto("/worker-runtime-gate.html");
+  await page.evaluate(() => {
+    const inline = document.createElement("script");
+    inline.textContent = "document.documentElement.dataset.cspCanary = 'ran';";
+    const external = document.createElement("script");
+    external.src = "https://example.invalid/csp-canary.js";
+    document.head.append(inline, external);
+  });
+  await expect.poll(() => page.evaluate(() => window.cspViolations)).toEqual(
+    expect.arrayContaining([
+      "script-src-elem:inline",
+      expect.stringMatching(/^script-src-elem:https:\/\/example\.invalid/),
+    ]),
+  );
+  expect(await page.locator("html").getAttribute("data-csp-canary")).toBeNull();
+});
+
+test("published Mermaid renders styled diagrams under CSP", async ({ page }) => {
+  const site = resolve(
+    process.env.INSPECT_WEB_WORKER_SITE ?? "../../artifacts/inspect-web-publish/wwwroot",
+  );
+  const manifest: unknown = JSON.parse(readFileSync(resolve(site, "manifest.json"), "utf8"));
+  const key = "node_modules/mermaid/dist/mermaid.core.mjs";
+  if (typeof manifest !== "object" || manifest === null || !(key in manifest)) {
+    throw new Error("Published Mermaid entry is missing.");
+  }
+  const entry = manifest[key];
+  if (typeof entry !== "object" || entry === null
+    || !("file" in entry) || typeof entry.file !== "string") {
+    throw new Error("Published Mermaid entry has no asset.");
+  }
+  await page.goto("/index.html");
+  await expect(page.locator(".home-search")).toHaveAttribute("aria-busy", "false", { timeout: 60_000 });
+  await page.evaluate(async url => {
+    type Mermaid = {
+      initialize: (config: { startOnLoad: boolean; securityLevel: "strict" }) => void;
+      render: (id: string, definition: string) => Promise<{ svg: string }>;
+    };
+    function isMermaid(value: unknown): value is Mermaid {
+      return typeof value === "object" && value !== null
+        && "initialize" in value && typeof value.initialize === "function"
+        && "render" in value && typeof value.render === "function";
+    }
+    const imported: unknown = await import(url);
+    if (typeof imported !== "object" || imported === null) {
+      throw new Error("Published Mermaid module is missing.");
+    }
+    const mermaid = Object.values(imported).find(isMermaid);
+    if (!mermaid) throw new Error("Published Mermaid export is missing.");
+    mermaid.initialize({ startOnLoad: false, securityLevel: "strict" });
+    const { svg } = await mermaid.render("csp-diagram", "graph TD; A[Package] --> B[Assembly]");
+    const container = document.createElement("div");
+    container.id = "diagram";
+    container.innerHTML = svg;
+    document.body.append(container);
+  }, `/${entry.file}`);
+  await expect(page.locator("#diagram svg")).toBeVisible();
+  await expect(page.locator("#diagram .node")).toHaveCount(2);
+  expect(await page.evaluate(() => window.cspViolations)).toEqual([]);
+});

--- a/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
@@ -70,13 +70,30 @@ public class BrowserStaticWebAppConfigTests
             "$(PublishDir)wwwroot",
             (string?)runtimeLoaderCommand.Attribute("Command"));
 
+        XElement contentSecurityPolicyTarget = Assert.Single(
+            project.Descendants("Target"),
+            element =>
+                (string?)element.Attribute("Name") ==
+                "PublishInspectWebContentSecurityPolicy");
+        Assert.Equal(
+            "PublishInspectWebRuntimeLoader",
+            (string?)contentSecurityPolicyTarget.Attribute("AfterTargets"));
+        XElement contentSecurityPolicyCommand = Assert.Single(
+            contentSecurityPolicyTarget.Elements("Exec"));
+        Assert.Contains(
+            "publish-content-security-policy.ts",
+            (string?)contentSecurityPolicyCommand.Attribute("Command"));
+        Assert.Contains(
+            "$(PublishDir)wwwroot",
+            (string?)contentSecurityPolicyCommand.Attribute("Command"));
+
         XElement verificationTarget = Assert.Single(
             project.Descendants("Target"),
             element =>
                 (string?)element.Attribute("Name") ==
                 "VerifyPublishedInspectWebSite");
         Assert.Equal(
-            "PublishInspectWebRuntimeLoader",
+            "PublishInspectWebContentSecurityPolicy",
             (string?)verificationTarget.Attribute("AfterTargets"));
         XElement verificationCommand = Assert.Single(
             verificationTarget.Elements("Exec"));

--- a/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
+++ b/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
@@ -65,7 +65,11 @@
     <Exec Command="node &quot;../scripts/publish-runtime-loader.ts&quot; &quot;$(PublishDir)wwwroot&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
-  <Target Name="VerifyPublishedInspectWebSite" AfterTargets="PublishInspectWebRuntimeLoader">
+  <Target Name="PublishInspectWebContentSecurityPolicy" AfterTargets="PublishInspectWebRuntimeLoader">
+    <Exec Command="node &quot;../scripts/publish-content-security-policy.ts&quot; &quot;$(PublishDir)wwwroot&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
+  <Target Name="VerifyPublishedInspectWebSite" AfterTargets="PublishInspectWebContentSecurityPolicy">
     <Exec Command="node &quot;../scripts/verify-site-artifact.ts&quot; &quot;$(PublishDir)wwwroot&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 

--- a/prototypes/inspect-web/playwright.config.ts
+++ b/prototypes/inspect-web/playwright.config.ts
@@ -3,7 +3,11 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./browser",
   testMatch: "*.spec.ts",
-  testIgnore: ["worker-runtime.spec.ts", "package-adoption.spec.ts"],
+  testIgnore: [
+    "worker-runtime.spec.ts",
+    "package-adoption.spec.ts",
+    "content-security-policy.spec.ts",
+  ],
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,

--- a/prototypes/inspect-web/playwright.worker.config.ts
+++ b/prototypes/inspect-web/playwright.worker.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./browser",
-  testMatch: "worker-runtime.spec.ts",
+  testMatch: ["worker-runtime.spec.ts", "content-security-policy.spec.ts"],
   workers: 1,
   forbidOnly: Boolean(process.env.CI),
   timeout: 120_000,

--- a/prototypes/inspect-web/scripts/publish-content-security-policy.ts
+++ b/prototypes/inspect-web/scripts/publish-content-security-policy.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function publishContentSecurityPolicy(siteArgument: string): void {
+  const site = resolve(siteArgument);
+  // HTML parsing normalizes CRLF and lone CR before CSP hashes script text.
+  const index = readFileSync(resolve(site, "index.html"), "utf8").replace(/\r\n?/g, "\n");
+  const maps = [...index.matchAll(/<script type="importmap">([\s\S]*?)<\/script>/g)];
+  const text = maps[0]?.[1];
+  if (maps.length !== 1 || !text?.trim()) {
+    throw new Error("Expected one populated SDK import map in published index.html.");
+  }
+
+  const config: unknown = JSON.parse(readFileSync(
+    new URL("../staticwebapp.config.json", import.meta.url), "utf8",
+  ));
+  if (typeof config !== "object" || config === null
+    || !("globalHeaders" in config)
+    || typeof config.globalHeaders !== "object" || config.globalHeaders === null
+    || !("Content-Security-Policy" in config.globalHeaders)
+    || typeof config.globalHeaders["Content-Security-Policy"] !== "string") {
+    throw new Error("Static Web Apps configuration is missing Content-Security-Policy.");
+  }
+  const template = config.globalHeaders["Content-Security-Policy"];
+  const placeholder = "{{IMPORT_MAP_HASH}}";
+  if (template.split(placeholder).length !== 2) {
+    throw new Error("Content-Security-Policy must contain one import-map hash placeholder.");
+  }
+  config.globalHeaders["Content-Security-Policy"] = template.replace(
+    placeholder, createHash("sha256").update(text).digest("base64"),
+  );
+  writeFileSync(resolve(site, "staticwebapp.config.json"), `${JSON.stringify(config, null, 2)}\n`);
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined
+  && import.meta.url === pathToFileURL(resolve(invokedPath)).href) {
+  const siteArgument = process.argv[2];
+  if (!siteArgument) {
+    throw new Error("Usage: node scripts/publish-content-security-policy.ts <published-wwwroot>");
+  }
+  publishContentSecurityPolicy(siteArgument);
+}

--- a/prototypes/inspect-web/scripts/serve-worker-runtime-gate.ts
+++ b/prototypes/inspect-web/scripts/serve-worker-runtime-gate.ts
@@ -6,6 +6,16 @@ const site = resolve(
   process.env.INSPECT_WEB_WORKER_SITE ?? "../../artifacts/inspect-web-publish/wwwroot",
 );
 await readFile(resolve(site, "manifest.json"));
+const config: unknown = JSON.parse(await readFile(resolve(site, "staticwebapp.config.json"), "utf8"));
+if (typeof config !== "object" || config === null || !("globalHeaders" in config)
+  || typeof config.globalHeaders !== "object" || config.globalHeaders === null) {
+  throw new Error("Published Static Web Apps configuration is missing globalHeaders.");
+}
+const headers = new Map<string, string>();
+for (const [name, value] of Object.entries(config.globalHeaders)) {
+  if (typeof value !== "string") throw new Error(`Invalid published header: ${name}`);
+  headers.set(name, value);
+}
 const contentTypes: Readonly<Record<string, string>> = {
   ".html": "text/html; charset=utf-8",
   ".js": "text/javascript; charset=utf-8",
@@ -15,6 +25,7 @@ const contentTypes: Readonly<Record<string, string>> = {
 };
 
 createServer((request, response) => {
+  for (const [name, value] of headers) response.setHeader(name, value);
   const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
   if (pathname === "/worker-runtime-gate.html") {
     response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/prototypes/inspect-web/staticwebapp.config.json
+++ b/prototypes/inspect-web/staticwebapp.config.json
@@ -3,7 +3,8 @@
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "no-referrer",
     "X-Frame-Options": "DENY",
-    "Strict-Transport-Security": "max-age=63072000; includeSubDomains"
+    "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-{{IMPORT_MAP_HASH}}'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https:; worker-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
   },
   "routes": [
     {

--- a/prototypes/inspect-web/test/content-security-policy.test.ts
+++ b/prototypes/inspect-web/test/content-security-policy.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+import { fileURLToPath } from "node:url";
+import { publishContentSecurityPolicy } from "../scripts/publish-content-security-policy.ts";
+
+const script = fileURLToPath(new URL("../scripts/publish-content-security-policy.ts", import.meta.url));
+const template = readFileSync(new URL("../staticwebapp.config.json", import.meta.url), "utf8");
+const map = '\n{\n  "imports": { "./_framework/dotnet.js": "./_framework/dotnet.first.js" }\n}\n';
+
+function createSite(context: TestContext, html: string): string {
+  const site = mkdtempSync(join(tmpdir(), "inspect-web-csp-"));
+  context.after(() => rmSync(site, { recursive: true, force: true }));
+  writeFileSync(join(site, "index.html"), html);
+  return site;
+}
+
+function expectedConfig(text: string): string {
+  const config: unknown = JSON.parse(template.replace(
+    "{{IMPORT_MAP_HASH}}", createHash("sha256").update(text).digest("base64"),
+  ));
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+test("publication authorizes the SDK import map without changing other hosting configuration", context => {
+  const html = `<script type="importmap">${map}</script><script>const unrelated = 1;</script>`;
+  const site = createSite(context, html);
+  const result = spawnSync(process.execPath, [script, site], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(readFileSync(join(site, "staticwebapp.config.json"), "utf8"), expectedConfig(map));
+  assert.equal(readFileSync(join(site, "index.html"), "utf8"), html);
+});
+
+for (const newline of ["\r\n", "\r"]) {
+  test(`publication hashes browser-normalized ${JSON.stringify(newline)} line endings`, context => {
+    const site = createSite(context, `<script type="importmap">${map.replaceAll("\n", newline)}</script>`);
+    publishContentSecurityPolicy(site);
+    assert.equal(readFileSync(join(site, "staticwebapp.config.json"), "utf8"), expectedConfig(map));
+  });
+}
+
+test("republication replaces the old hash and remains idempotent", context => {
+  const site = createSite(context, `<script type="importmap">${map}</script>`);
+  publishContentSecurityPolicy(site);
+  const next = map.replace("first", "second");
+  writeFileSync(join(site, "index.html"), `<script type="importmap">${next}</script>`);
+  for (let attempt = 0; attempt < 2; attempt++) {
+    publishContentSecurityPolicy(site);
+    assert.equal(readFileSync(join(site, "staticwebapp.config.json"), "utf8"), expectedConfig(next));
+  }
+});
+
+for (const [name, html] of [
+  ["missing", "<html></html>"],
+  ["empty", '<script type="importmap"></script>'],
+  ["whitespace-only", '<script type="importmap"> \n </script>'],
+  ["duplicate", `<script type="importmap">${map}</script><script type="importmap">${map}</script>`],
+  ["changed SDK markup", `<script type="importmap" id="changed">${map}</script>`],
+] as const) {
+  test(`publication fails visibly for a ${name} import map`, context => {
+    const site = createSite(context, html);
+    assert.throws(() => publishContentSecurityPolicy(site), /Expected one populated SDK import map/);
+  });
+}

--- a/prototypes/inspect-web/test/toolchain.test.ts
+++ b/prototypes/inspect-web/test/toolchain.test.ts
@@ -2714,8 +2714,8 @@ test("static hosting sends its security headers on every static response", () =>
   // These are response-header protections, so nothing in the source tree can stand in for
   // them: a linter reads the markup this project ships, while these constrain what a
   // browser will do with it once shipped. `nosniff` stops content-type guessing on the
-  // JSON, TSV and wasm this site serves, and the other three are the cheap defaults that
-  // need no coordination with page content.
+  // JSON, TSV and wasm this site serves. CSP's hash is filled after the SDK publishes
+  // the import map; the published-artifact browser gate checks the resulting policy.
   //
   // "static" in this test's name is load-bearing. Azure Static Web Apps does not apply
   // `globalHeaders` to responses produced by the managed functions under `/api/*`; those
@@ -2727,6 +2727,7 @@ test("static hosting sends its security headers on every static response", () =>
     "Referrer-Policy": "no-referrer",
     "X-Frame-Options": "DENY",
     "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-{{IMPORT_MAP_HASH}}'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https:; worker-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'",
   });
 
   // Azure Static Web Apps returns the union of `globalHeaders` and a matching route's
@@ -2757,7 +2758,7 @@ test("static hosting sends its security headers on every static response", () =>
   // global headers without naming any of them. Azure has acknowledged this since 2022
   // (Azure/static-web-apps#739): a route with `redirect` returns neither `globalHeaders`
   // nor its own `headers`. Such a route passes the disjointness check above while serving
-  // a 302 with none of the four headers on it, which is exactly the silent weakening this
+  // a 302 with none of the security headers on it, which is exactly the silent weakening this
   // test exists to prevent. There are no redirect routes today; this keeps it that way
   // rather than waiting for one to be added and quietly punch a hole.
   const redirecting = staticWebAppConfig.routes
@@ -2766,7 +2767,7 @@ test("static hosting sends its security headers on every static response", () =>
 
   assert.deepEqual(redirecting, [],
     "Azure Static Web Apps omits `globalHeaders` on redirect responses "
-      + "(Azure/static-web-apps#739), so this route would answer without any of the four "
+      + "(Azure/static-web-apps#739), so this route would answer without any of the security "
       + "headers while the config still reads as though they are global; serve the "
       + "redirect from a route that does not use `redirect`, or narrow this test's claim "
       + "deliberately");


### PR DESCRIPTION
## Summary

Enable an enforcing Content-Security-Policy for inspect-web's static deployment. This is the bounded CSP follow-up after Prism bundling in #5679, not another analyzer or a broader security redesign.

- Same-origin scripts and workers; permit .NET Wasm and only the hashed SDK import map as inline script content.
- Deny objects, frames, form submissions, and embedding; retain the same-origin base element.
- Keep inline styles for application/Mermaid rendering and HTTPS connections/images for existing acquisition and documentation features. These are explicit compatibility allowances, not an exfiltration-prevention claim.
- Generate the hash after .NET publishes the import map, preserving browser newline normalization and all other hosting configuration.
- Reuse the existing Firefox Worker lane to serve and check the published headers. No new CI lane, dependency, custom analyzer, or CSP reporting service.

**Design basis:** `prototypes/inspect-web/README.md#static-analysis` owns the static deployment policy. Standard CSP directives are the enforcement mechanism; Microsoft's Wasm CSP guidance supplies the runtime allowance. The existing acquisition policies and DOMPurify remain separate protections. This does not change API response headers, Vite development serving, or product platform settings.

## Demo

Before: the production response has no `Content-Security-Policy` header.

After, the local Release-published artifact returns:

```text
Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-DEoe/GQwvXVliAROBFfFW3Br2H2lafvOph55Dx9qOAk='; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https:; worker-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'
```

The digest varies with the SDK's published import map.

```console
$ npm run inspect-web-worker-browser-binding
...
published page boots with the exact CSP and import-map hash
published CSP blocks unapproved inline and external scripts
published Mermaid renders styled diagrams under CSP
published generated facades boot in a real Worker and serve cold and warm managed calls
restart destroys the old realm and explicitly boots a new epoch
a generated-facade bootstrap rejection fails held work and releases the partial realm
stalled Wasm initialization leaves page input available and exhausts startup
  7 passed (11.2s)
```

Notice that ordinary page rendering, the neighboring diagram scenario, and managed Worker calls still work with the policy enforced. The negative checks use harmless canaries.

## Validation

- [Current-head inspect-web CI](https://github.com/richlander/dotnet-inspect/actions/runs/34001014074/job/101400130117): **passed**, including normal Release publication and the published Firefox checks at `248edb895056f2f7c7d79b5f6aca6d8e4f8c8959`. The aggregate `ci-required` gate remains the review prerequisite.
- `npm run typecheck`
- `node --test test/content-security-policy.test.ts test/runtime-loader.test.ts test/toolchain.test.ts`: **65 passed**. Used an ignored worktree-local `TMPDIR` to avoid macOS `/var` canonical-path differences in existing bundler tests.
- `npm run analyze`
- `npm run inspect-web-worker-browser-binding`: **9 Node tests and 7 Firefox tests passed**.
- `npm run test:browser -- --list`: **119 Vite tests in 7 files**, excluding the published-only CSP, Worker, and package-adoption suites.
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release -p:WasmBuildNative=false -p:WasmEnableSIMD=true -p:WasmEnableExceptionHandling=true -- -class '*BrowserStaticWebAppConfigTests'`: **3 passed** after correcting the existing publish-order assertion.
- `npx --no-install markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

Local Release publication and the focused C# test build used `-p:WasmBuildNative=false -p:WasmEnableSIMD=true -p:WasmEnableExceptionHandling=true` to use the SDK's stock runtime. The normal local native relink hits an existing Emscripten wrapper failure on spaces in the shared SDK path. No SDK files or committed runtime settings were changed. **Normal production publication and its Firefox checks must pass in CI; the local override is not evidence for that native relink.**

The first CI attempt successfully published with normal production settings, then caught an existing C# assertion that still expected the old publish target order. The replacement commit updates only that test to check runtime loader → CSP generation → artifact verification. New-head CI is required before review; no review round was spent by this recovery.

The next CI attempt passed the engine tests and 119 existing Vite browser tests, but also discovered the three new published-only CSP cases under the Vite development server. The latest test-only correction adds that spec to Vite's existing `testIgnore` list. Discovery now contains exactly those 119 Vite cases; the three CSP cases still execute and pass in the seven-test published Firefox suite. No policy or CSP assertion was weakened.

The new unit tests also cover CRLF/lone-CR normalization, missing/empty/duplicate maps, changed SDK markup, changed fingerprints, and idempotent republication.

## Review scope

At most **three rounds**, retaining the user's bounded-review direction. Review this policy, its publish integration, and preservation of the exercised browser behavior. Broader destination restrictions, style rewrites, bespoke analyzers, and exhaustive application audits are outside this slice.

Candidate: `248edb895056f2f7c7d79b5f6aca6d8e4f8c8959`  
Effective base: `7313ea4f21210d15f7e001a3e72d3622268b7059` (`main`)

No merge authorization is recorded.
