### PR TITLE
Publish ecosystem namespace hints and core-package priorities

### DIFF
--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -28,11 +28,12 @@ required currency; existing search and full Integration behavior is unchanged.
 [Approved lazy traversal](approved-lazy-traversal.md) records the approved
 target experience for compact namespace hints, core-package starting points,
 Integration-owned contract knowledge, and Platform as an ecosystem selecting
-source-owned discovery/acquisition bindings. Those additions are not part of
-the implemented registration above. The [retrieval-knowledge contract](#retrieval-hints-and-core-packages)
-under #6028 defines inert namespace hints and core-package priorities; its
-implementation and runtime properties remain **unverified**. Executable
-source contributions retain separate prerequisites under #6012 and #5728.
+source-owned discovery/acquisition bindings. The [retrieval-knowledge contract](#retrieval-hints-and-core-packages)
+under #6028 is implemented by #6037: discovery and exact lookup expose inert
+namespace hints and core-package priorities, covered by the
+[retrieval-knowledge gates](#retrieval-knowledge-gates).
+Executable source contributions retain separate prerequisites under #6012
+and #5728; the new metadata does not advertise traversal availability.
 
 Participating normative owner:
 
@@ -514,16 +515,15 @@ composition decision places the private shipped package-set manifest in
 currency and validation remain below in `DotnetInspector.Packages`. One
 ecosystem source unit may author both a package-set registration and a pack
 registration, but the two static manifests remain separate and the pack stores
-only `PackageSetId`. No reusable package, source, query, service, Vocabulary,
+only `PackageSetId` for its curated-set contribution. No reusable package, source, query, service, Vocabulary,
 or browser-Core component references the application registry.
 
 ## Retrieval hints and core packages
 
-This is the focused catalog contract for #6028, within stage 2 of the
+This is the focused catalog contract for #6028, implemented by #6037 within stage 2 of the
 [eight-stage lazy-traversal adoption plan](approved-lazy-traversal.md#ownership-and-adoption).
-It is not implemented; the new runtime obligations in this section are
-**unverified** until the following catalog implementation supplies the
-[planned gates](#planned-retrieval-knowledge-gates).
+The existing registry and ordinary non-friend consumer suites enforce the
+[retrieval-knowledge gates](#retrieval-knowledge-gates).
 
 Each pack may contribute two independent, immutable ordered sequences:
 
@@ -603,10 +603,10 @@ package set nor substitutes a `System.*` package prefix for a platform target.
 The applicable source owner must issue its discovery/acquisition binding
 before the catalog can expose that separate capability.
 
-The first implementation will publish inert knowledge through the shared
+The implementation publishes inert knowledge through the shared
 catalog. The CLI and `InspectWeb.Engine.CatalogExports` are its production
 consumers; host metadata and operational adoption stay in #6012 stages 6 and 7.
-This focused contract and its following catalog implementation are two
+This focused contract and its catalog implementation are two
 slices within catalog stage 2, not a replacement roadmap. No existing
 architecture is retired, and no new host rendering strategy is introduced.
 
@@ -809,6 +809,27 @@ product sequence. The two new Aspire demos follow them. The literal
 demo-to-pack mapping is application policy and is not inferred from their
 package coordinates or titles.
 
+The initial retrieval metadata is independently authored alongside those
+capabilities:
+
+| Pack | Namespace roots | Core packages, in preference order |
+| --- | --- | --- |
+| Platform | `System` | none |
+| Microsoft.Extensions | `Microsoft.Extensions` | `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Configuration.Abstractions`, `Microsoft.Extensions.Logging.Abstractions` |
+| ASP.NET Core | `Microsoft.AspNetCore` | `Microsoft.AspNetCore.OpenApi`, `Microsoft.AspNetCore.Authentication.JwtBearer` |
+| Aspire | `Aspire` | `Aspire.Hosting` |
+
+Each root is a compact descriptive subtree, not a package correspondence.
+The Extensions entries prioritize foundational DI, configuration, and logging
+contracts even though the curated set excludes shared-framework-covered
+packages. ASP.NET Core starts with current OpenAPI and bearer-authentication
+add-on APIs rather than obsolete package versions of shared-framework
+fundamentals. Aspire starts with its hosting API. These choices are product
+preferences, not popularity rankings or complete ecosystem inventories.
+Platform deliberately contributes no package coordinate as a substitute for
+its future source-native discovery/acquisition binding. This metadata is not
+derived from package-set membership or demo records.
+
 | Global order | Scenario ID | Pack |
 | ---: | --- | --- |
 | 100 | `stj-serializer` | `ecosystem.platform` |
@@ -869,26 +890,35 @@ candidate packs, not registrations authorized by this design.
 
 ## Demo
 
-The retrieval-knowledge example below is a target API-data mockup, not a new
-CLI command or current runtime output:
+Retrieval knowledge is available through the shared catalog, not a new CLI
+command or browser action:
+
+```csharp
+var pack = ((EcosystemPackLookupResult.Known)EcosystemPackCatalog.Lookup(
+    EcosystemPackIds.MicrosoftExtensions)).Descriptor;
+Console.WriteLine(pack.Id);
+Console.WriteLine($"  Namespace roots: {string.Join(", ", pack.NamespaceRoots)}");
+Console.WriteLine("  Core packages (preference order; unversioned)");
+foreach (var package in pack.CorePackages)
+    Console.WriteLine($"    {package.PackageId}");
+Console.WriteLine($"  Curated set: {pack.PackageSet}");
+```
+
+Output:
 
 ```text
 ecosystem.microsoft-extensions
-  Namespace roots
-    Microsoft.Extensions.DependencyInjection
-    Microsoft.Extensions.Configuration
-    Microsoft.Extensions.Logging
+  Namespace roots: Microsoft.Extensions
   Core packages (preference order; unversioned)
     Microsoft.Extensions.DependencyInjection.Abstractions
     Microsoft.Extensions.Configuration.Abstractions
     Microsoft.Extensions.Logging.Abstractions
-  Curated set
-    package-set.microsoft-extensions
+  Curated set: package-set.microsoft-extensions
 ```
 
-The three core entries do not replace the curated membership. There is no
-root-to-package pairing despite the parallel-looking names. This mockup does
-not lock the shipped inventory, grant traversal, or perform package work.
+The three core entries do not replace the curated membership. One root and
+three core packages are independent sequences, not a positional pairing.
+Reading this metadata does not grant traversal or perform package work.
 A neighboring pack can have no roots, no core entries, and an existing demo
 capability; a hint-only registration remains invalid. A second pack may
 declare one of the same roots without either claiming exclusive ownership.
@@ -955,29 +985,20 @@ demo, or return a scanner binding.
 
 ## Required gates
 
-### Planned retrieval-knowledge gates
+### Retrieval-knowledge gates
 
-The following are target Release outcomes for the #6028 implementation
-follow-up, not currently passing gates. Existing registry and non-friend
-consumer suites are the intended enforcing surfaces; source/resolution
-interpretation remains with its own future consumer gates.
+These are active Release gates in the existing registry and non-friend
+consumer suites. Source/resolution interpretation remains with its own future
+consumer gates.
 
-The implementation must also revise
-`ProductEcosystemPackTests.ShippedPackManifestCarriesOnlyPackageSetIdentity`.
-Its current blanket exclusion of coordinate sequences is stronger than the
-retained curated-membership boundary and cannot remain the target gate for
-independent core references. The revised property permits those references
-while retaining ID-only curated composition and the existing no-lookup
-behavior. This gate revision is part of the implementation follow-up and is
-also **unverified** here; curated membership authority does not change.
-
-| Gate scenario | Required outcome |
+| Gate | Required outcome |
 | --- | --- |
-| Discover and look up unequal-length hint/core sequences on two packs sharing a root and a core package | Exact pack association, literal spelling, authored order, and complete independent immutable sequences survive; cross-pack overlap remains valid and no positional root-to-package mapping is introduced. |
-| Publish malformed roots or invalid, duplicate, versioned, or target-specific core coordinates | Complete registry construction fails visibly before any descriptor is published; overlapping but distinct roots remain valid. |
-| Discover empty knowledge on a demo-capable pack and attempt a knowledge-only registration | Empty contributions remain empty without changing the existing capability requirement or manufacturing traversal availability. |
-| Read metadata, then select one existing demo, scanner, or curated-set action | Knowledge discovery invokes no capability; explicit selection preserves the selected owner's existing input and outcome without activating neighbors. |
-| Discover a shipped core sequence beside its curated-set reference through a non-friend consumer | Literal application expectations preserve the two distinct roles; catalog discovery does not resolve curated membership or package coordinates. |
+| `EcosystemPackRegistryTests.RetrievalKnowledgePreservesIndependentImmutableSequencesAndPackIdentity` | Unequal-length sequences preserve exact pack association, literal spelling, authored order, and immutable snapshots; overlapping roots and cross-pack overlap remain valid. An unregistered curated-set identity is not resolved. |
+| `EcosystemPackRegistryTests.InvalidNamespaceRootsFailBeforePublication`, `InvalidCorePackagesFailBeforePublication`, and `MissingKnowledgeSequencesFailBeforePublication` | Malformed roots, missing sequences, and null, invalid, duplicate, versioned, or target-specific core coordinates fail complete construction visibly, without invoking demo sources. |
+| `EcosystemPackRegistryTests.EmptyKnowledgePreservesCapabilityRequirements` | Empty contributions remain empty; knowledge-only registrations fail the existing capability requirement. |
+| `EcosystemPackRegistryTests.ScannerSelectionReturnsOnlyTheSelectedBinding` | Reading knowledge and selecting one capability preserve the selected owner's outcome without invoking neighboring demo/scanner capabilities. |
+| `ProductEcosystemPackTests.ShippedRetrievalKnowledgeMatchesLiteralPolicy` | All four packs retain literal authored roots and core priorities, including Platform's empty core sequence. |
+| `PackageSetRegistryConsumerTests.PublicSurfaceKeepsCoreReferencesSeparateFromCuratedMembership` | An ordinary non-friend consumer reads immutable knowledge through discovery/lookup; Extensions core entries and curated membership remain distinct, and Platform gains no package-set or scanner capability. |
 
 ### Existing and staged capability gates
 
@@ -1012,13 +1033,12 @@ Application adoption adds
 `ProductEcosystemPackTests.ShippedManifestMatchesLiteralPolicy` and
 `ProductEcosystemPackTests.EveryPackageSetReferenceResolves` with literal
 descriptor and reference expectations, plus
-`ProductEcosystemPackTests.ShippedPackManifestCarriesOnlyPackageSetIdentity`.
-That current gate checks that registration and descriptor property shapes carry
-`PackageSetId` and no package-set descriptor, registration, coordinate
-sequence, or registry property. Its blanket coordinate exclusion must narrow
-to the curated-membership boundary when independent core references are
-implemented, as required by the [planned gates](#planned-retrieval-knowledge-gates);
-it is not a permanent prohibition on the separate core contribution.
+`ProductEcosystemPackTests.ShippedPackManifestKeepsCuratedMembershipAsIdentity`.
+That gate checks that registration and descriptor property shapes carry
+`PackageSetId` and no package-set descriptor, registration, or registry
+property. Independent core coordinates are permitted; their authored content
+and distinction from curated membership are covered by the
+[retrieval-knowledge gates](#retrieval-knowledge-gates).
 `EcosystemPackRegistryTests.SyntheticManifestIsDiscoverableInDeclaredOrder`
 constructs and discovers a pack with an unregistered package-set identity,
 gating the generic registry path's no-lookup behavior.

--- a/docs/design/package-set-registry.md
+++ b/docs/design/package-set-registry.md
@@ -39,8 +39,8 @@ Related designs:
 - [Package source model](package-source-model.md) owns source authorization,
   provider routing, version discovery, failures, and payload acquisition.
 - [Static Ecosystem Packs](ecosystem-packs.md) owns ecosystem registration and
-  the front-end-only application assembly. An ecosystem pack stores only
-  `PackageSetId`; the package-set manifest remains a separate registry even
+  the front-end-only application assembly. For its curated-set contribution,
+  an ecosystem pack stores only `PackageSetId`; the package-set manifest remains a separate registry even
   when both registrations are authored in one pack source unit.
 
 ## Authority and exact claim
@@ -369,7 +369,8 @@ MicrosoftExtensionsPack.Registration
 
 These are separate values published by separate complete static manifests. The
 package-set registration contains the coordinates. The ecosystem-pack
-registration contains only `PackageSetIds.MicrosoftExtensions`. Neither table
+registration's curated-set contribution contains only
+`PackageSetIds.MicrosoftExtensions`. Neither table
 enumerates, looks up, or constructs the other during runtime publication.
 Source authors spell both values explicitly even when they share one source
 unit. That separation is a reviewed application-authoring rule; independent
@@ -656,7 +657,7 @@ lower-owner no-friend gates named by
 [Static Ecosystem Packs](ecosystem-packs.md#required-gates). Ecosystem-pack
 adoption is enforced by
 `ProductEcosystemPackTests.EveryPackageSetReferenceResolves` and
-`ProductEcosystemPackTests.ShippedPackManifestCarriesOnlyPackageSetIdentity`.
+`ProductEcosystemPackTests.ShippedPackManifestKeepsCuratedMembershipAsIdentity`.
 
 Aspire membership is enforced by this Release gate:
 

--- a/src/DotnetInspector.Ecosystems.Tests/EcosystemPackRegistryTests.cs
+++ b/src/DotnetInspector.Ecosystems.Tests/EcosystemPackRegistryTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using DotnetInspector.Packages;
 using DotnetInspector.Queries.Definitions;
 using ILInspector.Metadata;
 
@@ -37,6 +38,131 @@ public sealed class EcosystemPackRegistryTests
             out EcosystemPackId? unknownId));
         Assert.IsType<EcosystemPackLookupResult.Unknown>(
             registry.Lookup(unknownId));
+    }
+
+    [Fact]
+    public void RetrievalKnowledgePreservesIndependentImmutableSequencesAndPackIdentity()
+    {
+        string[] roots = ["Example.Shared.Child", "Example.Shared"];
+        PackageCoordinate[] core =
+        [
+            new("Example.Zeta"),
+            new("Example.Core"),
+            new("Example.Alpha"),
+        ];
+        EcosystemPackRegistry registry = Registry(
+            Pack("ecosystem.first", 100, "package-set.not-registered")
+            with { NamespaceRoots = roots, CorePackages = core },
+            Pack("ecosystem.second", 200, null, Demo("second", 100, CreateSecondRecords))
+            with
+            {
+                NamespaceRoots = ["Example.Shared", "example.Shared", "9-root"],
+                CorePackages = [new("example.core")],
+            });
+        roots[0] = "Changed";
+        core[0] = new("Changed");
+
+        EcosystemPackDescriptor first = registry.Packs[0];
+        EcosystemPackDescriptor second = registry.Packs[1];
+        Assert.Equal("ecosystem.first", first.Id.Value);
+        Assert.Equal(["Example.Shared.Child", "Example.Shared"], first.NamespaceRoots);
+        Assert.Equal(
+            ["Example.Zeta", "Example.Core", "Example.Alpha"],
+            first.CorePackages.Select(package => package.PackageId));
+        Assert.Equal("package-set.not-registered", first.PackageSet!.Value);
+        Assert.Equal("ecosystem.second", second.Id.Value);
+        Assert.Equal(["Example.Shared", "example.Shared", "9-root"], second.NamespaceRoots);
+        Assert.Equal("example.core", Assert.Single(second.CorePackages).PackageId);
+        Assert.Null(second.PackageSet);
+        Assert.All(registry.Packs, pack => Assert.Same(
+            pack,
+            Assert.IsType<EcosystemPackLookupResult.Known>(registry.Lookup(pack.Id)).Descriptor));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("Example. Space")]
+    [InlineData("Example.\tSpace")]
+    [InlineData("Example.\u00a0Space")]
+    [InlineData("Example.*")]
+    [InlineData("Example?")]
+    [InlineData(".Example")]
+    [InlineData("Example.")]
+    [InlineData("Example..Child")]
+    [InlineData("Example.Valid")]
+    public void InvalidNamespaceRootsFailBeforePublication(string? root)
+    {
+        s_firstInvocations = 0;
+        ArgumentException error = Assert.Throws<ArgumentException>(() => Registry(
+            Pack("ecosystem.first", 100, null, Demo("first", 100, CreateFirstRecords)),
+            Pack("ecosystem.second", 200, "package-set.second")
+            with { NamespaceRoots = ["Example.Valid", root!] }));
+
+        Assert.Contains("ecosystem.second", error.Message);
+        Assert.Contains("namespace root", error.Message);
+        Assert.Equal("registrations", error.ParamName);
+        Assert.Equal(0, s_firstInvocations);
+    }
+
+    public static TheoryData<PackageCoordinate[]> InvalidCorePackages => new()
+    {
+        { [null!] },
+        { [new(null!)] },
+        { [new("")] },
+        { [new("Invalid Package")] },
+        { [new("Example.Core", "1.0.0")] },
+        { [new("Example.Core", "")] },
+        { [new("Example.Core", Framework: "net10.0")] },
+        { [new("Example.Core", Framework: "")] },
+        { [new("Example.Core", RuntimeIdentifier: "linux-x64")] },
+        { [new("Example.Core", RuntimeIdentifier: "")] },
+        { [new("Example.Core"), new("example.core")] },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidCorePackages))]
+    public void InvalidCorePackagesFailBeforePublication(PackageCoordinate[] corePackages)
+    {
+        s_firstInvocations = 0;
+        ArgumentException error = Assert.Throws<ArgumentException>(() => Registry(
+            Pack("ecosystem.first", 100, null, Demo("first", 100, CreateFirstRecords)),
+            Pack("ecosystem.second", 200, "package-set.second")
+            with { CorePackages = corePackages }));
+
+        Assert.Contains("ecosystem.second", error.Message);
+        Assert.Contains("core", error.Message);
+        Assert.Equal("registrations", error.ParamName);
+        Assert.Equal(0, s_firstInvocations);
+    }
+
+    [Fact]
+    public void MissingKnowledgeSequencesFailBeforePublication()
+    {
+        EcosystemPackRegistration pack = Pack("ecosystem.first", 100, "package-set.first");
+        Assert.Throws<ArgumentException>(() => Registry(pack with { NamespaceRoots = null! }));
+        Assert.Throws<ArgumentException>(() => Registry(pack with { CorePackages = null! }));
+    }
+
+    [Fact]
+    public void EmptyKnowledgePreservesCapabilityRequirements()
+    {
+        EcosystemPackRegistry registry = Registry(
+            Pack("ecosystem.first", 100, null, Demo("first", 100, CreateFirstRecords)));
+        EcosystemPackDescriptor descriptor = Assert.Single(registry.Packs);
+
+        Assert.Empty(descriptor.NamespaceRoots);
+        Assert.Empty(descriptor.CorePackages);
+        Assert.False(descriptor.HasScanner);
+        Assert.IsType<EcosystemScannerSelectionResult.Unavailable>(
+            registry.SelectScanner(descriptor.Id));
+        Assert.Throws<ArgumentException>(() => Registry(
+            Pack("ecosystem.hints-only", 100, null)
+            with { NamespaceRoots = ["Example"] }));
+        Assert.Throws<ArgumentException>(() => Registry(
+            Pack("ecosystem.core-only", 100, null)
+            with { CorePackages = [new("Example.Core")] }));
     }
 
     [Fact]
@@ -201,14 +327,26 @@ public sealed class EcosystemPackRegistryTests
         var second = EcosystemIntegrationScannerBinding.Create(ScanSecond);
         EcosystemPackRegistry registry = Registry(
             Pack("ecosystem.first", 100, "package-set.first", Demo("first", 100, CreateFirstRecords))
-                with { Scanner = first },
+                with
+                {
+                    Scanner = first,
+                    NamespaceRoots = ["Example.First"],
+                    CorePackages = [new("Example.Core")],
+                },
             Pack("ecosystem.second", 200, null, Demo("second", 200, CreateSecondRecords))
-                with { Scanner = second });
+                with
+                {
+                    Scanner = second,
+                    NamespaceRoots = ["Example.Second"],
+                    CorePackages = [new("Example.Other")],
+                });
 
         Assert.All(registry.Packs, pack => Assert.True(pack.HasScanner));
         Assert.Equal(2, registry.Demos.Length);
         var lookup = Assert.IsType<EcosystemPackLookupResult.Known>(
             registry.Lookup(registry.Packs[0].Id));
+        Assert.Equal(["Example.First"], lookup.Descriptor.NamespaceRoots);
+        Assert.Equal("Example.Core", Assert.Single(lookup.Descriptor.CorePackages).PackageId);
         Assert.Equal("package-set.first", lookup.Descriptor.PackageSet!.Value);
         var selected = Assert.IsType<EcosystemScannerSelectionResult.Known>(
             registry.SelectScanner(registry.Packs[1].Id));

--- a/src/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
+++ b/src/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
@@ -94,7 +94,7 @@ public sealed class ProductEcosystemPackTests
     }
 
     [Fact]
-    public void ShippedPackManifestCarriesOnlyPackageSetIdentity()
+    public void ShippedPackManifestKeepsCuratedMembershipAsIdentity()
     {
         Type[] packTypes =
         [
@@ -113,6 +113,46 @@ public sealed class ProductEcosystemPackTests
                     type.GetProperties(),
                     property => CarriesPackageSetState(property.PropertyType));
             });
+    }
+
+    [Fact]
+    public void ShippedRetrievalKnowledgeMatchesLiteralPolicy()
+    {
+        Assert.Collection(
+            EcosystemPackCatalog.Discover(),
+            platform => AssertKnowledge(platform, ["System"], []),
+            extensions => AssertKnowledge(
+                extensions,
+                ["Microsoft.Extensions"],
+                [
+                    "Microsoft.Extensions.DependencyInjection.Abstractions",
+                    "Microsoft.Extensions.Configuration.Abstractions",
+                    "Microsoft.Extensions.Logging.Abstractions",
+                ]),
+            aspNetCore => AssertKnowledge(
+                aspNetCore,
+                ["Microsoft.AspNetCore"],
+                [
+                    "Microsoft.AspNetCore.OpenApi",
+                    "Microsoft.AspNetCore.Authentication.JwtBearer",
+                ]),
+            aspire => AssertKnowledge(aspire, ["Aspire"], ["Aspire.Hosting"]));
+
+        static void AssertKnowledge(
+            EcosystemPackDescriptor pack,
+            string[] roots,
+            string[] corePackageIds)
+        {
+            Assert.Equal(roots, pack.NamespaceRoots);
+            Assert.Equal(corePackageIds, pack.CorePackages.Select(package => package.PackageId));
+            Assert.All(pack.CorePackages, package =>
+            {
+                Assert.Null(PackageCoordinateResolver.Validate(package));
+                Assert.Null(package.Version);
+                Assert.Null(package.Framework);
+                Assert.Null(package.RuntimeIdentifier);
+            });
+        }
     }
 
     [Fact]
@@ -359,7 +399,6 @@ public sealed class ProductEcosystemPackTests
         type == typeof(PackageSetDescriptor)
         || type == typeof(PackageSetRegistration)
         || type == typeof(PackageSetRegistry)
-        || type == typeof(PackageCoordinate)
         || (type.IsArray && CarriesPackageSetState(type.GetElementType()!))
         || (type.IsGenericType
             && type.GetGenericArguments().Any(CarriesPackageSetState));

--- a/src/DotnetInspector.Ecosystems/EcosystemPackDescriptor.cs
+++ b/src/DotnetInspector.Ecosystems/EcosystemPackDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using DotnetInspector.Packages;
 using DotnetInspector.Queries.Definitions;
 using ILInspector.Metadata;
 
@@ -14,7 +15,9 @@ public sealed class EcosystemPackDescriptor
         int order,
         PackageSetId? packageSet,
         IEnumerable<EcosystemDemoDescriptor> demos,
-        bool hasScanner)
+        bool hasScanner,
+        ImmutableArray<string> namespaceRoots,
+        ImmutableArray<PackageCoordinate> corePackages)
     {
         Id = id;
         Title = title;
@@ -23,6 +26,8 @@ public sealed class EcosystemPackDescriptor
         PackageSet = packageSet;
         Demos = [.. demos];
         HasScanner = hasScanner;
+        NamespaceRoots = namespaceRoots;
+        CorePackages = corePackages;
     }
 
     public EcosystemPackId Id { get; }
@@ -38,6 +43,12 @@ public sealed class EcosystemPackDescriptor
     public ImmutableArray<EcosystemDemoDescriptor> Demos { get; }
 
     public bool HasScanner { get; }
+
+    /// <summary>Literal namespace-subtree hints in authored order, not an exhaustive inventory.</summary>
+    public ImmutableArray<string> NamespaceRoots { get; }
+
+    /// <summary>Unversioned starting points in pack-local preference order, independent of curated membership.</summary>
+    public ImmutableArray<PackageCoordinate> CorePackages { get; }
 }
 
 /// <summary>Immutable product metadata for one ecosystem demo.</summary>

--- a/src/DotnetInspector.Ecosystems/EcosystemPackRegistry.cs
+++ b/src/DotnetInspector.Ecosystems/EcosystemPackRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using DotnetInspector.Packages;
 using DotnetInspector.Queries.Definitions;
 using ILInspector.Metadata;
 
@@ -17,7 +18,12 @@ internal sealed record EcosystemPackRegistration(
     int Order,
     PackageSetId? PackageSet,
     IReadOnlyList<EcosystemDemoRegistration> Demos,
-    EcosystemIntegrationScannerBinding? Scanner = null);
+    EcosystemIntegrationScannerBinding? Scanner = null)
+{
+    public IReadOnlyList<string> NamespaceRoots { get; init; } = [];
+
+    public IReadOnlyList<PackageCoordinate> CorePackages { get; init; } = [];
+}
 
 internal sealed class EcosystemPackRegistry
 {
@@ -80,6 +86,10 @@ internal sealed class EcosystemPackRegistry
                     nameof(registrations));
             }
 
+            ImmutableArray<string> namespaceRoots =
+                SnapshotNamespaceRoots(registration, nameof(registrations));
+            ImmutableArray<PackageCoordinate> corePackages =
+                SnapshotCorePackages(registration, nameof(registrations));
             EcosystemDemoRegistration[] demos =
             [
                 .. registration.Demos
@@ -155,7 +165,9 @@ internal sealed class EcosystemPackRegistry
                 registration.Order,
                 registration.PackageSet,
                 descriptors.MoveToImmutable(),
-                registration.Scanner is not null);
+                registration.Scanner is not null,
+                namespaceRoots,
+                corePackages);
             _packsById.Add(
                 packDescriptor.Id,
                 new PackEntry(packDescriptor, registration.Scanner));
@@ -206,6 +218,95 @@ internal sealed class EcosystemPackRegistry
             new EcosystemDemoSelection(
                 entry.Descriptor,
                 entry.Source.Resolve()));
+    }
+
+    private static ImmutableArray<string> SnapshotNamespaceRoots(
+        EcosystemPackRegistration registration,
+        string parameterName)
+    {
+        ImmutableArray<string> roots =
+        [
+            .. registration.NamespaceRoots
+                ?? throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' has no namespace-root sequence.",
+                    parameterName),
+        ];
+        var uniqueRoots = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string root in roots)
+        {
+            if (string.IsNullOrWhiteSpace(root)
+                || root.Any(character => char.IsWhiteSpace(character) || character is '*' or '?')
+                || root[0] == '.'
+                || root[^1] == '.'
+                || root.Contains("..", StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' contains invalid namespace root '{root}'.",
+                    parameterName);
+            }
+
+            if (!uniqueRoots.Add(root))
+            {
+                throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' contains duplicate namespace root '{root}'.",
+                    parameterName);
+            }
+        }
+
+        return roots;
+    }
+
+    private static ImmutableArray<PackageCoordinate> SnapshotCorePackages(
+        EcosystemPackRegistration registration,
+        string parameterName)
+    {
+        ImmutableArray<PackageCoordinate> packages =
+        [
+            .. registration.CorePackages
+                ?? throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' has no core-package sequence.",
+                    parameterName),
+        ];
+        var packageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (PackageCoordinate package in packages)
+        {
+            if (package is null)
+            {
+                throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' contains a null core package.",
+                    parameterName);
+            }
+
+            PackageCoordinateResolution.Invalid? invalid =
+                PackageCoordinateResolver.Validate(package);
+            if (invalid is not null)
+            {
+                throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' contains invalid core package"
+                    + $" coordinate '{package.PackageId}': {invalid.Message}",
+                    parameterName);
+            }
+
+            if (package.Version is not null
+                || package.Framework is not null
+                || package.RuntimeIdentifier is not null)
+            {
+                throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' contains a versioned or"
+                    + " target-specific core-package coordinate.",
+                    parameterName);
+            }
+
+            if (!packageIds.Add(package.PackageId))
+            {
+                throw new ArgumentException(
+                    $"Ecosystem pack '{registration.Id}' contains duplicate core-package"
+                    + $" ID '{package.PackageId}'.",
+                    parameterName);
+            }
+        }
+
+        return packages;
     }
 
     private static void ValidateDisplayMetadata(

--- a/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
+++ b/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
@@ -17,7 +17,10 @@ internal static class ProductEcosystemPacks
                 Demo(ProductDemoIds.StjSerializer, "System.Text.Json", "Browse a real package API", 100, CreateStjSerializerRecords),
                 Demo(ProductDemoIds.StjSerializeCallGraph, "Serialize call graph", "Dense package-local STJ graph", 300, CreateStjSerializeCallGraphRecords),
                 Demo(ProductDemoIds.StjGetDecimalCallGraph, "JsonElement.GetDecimal", "STJ number parse path", 800, CreateStjGetDecimalCallGraphRecords),
-            ]),
+            ])
+        {
+            NamespaceRoots = ["System"],
+        },
         new(
             EcosystemPackIds.MicrosoftExtensions,
             "Microsoft.Extensions",
@@ -30,14 +33,31 @@ internal static class ProductEcosystemPacks
                 Demo(ProductDemoIds.OptionsAddCallGraph, "Options hub", "Inbound fan-in at AddOptions", 500, CreateOptionsAddCallGraphRecords),
                 Demo(ProductDemoIds.DiTryAddCallGraph, "DI TryAdd hub", "Keyed/scoped Try* fan-in", 600, CreateDiTryAddCallGraphRecords),
                 Demo(ProductDemoIds.HttpAddHttpClientCallGraph, "AddHttpClient", "HttpClient factory registration", 700, CreateHttpAddHttpClientCallGraphRecords),
-            ]),
+            ])
+        {
+            NamespaceRoots = ["Microsoft.Extensions"],
+            CorePackages =
+            [
+                new("Microsoft.Extensions.DependencyInjection.Abstractions"),
+                new("Microsoft.Extensions.Configuration.Abstractions"),
+                new("Microsoft.Extensions.Logging.Abstractions"),
+            ],
+        },
         new(
             EcosystemPackIds.AspNetCore,
             "ASP.NET Core",
             "ASP.NET Core package content.",
             300,
             PackageSetIds.AspNetCore,
-            []),
+            [])
+        {
+            NamespaceRoots = ["Microsoft.AspNetCore"],
+            CorePackages =
+            [
+                new("Microsoft.AspNetCore.OpenApi"),
+                new("Microsoft.AspNetCore.Authentication.JwtBearer"),
+            ],
+        },
         new(
             EcosystemPackIds.Aspire,
             "Aspire",
@@ -48,7 +68,11 @@ internal static class ProductEcosystemPacks
                 Demo(ProductDemoIds.AspirePostgresCallGraph, "Aspire AddPostgres", "PostgreSQL resource registration graph", 900, CreateAspirePostgresCallGraphRecords),
                 Demo(ProductDemoIds.AspireRedisCallGraph, "Aspire AddRedis", "Redis resource registration graph", 1000, CreateAspireRedisCallGraphRecords),
             ],
-            Scanner: EcosystemIntegrationScanner.AspireBinding),
+            Scanner: EcosystemIntegrationScanner.AspireBinding)
+        {
+            NamespaceRoots = ["Aspire"],
+            CorePackages = [new("Aspire.Hosting")],
+        },
     ]);
 
     private static EcosystemDemoRegistration Demo(

--- a/tests/DotnetInspector.Ecosystems.Consumer.Tests/PackageSetRegistryConsumerTests.cs
+++ b/tests/DotnetInspector.Ecosystems.Consumer.Tests/PackageSetRegistryConsumerTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Immutable;
 using DotnetInspector.Ecosystems;
+using DotnetInspector.Packages;
 using ILInspector.Metadata;
 
 namespace DotnetInspector.Ecosystems.Consumer.Tests;
@@ -42,6 +44,44 @@ public sealed class PackageSetRegistryConsumerTests
         Assert.Equal(
             ProductDemoIds.StjSerializer,
             selected.Selection.Scenario.ScenarioId);
+    }
+
+    [Fact]
+    public void PublicSurfaceKeepsCoreReferencesSeparateFromCuratedMembership()
+    {
+        EcosystemPackDescriptor descriptor = Assert.IsType<EcosystemPackLookupResult.Known>(
+            EcosystemPackCatalog.Lookup(EcosystemPackIds.MicrosoftExtensions)).Descriptor;
+        ImmutableArray<string> roots = descriptor.NamespaceRoots;
+        ImmutableArray<PackageCoordinate> core = descriptor.CorePackages;
+
+        Assert.Same(
+            descriptor,
+            EcosystemPackCatalog.Discover().Single(pack => pack.Id == descriptor.Id));
+        Assert.Equal(["Microsoft.Extensions"], roots);
+        Assert.Equal(
+            [
+                "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Configuration.Abstractions",
+                "Microsoft.Extensions.Logging.Abstractions",
+            ],
+            core.Select(package => package.PackageId));
+        Assert.Equal(PackageSetIds.MicrosoftExtensions, descriptor.PackageSet);
+        PackageSetDescriptor curated = Assert.IsType<PackageSetLookupResult.Known>(
+            PackageSetCatalog.Lookup(descriptor.PackageSet!)).Descriptor;
+        Assert.Equal(44, curated.Members.Length);
+        Assert.Contains(curated.Members, member => member.PackageId == "Microsoft.Extensions.Http.Resilience");
+        Assert.DoesNotContain(core, member => member.PackageId == "Microsoft.Extensions.Http.Resilience");
+        Assert.DoesNotContain(
+            curated.Members,
+            member => member.PackageId == "Microsoft.Extensions.DependencyInjection.Abstractions");
+
+        EcosystemPackDescriptor platform = Assert.IsType<EcosystemPackLookupResult.Known>(
+            EcosystemPackCatalog.Lookup(EcosystemPackIds.Platform)).Descriptor;
+        Assert.Equal(["System"], platform.NamespaceRoots);
+        Assert.Empty(platform.CorePackages);
+        Assert.Null(platform.PackageSet);
+        Assert.False(platform.HasScanner);
+        Assert.Equal(3, platform.Demos.Length);
     }
 
     [Fact]


### PR DESCRIPTION
Make ecosystem retrieval knowledge available as a small shared catalog
foundation, without presenting descriptive metadata as working traversal.

Closes #6037. Implements the focused contract from #6032 within catalog
stage 2 of the eight-stage #6012 adoption plan, under #5728.

## Demo

Before: the shared descriptor exposes curated-set identity, demos, and scanner
availability, but no namespace hints or core-package starting points.

After: an ordinary non-friend consumer reads two independent immutable
sequences through the same discovery and exact-lookup surface:

```csharp
var pack = ((EcosystemPackLookupResult.Known)EcosystemPackCatalog.Lookup(
    EcosystemPackIds.MicrosoftExtensions)).Descriptor;
Console.WriteLine(pack.Id);
Console.WriteLine($"  Namespace roots: {string.Join(", ", pack.NamespaceRoots)}");
Console.WriteLine("  Core packages (preference order; unversioned)");
foreach (var package in pack.CorePackages)
    Console.WriteLine($"    {package.PackageId}");
Console.WriteLine($"  Curated set: {pack.PackageSet}");
```

Actual Release output from a file-based app referencing the changed product:

```text
ecosystem.microsoft-extensions
  Namespace roots: Microsoft.Extensions
  Core packages (preference order; unversioned)
    Microsoft.Extensions.DependencyInjection.Abstractions
    Microsoft.Extensions.Configuration.Abstractions
    Microsoft.Extensions.Logging.Abstractions
  Curated set: package-set.microsoft-extensions
```

Neighboring Platform output from the same app:

```text
ecosystem.platform
  Namespace roots: System
  Core packages (preference order; unversioned)
    (none)
  Curated set: (none)
  Scanner available: False
```

This is API data, not a new CLI command or browser action. The three Extensions
core entries intentionally differ from the existing 44-member curated set,
whose policy excludes shared-framework-covered packages. The consumer gate
demonstrates both directions of that distinction. Platform's existing three
demos remain available; its hint does not imply a source-native binding.

## Design basis

Sole normative owner:
`docs/design/ecosystem-packs.md#retrieval-hints-and-core-packages`.
The owned claim is immutable, exact-pack-associated, independent authored-order
namespace hints and core references, with visible intrinsic declaration failures
and unchanged capability selection.

Supporting roles:

- `approved-lazy-traversal.md` supplies experience constraints and the
  eight-stage adoption path.
- Packages supplies `PackageCoordinate` and its existing network-free
  validation. No coordinate grammar is duplicated.
- Package Set Registry retains curated identity, membership, and lookup.
  Its adjacent ID-only wording is clarified, not given new semantics.
- Source/Metadata owners retain namespace candidate discovery, acquisition,
  Platform bindings, and actual type identity.
- Workspace Definitions and Integrations retain existing execution bindings.

The implementation follows the existing immutable package-set snapshots and
static pack table. Its added complexity is two descriptor arrays and intrinsic
publication validation, not a new registry framework, correspondence map, or
loader. No deliberate architectural divergence or new dependency is introduced.

## Authored content and boundaries

Each shipped pack has one compact root: `System`, `Microsoft.Extensions`,
`Microsoft.AspNetCore`, or `Aspire`. Core priorities are the three Extensions
abstractions above, ASP.NET Core OpenAPI then JWT bearer add-on APIs, and
`Aspire.Hosting`. Platform contributes no package-backed substitute for its
future source-native binding. The owner document records the content rationale.

The existing blanket coordinate-shape exclusion is narrowed to curated
membership authority. Independent core coordinates are now allowed, while
package-set descriptors, registrations, and registry objects remain excluded
from the pack shape. Literal content and ordinary consumer outcomes preserve
the distinct roles; generic discovery still accepts an unregistered curated ID
without looking it up.

Production consumers remain CLI and `InspectWeb.Engine.CatalogExports`. The
overall eight-stage path is source/resolution, catalog, Scope, query populations,
Workspace Definitions, CLI, browser, and authorized release/deployment.
This PR completes only the inert catalog slice within stage 2; metadata and
operational host adoption stay in stages 6 and 7.

No architecture is replaced, and no single-host exception or new rendering
strategy is needed: the existing typed catalog/host boundary remains.
Source intent (#5602), namespace-guided retrieval, Platform binding, Scope,
query populations, host UI, editor persistence, #6024, and #5988 remain outside
this PR. Curated membership, demo records, scanner bindings, and action results
are unchanged.

## Validation

```sh
dotnet run --project src/DotnetInspector.Ecosystems.Tests -c Release
dotnet run --project tests/DotnetInspector.Ecosystems.Consumer.Tests -c Release
npx markdownlint-cli docs/design/ecosystem-packs.md docs/design/package-set-registry.md
git diff --check
```

76 registry/product/boundary cases and 4 ordinary consumer cases pass in
Release. The API demo also runs in Release against the changed product.
Existing CI already runs both suites; no new CI job or testing tool is added.

Boundary outcomes cover unequal-length sequences, input snapshot independence,
authored ordering, ordinal root spelling, overlapping roots, cross-pack core
overlap, malformed declarations, missing/empty sequences, the unchanged
capability requirement, and selecting one capability without invoking its
neighbors. Existing platform contracts are inherited through supported types
and dependencies; this is not an executable traversal or acquisition claim.
