### PR TITLE
Consume Metadata admission in production package roles

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -2407,11 +2407,19 @@ snapshots retained by Metadata groups rather than applying the same limit to
 both copies.
 
 Publication is all-or-nothing. Every selected asset must materialize within the
-per-entry and aggregate limits before a role group is created. A published
-valid assembly retains its artifact registration, decoded identity, and
-non-empty MVID. A selected malformed, native, module, or empty-MVID asset
+per-entry and aggregate limits before a role group is created. Each distinct
+artifact receives Metadata's
+[admission-scoped assembly projection](assembly-inspection-query.md#admission-scoped-artifact-projection)
+before publication; those facts remain provisional until publication succeeds.
+A published valid assembly retains its artifact registration and consumes the
+projected identity and non-empty MVID without reopening content to decode them.
+An artifact shared by distinct roles reuses those materialized facts.
+A selected malformed, native, module, or empty-MVID asset
 remains a participant through the compatibility rejection carrier defined by
-the assembly-inspection-query owner. The artifact session and its query lease
+the assembly-inspection-query owner; identities unsuitable for a compatibility
+descriptor also retain that route. This includes preservation of partially
+decoded identity rather than substituting a fallback name for every
+non-projectable image. The artifact session and its query lease
 transfer to the exact distinct role groups, and workspace close releases them
 only after those groups report quiescence. Failure before transfer attempts
 group, query-lease, and artifact-session cleanup without replacing the primary
@@ -2426,12 +2434,18 @@ gates one valid and one malformed selected asset, one source entry open per
 distinct asset, exact package binding identities in artifact provenance,
 visible available/rejected query outcomes, and artifact release after an
 active group operation completes.
+`ArtifactBackedPackageRealization_ReusesAdmissionFactsAcrossRoles` gates reuse
+of the admitted identity and MVID when one artifact participates in distinct
+surface and implementation groups.
 `ArtifactBackedPackageRealization_RejectsAggregateBudgetWithoutPartialGroup`
 gates aggregate retained-byte rejection and absence of a partial group.
 The synchronous stream-backed realization remains available for current
-callers. CLI and browser/Wasm adoption are separate slices in
-[#5577](https://github.com/richlander/dotnet-inspect/issues/5577); this slice
-adds no host retention, cache, eviction, or presentation behavior.
+callers. The CLI and browser/Wasm adopters described below consume this shared
+admission path; their host adoption is tracked in
+[#5577](https://github.com/richlander/dotnet-inspect/issues/5577).
+Admission adoption adds no host retention, cache, eviction, or presentation
+behavior and leaves group snapshot acquisition and query revalidation on the
+existing compatibility path.
 
 The CLI adoption is the remote `package --all-libraries` grouped
 Integrations path when the command resolves one default or explicit target framework and

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -572,6 +572,23 @@ to an internal `AssemblyImage` or `AssemblyInspectionSession` for the duration
 of one operation, but the adapter cannot escape the artifact callback or
 recreate a parameterless opener.
 
+`ResolvedAssemblyReference.CreateFromArtifactProjection` adapts successful
+projection facts for existing compatibility consumers without opening content
+again to decode identity or MVID. It requires the exact artifact and generation
+identities, binds the projected MVID, and preserves the caller's independently
+supplied guarded opener and provenance. Neither capability comes from the
+projection. As with existing descriptor factories, the compatibility identity
+must have a nonblank name.
+
+The first production adopter is shared package-role realization:
+`InspectionWorkspace.RealizePackageAssemblyContextRolesAsync`, already used by
+Browser package inspection and the CLI artifact-backed package Integrations
+path. It consumes successful admission facts only after artifact publication.
+Non-projectable images and identities unsuitable for compatibility descriptors
+retain the existing rejection-carrier route, including any partially decoded
+identity. This adoption does not migrate group queries to
+`ArtifactAssemblyInspection.Execute` or enable assembly-pattern Package Query.
+
 General removal of `ResolvedAssemblyReference.Path` and
 `ResolvedAssemblyReference.OpenRead` waits for their existing consumers to
 migrate. This slice adds the content-free route required by context
@@ -611,6 +628,9 @@ conformance or the outer authorization-result mapping.
 - `QueryValidation_ClassifiesNativeModuleMalformedAndEmptyMvid`
 - `QueryValidation_RejectsArtifactGenerationAssemblyIdentityAndMvidMismatch`
 - `AdmissionProjection_ExactArtifactIdentityIsNonVacuous`
+- `CompatibilityDescriptor_UsesProjectedFactsWithoutOpeningContent`
+- `CompatibilityDescriptor_RejectsAnotherArtifactBeforeOpeningContent`
+- `CompatibilityDescriptor_RequiresANonblankIdentity`
 
 The first gate uses the existing artifact-backed fixture from #4954/#4957 and
 requires the same `ArtifactAcquisitionRegistration.Artifact` object, assembly
@@ -627,6 +647,14 @@ gates use both Windows Metadata kinds and require the
 MetadataPrimitives-owned classifier to reject before `MetadataReader`
 construction or other managed metadata work; `MDP017` continues to own the
 classifier's format detection and bounded-work guarantees.
+
+The compatibility gates use real admission projections to require descriptor
+construction without an open, exact artifact/generation correspondence,
+projected identity and MVID, and the unchanged caller-supplied opener. They
+also require rejection of a blank compatibility identity. The package owner's
+`ArtifactBackedPackageRealization_ReusesAdmissionFactsAcrossRoles` gate checks
+that one retained artifact selected into two distinct production role groups
+supplies the same materialized identity facts to both.
 
 ##### Non-goals
 

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
@@ -1090,6 +1090,44 @@ public sealed class PackageAssemblyContextRealizationTests
     }
 
     [Fact]
+    public async Task ArtifactBackedPackageRealization_ReusesAdmissionFactsAcrossRoles()
+    {
+        byte[] surface = IntegrationAssembly("Artifact.Primary", "SurfaceType");
+        byte[] implementation = IntegrationAssembly("Artifact.Primary", "ImplementationType");
+        byte[] shared = IntegrationAssembly("Artifact.Shared", "SharedType");
+        const string sharedPath = "lib/net11.0/Artifact.Shared.dll";
+        var content = new TrackingPackageContent(
+            ("lib/net11.0/Artifact.Primary.dll", surface),
+            (sharedPath, shared),
+            ("runtimes/linux-x64/lib/net11.0/Artifact.Primary.dll", implementation));
+        PackageRootBinding binding = Binding(
+            "Artifact.Projection.Sample",
+            content,
+            runtimeIdentifier: "linux-x64");
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        using PackageAssemblyContextRealization realization =
+            await workspace.RealizePackageAssemblyContextRolesAsync(
+                binding,
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, content.EntryOpenRequests);
+        Assert.NotSame(realization.SurfaceGroup, realization.ImplementationGroup);
+        ResolvedAssemblyReference surfaceShared = realization.SurfaceParticipants
+            .Single(participant => participant.Asset.Path == sharedPath).Participant.Assembly;
+        ResolvedAssemblyReference implementationShared = realization.ImplementationParticipants
+            .Single(participant => participant.Asset.Path == sharedPath).Participant.Assembly;
+        Assert.Same(
+            surfaceShared.Registration.ArtifactRegistration,
+            implementationShared.Registration.ArtifactRegistration);
+        Assert.Same(surfaceShared.Identity, implementationShared.Identity);
+        Assert.Equal("Artifact.Shared", surfaceShared.Identity.Name);
+        Assert.NotNull(surfaceShared.Registration.ModuleVersionId);
+        Assert.Equal(
+            surfaceShared.Registration.ModuleVersionId,
+            implementationShared.Registration.ModuleVersionId);
+    }
+
+    [Fact]
     public async Task ArtifactBackedPackageRealization_RejectsAggregateBudgetWithoutPartialGroup()
     {
         var content = new TrackingPackageContent(
@@ -1448,7 +1486,8 @@ public sealed class PackageAssemblyContextRealizationTests
     static PackageRootBinding Binding(
         string packageId,
         IPackageContent content,
-        string? displayPackageId = null)
+        string? displayPackageId = null,
+        string? runtimeIdentifier = null)
     {
         const string version = "1.0.0";
         const string producer = "tests";
@@ -1460,6 +1499,7 @@ public sealed class PackageAssemblyContextRealizationTests
         return PackageRootBinding.CreateFromSource(
             payload,
             Framework,
+            runtimeIdentifier,
             displayPackageId: displayPackageId);
     }
 

--- a/src/DotnetInspector.Queries/PackageArtifactAssemblyContextRealization.cs
+++ b/src/DotnetInspector.Queries/PackageArtifactAssemblyContextRealization.cs
@@ -85,8 +85,19 @@ public sealed partial class InspectionWorkspace
                         preparation.Options,
                         cancellationToken)
                     .ConfigureAwait(false);
+            var admissionByArtifact =
+                new Dictionary<ArtifactIdentity, ArtifactAssemblyProjectionOutcome>();
             ArtifactSetPublicationOutcome publication =
-                await session.SealAsync(cancellationToken)
+                await session.SealWithProjectionAsync(
+                        (view, token) =>
+                        {
+                            admissionByArtifact.Add(
+                                view.Artifact,
+                                ArtifactAssemblyInspection.Project(view, token));
+                            // Non-projectable images still publish as compatibility carriers.
+                            return null;
+                        },
+                        cancellationToken)
                     .ConfigureAwait(false);
             if (publication
                 is ArtifactSetPublicationOutcome.NotPublished rejected)
@@ -106,6 +117,7 @@ public sealed partial class InspectionWorkspace
                 CreateArtifactRole(
                     preparation.SurfaceAssets,
                     contentByAsset,
+                    admissionByArtifact,
                     cancellationToken);
             ImmutableArray<RoleAssembly> implementationRole =
                 preparation.Shared
@@ -113,6 +125,7 @@ public sealed partial class InspectionWorkspace
                     : CreateArtifactRole(
                         preparation.ImplementationAssets,
                         contentByAsset,
+                        admissionByArtifact,
                         cancellationToken);
             realization = CreatePackageAssemblyContextRealization(
                 preparation,
@@ -290,6 +303,8 @@ public sealed partial class InspectionWorkspace
         ImmutableArray<RoleAsset> assets,
         IReadOnlyDictionary<RoleAsset, ArtifactContentReference>
             contentByAsset,
+        IReadOnlyDictionary<ArtifactIdentity, ArtifactAssemblyProjectionOutcome>
+            admissionByArtifact,
         CancellationToken cancellationToken)
     {
         var result =
@@ -299,14 +314,30 @@ public sealed partial class InspectionWorkspace
             cancellationToken.ThrowIfCancellationRequested();
             RoleAsset asset = assets[index];
             ArtifactContentReference content = contentByAsset[asset];
-            ResolvedAssemblyReference assembly =
-                ResolvedAssemblyReference
-                    .CreateFromArtifactWithFallbackIdentity(
-                        content.Registration,
-                        content.OpenRead,
-                        RejectionCarrierIdentity(index),
-                        PackageProvenance(asset),
-                        out bool usedFallbackIdentity);
+            ResolvedAssemblyReference assembly;
+            bool usedFallbackIdentity;
+            if (admissionByArtifact[content.Registration.Artifact]
+                is ArtifactAssemblyProjectionOutcome.Projected projected
+                && !string.IsNullOrWhiteSpace(projected.Value.Identity.Name))
+            {
+                assembly = ResolvedAssemblyReference.CreateFromArtifactProjection(
+                    content.Registration,
+                    projected.Value,
+                    content.OpenRead,
+                    PackageProvenance(asset));
+                usedFallbackIdentity = false;
+            }
+            else
+            {
+                // Compatibility carriers can retain partially decoded identity,
+                // including an assembly name whose MVID was empty or unreadable.
+                assembly = ResolvedAssemblyReference.CreateFromArtifactWithFallbackIdentity(
+                    content.Registration,
+                    content.OpenRead,
+                    RejectionCarrierIdentity(index),
+                    PackageProvenance(asset),
+                    out usedFallbackIdentity);
+            }
             result.Add(new RoleAssembly(
                 asset.PackageIndex,
                 asset.Package,

--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -783,6 +783,46 @@ public sealed class ResolvedAssemblyReference
             lastWriteTimeUtc);
     }
 
+    /// <summary>
+    /// Adapts admission-projected facts to a compatibility descriptor without
+    /// opening content. The caller retains ownership of the guarded opener.
+    /// </summary>
+    public static ResolvedAssemblyReference CreateFromArtifactProjection(
+        ArtifactAcquisitionRegistration artifactRegistration,
+        ArtifactAssemblyProjection projection,
+        Func<Stream> openRead,
+        AssemblyResolutionProvenance provenance,
+        DateTime? lastWriteTimeUtc = null)
+    {
+        ArgumentNullException.ThrowIfNull(artifactRegistration);
+        ArgumentNullException.ThrowIfNull(projection);
+        ArgumentNullException.ThrowIfNull(openRead);
+        ArgumentNullException.ThrowIfNull(provenance);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projection.Identity.Name);
+        if (!ReferenceEquals(
+                artifactRegistration.Artifact,
+                projection.Registration.Artifact)
+            || !ReferenceEquals(
+                artifactRegistration.Generation,
+                projection.Registration.Generation))
+        {
+            throw new ArgumentException(
+                "The projection must describe the exact artifact registration.",
+                nameof(projection));
+        }
+
+        var registration =
+            new AssemblyAcquisitionRegistration(artifactRegistration);
+        registration.BindModuleVersionId(projection.Registration.ModuleVersionId);
+        return new ResolvedAssemblyReference(
+            registration,
+            projection.Identity,
+            path: null,
+            openRead,
+            provenance,
+            lastWriteTimeUtc);
+    }
+
     static ResolvedAssemblyReference CreateFromStreamWithFallbackIdentityCore(
         ArtifactAcquisitionRegistration? artifactRegistration,
         Func<Stream> openRead,

--- a/tests/ILInspector.Metadata.Tests/ArtifactAssemblyInspectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ArtifactAssemblyInspectionTests.cs
@@ -56,6 +56,80 @@ public sealed class ArtifactAssemblyInspectionTests
     }
 
     [Fact]
+    public void CompatibilityDescriptor_UsesProjectedFactsWithoutOpeningContent()
+    {
+        using var artifact = new RetainedImage(AssemblyBytes());
+        ArtifactAssemblyProjection projection = artifact.Project();
+        artifact.Publish();
+        int opens = 0;
+        Stream Open()
+        {
+            opens++;
+            return artifact.Content.OpenRead(
+                artifact.QueryLease ?? throw new InvalidOperationException("The artifact is not published."));
+        }
+        Func<Stream> opener = Open;
+        AssemblyResolutionProvenance provenance = AssemblyResolutionProvenance.Local("test");
+
+        ResolvedAssemblyReference descriptor = ResolvedAssemblyReference.CreateFromArtifactProjection(
+            artifact.Contribution.Registration, projection, opener, provenance);
+
+        Assert.Equal(0, opens);
+        Assert.Same(projection.Identity, descriptor.Identity);
+        Assert.Same(artifact.Contribution.Registration, descriptor.Registration.ArtifactRegistration);
+        Assert.Equal(Mvid, descriptor.Registration.ModuleVersionId);
+        Assert.Same(opener, descriptor.OpenRead);
+        Assert.Same(provenance, descriptor.Provenance);
+        Assert.Null(descriptor.Path);
+        using AssemblyInspectionSession session = AssemblyInspectionSession.Open(descriptor);
+        Assert.Equal("ArtifactBound", session.AssemblyInfo().AssemblyName);
+        Assert.Equal(1, opens);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CompatibilityDescriptor_RejectsAnotherArtifactBeforeOpeningContent(bool foreignGeneration)
+    {
+        using var artifact = new RetainedImage(AssemblyBytes());
+        using var foreign = new RetainedImage(AssemblyBytes());
+        ArtifactAssemblyProjection projection = artifact.Project();
+        ArtifactAcquisitionRegistration registration = foreignGeneration
+            ? foreign.Contribution.Registration
+            : artifact.Add(AssemblyBytes()).Registration;
+        int opens = 0;
+
+        Assert.Throws<ArgumentException>(() =>
+            ResolvedAssemblyReference.CreateFromArtifactProjection(
+                registration,
+                projection,
+                () =>
+                {
+                    opens++;
+                    throw new InvalidOperationException("Content must not be opened.");
+                },
+                AssemblyResolutionProvenance.Local("test")));
+        Assert.Equal(0, opens);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void CompatibilityDescriptor_RequiresANonblankIdentity(string name)
+    {
+        using var artifact = new RetainedImage(AssemblyBytes());
+        ArtifactAssemblyProjection projection = artifact.Project();
+        projection = projection with { Identity = projection.Identity with { Name = name } };
+
+        Assert.Throws<ArgumentException>(() =>
+            ResolvedAssemblyReference.CreateFromArtifactProjection(
+                artifact.Contribution.Registration,
+                projection,
+                () => throw new InvalidOperationException("Content must not be opened."),
+                AssemblyResolutionProvenance.Local("test")));
+    }
+
+    [Fact]
     public void AdmissionProjection_PublicSurfaceCarriesNoProvenanceContentOrLeaseCapability()
     {
         var visited = new HashSet<Type>();


### PR DESCRIPTION
Make the Metadata foundation useful in production now: the existing shared
package-role realization consumes #5946's admission-projected facts in both
the CLI and Browser, rather than leaving the API exercised only by tests.

Closes #6040. Part of #5766; the full assembly-pattern Query delivery remains
#6030.

## Demo

Run the changed CLI against a real package:

```sh
dotnet run --project src/dotnet-inspect -c Release --no-build -- \
  package Microsoft.Extensions.Logging.Console@10.0.0 \
  --all-libraries --tfm net10.0 -S '@Integrations'
```

The result contains five Logging integrations, including:

```text
# microsoft.extensions.logging.console 10.0.0
## Integration: Logging

lib/net10.0/Microsoft.Extensions.Logging.Console.dll | net10.0 |
  Microsoft.Extensions.Logging.ConsoleLoggerExtensions.AddConsole(...)
  Microsoft.Extensions.Logging.ConsoleLoggerExtensions.AddConsoleFormatter(...)
  Microsoft.Extensions.Logging.ConsoleLoggerExtensions.AddJsonConsole(...)
  Microsoft.Extensions.Logging.ConsoleLoggerExtensions.AddSimpleConsole(...)
  Microsoft.Extensions.Logging.ConsoleLoggerExtensions.AddSystemdConsole(...)
```

The rows above are reformatted from the actual Markdown table. Presentation is
unchanged; the substantive change is the production construction path:

- Before: publish retained images, then decode compatibility identity/MVID
  independently for each role descriptor.
- After: project each distinct retained image during admission, publish, then
  construct successful role descriptors from those materialized facts.
  A retained image shared by distinct roles supplies the same facts to both.

The existing Browser single-coordinate scenario opens an artifact-backed
package scope and produces an available API surface through this same path.
The neighboring multi-coordinate scenario retains its existing compatibility
route. The CLI mixed-image scenario still presents the valid surface while
reporting the rejected implementation without a path fallback.

## Design basis and scope

Normative owner:
`docs/design/assembly-inspection-query.md#admission-scoped-artifact-projection`,
specifically **Relationship to compatibility descriptors**.

Claim: a compatibility descriptor consumes the exact admitted identity/MVID
without opening content again to decode them. It retains its existing
independently supplied guarded opener, provenance, and artifact correspondence.
The adjacent package/workspace owner continues to own publication, role
selection, budgets, and cleanup.

The simplest sufficient design is one Metadata-owned adapter plus adoption in
the existing shared realization. The comparable implementation is the existing
artifact fallback descriptor factory: retain its partial-identity behavior
for non-projectable images instead of replacing all failures with a fabricated
assembly name. Blank compatibility names also retain that path.

Production-host adoption has **one remaining implementation step: this PR**.
`BrowserInspectionScope` and `PackageIntegrationsWorkspace` already call
`RealizePackageAssemblyContextRolesAsync`; both consume this step directly.
The CLI scope is its artifact-backed `package --all-libraries` grouped
Integrations route whose frozen surface selection matches the visible
libraries, not every CLI package route.

The broader #5766 plan has 12 milestones; #6030 remains the full semantic Query
consumer milestone. This immediate adoption does not wait for that milestone.
It is not a replacement architecture: the existing fallback factory remains
necessary for rejection carriers, and group snapshot acquisition/revalidation
remains on the compatibility path. General compatibility-descriptor retirement,
sparse Query projection, literal matching, and exact result reopening remain
outside this PR.

No renderer, output model, command flag, host-specific algorithm, or new
platform mechanism is introduced. Existing host/rendering contracts apply.

## Validation

All commands used Release on .NET SDK `11.0.100-preview.7.26381.103`.

| Gate | Result |
| --- | --- |
| Metadata `ArtifactAssemblyInspectionTests` and `InspectionAcquisitionPlanTests` | 130 passed |
| Queries `*ArtifactBackedPackageRealization*` | 3 passed |
| CLI `PackageIntegrationsWorkspaceTests` | 37 passed |
| Browser single-coordinate artifact scope and neighboring composite scope | 2 passed |
| Changed Markdown and `git diff --check` | Passed |

The new factory gates require zero descriptor-construction opens, exact
artifact/generation correspondence, projected identity/MVID, and preservation
of the supplied opener. The new shared-role gate requires reuse of admission
facts across distinct groups. Existing production-adapter gates retain the
valid/rejected outcomes, source acquisition counts, byte bounds, and disposal
behavior. The Browser prerequisite bundle was built with a worktree-local
Node 24 runtime; no central runtime was modified.

The existing explicit `unverified` limits on dedicated malformed-metadata
branch evidence from #5946 remain unchanged. This PR adds no malformed-binary
reproductions or fuzzing.
