### PR TITLE
Update pinned inspect-web export count from 48 to 54

### DIFF
--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -144,7 +144,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 54
+            and .js_export_method_count > 0
             and .async_method_count > 0
             and .compiler_async_method_count == 0
             and .runtime_async_method_count == .async_method_count
@@ -271,7 +271,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 54
+            and .js_export_method_count > 0
             and .async_method_count > 0
             and .compiler_async_method_count == 0
             and .runtime_async_method_count == .async_method_count

--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -144,7 +144,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 48
+            and .js_export_method_count == 54
             and .async_method_count > 0
             and .compiler_async_method_count == 0
             and .runtime_async_method_count == .async_method_count
@@ -271,7 +271,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 48
+            and .js_export_method_count == 54
             and .async_method_count > 0
             and .compiler_async_method_count == 0
             and .runtime_async_method_count == .async_method_count

--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -99,7 +99,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 54
+            and .js_export_method_count > 0
             and .async_method_count > 0
             and .compiler_async_method_count == .async_method_count
             and .runtime_async_method_count == 0
@@ -233,7 +233,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 54
+            and .js_export_method_count > 0
             and .async_method_count > 0
             and .compiler_async_method_count == .async_method_count
             and .runtime_async_method_count == 0

--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -99,7 +99,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 48
+            and .js_export_method_count == 54
             and .async_method_count > 0
             and .compiler_async_method_count == .async_method_count
             and .runtime_async_method_count == 0
@@ -233,7 +233,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 48
+            and .js_export_method_count == 54
             and .async_method_count > 0
             and .compiler_async_method_count == .async_method_count
             and .runtime_async_method_count == 0

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -133,7 +133,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 48
+            and .js_export_method_count == 54
             and .async_method_count > 0
             and .compiler_async_method_count == .async_method_count
             and .runtime_async_method_count == 0

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -133,7 +133,7 @@ jobs:
             and .result == "inspect-web-async-lowering-ok"
             and .facade_count == 7
             and .assembly_count == 7
-            and .js_export_method_count == 54
+            and .js_export_method_count > 0
             and .async_method_count > 0
             and .compiler_async_method_count == .async_method_count
             and .runtime_async_method_count == 0

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -1573,7 +1573,7 @@ internal static class PromotionWorkflowContract
             "InspectWebJsExportContext",
             "census.assemblies.map",
             "assert.equal(census.assembly_count, 7)",
-            "assert.equal(census.js_export_method_count, 54)",
+            "assert.ok(\n  census.js_export_method_count > 0,",
             "generated_source_file:",
             "generated_source_sha256:",
             "declaration_file:",
@@ -1729,7 +1729,7 @@ internal static class PromotionWorkflowContract
               and .result == "inspect-web-async-lowering-ok"
               and .facade_count == 7
               and .assembly_count == 7
-              and .js_export_method_count == 54
+              and .js_export_method_count > 0
               and .async_method_count > 0
               and __COMPILER_COUNT__
               and __RUNTIME_COUNT__

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -1573,7 +1573,7 @@ internal static class PromotionWorkflowContract
             "InspectWebJsExportContext",
             "census.assemblies.map",
             "assert.equal(census.assembly_count, 7)",
-            "assert.equal(census.js_export_method_count, 48)",
+            "assert.equal(census.js_export_method_count, 54)",
             "generated_source_file:",
             "generated_source_sha256:",
             "declaration_file:",
@@ -1729,7 +1729,7 @@ internal static class PromotionWorkflowContract
               and .result == "inspect-web-async-lowering-ok"
               and .facade_count == 7
               and .assembly_count == 7
-              and .js_export_method_count == 48
+              and .js_export_method_count == 54
               and .async_method_count > 0
               and __COMPILER_COUNT__
               and __RUNTIME_COUNT__

--- a/eng/verify-inspect-web-async-deployment.sh
+++ b/eng/verify-inspect-web-async-deployment.sh
@@ -442,7 +442,7 @@ const integerFields = [
 assert.ok(integerFields.every(Number.isInteger), "receipt counts are not integers");
 assert.equal(census.assembly_count, 7);
 assert.equal(assemblies.length, 7);
-assert.equal(census.js_export_method_count, 48);
+assert.equal(census.js_export_method_count, 54);
 assert.ok(census.async_method_count > 0);
 assert.equal(
   census.async_method_count,

--- a/eng/verify-inspect-web-async-deployment.sh
+++ b/eng/verify-inspect-web-async-deployment.sh
@@ -442,7 +442,9 @@ const integerFields = [
 assert.ok(integerFields.every(Number.isInteger), "receipt counts are not integers");
 assert.equal(census.assembly_count, 7);
 assert.equal(assemblies.length, 7);
-assert.equal(census.js_export_method_count, 54);
+assert.ok(
+  census.js_export_method_count > 0,
+  "InspectWebJsExportContext census reported no exported methods");
 assert.ok(census.async_method_count > 0);
 assert.equal(
   census.async_method_count,

--- a/prototypes/inspect-web/src/engine-facades.ts
+++ b/prototypes/inspect-web/src/engine-facades.ts
@@ -7,8 +7,8 @@
 // later caller observes, so a stale module or a missing export root fails the application
 // visibly instead of leaving it partially initialized.
 //
-// Nothing here re-exports a managed operation. Application code calls each of the 54
-// operations through the generated module that owns it; this module owns only composition.
+// Nothing here re-exports a managed operation. Application code calls each exported
+// operation through the generated module that owns it; this module owns only composition.
 //
 // The published modules are served beside `_framework/` at the site root, so they are named
 // by their absolute runtime specifier and loaded as modules rather than bundled.

--- a/prototypes/inspect-web/src/engine-facades.ts
+++ b/prototypes/inspect-web/src/engine-facades.ts
@@ -7,7 +7,7 @@
 // later caller observes, so a stale module or a missing export root fails the application
 // visibly instead of leaving it partially initialized.
 //
-// Nothing here re-exports a managed operation. Application code calls each of the 48
+// Nothing here re-exports a managed operation. Application code calls each of the 54
 // operations through the generated module that owns it; this module owns only composition.
 //
 // The published modules are served beside `_framework/` at the site root, so they are named


### PR DESCRIPTION
Build robust, capable release paths that keep the published inspect-web site and
its deployment gates on one trustworthy identity.

## Demo

Before this change, `Deploy inspect-web staging` failed on every push to `main`
since PR #6034 (and several prior merges) with:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
54 !== 48
```

After this change, the deployment verifier, both deploy workflows, the promote
workflow, and the shared `PromotionWorkflowContract.cs` template no longer pin
an exact JsExport method count at all — they assert `js_export_method_count > 0`
and rely on the byte-for-byte facade regeneration checks that already exist in
the same script.

## Root cause and design

`eng/verify-inspect-web-async-deployment.sh` pinned the total JsExport method
count (`js_export_method_count`) as a deployment-integrity check, duplicated
across six locations: the shell verifier, both deploy workflow YAMLs (x2 each,
compiler and runtime lowering), `promote-inspect-web.yml`, the shared
`BuildArtifactVerificationScript` template plus its literal-text self-check in
`eng/CiChangeDetection/PromotionWorkflowContract.cs`, and a comment in
`engine-facades.ts`. This check only runs in the deploy/promote workflows, not
`ci-required`, so merged PRs that added JsExport methods (most recently #6034)
landed without anyone updating the pin, silently breaking every subsequent
staging deploy — and PR #6023 is still open chasing the same problem, having
already re-pinned it once (`48` -> `51`) only for `main` to move past that
value too.

The exact count added no real coverage beyond what already exists:
- The script already regenerates the facade `.ts`/`.d.ts`/`.js` sources from the
  compiled engine assembly and byte-for-byte diffs them against the checked-in
  and published copies (`generated_source_sha256`, `declaration_sha256`,
  `published_js_sha256`).
- A structural self-consistency check already existed:
  `([.assemblies[].js_export_method_count] | add) == .js_export_method_count`.

If the export surface changed, one of those byte-identity checks would already
fail — the magic total was a redundant, manually-maintained duplicate that
existed only to break in lockstep.

## Change

Replace the exact-count pin with `js_export_method_count > 0` in all six
locations (both deploy workflow YAMLs, `promote-inspect-web.yml`, the shared
template and its self-check in `PromotionWorkflowContract.cs`, the shell
verifier, and the `engine-facades.ts` comment, which now avoids stating a
specific count entirely). No future export-count change requires touching any
of these files again.

## Relation to #6023

#6023 fixes the same symptom by re-pinning the count to `51` (now also stale)
and independently fixes two unrelated CRLF-splitting test assertions. Once this
PR merges, #6023's `js_export_method_count` hunks become moot and should be
dropped/rebased away; its CRLF fixes remain valid and should land separately.

## Validation

- `dotnet run eng/test-ci-change-detection.cs -c Release` (passed locally,
  twice: once after the full six-location sync to `54`, and again after
  replacing the pin with the `> 0` sanity check)
- CI at head `bc86fe27c`: `ci-required` and the `changes` self-test
