### PR TITLE
Retire the unconsumed Queries body-signal population profile

### DIFF
--- a/docs/design/direct-member-comparison.md
+++ b/docs/design/direct-member-comparison.md
@@ -7,8 +7,9 @@ This is the Queries-owned target design for
 rank 5 and delivery step 6 of
 [#4706](https://github.com/richlander/dotnet-inspect/issues/4706).
 The physical-pair adapter is implemented by `DirectMemberComparisonQuery` and
-consumed by CLI `match --body`. Workspace forwarding selection, Browser and
-comparison-tool adoption, and broader retirement remain separate work.
+consumed by CLI `match --body` (#5967) and Browser Method Body Diff (#5990).
+Workspace forwarding selection, comparison-tool adoption, and broader
+retirement remain separate work.
 
 `DotnetInspector.Queries` is the single architectural owner. Its optional
 `DotnetInspector.ResearchQueries` companion is the physical dependency boundary
@@ -173,27 +174,27 @@ for unrelated package-role, whole-assembly, body-signal, or Source migrations.
 It does not invoke root-to-terminal forwarding composition. Those scenarios
 remain separate; a physical `ExactAddress` is not retargeted.
 
-The selected route has **8 delivery milestones: 2 complete, 6 remaining** at
+The selected route has **8 delivery milestones: 6 complete, 2 remaining** at
 this update. These are outcomes, not a promise of eight PRs:
 
 | Tracker step | Selected outcome | Status |
 | --- | --- | --- |
 | 1 | Population sealing and exact projection receipt | Complete: #5874 |
 | 18 | Research designated-pair local session | Complete: #5908 |
-| 5 | Lock and implement borrowed-input local publication | Implemented in the combined #5925 cutover; landing pending |
-| 6 | Implement the physical-pair Queries adapter | Implemented in the combined #5925 cutover; landing pending |
-| 8 | Cut over CLI `match --body`, including presentation and removal of its replaced dispatch/wrapper | Implemented in the combined #5925 cutover; landing pending |
-| 9 | Add the Browser managed facade, explicit pair interaction, and typed result view | Planned |
-| 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | After both hosts |
-| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | After both hosts |
+| 5 | Lock and implement borrowed-input local publication | Complete: #5967 |
+| 6 | Implement the physical-pair Queries adapter | Complete: #5967 |
+| 8 | Cut over CLI `match --body`, including presentation and removal of its replaced dispatch/wrapper | Complete: #5967 |
+| 9 | Add the Browser managed facade, explicit pair interaction, and typed result view | Complete: #5990 |
+| 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | #6044 retires the unconsumed body-signal population profile |
+| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Remaining; retained tool/Source callers and #5125 still constrain deletion |
 
-Each host path contains **5 milestones, 2 complete and 3 remaining**:
+Each host path contains **5 milestones, all complete**:
 1, 18, 5, 6, then 8 or 9. The two scoped cleanups close the selected route,
 not all global retirement in #4706.
 
-Landing the combined cutover completes steps 5, 6, and 8 together: **5 of the
-8 route milestones complete, 3 remaining**. The CLI path then has all five
-milestones; the Browser path has four, with its actual host adoption remaining.
+Landing the scoped Queries cleanup completes seven of this route's eight
+milestones. It does not complete whole-assembly or body-signal execution
+migration, comparison-tool adoption, or global Queries retirement.
 
 Keep the first publication and adapter runtime together with the CLI
 adopting change; the bounded first-adopter exception permits that focused
@@ -207,8 +208,22 @@ The CLI cutover replaces `MatchCommand.BuildImplementationDiffView`'s direct
 Final owner cleanups use
 an actual caller inventory: preserve Source-dependent and assembly-comparison
 behavior, but do not retain unused substrate merely for a future proposal.
-This implementation claims the CLI adoption and that replaced host dispatch
-only, not Browser adoption or global Queries/Research retirement.
+Both bounded hosts now consume the public query. Their adoption and the
+replaced CLI dispatch do not establish global Queries/Research retirement.
+
+The post-adoption caller inventory for #6044 identifies the body-signal
+population binding/request and its sealing/projection branches as unused
+Queries substrate: only `QueryComparisonPopulationTests` constructed that
+profile. Those shared identity, selection, and receipt cases now use the
+implementation profile consumed by both hosts. Existing body-signal and
+whole-assembly query input/result shapes still serve `DiffCommand` and
+`DiffSections`, so they remain until their actual callers migrate.
+
+Research `CompareMembers` still serves `ReturnToSender`, both round-trip
+comparison helpers, and the supported PDB-source composition. Native result
+translations still serve CLI or harness presentation. These are retained
+caller obligations, not unused placeholders; #5125 remains the focused
+Research body-index association retirement issue.
 
 ### Broader migration snapshot
 
@@ -276,7 +291,9 @@ differently named pair remains `SelectionDrift`, covered by prerequisite #5877.
 
 The Queries gates below run in `DirectMemberComparisonQueryTests` in Release.
 CLI adoption is covered by `MatchCommandTests` and `MatchDiscoveryTests`.
-Browser and comparison-tool gates remain **unimplemented and unverified**.
+Browser gates landed in #5990, including published-Wasm acceptance and
+`BrowserMethodBodyOperationTests`. Comparison-tool adoption gates remain
+**unimplemented and unverified**.
 These names describe outcomes, not test seams or a source-scanning policy.
 
 | Gate owner | Required observable outcome |

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -435,10 +435,12 @@ consumer's convenience.
 
 **Status:** #5860 implements the #4711 population sealer and companion-internal
 projection, with the named Release gates in
-[Migration and gates](#migration-and-gates). Public comparison query execution
-has not migrated: that adoption is step 7 of #4706, after Queries publication
-can retain the receipt. Body-signal target-evidence migration still
-requires #4777.
+[Migration and gates](#migration-and-gates). The implementation profile is
+consumed by `DirectMemberComparisonQuery`, CLI `match --body` (#5967), and
+Browser Method Body Diff (#5990). Whole-assembly and body-signal query execution
+remain separate step-7 migrations in #4706. The unconsumed Queries body-signal
+population profile is retired in #6044; its target-evidence migration still
+requires #4777 and an actual execution adopter.
 
 This boundary is owned by the L1 `DotnetInspector.Queries` component and this
 document. The component spans the core query assembly and the optional
@@ -474,8 +476,8 @@ workspace lifetime contract. A comparison may borrow its participant evidence,
 but the group does not become the comparison-population owner and its disposal
 rules do not move into this boundary.
 
-`QueryComparisonPopulationSealer.Execute` now accepts separately typed,
-Queries-owned implementation or body-signal population requests and returns a
+`QueryComparisonPopulationSealer.Execute` accepts a typed, Queries-owned
+implementation population request and returns a
 sealed `QueryComparisonPopulation<TBinding>` or typed rejection. The internal
 `QueryPopulationProjection.Execute` in the ResearchQueries companion admits the
 sealed inputs and returns `ProjectedQueryPopulation` with its inert
@@ -486,16 +488,16 @@ one question; the question map identifies the unique admitted question, even
 when both sides are empty.
 
 The existing `ImplementationComparisonInput`, `BodySignalComparisonInput`, and
-their public `Execute` result contracts are unchanged in this slice. The new
-receipt is not discarded to adapt them prematurely. #4706 counts the shared
+their public `Execute` result contracts remain supported by the CLI `diff`
+consumer. The receipt is not discarded to adapt them prematurely. #4706 counts the shared
 population boundary as step 1, local CLI/browser adoption as steps 8/9, and
 final Queries/Research retirement as steps 16/17.
 
 ### Population contract
 
-Each `ImplementationComparisonQuery.Execute` or
-`BodySignalComparisonQuery.Execute` invocation is one query question. Before
-Research execution, L1 snapshots and seals:
+Each sealing invocation is one query question. The current execution consumer
+is `DirectMemberComparisonQuery.Execute`. Before Research execution, L1
+snapshots and seals:
 
 - one opaque, operation-local `QueryComparisonOperationId`;
 - one opaque `QueryComparisonQuestionId` parented by that operation;
@@ -526,20 +528,19 @@ id kinds. The sealer does not deduplicate borrowed values, and it does not open
 content, hash bytes, read an MVID, compare paths, or use list position as the
 resulting identity.
 
-The boundary has two separately typed profiles corresponding to the current
-queries:
+The implemented boundary has one typed profile used by the direct-member query:
 
 | Profile | Query-owned input binding | Borrowed owner values |
 | --- | --- | --- |
 | Implementation comparison | one binding per submitted assembly input | exact `ResolvedAssemblyReference`, `IAssemblyReferenceResolver`, and `LibraryBodyIndex` |
-| Body-signal comparison | one binding per submitted body index | exact `LibraryBodyIndex` |
 
-The profiles share identity and sealing rules, not an untyped input bag.
-The public execution migration must replace the Research-owned
-`ImplementationAssemblyInput` at the public L1 input seam with a query-owned
-idless binding. Body-signal comparison likewise wraps each index in a
-query-owned idless binding instead of treating `LibraryBodyIndex.Path` or
-object position as identity.
+The separate whole-assembly execution migration must replace the Research-owned
+`ImplementationAssemblyInput` at its public L1 input seam with a query-owned
+idless binding. A body-signal adoption must supply its required Metadata target
+evidence and an actual public execution consumer together; the unused
+index-only population request, sealer overload, and projection are not retained
+as placeholders for that future work. Research's own supported profiles and the
+existing `BodySignalComparisonQuery` are unchanged by this Queries contraction.
 
 The sealer copies caller-owned collections and selection sets into immutable
 storage before returning. Subsequent caller mutation cannot change the

--- a/docs/design/local-comparison-publication.md
+++ b/docs/design/local-comparison-publication.md
@@ -7,8 +7,9 @@ This is the Queries-owned target contract for
 first profile of publication step 5 in
 [#4706](https://github.com/richlander/dotnet-inspect/issues/4706).
 The borrowed-input profile is implemented by `DirectMemberComparisonQuery`
-in `DotnetInspector.ResearchQueries` and consumed by CLI `match --body`.
-The Release gates below cover this profile; Browser adoption remains separate.
+in `DotnetInspector.ResearchQueries` and consumed by CLI `match --body` (#5967)
+and Browser Method Body Diff (#5990). The Release gates below cover publication;
+the Browser owner supplies its own facade and interaction gates.
 
 `DotnetInspector.Queries` is the sole architectural owner. The optional
 `DotnetInspector.ResearchQueries` companion supplies the physical dependency
@@ -26,8 +27,7 @@ The immediate consumer is the
 [direct-member adapter](direct-member-comparison.md) for two explicitly
 selected methods in one already-open implementation assembly. CLI
 `match --body` serves this scenario (formerly `--implementation`). Inspect Web
-will expose
-an explicit comparison action over its existing member selection and retained
+exposes an explicit comparison action over its existing member selection and retained
 implementation participant.
 
 The same method on both sides is valid. Different member names do not imply

--- a/src/DotnetInspector.Queries.Tests/QueryComparisonPopulationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/QueryComparisonPopulationTests.cs
@@ -16,7 +16,6 @@ public sealed class QueryComparisonPopulationTests
     public void ComparisonPopulation_SealsImmutableInputAndSelectionSnapshots()
     {
         ImplementationComparisonBinding implementation = ImplementationBinding();
-        BodySignalComparisonBinding bodySignal = new(implementation.BodyIndex);
         List<ImplementationComparisonBinding?> before = [implementation];
         List<ImplementationComparisonBinding?> after = [];
         HashSet<string> types = new(StringComparer.Ordinal)
@@ -62,15 +61,15 @@ public sealed class QueryComparisonPopulationTests
             },
             population.MemberTargetIdentities);
 
-        QueryComparisonPopulation<BodySignalComparisonBinding> omitted =
-            Seal(new BodySignalComparisonPopulationRequest(
-                [bodySignal],
+        QueryComparisonPopulation<ImplementationComparisonBinding> omitted =
+            Seal(new ImplementationComparisonPopulationRequest(
+                [implementation],
                 [],
                 TypeFilters: null,
                 MemberTargetIdentities: null));
-        QueryComparisonPopulation<BodySignalComparisonBinding> explicitlyEmpty =
-            Seal(new BodySignalComparisonPopulationRequest(
-                [bodySignal],
+        QueryComparisonPopulation<ImplementationComparisonBinding> explicitlyEmpty =
+            Seal(new ImplementationComparisonPopulationRequest(
+                [implementation],
                 [],
                 TypeFilters: new HashSet<string>(StringComparer.Ordinal),
                 MemberTargetIdentities:
@@ -83,14 +82,13 @@ public sealed class QueryComparisonPopulationTests
         Assert.NotNull(explicitlyEmpty.MemberTargetIdentities);
         Assert.Empty(explicitlyEmpty.MemberTargetIdentities);
 
-        AssertEveryDeclaredSealingRejection(implementation, bodySignal);
+        AssertEveryDeclaredSealingRejection(implementation);
     }
 
     [Fact]
     public void QueryPopulationBindings_AreIdlessBorrowedWrappers()
     {
         ImplementationComparisonBinding implementation = ImplementationBinding();
-        BodySignalComparisonBinding bodySignal = new(implementation.BodyIndex);
 
         Assert.Equal(
             new Dictionary<string, Type>
@@ -103,14 +101,6 @@ public sealed class QueryComparisonPopulationTests
                     typeof(LibraryBodyIndex),
             },
             PublicProperties(typeof(ImplementationComparisonBinding)));
-        Assert.Equal(
-            new Dictionary<string, Type>
-            {
-                [nameof(BodySignalComparisonBinding.BodyIndex)] =
-                    typeof(LibraryBodyIndex),
-            },
-            PublicProperties(typeof(BodySignalComparisonBinding)));
-
         Type[] identityTypes =
         [
             typeof(QueryComparisonOperationId),
@@ -120,7 +110,6 @@ public sealed class QueryComparisonPopulationTests
         foreach (Type bindingType in new[]
         {
             typeof(ImplementationComparisonBinding),
-            typeof(BodySignalComparisonBinding),
         })
         {
             Assert.True(bindingType.IsSealed);
@@ -142,21 +131,11 @@ public sealed class QueryComparisonPopulationTests
                 [],
                 null,
                 null));
-        QueryComparisonPopulation<BodySignalComparisonBinding> sealedBodySignal =
-            Seal(new BodySignalComparisonPopulationRequest(
-                [],
-                [bodySignal],
-                null,
-                null));
-
         ImplementationComparisonBinding retainedImplementation =
             Assert.Single(sealedImplementation.Before).Binding;
         Assert.Same(implementation.Assembly, retainedImplementation.Assembly);
         Assert.Same(implementation.Resolver, retainedImplementation.Resolver);
         Assert.Same(implementation.BodyIndex, retainedImplementation.BodyIndex);
-        Assert.Same(
-            bodySignal.BodyIndex,
-            Assert.Single(sealedBodySignal.After).Binding.BodyIndex);
     }
 
     [Fact]
@@ -176,21 +155,6 @@ public sealed class QueryComparisonPopulationTests
                 null,
                 null));
         AssertFreshPopulation(firstImplementation, secondImplementation);
-
-        BodySignalComparisonBinding bodySignal = new(implementation.BodyIndex);
-        QueryComparisonPopulation<BodySignalComparisonBinding> firstBodySignal =
-            Seal(new BodySignalComparisonPopulationRequest(
-                [bodySignal],
-                [bodySignal, bodySignal],
-                null,
-                null));
-        QueryComparisonPopulation<BodySignalComparisonBinding> secondBodySignal =
-            Seal(new BodySignalComparisonPopulationRequest(
-                [bodySignal],
-                [bodySignal, bodySignal],
-                null,
-                null));
-        AssertFreshPopulation(firstBodySignal, secondBodySignal);
     }
 
     [Fact]
@@ -204,22 +168,12 @@ public sealed class QueryComparisonPopulationTests
                 null,
                 null));
         AssertOccurrencePopulation(implementationPopulation, implementation);
-
-        BodySignalComparisonBinding bodySignal = new(implementation.BodyIndex);
-        QueryComparisonPopulation<BodySignalComparisonBinding> bodySignalPopulation =
-            Seal(new BodySignalComparisonPopulationRequest(
-                [bodySignal, bodySignal],
-                [bodySignal],
-                null,
-                null));
-        AssertOccurrencePopulation(bodySignalPopulation, bodySignal);
     }
 
     [Fact]
     public void ResearchPopulationProjection_IsTotalAndBijective()
     {
         ImplementationComparisonBinding implementation = ImplementationBinding();
-        BodySignalComparisonBinding bodySignal = new(implementation.BodyIndex);
         QueryComparisonPopulation[] populations =
         [
             Seal(new ImplementationComparisonPopulationRequest(
@@ -233,21 +187,6 @@ public sealed class QueryComparisonPopulationTests
                 null,
                 null)),
             Seal(new ImplementationComparisonPopulationRequest(
-                [],
-                [],
-                null,
-                null)),
-            Seal(new BodySignalComparisonPopulationRequest(
-                [bodySignal],
-                [],
-                null,
-                null)),
-            Seal(new BodySignalComparisonPopulationRequest(
-                [],
-                [bodySignal],
-                null,
-                null)),
-            Seal(new BodySignalComparisonPopulationRequest(
                 [],
                 [],
                 null,
@@ -351,10 +290,9 @@ public sealed class QueryComparisonPopulationTests
     [Fact]
     public void ResearchPopulationProjection_RejectsMissingExtraSubstitutedAndWrongSideMappings()
     {
-        ImplementationComparisonBinding implementation = ImplementationBinding();
-        BodySignalComparisonBinding borrowed = new(implementation.BodyIndex);
-        QueryComparisonPopulation<BodySignalComparisonBinding> population =
-            Seal(new BodySignalComparisonPopulationRequest(
+        ImplementationComparisonBinding borrowed = ImplementationBinding();
+        QueryComparisonPopulation<ImplementationComparisonBinding> population =
+            Seal(new ImplementationComparisonPopulationRequest(
                 [borrowed, borrowed],
                 [borrowed],
                 null,
@@ -368,8 +306,8 @@ public sealed class QueryComparisonPopulationTests
             valid.Questions,
             valid.Inputs));
 
-        QueryComparisonPopulation<BodySignalComparisonBinding> foreignPopulation =
-            Seal(new BodySignalComparisonPopulationRequest(
+        QueryComparisonPopulation<ImplementationComparisonBinding> foreignPopulation =
+            Seal(new ImplementationComparisonPopulationRequest(
                 [borrowed, borrowed],
                 [borrowed],
                 null,
@@ -475,24 +413,27 @@ public sealed class QueryComparisonPopulationTests
                 valid.Inputs),
             QueryPopulationProjectionRejection.QuestionMappingMismatch);
 
-        ProjectionParts implementationParts = PrepareParts(
-            Seal(new ImplementationComparisonPopulationRequest(
-                [implementation, implementation],
-                [implementation],
-                null,
-                null)));
+        ResearchAdmittedPopulation bodySignalAdmission = Admit(
+            new ResearchComparisonAdmissionRequest(
+                ResearchComparisonProfile.BodySignal,
+                [new ResearchComparisonAdmissionQuestion(
+                    [
+                        new BodySignalComparisonInputOccurrence(borrowed.BodyIndex),
+                        new BodySignalComparisonInputOccurrence(borrowed.BodyIndex),
+                    ],
+                    [new BodySignalComparisonInputOccurrence(borrowed.BodyIndex)])]));
         AssertProjectionRejected(
             QueryToResearchPopulationReceipt.Create(
                 valid.Projection,
-                implementationParts.Admission,
-                new(population.Operation, implementationParts.Admission.Operation),
+                bodySignalAdmission,
+                new(population.Operation, bodySignalAdmission.Operation),
                 [new(population.Question,
-                    implementationParts.Admission.Questions.Single().Id)],
+                    bodySignalAdmission.Questions.Single().Id)],
                 [
                     .. population.InputIds.Select(
                         (id, index) => new QueryResearchInputCorrespondence(
                             id,
-                            implementationParts.Admission.Inputs[index].Id,
+                            bodySignalAdmission.Inputs[index].Id,
                             id.Side)),
                 ]),
             QueryPopulationProjectionRejection.ProfileMismatch);
@@ -501,9 +442,9 @@ public sealed class QueryComparisonPopulationTests
     [Fact]
     public void QueryPopulationIdentities_AreOwnerIssuedAndNonConvertible()
     {
-        QueryComparisonPopulation<BodySignalComparisonBinding> queryPopulation =
-            Seal(new BodySignalComparisonPopulationRequest(
-                [new(ImplementationBinding().BodyIndex)],
+        QueryComparisonPopulation<ImplementationComparisonBinding> queryPopulation =
+            Seal(new ImplementationComparisonPopulationRequest(
+                [ImplementationBinding()],
                 [],
                 null,
                 null));
@@ -592,7 +533,6 @@ public sealed class QueryComparisonPopulationTests
         Type[] forbidden =
         [
             typeof(ImplementationComparisonBinding),
-            typeof(BodySignalComparisonBinding),
             typeof(ResolvedAssemblyReference),
             typeof(IAssemblyReferenceResolver),
             typeof(LibraryBodyIndex),
@@ -730,8 +670,7 @@ public sealed class QueryComparisonPopulationTests
     }
 
     static void AssertEveryDeclaredSealingRejection(
-        ImplementationComparisonBinding implementation,
-        BodySignalComparisonBinding bodySignal)
+        ImplementationComparisonBinding implementation)
     {
         HashSet<QueryPopulationRejectionKind> observed = [];
 
@@ -748,13 +687,13 @@ public sealed class QueryComparisonPopulationTests
             null);
         Observe(
             QueryComparisonPopulationSealer.Execute(
-                new BodySignalComparisonPopulationRequest(
+                new ImplementationComparisonPopulationRequest(
                     [null],
                     [],
                     null,
                     null)),
             QueryPopulationRejectionKind.MissingBinding,
-            QueryComparisonProfile.BodySignal,
+            QueryComparisonProfile.ImplementationComparison,
             QueryComparisonSide.Before,
             0);
         Observe(
@@ -781,13 +720,13 @@ public sealed class QueryComparisonPopulationTests
             0);
         Observe(
             QueryComparisonPopulationSealer.Execute(
-                new BodySignalComparisonPopulationRequest(
+                new ImplementationComparisonPopulationRequest(
                     [],
-                    [bodySignal with { BodyIndex = null! }],
+                    [implementation with { BodyIndex = null! }],
                     null,
                     null)),
             QueryPopulationRejectionKind.MissingBodyIndex,
-            QueryComparisonProfile.BodySignal,
+            QueryComparisonProfile.ImplementationComparison,
             QueryComparisonSide.After,
             0);
         Observe(
@@ -803,13 +742,13 @@ public sealed class QueryComparisonPopulationTests
             null);
         Observe(
             QueryComparisonPopulationSealer.Execute(
-                new BodySignalComparisonPopulationRequest(
-                    [bodySignal],
+                new ImplementationComparisonPopulationRequest(
+                    [implementation],
                     [],
                     null,
                     new HashSet<string> { null! })),
             QueryPopulationRejectionKind.MissingMemberTarget,
-            QueryComparisonProfile.BodySignal,
+            QueryComparisonProfile.ImplementationComparison,
             null,
             null);
 
@@ -953,12 +892,6 @@ public sealed class QueryComparisonPopulationTests
     static QueryComparisonPopulation<ImplementationComparisonBinding> Seal(
         ImplementationComparisonPopulationRequest request)
         => Assert.IsType<QueryComparisonPopulation<ImplementationComparisonBinding>>(
-            Assert.IsType<QueryPopulationSealingOutcome.Sealed>(
-                QueryComparisonPopulationSealer.Execute(request)).Population);
-
-    static QueryComparisonPopulation<BodySignalComparisonBinding> Seal(
-        BodySignalComparisonPopulationRequest request)
-        => Assert.IsType<QueryComparisonPopulation<BodySignalComparisonBinding>>(
             Assert.IsType<QueryPopulationSealingOutcome.Sealed>(
                 QueryComparisonPopulationSealer.Execute(request)).Population);
 

--- a/src/DotnetInspector.Queries/QueryComparisonPopulation.cs
+++ b/src/DotnetInspector.Queries/QueryComparisonPopulation.cs
@@ -8,7 +8,6 @@ namespace DotnetInspector.Queries;
 public enum QueryComparisonProfile
 {
     ImplementationComparison,
-    BodySignal,
 }
 
 public enum QueryComparisonSide
@@ -52,17 +51,9 @@ public sealed record ImplementationComparisonBinding(
     IAssemblyReferenceResolver Resolver,
     LibraryBodyIndex BodyIndex);
 
-public sealed record BodySignalComparisonBinding(LibraryBodyIndex BodyIndex);
-
 public sealed record ImplementationComparisonPopulationRequest(
     IReadOnlyList<ImplementationComparisonBinding?>? Before,
     IReadOnlyList<ImplementationComparisonBinding?>? After,
-    IReadOnlySet<string>? TypeFilters = null,
-    IReadOnlySet<string>? MemberTargetIdentities = null);
-
-public sealed record BodySignalComparisonPopulationRequest(
-    IReadOnlyList<BodySignalComparisonBinding?>? Before,
-    IReadOnlyList<BodySignalComparisonBinding?>? After,
     IReadOnlySet<string>? TypeFilters = null,
     IReadOnlySet<string>? MemberTargetIdentities = null);
 

--- a/src/DotnetInspector.Queries/QueryComparisonPopulationSealer.cs
+++ b/src/DotnetInspector.Queries/QueryComparisonPopulationSealer.cs
@@ -4,7 +4,7 @@ namespace DotnetInspector.Queries;
 
 /// <summary>
 /// Seals borrowed input occurrences and selection values without inspecting content.
-/// Public comparison execution adopts this boundary in a later migration.
+/// The direct-member query consumes this boundary for local comparison.
 /// </summary>
 public static class QueryComparisonPopulationSealer
 {
@@ -22,17 +22,6 @@ public static class QueryComparisonPopulationSealer
                     : binding.BodyIndex is null
                         ? QueryPopulationRejectionKind.MissingBodyIndex
                         : null);
-    }
-
-    public static QueryPopulationSealingOutcome Execute(
-        BodySignalComparisonPopulationRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        return Seal(request.Before, request.After, request.TypeFilters,
-            request.MemberTargetIdentities, QueryComparisonProfile.BodySignal,
-            static binding => binding.BodyIndex is null
-                ? QueryPopulationRejectionKind.MissingBodyIndex
-                : null);
     }
 
     static QueryPopulationSealingOutcome Seal<TBinding>(

--- a/src/DotnetInspector.ResearchQueries/QueryPopulationProjection.cs
+++ b/src/DotnetInspector.ResearchQueries/QueryPopulationProjection.cs
@@ -86,13 +86,6 @@ internal sealed class QueryPopulationProjection
                         input.Binding.Assembly, input.Binding.Resolver, input.Binding.BodyIndex));
                 }
                 break;
-            case QueryComparisonPopulation<BodySignalComparisonBinding> bodySignal:
-                foreach (var input in bodySignal.Inputs)
-                {
-                    occurrences.Add(input.Id,
-                        new BodySignalComparisonInputOccurrence(input.Binding.BodyIndex));
-                }
-                break;
             default:
                 throw new ArgumentException("Unsupported sealed comparison profile.", nameof(population));
         }
@@ -141,7 +134,6 @@ internal sealed class QueryPopulationProjection
         {
             QueryComparisonProfile.ImplementationComparison =>
                 ResearchComparisonProfile.ImplementationComparison,
-            QueryComparisonProfile.BodySignal => ResearchComparisonProfile.BodySignal,
             _ => throw new ArgumentOutOfRangeException(nameof(profile)),
         };
 


### PR DESCRIPTION
## Summary

Remove the unused Queries body-signal population profile now that both
physical-pair consumers have landed. The implementation profile and its
occurrence/receipt guarantees remain the path used by CLI `match --body` and
Browser Method Body Diff.

Closes #6044. Advances scoped step 16 of #4706 under the production-first
cleanup direction in #5865. This is not global Queries or Research retirement.

Design basis:
`docs/design/inspection-layers.md#queries-to-research-population-boundary`
owns immutable occurrence sealing and exact, inert Queries-to-Research
correspondence. Local publication is the consumed result contract; Research
admission and the two host contracts are unchanged.

The caller inventory found the retired binding/request constructed only by
`QueryComparisonPopulationTests`. Remove that profile's enum alternative,
types, sealer overload, and companion projection branch rather than inventing
an execution consumer to retain them. Shared receipt, selection, rejection,
and identity cases now exercise the implementation profile. Mismatched
Research-profile rejection remains covered with Research-issued admission.

## Demo

Before: Queries carried two sealing/projection profiles, while the real
direct-member consumer used only implementation comparison.
After: the unused body-signal profile is removed; the actual CLI route still
preserves the same independent native outcomes.

From a Release-built checkout:

```bash
dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll match \
  DotnetInspector.Tests.MatchSampleA.Greet \
  DotnetInspector.Tests.MatchSampleA.GreetFormal \
  --library artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
  --body --json --compact --all
```

Actual output at `56705cfe1`, reduced from the emitted JSON:

| Pair | C# evidence | IL evidence |
| --- | --- | --- |
| `Greet` / `GreetFormal` | Both endpoints `Complete`; `is_exact: false` | Both endpoints `Complete`; `OperandDiff` |
| `Greet` / `Greet` | Both endpoints `Complete`; `is_exact: true` | Both endpoints `Complete`; `Exact` |
| `MatchSampleWithoutBody.GetValue` / itself | Both endpoints `NoApplicableInput` | Both endpoints `NoApplicableInput` |

All three actual invocations exit 0. The bodyless neighbor retains unavailable
body evidence rather than being reported as exact.

## Retained callers and remaining work

`BodySignalComparisonQuery`, `ImplementationComparisonQuery`, and their legacy
input/result contracts still serve `DiffCommand` and `DiffSections`. They are
not removed. Body-signal target-evidence and execution adoption remains #4777;
the unused index-only profile is not a placeholder for that future work.

Research `CompareMembers` still serves both round-trip helpers, ReturnToSender,
and its supported PDB-source composition. Native result translations still
serve CLI or harness presentation. Preserve them until caller-backed migration
or an explicit owner decision permits deletion. #5125 remains the focused
legacy body-index association work.

The bounded route is 6/8 landed: sealing #5874, designated pairing #5908,
publication/adapter/CLI #5967, and Browser #5990. This cleanup makes 7/8 when
landed; scoped Research cleanup remains. Broader assembly, Source, tool, and
workspace migrations remain explicitly incomplete.

No new algorithm, acquisition, rendering strategy, dependency, platform
exception, or repository-wide absence gate is introduced. Structured native
evidence continues through CLI Markout and the existing Browser typed facade.

## Validation

Candidate: `56705cfe11c87ec83009af6cbbfabc597b4dbcd8`.
Effective base: `94de72f5503dec46fde511dc98b07edc88d1aa49`.

- Release Queries population, direct-member, body-signal, and implementation
  classes: 39 passed.
- Release CLI MatchCommand, MatchDiscovery, DiffCommand, and SectionPipeline:
  597 passed initially; two cases needed the existing RouteLearning fixture
  built, then both passed on focused rerun.
- Three actual CLI demo invocations above passed.
- Changed Markdown lint and diff whitespace check passed.
- Release Browser method-body consumer and facade-context classes: 21 passed.
  The existing managed test profile uses `WasmBuildNative=false`,
  `WasmEnableSIMD=true`, and `WasmEnableExceptionHandling=true`; no new native
  publish or hosted-demo claim is made.
- Required frontend build/typecheck passed after bootstrap.
- Current-head `ci-required` and adversarial review are pending.

Review runs after the ordinary current-head CI prerequisite. No merge is
authorized.
