### PR TITLE
Pin production primary-constructor storage shape

### DIFF
--- a/docs/design/memory-safety-modes.md
+++ b/docs/design/memory-safety-modes.md
@@ -107,9 +107,9 @@ subsequent #5257/#5255 gates; an explicit-layout fixture does not establish them
 
 This is a prerequisite within stage 2 of #5226's existing three-stage adoption:
 Metadata facts, shared CSharp adoption, then CLI and browser/Wasm outcomes.
-Both hosts' whole-type source path uses `AssemblyContextSourceQuery` and the
-same product composer. This slice adds neither a host-local policy nor a new
-adoption stage.
+CLI whole-type decompilation calls `MemberBodyProducer.Project` directly;
+the browser reaches the same composer through `AssemblyContextSourceQuery`.
+This slice adds neither a host-local policy nor a new adoption stage.
 
 ## What the optimistic mode adds
 

--- a/docs/design/memory-safety-modes.md
+++ b/docs/design/memory-safety-modes.md
@@ -72,6 +72,45 @@ in argument position types as `Span<byte>`, not `void*` — so the raise is mode
 fidelity, applied unconditionally by `StackAllocSpanPass`. The unsafe *wrapping* of that
 stackalloc (under `[SkipLocalsInit]`) remains gated on the new rules.
 
+## Primary-constructor storage shape
+
+**Owner and claim:** Decompiler whole-type composition retains an explicit
+storage declaration and ordinary constructor when hiding that storage behind
+a primary-constructor parameter would remove a required declaration site.
+This is the source-shape prerequisite
+[#6046](https://github.com/richlander/dotnet-inspect/issues/6046), within #5255,
+for the [CSharp declaration-spelling consumer](csharp-memory-safety-spelling.md)
+in #5257. CSharp owns whether the field and constructor spell `safe`, `unsafe`,
+or neither; a parameter is not a substitute declaration site.
+
+The current production `MemberBodyProducer.Project` already chooses the
+lowered form: capture fields are explicit fields, and parameter-dependent
+stores remain in ordinary constructors. This contract preserves that behavior;
+it does not introduce primary-constructor syntax for ordinary inputs or claim
+to recover the original source form. The compile-back planner's independent
+primary-constructor synthesis does not establish production reconstruction.
+No new fallback API or harness-only rewrite is needed.
+
+Preserving storage does not authorize moving it across an observable constructor
+chain. The existing constructor-call diagnostics permit parameter stores around
+the elided parameterless `System.Object` constructor, but retain a visible
+unsupported residual before a nontrivial base-constructor call.
+
+The Release `PrimaryConstructorStorageTests` gate exercises the product
+composer with updated-rules explicit-layout safe and unsafe fields and with
+ordinary captures. It observes retained declarations, offsets, constructor
+parameters, and stores, not completed model-aware spelling.
+`ConstructorCallDiagnosticsPassTests` gates the constructor-chain decline.
+Extended-layout declaration legality, caller-contract replay, and whole-output
+compilation under updated semantics remain unverified here and belong to the
+subsequent #5257/#5255 gates; an explicit-layout fixture does not establish them.
+
+This is a prerequisite within stage 2 of #5226's existing three-stage adoption:
+Metadata facts, shared CSharp adoption, then CLI and browser/Wasm outcomes.
+Both hosts' whole-type source path uses `AssemblyContextSourceQuery` and the
+same product composer. This slice adds neither a host-local policy nor a new
+adoption stage.
+
 ## What the optimistic mode adds
 
 Optimistic mode (`MetadataSource.SimulateNewRules`; harness `--simulate-new-rules`)

--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/PrimaryConstructorStorage.cs
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/PrimaryConstructorStorage.cs
@@ -1,0 +1,17 @@
+using System.Runtime.InteropServices;
+
+namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
+
+[StructLayout(LayoutKind.Explicit)]
+public class ExplicitSafePrimaryStorage(int value)
+{
+    [FieldOffset(0)]
+    public safe readonly int Value = value;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public struct ExplicitUnsafePrimaryStorage(int value)
+{
+    [FieldOffset(0)]
+    public unsafe int Value = value;
+}

--- a/src/ILInspector.Decompiler.Tests/PrimaryConstructorStorageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrimaryConstructorStorageTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Fixtures;
+using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Validity")]
+public class PrimaryConstructorStorageTests
+{
+    [Theory]
+    [InlineData("ExplicitSafePrimaryStorage", false, true)]
+    [InlineData("ExplicitUnsafePrimaryStorage", true, false)]
+    public void LayoutStorage_RetainsFieldAndOrdinaryConstructor(
+        string name, bool requiresUnsafe, bool isReadOnly)
+    {
+        string path = FixtureCatalog.DecompilerUnsafeNew.AssemblyPath();
+        using var pe = new PEReader(File.OpenRead(path));
+        var type = Assert.Single(ApiSurfaceExtractor.Extract(pe).Types,
+            t => t.FullName == $"ILInspector.Decompiler.Fixtures.NewUnsafe.{name}");
+        Assert.Equal(ApiTypeLayout.Explicit, type.Layout);
+        Assert.Equal(MemorySafetyRulesState.Updated,
+            Assert.IsType<MemorySafetyRulesResult.Available>(type.MemorySafety!.Rules).State);
+        var storage = Assert.Single(type.Members, m => m.Kind == "field" && m.Name == "Value");
+        var facts = Assert.IsType<ApiMemberMemorySafetyFacts>(storage.MemorySafety);
+        Assert.Equal(MemorySafetyPointerEvidence.Absent, facts.SignaturePointer);
+        if (requiresUnsafe)
+            Assert.IsType<MemorySafetyMemberContractResult.Explicit>(facts.CallerContract);
+        else
+            Assert.IsType<MemorySafetyMemberContractResult.None>(facts.CallerContract);
+
+        var declaration = Project(type, path);
+        Assert.Null(declaration.ParameterList);
+        var field = Assert.Single(declaration.Members.OfType<FieldDeclarationSyntax>());
+        var variable = Assert.Single(field.Declaration.Variables);
+        Assert.Equal("Value", variable.Identifier.ValueText);
+        Assert.Null(variable.Initializer);
+        Assert.Equal(isReadOnly, field.Modifiers.Any(SyntaxKind.ReadOnlyKeyword));
+        Assert.Contains(field.AttributeLists.SelectMany(list => list.Attributes),
+            attribute => attribute.ToString() == "FieldOffset(0)");
+
+        var constructor = Assert.Single(declaration.Members.OfType<ConstructorDeclarationSyntax>());
+        Assert.Equal(name, constructor.Identifier.ValueText);
+        Assert.Equal("value", Assert.Single(constructor.ParameterList.Parameters).Identifier.ValueText);
+        Assert.Contains(constructor.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            assignment => assignment.Left.ToString() is "Value" or "this.Value"
+                && assignment.Right is IdentifierNameSyntax { Identifier.ValueText: "value" });
+    }
+
+    [Fact]
+    public void OrdinaryCaptures_KeepTheirExistingLoweredShape()
+    {
+        string path = FixtureCatalog.DecompilerLadderRung5.AssemblyPath();
+        using var pe = new PEReader(File.OpenRead(path));
+        var type = Assert.Single(ApiSurfaceExtractor.Extract(pe).Types,
+            t => t.FullName == "LadderRung5.PrimaryCounter");
+
+        var declaration = Project(type, path);
+        Assert.Null(declaration.ParameterList);
+        var fields = declaration.Members.OfType<FieldDeclarationSyntax>().ToArray();
+        Assert.Equal(["seed", "step"],
+            fields.SelectMany(field => field.Declaration.Variables)
+                .Select(variable => variable.Identifier.ValueText));
+        Assert.All(fields, field =>
+            Assert.Null(Assert.Single(field.Declaration.Variables).Initializer));
+        var constructor = Assert.Single(declaration.Members.OfType<ConstructorDeclarationSyntax>());
+        Assert.Equal(["seed", "step"],
+            constructor.ParameterList.Parameters.Select(parameter => parameter.Identifier.ValueText));
+        Assert.Equal(["this.seed = seed", "this.step = step"],
+            constructor.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Select(assignment => assignment.ToString()));
+    }
+
+    static TypeDeclarationSyntax Project(ApiType type, string path)
+    {
+        var result = MemberBodyProducer.Project(type, path, pdbPath: null);
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Output);
+        var tree = CSharpSyntaxTree.ParseText(result.Output);
+        return Assert.Single(tree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>());
+    }
+}


### PR DESCRIPTION
Pins a reliable production source-shape foundation for CSharp memory-safety
spelling without adding redundant reconstruction machinery.

Fixes #6046; advances the narrow source-shape prerequisite in #5255 for #5257.
Overall tracker: #5226.

Card revision: `027256b4ffd5e6f20b4193e0ae06a21a182bc2f8`.

## Change

**Conclusion: REVIEW** — production already emits explicit fields and ordinary
constructors. This change records the Decompiler-owned contract and adds
compiler-produced regression evidence; it does not change product output.

The normative owner is `docs/design/memory-safety-modes.md`, **Primary-constructor
storage shape**. CSharp independently owns declaration modifiers. There is no
new raise, fallback API, host-local policy, or compile-back-planner rewrite.

## Demo

The new updated-rules fixture begins with a primary constructor and an explicitly
safe, offset-bearing field:

```csharp
[StructLayout(LayoutKind.Explicit)]
public class ExplicitSafePrimaryStorage(int value)
{
    [FieldOffset(0)]
    public safe readonly int Value = value;
}
```

The production CLI at the card revision, using `type` with
`-S "Decompiled Source" --bare`, produces:

```csharp
using System.Runtime.InteropServices;

namespace ILInspector.Decompiler.Fixtures.NewUnsafe;

[StructLayout(LayoutKind.Explicit)]
public class ExplicitSafePrimaryStorage
{
    [FieldOffset(0)]
    public readonly int Value;

    public ExplicitSafePrimaryStorage(int value) => Value = value;
}
```

The field and ordinary constructor remain separate declaration sites.
**This is source-shape evidence, not completed v2 spelling:** the missing
`safe` is the pre-existing #5257 work. No claim is made that this output already
compiles under updated semantics.

The ordinary-capture neighbor remains unchanged:

```csharp
namespace LadderRung5;

public class PrimaryCounter
{
    private int seed;
    private int step;

    public PrimaryCounter(int seed, int step)
    {
        this.seed = seed;
        this.step = step;
    }

    public int Next() => seed + step;

    public int SeedPlus(int extra) => seed + extra;
}
```

The second new fixture covers an updated-rules explicit-layout struct whose
pointer-free field has an explicit unsafe caller contract. Its declaration and
parameter store remain explicit too.

## Evidence

- Baseline normal graph: `dotnet build dotnet-inspect.slnx -c Release -m:2
  -p:UseSharedCompilation=false -v:q` succeeded.
- Focused Release run: **19 passed**, zero failed or skipped:

```sh
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -class ILInspector.Decompiler.Tests.PrimaryConstructorStorageTests \
  -class ILInspector.Decompiler.Tests.ConstructorCallDiagnosticsPassTests \
  -class ILInspector.Decompiler.Tests.LadderRung5GateTests
```

- `PrimaryConstructorStorageTests` observes the first product projection:
  explicit fields, offsets, readonly state, ordinary constructor parameters,
  and parameter-dependent assignments. It parses but does not repair source.
- Existing constructor-call gates preserve the visible decline for parameter
  stores before nontrivial base constructors; no ordering behavior changes.
- `npx markdownlint-cli docs/design/memory-safety-modes.md` passed.
- Structural A/B and changed-method census are not applicable: the exact
  authored diff contains one owner-document section, inspected fixture source,
  and product-outcome tests, with no raise/printer/product changes.

## Compatibility and remaining work

The existing three-stage #5226 adoption stays: Metadata facts, shared CSharp
adoption, then CLI and browser/Wasm outcome gates. CLI whole-type decompilation
calls `MemberBodyProducer.Project` directly in `ApiCommand`; browser
`SourceExports.QueryTypeSourceCore` reaches the same composer through
`AssemblyContextSourceQuery`. No new adoption stage, dependency, platform
exception, or rendering architecture is introduced.

Required `safe`/`unsafe` spelling, extended-layout declaration legality, and
whole-output v2 compilation remain unverified by this slice and stay with
#5257/#5255. Generated-name authentication remains #5595. The harness's primary
constructor synthesis is not presented as production support.
