### PR TITLE
Confirm resolver-lineage adoption through Browser endpoints

### DIFF
--- a/docs/design/models/resolver-lineage/README.md
+++ b/docs/design/models/resolver-lineage/README.md
@@ -84,7 +84,12 @@ intrinsic metadata reads, acquisition and budget enforcement, multiple nested
 composites, historical recipe carry-forward, and real host execution.
 Those are not implicitly proven by a successful model run.
 
-The #5801 compiled fixture is the existing product oracle for the minimal
-Services forwarding case. The new representation's Metadata, Services/CLI, and
-Queries/Browser adoption gates remain unverified until the four-step plan in
-the owning design lands. No inspected assembly is executed by this model.
+The #5801 compiled fixture is the product oracle for the minimal Services
+forwarding case. #5978 implements Metadata occurrence propagation, and #5982
+implements Services/CLI adoption and the compiled two-context gate. #6049
+confirms the Browser's existing composition through production export methods,
+including terminal navigation and graph expansion from canonical and facade
+origins. The owning design's **Evidence and limits** section names those
+Release gates and distinguishes managed endpoint evidence from live-Wasm
+execution. No model behavior or bounded result changes with that adoption
+record, and no inspected assembly is executed by this model.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1503,7 +1503,7 @@ provide that endpoint evidence:
   `System.Console` graph to its terminal browsable surface. It expands the
   member from both the canonical assembly and the `System.Runtime` facade
   using the product-issued type identity and selector, while preserving the
-  earlier retained scope and making no additional network requests.
+  earlier retained scope.
 - `MemberFacts_DistinguishesSurfaceAndBodyTokenResolution` and
   `GraphMemberSurface_UsesSurfaceAssetForImplementationOnlyType` exercise
   package member navigation and repeated surface/implementation selection.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1313,11 +1313,11 @@ progress.
 
 #### Resolver-lineage continuations
 
-> **Status: Metadata and Services/CLI implemented; Browser adoption pending.**
-> #5953 carries occurrences through Metadata; #5666 adopts them in the
+> **Status: implemented, with CLI and Browser endpoint evidence.**
+> #5978 carries occurrences through Metadata; #5982 adopts them in the
 > source-relative Services producer and the existing CLI API-surface path.
-> #5801 supplies the original compiled behavioral evidence.
-> #5274 tracks the remaining Queries/Browser endpoint adoption.
+> #6049 confirms the Browser's existing query composition through production
+> export methods. #5274 tracks the remaining binding-policy work.
 
 **Claim:** a selected assembly occurrence retains the policy-issued binding
 context required for its subsequent references, without changing the answers
@@ -1451,9 +1451,9 @@ alone is not host adoption; this sequencing follows #5865.
 | Step | Owning slice and completion |
 | --- | --- |
 | 1 | Binding owner: currency and companion model locked in #5912 under #5666. Product behavior was unchanged. |
-| 2 | Metadata (#5953): implemented selected occurrences across requests, results, deferred dependencies, and policy-dependent caches. Existing seed-only producers remain behavior-compatible; context-aware gates demonstrate distinct answers for a shared registration. |
-| 3 | Services (#5666): implemented `SourceRelativeAssemblyGroupBindingPolicy` continuation issuance, retiring learned-route insertion and registration-only intrinsic caching. The #5801 result and real CLI `diff` endpoint are exercised; `timeline` uses the same endpoint construction. |
-| 4 | Queries/Browser: adopt through `AssemblyContextTypeResolutionQuery` and `MemberCallGraphSession`, exercised by `PlatformCallGraphExports`. Confirm terminal member navigation and call-graph endpoints while retaining sealed participant provisioning and one attempt per authorized demand. |
+| 2 | Metadata (#5953, landed #5978): implemented selected occurrences across requests, results, deferred dependencies, and policy-dependent caches. Existing seed-only producers remain behavior-compatible; context-aware gates demonstrate distinct answers for a shared registration. |
+| 3 | Services (#5666, landed #5982): implemented `SourceRelativeAssemblyGroupBindingPolicy` continuation issuance, retiring learned-route insertion and registration-only intrinsic caching. The #5801 result and real CLI `diff` endpoint are exercised; `timeline` uses the same endpoint construction. |
+| 4 | Queries/Browser (#6049): endpoint gates confirm the existing composition through `AssemblyContextTypeResolutionQuery` and `MemberCallGraphSession`, exercised by `PlatformCallGraphExports`. Terminal member navigation and graph expansion retain sealed participant provisioning and one attempt per authorized demand. |
 
 The CLI production path is reached at step 3; the Browser path at step 4.
 Browser is an actual caller of both named query services. It is not evidence
@@ -1461,8 +1461,9 @@ for discovery-time route learning: the workspace-owned complete-plan and
 one-attempt contract remains unchanged. No Browser filesystem resolver or
 host-specific continuation algorithm is introduced.
 
-Step 3 retires the Services learned-route representation; the replacement is
-incomplete until step 4 closes both-host adoption. Other transforming
+Step 3 retired the Services learned-route representation. The existing Queries
+composition also consumes that implementation; step 4 confirms its Browser
+endpoint behavior rather than introducing another runtime cutover. Other transforming
 policies remain the separately scoped work in #5667, #5668, and #5669.
 Retirement requires the affected existing consumers to have safely cut over;
 the presence of the new currency alone does not justify deletion. If that
@@ -1494,9 +1495,30 @@ delegate-version refresh, and the compiled two-context case.
 oracle; CLI `CommandLine_ForwardedConstraint_ReportsDependencyCompleteness`
 exercises the real command and its missing-dependency neighbor.
 Existing `MemberCallGraphSessionTests` provide query-level regression coverage,
-not Browser endpoint adoption. That endpoint enforcement remains unverified
-until step 4. No feature-specific rendering domain is added: the existing API
-and call-graph models and their lowering owners remain.
+not Browser endpoint adoption. Browser's Release `BrowserEngineBoundaryTests`
+provide that endpoint evidence:
+
+- `PlatformCallGraph_ResolvesDefinitionsBehindFacadesWithoutHostProbing`
+  follows a returned `System.IO.TextWriter.WriteLine` target from a
+  `System.Console` graph to its terminal browsable surface. It expands the
+  member from both the canonical assembly and the `System.Runtime` facade
+  using the product-issued type identity and selector, while preserving the
+  earlier retained scope and making no additional network requests.
+- `MemberFacts_DistinguishesSurfaceAndBodyTokenResolution` and
+  `GraphMemberSurface_UsesSurfaceAssetForImplementationOnlyType` exercise
+  package member navigation and repeated surface/implementation selection.
+- `QueryMemberCallGraph_RejectsCollapsedContextCoordinates` keeps an
+  incomplete workspace request visibly rejected.
+
+These are managed invocations of the production Browser export methods, not
+DOM or live-Wasm execution evidence. The supported endpoint path starts from
+sealed canonical participants: selecting a forwarded terminal definition as
+the next canonical root is not replay of a transitive continuation.
+This confirms the existing composition, not a Browser demonstration of the
+model's two-context nonparticipant case. The host continues projecting physical
+navigation identity; this adoption introduces no lineage wire representation.
+No feature-specific rendering domain is added: the existing API and call-graph
+models and their lowering owners remain.
 
 The comparative baseline is explicit context association, not a new loading
 mechanism. [AssemblyLoadContext][lineage-alc] associates assemblies with loading

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -5309,6 +5309,7 @@ public sealed class BrowserEngineBoundaryTests
                     BrowserPackageJsonContext.Default.BrowserPackageSurface));
         BrowserAssemblySurface facadeAssembly =
             Assert.Single(facadeSurface.Assemblies);
+        Assert.Equal("System.Runtime", facadeAssembly.Id);
 
         foreach (BrowserAssemblySurface origin
             in new[] { terminalAssembly, facadeAssembly })
@@ -5342,7 +5343,6 @@ public sealed class BrowserEngineBoundaryTests
             Assert.NotEmpty(continued.Callees.Children);
         }
 
-        Assert.Equal(requestsBeforeGraph, handler.Requests);
         Assert.Equal(2, console.Scope.Members.Length);
         Assert.True(
             BrowserPackageWorkspace.IsScopeRetained(console.Scope));

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -5276,6 +5276,76 @@ public sealed class BrowserEngineBoundaryTests
         Assert.DoesNotContain(
             forwarded,
             target => target.Assembly == "System.Runtime");
+
+        BrowserCallGraphTarget destination = forwarded[0];
+        BrowserPackageSurface terminalSurface =
+            Assert.IsType<BrowserPackageSurface>(
+                JsonSerializer.Deserialize(
+                    await PackageExports.LoadRuntimePackAssembly(
+                        framework,
+                        $"{destination.Assembly}.dll",
+                        Assert.IsType<string>(destination.PlatformPack)),
+                    BrowserPackageJsonContext.Default.BrowserPackageSurface));
+        BrowserTypeSurface terminalType = Assert.Single(
+            terminalSurface.Types,
+            type => type.DefinitionId == destination.TypeDefinitionId);
+        BrowserMemberSurface terminalMember = Assert.Single(
+            terminalType.Api,
+            member => member.GraphSelectorKey == destination.SelectorKey);
+        Assert.Equal(destination.MemberName, terminalMember.Name);
+        BrowserAssemblySurface terminalAssembly = Assert.Single(
+            terminalSurface.Assemblies,
+            assembly => assembly.Id == terminalType.AssemblyId);
+        Assert.Equal(destination.Assembly, terminalAssembly.Id);
+        Assert.Equal(destination.AssemblyVersion, terminalAssembly.Version);
+
+        BrowserPackageSurface facadeSurface =
+            Assert.IsType<BrowserPackageSurface>(
+                JsonSerializer.Deserialize(
+                    await PackageExports.LoadRuntimePackAssembly(
+                        framework,
+                        "System.Runtime.dll",
+                        "netcore.app"),
+                    BrowserPackageJsonContext.Default.BrowserPackageSurface));
+        BrowserAssemblySurface facadeAssembly =
+            Assert.Single(facadeSurface.Assemblies);
+
+        foreach (BrowserAssemblySurface origin
+            in new[] { terminalAssembly, facadeAssembly })
+        {
+            BrowserCallGraph continued =
+                Assert.IsType<BrowserCallGraph>(
+                    JsonSerializer.Deserialize(
+                        await CallGraphExports.ExpandPlatformCallGraph(
+                            framework,
+                            origin.Id,
+                            "netcore.app",
+                            origin.Version,
+                            origin.Culture,
+                            origin.PublicKeyToken,
+                            Assert.IsType<string>(destination.TypeDefinitionId),
+                            destination.MemberName,
+                            destination.SelectorKey,
+                            metadataToken: 0),
+                        BrowserCallGraphJsonContext.Default.BrowserCallGraph));
+
+            Assert.False(continued.NoBody);
+            BrowserCallGraphTarget focus = Assert.Single(
+                continued.Targets,
+                target => target.Kind == "focus");
+            Assert.Equal(destination.Assembly, focus.Assembly);
+            Assert.Equal(destination.AssemblyVersion, focus.AssemblyVersion);
+            Assert.Equal(destination.TypeDefinitionId, focus.TypeDefinitionId);
+            Assert.Equal(destination.SelectorKey, focus.SelectorKey);
+            Assert.Equal(destination.TypeFullName, continued.Callees.TypeFullName);
+            Assert.Equal(destination.MemberName, continued.Callees.MemberName);
+            Assert.NotEmpty(continued.Callees.Children);
+        }
+
+        Assert.Equal(requestsBeforeGraph, handler.Requests);
+        Assert.Equal(2, console.Scope.Members.Length);
+        Assert.True(
+            BrowserPackageWorkspace.IsScopeRetained(console.Scope));
     }
 
     // A package coordinate becomes a flat-container path segment and a cache key. Both halves are


### PR DESCRIPTION
Confirms Browser production adoption of resolver lineage without adding a
second runtime mechanism. The Queries/Browser paths already consume the
Services implementation from #5982; this closes the endpoint-evidence and
adoption-status gap.

Closes #6049. Completes lineage step 4 of #5274, not that entire tracker or
#5865.

## Demo

The strengthened existing boundary case follows a real returned graph target:

```text
ExpandPlatformCallGraph(System.Console, Console.WriteLine)
  -> System.Private.CoreLib: System.IO.TextWriter.WriteLine
LoadRuntimePackAssembly(returned target assembly)
  -> browsable terminal type and exact product-issued member selector
ExpandPlatformCallGraph(terminal assembly, returned type + selector, token 0)
ExpandPlatformCallGraph(System.Runtime facade, same type + selector, token 0)
  -> the same canonical focus, with downstream callees
```

Both expansions return this focus-target projection:

```json
{
  "kind": "focus",
  "assembly": "System.Private.CoreLib",
  "typeDefinitionId": "System.IO.TextWriter",
  "memberName": "WriteLine"
}
```

The case also requires the exact returned assembly version and selector,
nonempty downstream callees, and the original two-member scope still retained.

Previously the case stopped after checking the first graph's forwarded target.
It now navigates to that target and exercises both direct canonical focus and
facade-to-terminal focus. Product behavior is unchanged. Physical identity is
asserted on the typed focus target, not the tree's logical `corelib` alias.

Neighboring real-export cases retain package surface/body selection, repeated
implementation-only member navigation, and rejection of collapsed workspace
coordinates.

## Design basis and scope

The sole normative owner is
[resolver-lineage continuations](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/type-forwarding-resolution.md#resolver-lineage-continuations):
the selected occurrence retains its resolver context without changing other
requests under the same policy version. The existing resolver-lineage model
supports association/cache/canonical-root behavior; the
binding-selection-version model supports snapshot lifecycle. Neither model
changes here.

`AssemblyContextTypeResolutionQuery` already constructs the updated Services
composite and retains Metadata's outcome. `MemberCallGraphSession` uses that
same producer for its catalog. The platform host resolves a forwarded
definition to one retained canonical participant before constructing the graph.
This slice therefore adds evidence, not an occurrence API or another binding
layer.

The four-step path is unchanged: #5912 design/model; #5978 Metadata; #5982
Services/CLI and learned-route retirement; this Browser endpoint confirmation.
The binding owner and model README now reflect that status, while #5274 keeps
the other transforming-policy and legacy-retirement work explicit.

These are native managed calls to actual production Browser export methods.
They are not DOM or live-Wasm execution evidence, nor a Browser demonstration
of the model's two-context nonparticipant scenario. The existing sealed
provisioning, one-attempt contract, wire DTOs, graph identities, rendering
models, and format-lowering owners are unchanged.

## Validation

The round-2 corrective worktree passed the Release engine build with zero
warnings/errors and all four selected `BrowserEngineBoundaryTests` cases
(4 passed, 0 skipped, 52.915 seconds), after integrating main through
`b7436df95e659d42200d310724e76f4415972615`:

- `PlatformCallGraph_ResolvesDefinitionsBehindFacadesWithoutHostProbing`
- `MemberFacts_DistinguishesSurfaceAndBodyTokenResolution`
- `GraphMemberSurface_UsesSurfaceAssetForImplementationOnlyType`
- `QueryMemberCallGraph_RejectsCollapsedContextCoordinates`

Both changed Markdown files pass markdownlint. The final base integration,
`18cb8b53185ef80104619cc2ffb7293b91a3be14` (#6045), only updates export-count
expectations in deployment/frontend code; it does not change the exercised
managed endpoint inputs, so that integration did not require another local run.

[Round 1](https://github.com/richlander/dotnet-inspect/pull/6053#issuecomment-5556285355)
returned CLEAN from both reviewers with two non-blocking evidence observations.
The replacement explicitly pins the facade origin to `System.Runtime` and
removes the new counter assertion and network-absence claim. The fixture's
acquisition client does not observe traffic from the production exports'
separate client. No production-code correction was needed.

Candidate: `8709836fd84de7d66ee13fded3ea78c713aff88e`.
Effective base: `18cb8b53185ef80104619cc2ffb7293b91a3be14`.
[Current-head CI](https://github.com/richlander/dotnet-inspect/actions/runs/34006385449)
succeeded. [Round 2](https://github.com/richlander/dotnet-inspect/pull/6053#issuecomment-5556508688)
is complete: GPT-6 Astra and Claude Opus 4.8 both returned CLEAN, with no
qualifying findings or observations. The reviewed candidate is unchanged.
Main movement through `4e518d23f085b86bd1c92a6b8d7db4f2a70be94c` was
classified as no interaction; no integration or extra round is required.

`review-clean` records that reviewed head, not merge readiness.
GitHub's 2026-09-06T03:00:15Z readiness response was still `UNKNOWN`.
No merge authorization is recorded.
