### PR TITLE
Restore npm audit as scheduled monitoring

### DIFF
--- a/.github/workflows/npm-audit-scheduled.yml
+++ b/.github/workflows/npm-audit-scheduled.yml
@@ -1,0 +1,35 @@
+name: npm audit scheduled
+
+on:
+  schedule:
+    - cron: '23 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit inspect-web dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Audit the committed lockfile
+        working-directory: prototypes/inspect-web
+        env:
+          npm_config_fetch_timeout: '30000'
+        run: bash scripts/audit-dependencies.sh "$RUNNER_TEMP/npm-audit"
+
+      - name: Preserve npm reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: npm-audit
+          path: ${{ runner.temp }}/npm-audit/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1427,14 +1427,14 @@ declared, not by whether its code reaches a browser. Vite is a devDependency and
 its `__vite__mapDeps` helper is in the shipped bundle, so that split was never
 the boundary it resembled.
 
-That check no longer runs in CI. `npm audit` needs npm's advisories endpoint,
+That check no longer gates merges. `npm audit` needs npm's advisories endpoint,
 and it exits non-zero both when it finds an advisory and when it cannot reach
 that endpoint, so the merge gate could not tell a vulnerable dependency from an
 npm outage. On 2026-09-04 the endpoint returned 503s and timeouts for over two
 hours and turned `ci-required` red on unrelated pull requests; a gate that
 blocks merges on a third party's uptime is not measuring this repository.
 
-What watches the lockfile now is Dependabot: the same 168 packages against the
+Dependabot watches the lockfile: the same 168 packages against the
 same advisory database, with vulnerability alerts enabled and a weekly npm
 update schedule for `/prototypes/inspect-web`. The honest difference is timing.
 `npm audit` blocked the merge that introduced an advisory; Dependabot reports
@@ -1442,6 +1442,36 @@ one after it lands and opens a security update. That is weaker, and it is what
 lets the sanitization comment name a gate that is monitoring rather than
 enforcement. Run `npm audit --audit-level=info` locally to get the old answer on
 demand.
+
+The separate `npm audit scheduled` workflow adds an Actions signal at 05:23 UTC
+daily, or on manual dispatch. It is not part of `ci-required` and has no push or
+pull-request trigger. It audits inspect-web's committed lockfile with npm's
+`--package-lock-only --include=dev --audit-level=info --json`: no dependency
+installation or automatic fixes, and development dependencies are included.
+The annotated-source-viewer prototype currently has neither dependencies nor a
+lockfile, so it is not an additional audit target.
+
+`scripts/audit-dependencies.sh` only orchestrates npm's report. A successful
+audit exits 0; reported advisories exit 1 without retrying. An incomplete audit
+(including endpoint failure) is retried after 10 and 30 seconds, then exits 2
+if it still cannot complete. npm's fetch retries do not retry the audit POSTs,
+so these are whole-command retries. The job has a ten-minute timeout and
+30-second npm fetch timeouts. Both non-success outcomes fail the scheduled job,
+with distinct annotations and step summaries; a failed acquisition is never
+described as a clean audit. Every attempt's JSON and stderr are retained in the
+`npm-audit` artifact for 14 days. Dependabot and this schedule are monitoring,
+not merge enforcement.
+
+Run the same check locally from this directory with:
+
+```bash
+bash scripts/audit-dependencies.sh /tmp/inspect-web-npm-audit
+```
+
+`test/npm-audit.test.ts` exercises orchestration with controlled npm outcomes:
+success, informational advisories, transient recovery, and incomplete or
+malformed reports. It runs in the existing inspect-web Node suite on Unix
+hosts; it does not query the live advisory service or implement advisory rules.
 
 `staticwebapp.config.json` owns the browser's enforcing Content-Security-Policy
 on static responses. It follows the

--- a/prototypes/inspect-web/scripts/audit-dependencies.sh
+++ b/prototypes/inspect-web/scripts/audit-dependencies.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+reports="${1:?Usage: bash scripts/audit-dependencies.sh REPORT_DIRECTORY}"
+mkdir -p "$reports"
+
+report() {
+  printf '### npm audit: %s\n' "$1" | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+}
+
+attempt=0
+# npm's HTTP retry settings do not retry its audit POST requests.
+for delay in 0 10 30; do
+  if [ "$delay" -gt 0 ]; then
+    sleep "$delay"
+  fi
+  attempt=$((attempt + 1))
+  json="$reports/attempt-$attempt.json"
+  stderr="$reports/attempt-$attempt.stderr"
+
+  if npm audit --package-lock-only --include=dev --audit-level=info --json > "$json" 2> "$stderr"; then
+    report "no known advisories"
+    exit 0
+  fi
+
+  if jq -e '.error == null and (.metadata.vulnerabilities.total | numbers > 0)' "$json" > /dev/null 2>&1; then
+    report "advisories found"
+    echo "::error title=npm audit advisories::See the npm-audit artifact for npm's report."
+    exit 1
+  fi
+
+  echo "npm audit attempt $attempt did not complete; preserving its report and stderr."
+done
+
+report "incomplete after three attempts"
+echo "::error title=npm audit incomplete::The audit could not complete. This is not a clean dependency report; see the npm-audit artifact."
+exit 2

--- a/prototypes/inspect-web/test/npm-audit.test.ts
+++ b/prototypes/inspect-web/test/npm-audit.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import test, { type TestContext } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(new URL("../scripts/audit-dependencies.sh", import.meta.url));
+const options = { skip: process.platform === "win32" };
+
+interface AuditResult {
+  readonly status: number;
+  readonly stdout: string;
+}
+
+function audit(context: TestContext, results: readonly AuditResult[]) {
+  const directory = mkdtempSync(join(tmpdir(), "npm-audit-test-"));
+  context.after(() => rmSync(directory, { recursive: true, force: true }));
+  const bin = join(directory, "bin");
+  const reports = join(directory, "reports");
+  mkdirSync(bin);
+  writeFileSync(join(directory, "results.json"), JSON.stringify(results));
+  writeFileSync(join(directory, "calls"), "");
+  writeFileSync(join(directory, "delays"), "");
+  writeFileSync(join(bin, "npm"), `#!/bin/sh
+exec "$AUDIT_TEST_NODE" "$AUDIT_TEST_DIRECTORY/npm.cjs" "$@"
+`, { mode: 0o755 });
+  writeFileSync(join(bin, "sleep"), `#!/bin/sh
+printf '%s\\n' "$1" >> "$AUDIT_TEST_DIRECTORY/delays"
+`, { mode: 0o755 });
+  writeFileSync(join(directory, "npm.cjs"), `
+const fs = require("node:fs");
+const directory = process.env.AUDIT_TEST_DIRECTORY;
+const calls = fs.readFileSync(directory + "/calls", "utf8").trim().split("\\n").filter(Boolean);
+const results = JSON.parse(fs.readFileSync(directory + "/results.json", "utf8"));
+const result = results[calls.length];
+fs.appendFileSync(directory + "/calls", JSON.stringify(process.argv.slice(2)) + "\\n");
+if (!result) throw new Error("Unexpected extra audit attempt");
+process.stdout.write(result.stdout);
+process.stderr.write("npm diagnostic " + (calls.length + 1));
+process.exitCode = result.status;
+`);
+  const execution = spawnSync("bash", [script, reports], {
+    cwd: directory,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+      AUDIT_TEST_NODE: process.execPath,
+      AUDIT_TEST_DIRECTORY: directory,
+      GITHUB_STEP_SUMMARY: join(directory, "summary"),
+    },
+    timeout: 10_000,
+  });
+  assert.ifError(execution.error);
+  const calls = readFileSync(join(directory, "calls"), "utf8").trim().split("\n");
+  for (const call of calls) {
+    assert.deepEqual(JSON.parse(call), [
+      "audit", "--package-lock-only", "--include=dev", "--audit-level=info", "--json",
+    ]);
+  }
+  return {
+    execution,
+    calls,
+    reports,
+    summary: readFileSync(join(directory, "summary"), "utf8"),
+    delays: readFileSync(join(directory, "delays"), "utf8"),
+  };
+}
+
+const clean = { status: 0, stdout: '{"metadata":{"vulnerabilities":{"total":0}}}' };
+const advisory = { status: 1, stdout: '{"metadata":{"vulnerabilities":{"info":1,"total":1}}}' };
+const unavailable = { status: 1, stdout: '{"error":{"code":"E503","summary":"Service Unavailable"}}' };
+
+test("a successful npm audit is reported without retries", options, context => {
+  const result = audit(context, [clean]);
+  assert.equal(result.execution.status, 0);
+  assert.equal(result.summary, "### npm audit: no known advisories\n");
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.delays, "");
+  assert.equal(readFileSync(join(result.reports, "attempt-1.json"), "utf8"), clean.stdout);
+});
+
+test("an informational advisory fails immediately without retrying", options, context => {
+  const result = audit(context, [advisory]);
+  assert.equal(result.execution.status, 1);
+  assert.equal(result.summary, "### npm audit: advisories found\n");
+  assert.match(result.execution.stdout, /::error title=npm audit advisories::/);
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.delays, "");
+});
+
+test("an incomplete audit can recover on the next attempt", options, context => {
+  const result = audit(context, [unavailable, clean]);
+  assert.equal(result.execution.status, 0);
+  assert.equal(result.calls.length, 2);
+  assert.equal(result.delays, "10\n");
+  assert.equal(readFileSync(join(result.reports, "attempt-1.json"), "utf8"), unavailable.stdout);
+  assert.equal(readFileSync(join(result.reports, "attempt-2.json"), "utf8"), clean.stdout);
+});
+
+test("an advisory after an incomplete attempt still fails as an advisory", options, context => {
+  const result = audit(context, [unavailable, advisory]);
+  assert.equal(result.execution.status, 1);
+  assert.equal(result.summary, "### npm audit: advisories found\n");
+  assert.equal(result.calls.length, 2);
+});
+
+for (const [name, failure] of [
+  ["endpoint failure", unavailable],
+  ["malformed output", { status: 1, stdout: "not JSON" }],
+  ["missing report", { status: 1, stdout: "" }],
+  ["incomplete report with advisory counts", {
+    status: 1,
+    stdout: '{"error":{"code":"E503"},"metadata":{"vulnerabilities":{"total":1}}}',
+  }],
+] as const) {
+  test(`${name} remains a visible incomplete audit after bounded backoff`, options, context => {
+    const result = audit(context, [failure, failure, failure]);
+    assert.equal(result.execution.status, 2);
+    assert.equal(result.summary, "### npm audit: incomplete after three attempts\n");
+    assert.match(result.execution.stdout, /::error title=npm audit incomplete::/);
+    assert.equal(result.calls.length, 3);
+    assert.equal(result.delays, "10\n30\n");
+    assert.equal(readdirSync(result.reports).length, 6);
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      assert.equal(readFileSync(join(result.reports, `attempt-${attempt}.json`), "utf8"), failure.stdout);
+      assert.equal(readFileSync(join(result.reports, `attempt-${attempt}.stderr`), "utf8"), `npm diagnostic ${attempt}`);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Restore npm auditing as scheduled monitoring, not a merge gate. Fixes #5769.

- New standalone workflow runs daily at 05:23 UTC or on manual dispatch, with read-only repository permission and a ten-minute job timeout. It is not added to `ci-required` and has no push or PR trigger.
- Audit inspect-web's committed lockfile with stock `npm audit --package-lock-only --include=dev --audit-level=info --json`. No dependency installation or automatic fixes are needed.
- A small shell wrapper distinguishes native advisory reports (exit 1, no retry) from incomplete audits (10/30-second backoff, then exit 2). Success remains exit 0. Each attempt retains its JSON and stderr; Actions uploads them for 14 days, including on failure.
- Keep Dependabot. This adds an Actions signal, not a new advisory source or custom analyzer. The annotated-source-viewer prototype has no dependencies or lockfile today and is not an audit target.

**Design basis:** `prototypes/inspect-web/README.md#static-analysis` owns the scheduled monitoring claim. [npm audit](https://docs.npmjs.com/cli/v11/commands/npm-audit) owns vulnerability assessment and lockfile semantics. The existing scheduled CodeQL workflow supplies the standalone-workflow precedent. npm's [fetch implementation](https://github.com/npm/make-fetch-happen/blob/main/lib/remote.js) does not retry audit POSTs (also verified in installed npm 11.19.0), motivating the bounded whole-command retries. This is orchestration of off-the-shelf results, not additional detection rules or a security redesign.

## Demo

Before: Dependabot monitors the lockfile, but the removed merge-gating npm command supplies no scheduled Actions signal.

After, run the same script used by the workflow:

```console
$ cd prototypes/inspect-web
$ bash scripts/audit-dependencies.sh /tmp/inspect-web-npm-audit
### npm audit: no known advisories
```

That is a real audit of the current committed lockfile, not a mocked success.

A neighboring controlled-registry probe ran the same script with **real npm**, a development dependency, and an informational advisory; an outage case returned HTTP 503. No inspected package code was installed or executed. Its output:

```text
clean: exit=0
### npm audit: no known advisories
advisory: exit=1
### npm audit: advisories found
outage: exit=2
npm audit attempt 1 did not complete; preserving its report and stderr.
npm audit attempt 2 did not complete; preserving its report and stderr.
npm audit attempt 3 did not complete; preserving its report and stderr.
### npm audit: incomplete after three attempts
```

The native probe bypassed wall-clock sleeps; the checked-in tests assert the requested 10/30-second delays. Notice that the outage is not reported as a clean audit, and an advisory does not trigger repeated audit requests.

## Validation

- `node --test test/npm-audit.test.ts`: **8 passed**. Cases include clean results, informational advisories, transient recovery, advisory-after-retry, endpoint failure, malformed/missing output, and incomplete reports carrying counts. These run in the existing inspect-web Node suite; they test orchestration, not advisory detection.
- `bash -n scripts/audit-dependencies.sh`: passed.
- `npm run typecheck`: passed after restoring existing dependencies (`tsc` was initially missing).
- `npm run analyze`: passed; existing Knip configuration hints are unchanged.
- `npx --no-install markdownlint-cli prototypes/inspect-web/README.md` from the repository root: passed.
- Parsed the workflow with the existing `yaml` dependency: triggers are exactly `schedule` and `workflow_dispatch`.
- Live lockfile audit and real-npm controlled-registry probe: passed as demonstrated above.
- `git diff --check`: passed.

The hosted schedule is not yet active: a new scheduled workflow must land on the default branch. Normal PR CI remains required before review. Local probes are evidence for the script, not a claim that a hosted scheduled run has already occurred.

## Scope and review

This is one complete scheduled-monitoring slice for #5769, with the GitHub Actions scheduled/manual job as its consumer. It adds no product architecture, shared runtime substrate, host-neutral rendering domain, or dependency. Its only additional logic is outcome reporting and bounded retries requested by the issue. Broader analyzers, automatic remediation, new package ecosystems, vulnerability reproduction, exhaustive threat-model expansion, and new merge gates are outside scope. Maximum **three review rounds**; merge remains separately authorized.

Candidate: `51a1c2ce92aa44d3c1310c217474d4d1813d12fe`  
Effective base: `b7436df95e659d42200d310724e76f4415972615` (`main`)
