### PR TITLE
Document export-count pin discipline in ts-jsexport.md

### DIFF
--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -899,6 +899,17 @@ issue references below.
   mappings, compiles all seven `.js` and `.d.ts` outputs against the SDK-owned
   `dotnet.d.ts` from the engine's MSBuild-resolved Browser/Wasm runtime pack
   with host-independent LF output, and proves all 21 files are current;
+- the deployment and promotion verifiers pin the exact rooted-assembly set (the
+  seven names above) and structural invariants such as exactly one SDK
+  `create()` call, one runtime, and zero entry-point invocations, but assert
+  only `js_export_method_count > 0` rather than an exact total: the total
+  drifts with ordinary per-method feature work across seven independently
+  owned export classes, while the byte-for-byte source, declaration, and
+  published-JavaScript comparisons already in the same verifiers catch any
+  change to the exported surface. An exact-count assertion here would
+  duplicate that coverage while adding a value contributors must remember to
+  bump in lockstep across every workflow copy — see
+  [#6051](https://github.com/richlander/dotnet-inspect/issues/6051);
 - `verify-engine-facade-runtime.ts` executes the compiler-derived JavaScript
   without a `window` global, proves initialization performs no managed
   operation or entry-point call, and then exercises explicit host


### PR DESCRIPTION
Build robust, capable release paths whose deployment/promotion contract is
easy to describe, review, and change.

## Demo

Before this change, `docs/design/ts-jsexport.md`'s Acceptance section listed
`eng/generate-inspect-web-engine-facade.sh --check`'s guarantees but said
nothing about why `eng/verify-inspect-web-async-deployment.sh` (fixed in #6045)
asserts `js_export_method_count > 0` instead of an exact total. A future
contributor reading the design doc alone had no record of that decision and
could easily "fix" it by re-pinning an exact count, repeating the #6023/#6034
breakage cycle.

After this change, the Acceptance section records the rule: the seven
rooted-assembly names and structural invariants (one SDK `create()`, one
runtime, zero entry points) are stable enough to pin exactly because changing
them is a deliberate, reviewed architectural event; the total exported-method
count is not, because it drifts with ordinary per-method feature work spread
across those independently owned export classes — and it's already covered by
the byte-for-byte source/declaration/published-JS comparisons in the same
verifier, so an exact pin would only duplicate that coverage while adding a
value contributors must remember to bump in lockstep.

## Investigation (issue #6051)

This closes out issue #6051's three follow-up items:

1. **Other duplicated/manually-maintained facts.** Reviewed
   `eng/verify-inspect-web-async-deployment.sh`,
   `eng/generate-inspect-web-engine-facade.sh`,
   `eng/CiChangeDetection/PromotionWorkflowContract.cs`, and
   `tests/ILInspector.JsExportSurface.Tests`. No other production-surface
   magic-number pins remain: the exact-count assertions in
   `JsExportSurfaceBuilderTests.cs` (e.g. `Assert.Equal(53, ...)`) are against
   fixed, test-authored fixture assemblies, not the live inspect-web
   production surface, so they don't drift with ordinary feature work and
   don't need the same treatment.
2. **Making the deployment/promotion contract easier to describe and change.**
   `PromotionWorkflowContract.cs` already implements the single-template
   pattern the issue asked for: `BuildArtifactVerificationScript` is the one
   source of truth, and every workflow YAML copy is diffed byte-for-byte
   against it (`ValidateArtifactVerificationScript`), so drift between copies
   fails CI immediately. Replacing the workflow YAML copies themselves with a
   generated/templated file would introduce a new build-time YAML-generation
   architecture, which is a separate, larger decision requiring its own
   production-host adoption plan and explicit approval — not something to
   introduce speculatively here.
3. **Confirming coverage isn't lost.** The `> 0` check (added in #6045) is a
   liveness sanity check only; the real completeness guarantee is unchanged
   and lives in the same script's byte-for-byte comparisons of generated vs.
   checked-in facade sources, generated vs. compiled declarations, and
   compiled vs. published JavaScript. This PR documents that division of
   labor so it isn't rediscovered by another future contributor.

## Change

Markdown-only: one new bullet in `docs/design/ts-jsexport.md`'s Acceptance
section.

## Validation

- `npx markdownlint-cli docs/design/ts-jsexport.md` (clean)
