### PR TITLE
Add explicit ecosystem tool-package references

### DIFF
--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -35,6 +35,11 @@ namespace hints and core-package priorities, covered by the
 Executable source contributions retain separate prerequisites under #6012
 and #5728; the new metadata does not advertise traversal availability.
 
+Explicit [tool-package references](#tool-package-references) are implemented
+under #6060, beginning with `Aspire.Cli`. They are independent discovery
+metadata, not installation or execution actions; tool prefixes are not part
+of this contribution.
+
 Participating normative owner:
 
 - [Static workspaces: definitions, assembly groups, and projections](workspace-definitions.md#product-demos-are-closed-section-presets)
@@ -91,6 +96,7 @@ One pack registration may contain:
 
 - stable ecosystem identity and product-owned discovery metadata;
 - compact namespace hints and ordered core-package starting points;
+- explicit tool-package references;
 - one optional package-set identity;
 - zero or more ordered package-prefix discovery entries; and
 - one optional Integration-owned static scanner binding; and
@@ -172,6 +178,7 @@ EcosystemPackRegistration
   Descriptor   EcosystemPackDescriptor
   NamespaceRoots immutable ordered namespace-root sequence
   CorePackages immutable ordered PackageCoordinate sequence
+  ToolPackages immutable ordered PackageCoordinate sequence
   PackageSet   PackageSetId?
   Prefixes     immutable ordered EcosystemPackagePrefix sequence
   Scanner      EcosystemIntegrationScannerBinding?
@@ -215,7 +222,7 @@ a parallel demo ID or infer identity from title, order, package coordinate, or
 ecosystem.
 
 The public discovery boundary exposes immutable pack, prefix-action, and demo
-descriptor metadata, namespace roots, core-package priorities, package-set
+descriptor metadata, namespace roots, core-package priorities, tool references, package-set
 identity, and whether a scanner is available.
 `EcosystemPackDescriptor.HasScanner` reports scanner availability without
 exposing the binding. `EcosystemPackCatalog.SelectScanner` accepts the exact
@@ -503,8 +510,9 @@ rather than deriving expectations from either registry.
 This is a deliberate split between two co-located static tables. For its
 curated-set contribution, the pack carries only `PackageSetId`, not package-set
 descriptors, registrations, membership coordinates, or registry access.
-Independent core-package references are governed by the separate
-[retrieval-knowledge contract](#retrieval-hints-and-core-packages). Literal
+Independent core-package and tool references are governed by the
+[retrieval-knowledge contract](#retrieval-hints-and-core-packages) and
+[tool-package contract](#tool-package-references). Literal
 application gates prove shipped references resolve, while the generic discovery
 gate retains the no-lookup runtime contract without asserting static
 initialization timing.
@@ -624,6 +632,64 @@ supply implementations. Their operational progress does not block this inert
 catalog contract and does not transfer their semantics into it. Scope
 admission, query populations, Workspace editing, persistence, and #6024's
 editor/Save/Inspect boundary remain outside this slice.
+
+## Tool-package references
+
+The catalog may contribute an independent, immutable, authored-order
+`ToolPackages` sequence under the descriptor's exact `EcosystemPackId`.
+These are explicit package references for .NET tools, not core API starting
+points, curated membership, package prefixes, or commands. Discovery and exact
+lookup preserve the same sequence. Empty means no authored contribution, not
+that an ecosystem has no tools.
+
+Entries use the package owner's `PackageCoordinate` and its existing intrinsic
+validation. As with core references, they have no version, framework, or
+runtime-identifier override. Null sequences or entries, invalid coordinates,
+overrides, and duplicate IDs within one tool sequence under ordinal
+case-insensitive equality fail complete registry construction visibly.
+Authored spelling and order survive publication. References may overlap
+between packs or contribution roles; no correspondence, exclusive ownership,
+or automatic union is inferred.
+
+Tool references remain separate from namespace hints, core priorities, and the
+curated `PackageSetId`. The catalog neither derives them from those neighbors
+nor resolves a package set to publish them. They do not create an action or
+satisfy the existing contributed-capability requirement by themselves.
+Reading them does not select a demo or scanner, acquire an inspected package,
+add a package to an inspection population, install a tool, or execute a command.
+No tool-prefix or expected/maximum-package-count field is part of this
+contribution. Operation limits remain consumer-owned.
+
+### Authored tool evidence
+
+An entry identifies a package the product has chosen as a .NET tool.
+Authorship uses published package metadata and ecosystem documentation, not
+name heuristics: a `.Tools` suffix does not establish `DotnetTool` packaging.
+The catalog validates coordinate shape without contacting a source; it does
+not claim that every future resolved version has a particular package type,
+command name, platform support, or compatibility with an inspected workspace.
+Any later operational consumer must use the resolved package's actual metadata
+under its source/operation contract rather than treating this reference as
+installation or execution authority.
+
+The first contribution is unversioned `Aspire.Cli` on the existing Aspire
+pack. Its [published 13.5.3 nuspec][aspire-cli-nuspec] declares `DotnetTool`,
+and [Aspire's installation documentation][aspire-cli-install] identifies the
+package as its .NET tool. The observed version is authorship evidence, not
+a manifest pin. `dotnet-ef` and `dotnet-grpc` demonstrate why tool package IDs
+cannot be inferred from API package prefixes; `Grpc.Tools` is instead a
+build-time dependency. These are supporting examples, not new pack
+registrations or a proposal for tool-prefix discovery.
+
+[aspire-cli-nuspec]: https://api.nuget.org/v3-flatcontainer/aspire.cli/13.5.3/aspire.cli.nuspec
+[aspire-cli-install]: https://aspire.dev/get-started/install-cli/
+
+The contribution follows the existing static metadata pattern within catalog
+stage 2 of #6012, coordinated by #5728. Its production consumers remain CLI
+and `InspectWeb.Engine.CatalogExports`; visible metadata adoption stays with
+their stages 6 and 7. No installation/execution path, new renderer, or source
+contract is introduced. The [tool-reference gates](#tool-reference-gates)
+enforce this catalog slice; they do not certify future package versions.
 
 ## Recorded package prefixes
 
@@ -819,6 +885,9 @@ capabilities:
 | ASP.NET Core | `Microsoft.AspNetCore` | `Microsoft.AspNetCore.OpenApi`, `Microsoft.AspNetCore.Authentication.JwtBearer` |
 | Aspire | `Aspire` | `Aspire.Hosting` |
 
+Aspire additionally contributes `Aspire.Cli` in its separate tool-package
+sequence; the other three packs contribute no tool references.
+
 Each root is a compact descriptive subtree, not a package correspondence.
 The Extensions entries prioritize foundational DI, configuration, and logging
 contracts even though the curated set excludes shared-framework-covered
@@ -923,6 +992,30 @@ A neighboring pack can have no roots, no core entries, and an existing demo
 capability; a hint-only registration remains invalid. A second pack may
 declare one of the same roots without either claiming exclusive ownership.
 
+Explicit tools use the same inert discovery boundary:
+
+```csharp
+var aspire = ((EcosystemPackLookupResult.Known)EcosystemPackCatalog.Lookup(
+    EcosystemPackIds.Aspire)).Descriptor;
+Console.WriteLine(aspire.Id);
+Console.WriteLine($"  Core packages: {string.Join(", ", aspire.CorePackages.Select(p => p.PackageId))}");
+Console.WriteLine($"  Tool packages: {string.Join(", ", aspire.ToolPackages.Select(p => p.PackageId))}");
+Console.WriteLine($"  Curated set: {aspire.PackageSet}");
+```
+
+Output:
+
+```text
+ecosystem.aspire
+  Core packages: Aspire.Hosting
+  Tool packages: Aspire.Cli
+  Curated set: package-set.aspire
+```
+
+The neighboring Microsoft.Extensions pack still has core references and a
+curated-set identity but an empty tool sequence. Neither reading activates an
+existing capability or installs anything.
+
 Scanner selection is a shared application-catalog API, not a new CLI or
 browser action:
 
@@ -1000,6 +1093,19 @@ consumer gates.
 | `ProductEcosystemPackTests.ShippedRetrievalKnowledgeMatchesLiteralPolicy` | All four packs retain literal authored roots and core priorities, including Platform's empty core sequence. |
 | `PackageSetRegistryConsumerTests.PublicSurfaceKeepsCoreReferencesSeparateFromCuratedMembership` | An ordinary non-friend consumer reads immutable knowledge through discovery/lookup; Extensions core entries and curated membership remain distinct, and Platform gains no package-set or scanner capability. |
 
+### Tool-reference gates
+
+These active Release gates cover explicit catalog references, not remote
+package-type classification or tool execution:
+
+| Gate | Required outcome |
+| --- | --- |
+| `EcosystemPackRegistryTests.ToolReferencesRemainIndependentAndInert` | Exact identity, authored order, immutable snapshots, and independent contribution roles survive discovery/lookup, including cross-pack overlap and an unregistered curated-set ID; selecting an existing capability invokes no neighbor. |
+| `EcosystemPackRegistryTests.InvalidToolPackagesFailBeforePublication` and `MissingKnowledgeSequencesFailBeforePublication` | Invalid/null references or sequences, overrides, and within-list duplicate IDs fail complete publication visibly. |
+| `EcosystemPackRegistryTests.EmptyKnowledgePreservesCapabilityRequirements` | Empty tool contributions remain empty, and tool references alone do not satisfy the existing capability requirement. |
+| `ProductEcosystemPackTests.ShippedToolPackagesMatchLiteralPolicy` | Only Aspire contributes a tool reference, exactly unversioned `Aspire.Cli`; other shipped packs remain empty. |
+| `PackageSetRegistryConsumerTests.PublicSurfaceSeparatesToolsFromInspectionPackages` | An ordinary non-friend consumer reads the explicit tool separately from core references and curated membership through the public catalog. |
+
 ### Existing and staged capability gates
 
 The pattern's target Release suite is `EcosystemPackRegistryTests` plus an
@@ -1036,9 +1142,10 @@ descriptor and reference expectations, plus
 `ProductEcosystemPackTests.ShippedPackManifestKeepsCuratedMembershipAsIdentity`.
 That gate checks that registration and descriptor property shapes carry
 `PackageSetId` and no package-set descriptor, registration, or registry
-property. Independent core coordinates are permitted; their authored content
-and distinction from curated membership are covered by the
-[retrieval-knowledge gates](#retrieval-knowledge-gates).
+property. Independent core and tool coordinates are permitted; their authored
+content and distinction from curated membership are covered by the
+[retrieval-knowledge gates](#retrieval-knowledge-gates) and
+[tool-reference gates](#tool-reference-gates).
 `EcosystemPackRegistryTests.SyntheticManifestIsDiscoverableInDeclaredOrder`
 constructs and discovers a pack with an unregistered package-set identity,
 gating the generic registry path's no-lookup behavior.
@@ -1119,6 +1226,7 @@ This design does not define:
 - an ecosystem class, module object, scanner object, factory, service
   provider, or execution graph;
 - package-set membership or prefix-query results;
+- tool-prefix discovery, tool installation, or command execution;
 - a new Integration concept, classifier, evidence shape, or query;
 - package acquisition or workspace behavior;
 - demo definition-record, resolution, section, run-plan, or execution

--- a/src/DotnetInspector.Ecosystems.Tests/EcosystemPackRegistryTests.cs
+++ b/src/DotnetInspector.Ecosystems.Tests/EcosystemPackRegistryTests.cs
@@ -106,7 +106,7 @@ public sealed class EcosystemPackRegistryTests
         Assert.Equal(0, s_firstInvocations);
     }
 
-    public static TheoryData<PackageCoordinate[]> InvalidCorePackages => new()
+    public static TheoryData<PackageCoordinate[]> InvalidPackageReferences => new()
     {
         { [null!] },
         { [new(null!)] },
@@ -122,7 +122,7 @@ public sealed class EcosystemPackRegistryTests
     };
 
     [Theory]
-    [MemberData(nameof(InvalidCorePackages))]
+    [MemberData(nameof(InvalidPackageReferences))]
     public void InvalidCorePackagesFailBeforePublication(PackageCoordinate[] corePackages)
     {
         s_firstInvocations = 0;
@@ -138,11 +138,77 @@ public sealed class EcosystemPackRegistryTests
     }
 
     [Fact]
+    public void ToolReferencesRemainIndependentAndInert()
+    {
+        s_firstInvocations = 0;
+        s_secondInvocations = 0;
+        s_firstScannerInvocations = 0;
+        PackageCoordinate[] tools = [new("Example.Tool.Zeta"), new("Example.Tool.Alpha")];
+        var scanner = EcosystemIntegrationScannerBinding.Create(ScanFirst);
+        EcosystemPackRegistry registry = Registry(
+            Pack("ecosystem.first", 100, "package-set.not-registered", Demo("first", 100, CreateFirstRecords))
+            with
+            {
+                NamespaceRoots = ["Unrelated"],
+                CorePackages = [new("Example.Tool.Alpha")],
+                ToolPackages = tools,
+                Scanner = scanner,
+            },
+            Pack("ecosystem.second", 200, null, Demo("second", 200, CreateSecondRecords))
+            with { ToolPackages = [new("example.tool.alpha")] });
+        tools[0] = new("Changed");
+
+        EcosystemPackDescriptor first = registry.Packs[0];
+        EcosystemPackDescriptor second = registry.Packs[1];
+        Assert.Equal(["Example.Tool.Zeta", "Example.Tool.Alpha"],
+            first.ToolPackages.Select(package => package.PackageId));
+        Assert.Equal("Example.Tool.Alpha", Assert.Single(first.CorePackages).PackageId);
+        Assert.Equal(["Unrelated"], first.NamespaceRoots);
+        Assert.Equal("package-set.not-registered", first.PackageSet!.Value);
+        Assert.Equal("ecosystem.second", second.Id.Value);
+        Assert.Equal("example.tool.alpha", Assert.Single(second.ToolPackages).PackageId);
+        Assert.Empty(second.CorePackages);
+        Assert.Empty(second.NamespaceRoots);
+        Assert.All(registry.Packs, pack => Assert.Same(
+            pack,
+            Assert.IsType<EcosystemPackLookupResult.Known>(registry.Lookup(pack.Id)).Descriptor));
+        Assert.Equal(0, s_firstInvocations);
+        Assert.Equal(0, s_secondInvocations);
+        Assert.Equal(0, s_firstScannerInvocations);
+
+        _ = registry.SelectDemo("first");
+        Assert.Same(scanner, Assert.IsType<EcosystemScannerSelectionResult.Known>(
+            registry.SelectScanner(first.Id)).Binding);
+        Assert.IsType<EcosystemScannerSelectionResult.Unavailable>(
+            registry.SelectScanner(second.Id));
+        Assert.Equal(1, s_firstInvocations);
+        Assert.Equal(0, s_secondInvocations);
+        Assert.Equal(0, s_firstScannerInvocations);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidPackageReferences))]
+    public void InvalidToolPackagesFailBeforePublication(PackageCoordinate[] toolPackages)
+    {
+        s_firstInvocations = 0;
+        ArgumentException error = Assert.Throws<ArgumentException>(() => Registry(
+            Pack("ecosystem.first", 100, null, Demo("first", 100, CreateFirstRecords)),
+            Pack("ecosystem.second", 200, "package-set.second")
+            with { ToolPackages = toolPackages }));
+
+        Assert.Contains("ecosystem.second", error.Message);
+        Assert.Contains("tool", error.Message);
+        Assert.Equal("registrations", error.ParamName);
+        Assert.Equal(0, s_firstInvocations);
+    }
+
+    [Fact]
     public void MissingKnowledgeSequencesFailBeforePublication()
     {
         EcosystemPackRegistration pack = Pack("ecosystem.first", 100, "package-set.first");
         Assert.Throws<ArgumentException>(() => Registry(pack with { NamespaceRoots = null! }));
         Assert.Throws<ArgumentException>(() => Registry(pack with { CorePackages = null! }));
+        Assert.Throws<ArgumentException>(() => Registry(pack with { ToolPackages = null! }));
     }
 
     [Fact]
@@ -154,6 +220,7 @@ public sealed class EcosystemPackRegistryTests
 
         Assert.Empty(descriptor.NamespaceRoots);
         Assert.Empty(descriptor.CorePackages);
+        Assert.Empty(descriptor.ToolPackages);
         Assert.False(descriptor.HasScanner);
         Assert.IsType<EcosystemScannerSelectionResult.Unavailable>(
             registry.SelectScanner(descriptor.Id));
@@ -163,6 +230,9 @@ public sealed class EcosystemPackRegistryTests
         Assert.Throws<ArgumentException>(() => Registry(
             Pack("ecosystem.core-only", 100, null)
             with { CorePackages = [new("Example.Core")] }));
+        Assert.Throws<ArgumentException>(() => Registry(
+            Pack("ecosystem.tools-only", 100, null)
+            with { ToolPackages = [new("Example.Tool")] }));
     }
 
     [Fact]

--- a/src/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
+++ b/src/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
@@ -156,6 +156,19 @@ public sealed class ProductEcosystemPackTests
     }
 
     [Fact]
+    public void ShippedToolPackagesMatchLiteralPolicy()
+    {
+        Assert.Collection(
+            EcosystemPackCatalog.Discover(),
+            platform => Assert.Empty(platform.ToolPackages),
+            extensions => Assert.Empty(extensions.ToolPackages),
+            aspNetCore => Assert.Empty(aspNetCore.ToolPackages),
+            aspire => Assert.Equal(
+                new PackageCoordinate("Aspire.Cli"),
+                Assert.Single(aspire.ToolPackages)));
+    }
+
+    [Fact]
     public void ShippedDemoManifestMatchesLiteralPolicy()
     {
         var expected = new[]

--- a/src/DotnetInspector.Ecosystems/EcosystemPackDescriptor.cs
+++ b/src/DotnetInspector.Ecosystems/EcosystemPackDescriptor.cs
@@ -17,7 +17,8 @@ public sealed class EcosystemPackDescriptor
         IEnumerable<EcosystemDemoDescriptor> demos,
         bool hasScanner,
         ImmutableArray<string> namespaceRoots,
-        ImmutableArray<PackageCoordinate> corePackages)
+        ImmutableArray<PackageCoordinate> corePackages,
+        ImmutableArray<PackageCoordinate> toolPackages)
     {
         Id = id;
         Title = title;
@@ -28,6 +29,7 @@ public sealed class EcosystemPackDescriptor
         HasScanner = hasScanner;
         NamespaceRoots = namespaceRoots;
         CorePackages = corePackages;
+        ToolPackages = toolPackages;
     }
 
     public EcosystemPackId Id { get; }
@@ -49,6 +51,9 @@ public sealed class EcosystemPackDescriptor
 
     /// <summary>Unversioned starting points in pack-local preference order, independent of curated membership.</summary>
     public ImmutableArray<PackageCoordinate> CorePackages { get; }
+
+    /// <summary>Explicit unversioned .NET tool references in authored order, not installation requests.</summary>
+    public ImmutableArray<PackageCoordinate> ToolPackages { get; }
 }
 
 /// <summary>Immutable product metadata for one ecosystem demo.</summary>

--- a/src/DotnetInspector.Ecosystems/EcosystemPackRegistry.cs
+++ b/src/DotnetInspector.Ecosystems/EcosystemPackRegistry.cs
@@ -23,6 +23,8 @@ internal sealed record EcosystemPackRegistration(
     public IReadOnlyList<string> NamespaceRoots { get; init; } = [];
 
     public IReadOnlyList<PackageCoordinate> CorePackages { get; init; } = [];
+
+    public IReadOnlyList<PackageCoordinate> ToolPackages { get; init; } = [];
 }
 
 internal sealed class EcosystemPackRegistry
@@ -89,7 +91,11 @@ internal sealed class EcosystemPackRegistry
             ImmutableArray<string> namespaceRoots =
                 SnapshotNamespaceRoots(registration, nameof(registrations));
             ImmutableArray<PackageCoordinate> corePackages =
-                SnapshotCorePackages(registration, nameof(registrations));
+                SnapshotPackageReferences(
+                    registration.Id, registration.CorePackages, "core", nameof(registrations));
+            ImmutableArray<PackageCoordinate> toolPackages =
+                SnapshotPackageReferences(
+                    registration.Id, registration.ToolPackages, "tool", nameof(registrations));
             EcosystemDemoRegistration[] demos =
             [
                 .. registration.Demos
@@ -167,7 +173,8 @@ internal sealed class EcosystemPackRegistry
                 descriptors.MoveToImmutable(),
                 registration.Scanner is not null,
                 namespaceRoots,
-                corePackages);
+                corePackages,
+                toolPackages);
             _packsById.Add(
                 packDescriptor.Id,
                 new PackEntry(packDescriptor, registration.Scanner));
@@ -256,15 +263,17 @@ internal sealed class EcosystemPackRegistry
         return roots;
     }
 
-    private static ImmutableArray<PackageCoordinate> SnapshotCorePackages(
-        EcosystemPackRegistration registration,
+    private static ImmutableArray<PackageCoordinate> SnapshotPackageReferences(
+        EcosystemPackId packId,
+        IReadOnlyList<PackageCoordinate> references,
+        string role,
         string parameterName)
     {
         ImmutableArray<PackageCoordinate> packages =
         [
-            .. registration.CorePackages
+            .. references
                 ?? throw new ArgumentException(
-                    $"Ecosystem pack '{registration.Id}' has no core-package sequence.",
+                    $"Ecosystem pack '{packId}' has no {role}-package sequence.",
                     parameterName),
         ];
         var packageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -273,7 +282,7 @@ internal sealed class EcosystemPackRegistry
             if (package is null)
             {
                 throw new ArgumentException(
-                    $"Ecosystem pack '{registration.Id}' contains a null core package.",
+                    $"Ecosystem pack '{packId}' contains a null {role} package.",
                     parameterName);
             }
 
@@ -282,7 +291,7 @@ internal sealed class EcosystemPackRegistry
             if (invalid is not null)
             {
                 throw new ArgumentException(
-                    $"Ecosystem pack '{registration.Id}' contains invalid core package"
+                    $"Ecosystem pack '{packId}' contains invalid {role} package"
                     + $" coordinate '{package.PackageId}': {invalid.Message}",
                     parameterName);
             }
@@ -292,15 +301,15 @@ internal sealed class EcosystemPackRegistry
                 || package.RuntimeIdentifier is not null)
             {
                 throw new ArgumentException(
-                    $"Ecosystem pack '{registration.Id}' contains a versioned or"
-                    + " target-specific core-package coordinate.",
+                    $"Ecosystem pack '{packId}' contains a versioned or"
+                    + $" target-specific {role}-package coordinate.",
                     parameterName);
             }
 
             if (!packageIds.Add(package.PackageId))
             {
                 throw new ArgumentException(
-                    $"Ecosystem pack '{registration.Id}' contains duplicate core-package"
+                    $"Ecosystem pack '{packId}' contains duplicate {role}-package"
                     + $" ID '{package.PackageId}'.",
                     parameterName);
             }

--- a/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
+++ b/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
@@ -72,6 +72,7 @@ internal static class ProductEcosystemPacks
         {
             NamespaceRoots = ["Aspire"],
             CorePackages = [new("Aspire.Hosting")],
+            ToolPackages = [new("Aspire.Cli")],
         },
     ]);
 

--- a/tests/DotnetInspector.Ecosystems.Consumer.Tests/PackageSetRegistryConsumerTests.cs
+++ b/tests/DotnetInspector.Ecosystems.Consumer.Tests/PackageSetRegistryConsumerTests.cs
@@ -85,6 +85,26 @@ public sealed class PackageSetRegistryConsumerTests
     }
 
     [Fact]
+    public void PublicSurfaceSeparatesToolsFromInspectionPackages()
+    {
+        EcosystemPackDescriptor aspire = Assert.IsType<EcosystemPackLookupResult.Known>(
+            EcosystemPackCatalog.Lookup(EcosystemPackIds.Aspire)).Descriptor;
+        ImmutableArray<PackageCoordinate> tools = aspire.ToolPackages;
+
+        Assert.Same(aspire, EcosystemPackCatalog.Discover().Single(
+            pack => pack.Id == EcosystemPackIds.Aspire));
+        Assert.Equal(new PackageCoordinate("Aspire.Cli"), Assert.Single(tools));
+        Assert.Equal(new PackageCoordinate("Aspire.Hosting"), Assert.Single(aspire.CorePackages));
+        Assert.Equal(PackageSetIds.Aspire, aspire.PackageSet);
+        PackageSetDescriptor curated = Assert.IsType<PackageSetLookupResult.Known>(
+            PackageSetCatalog.Lookup(aspire.PackageSet!)).Descriptor;
+        Assert.DoesNotContain(curated.Members, package => package.PackageId == "Aspire.Cli");
+        Assert.All(
+            EcosystemPackCatalog.Discover().Where(pack => pack.Id != EcosystemPackIds.Aspire),
+            pack => Assert.Empty(pack.ToolPackages));
+    }
+
+    [Fact]
     public void PublicSurfaceHandsSelectedScannerToIntegrationOwner()
     {
         EcosystemPackDescriptor aspire = Assert.Single(


### PR DESCRIPTION
This advances robust ecosystem discovery through the existing, conventional
immutable catalog: explicit tool references keep a useful ecosystem relationship
without confusing tools with API starting points or curated inspection packages.

Closes #6060. Catalog stage 2 of #6012, coordinated under #5728.

## Demo

The public catalog now exposes `Aspire.Cli` beside, not inside, Aspire's core
packages or curated set. This is actual Release API output:

```text
ecosystem.aspire
  Core packages: Aspire.Hosting
  Tool packages: Aspire.Cli
  Curated set: package-set.aspire
ecosystem.microsoft-extensions
  Core packages: Microsoft.Extensions.DependencyInjection.Abstractions, Microsoft.Extensions.Configuration.Abstractions, Microsoft.Extensions.Logging.Abstractions
  Tool packages: (none)
  Curated set: package-set.microsoft-extensions
```

Equivalent catalog read:

```csharp
foreach (var id in new[] { EcosystemPackIds.Aspire, EcosystemPackIds.MicrosoftExtensions })
{
    var pack = ((EcosystemPackLookupResult.Known)EcosystemPackCatalog.Lookup(id)).Descriptor;
    Console.WriteLine(pack.Id);
    Console.WriteLine($"  Core packages: {string.Join(", ", pack.CorePackages.Select(p => p.PackageId))}");
    Console.WriteLine($"  Tool packages: {(pack.ToolPackages.IsEmpty ? "(none)" : string.Join(", ", pack.ToolPackages.Select(p => p.PackageId)))}");
    Console.WriteLine($"  Curated set: {pack.PackageSet}");
}
```

Previously there was no explicit tool-reference contribution. The neighboring
Microsoft.Extensions pack remains empty for tools; reading either pack selects
no capability and installs nothing.

## Design basis and scope

**Normative owner:**
[`docs/design/ecosystem-packs.md#tool-package-references`](docs/design/ecosystem-packs.md#tool-package-references).
The catalog publishes an independent immutable, authored-order sequence of
unversioned .NET tool references under each exact ecosystem identity.

The existing Packages-owned `PackageCoordinate` and intrinsic validator supply
coordinate grammar. The existing catalog owns complete registration validation,
snapshot publication, exact lookup, and capability selection. This change
reuses those mechanisms and shares the private core/tool reference validation
loop; it adds no new cross-cutting pattern.

Published [`Aspire.Cli` 13.5.3 metadata](https://api.nuget.org/v3-flatcontainer/aspire.cli/13.5.3/aspire.cli.nuspec)
declares `DotnetTool`, and [official Aspire documentation](https://aspire.dev/get-started/install-cli/)
identifies its use. That version is authorship evidence, not a catalog pin.
The design distinguishes product-authored references from metadata about a
future resolved version. Examples such as `dotnet-ef`, `dotnet-grpc`, and
`Grpc.Tools` justify explicit classification instead of package-name heuristics;
this PR adds no new packs for those examples.

**Boundary cases:** an unregistered curated-set ID does not prevent tool
metadata discovery; authored order and spelling survive input-array mutation;
overlap with a core reference or another pack is allowed; duplicates within a
tool list, null/malformed entries, and version/target overrides fail publication.
Tools alone do not change the existing capability requirement.

**Consumer/adoption path:** CLI and `InspectWeb.Engine.CatalogExports` remain the
production consumers. The existing eight-stage path in #6012 is source/resolution,
catalog, Scope, query populations, Workspace Definitions, CLI, browser, and
authorized release/deployment. This is additional metadata in stage 2; visible
host adoption remains in stages 6 and 7. No architecture is being replaced, so
there is no retirement plan. Rendering is unchanged; this slice adds typed
catalog data rather than a host presentation path.

**Explicit non-actions:** no tool prefixes, expected/max-package-count fields,
source protocol, installation, execution, automatic traversal-population
admission, Scope/query/Workspace UI changes, or editor persistence. The user
approved concrete tools only. Existing platform contracts and defaults apply.
The pending recorded-prefix/source-request mismatch is not reopened here.

## Validation

- `dotnet run --project src/DotnetInspector.Ecosystems.Tests -c Release`:
  **89 passed**.
- `dotnet run --project tests/DotnetInspector.Ecosystems.Consumer.Tests -c Release`:
  **5 passed**.
- Actual public API demo executed in Release with `EnablePreviewFeatures=true`.
- `npx --no-install markdownlint-cli docs/design/ecosystem-packs.md`: passed.
- `git diff --check`: passed.

The owner document names the enforcing outcome-level gates. The suites already
run in normal CI; no new test tooling or CI expansion is introduced.

## Candidate

- Head: `5271161653432bde0a8f44efa916e4b07a19ea3f`.
- Effective base: `7617825b2883553f609961fe9ebdcf2486d2426c`.
- Branch: `feat/ecosystem-tool-packages`, targeting `main`.
- Round 1: **CLEAN** from GPT-6 Astra, Claude Opus 5, and GPT-5.6 Sol.
- [Reconciliation and no-interaction carry-forward](https://github.com/richlander/dotnet-inspect/pull/6062#issuecomment-5556647533).
