### PR TITLE
Widen fixture timing budget to fix flaky operation-timeout tests

### DIFF
--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -1204,8 +1204,16 @@ public sealed class SourceScopedRoutingTests : IDisposable
         ];
         var handlers = new List<NeverCompletesHandler>();
         const string SuccessFlat = "https://success.example/v3/flat2/";
+        // A 500ms request budget (2000ms operation ceiling, 4x per
+        // NuGetFetchOptions.FromRequestTimeout) leaves headroom for the two
+        // real request/response round trips (service index, then flat
+        // container) the first source's canned handler must complete before
+        // the deadline check runs. That check compares wall-clock elapsed
+        // time, not cancellation state, so a too-tight budget can time out
+        // an already-answered canned response under ordinary CI scheduling
+        // jitter alone -- see issue #6036.
         await using var composition = new DesktopPackageSourceComposition(
-            TimeSpan.FromMilliseconds(50),
+            TimeSpan.FromMilliseconds(500),
             new UnavailableCredentialSource(),
             (source, _) =>
             {
@@ -1277,8 +1285,13 @@ public sealed class SourceScopedRoutingTests : IDisposable
             : SuccessSource;
         if (localSuccess)
             WriteLocalPackage(successSource, "timeout-failover", "1.0.0");
+        // See the identical rationale in
+        // OperationContext_OperationTimeoutIsTerminalAcrossAuthorities
+        // (issue #6036): the surviving source's canned handler needs enough
+        // request budget to complete its round trips before a wall-clock
+        // deadline check can spuriously treat it as expired.
         await using var composition = new DesktopPackageSourceComposition(
-            TimeSpan.FromMilliseconds(50),
+            TimeSpan.FromMilliseconds(500),
             new UnavailableCredentialSource(),
             (source, _) => source.Url == TimedOutSource
                 ? new NeverCompletesHandler()


### PR DESCRIPTION
## Demo

Before (main): `SourceScopedRoutingTests.OperationContext_OperationTimeoutIsTerminalAcrossAuthorities` occasionally failed in CI (issue #6036) with:

```
Expected: ["1.0.0"], Actual: []
```

After: the same test (and its sibling `OperationContext_RequestTimeoutContinuesToLaterAuthorityWithinCeiling`, which shares the identical race) pass reliably, verified via 5 repeated targeted runs plus the full `SourceScopedRoutingTests` class (91/91).

## Root cause (resolves #6036)

Both tests used a 50ms per-request timeout (200ms operation ceiling, `RequestTimeout * 4` per `NuGetFetchOptions.FromRequestTimeout`) to force `NeverCompletesHandler` sources to hit the operation deadline quickly. That same tight budget also had to cover a *surviving* canned-response source completing two real request/response round trips (service index, then flat container) before the deadline check ran.

`NuGetOperationDeadline.RunRequestAsync`'s per-request expiry check (`ThrowIfRequestExpired`) compares wall-clock elapsed time since the request started, not whether the per-request `CancellationTokenSource` actually fired. So an already-answered canned response can still be judged "expired" if ordinary CI scheduling jitter (thread-pool contention, GC pauses) delays the post-await continuation past the 50ms budget -- even though no real I/O was outstanding.

This is a fixture timing assumption, not a product defect:

- `DesktopPackageSourceComposition.GetVersionsAsync` correctly preserves evidence admitted before an operation timeout forces the final state to `Failed`/`Partial`.
- `NuGetOperationDeadline`'s deadline math is correctly derived (`RequestTimeout * 4 == OperationTimeout`).

## Fix

Raise the request timeout from 50ms to 500ms (2000ms operation ceiling) in both tests. This gives the surviving source 10x more headroom against CI scheduling jitter while preserving each test's qualitative assertions unchanged:

- the operation timeout is terminal across authorities,
- not all remaining sources are attempted before the ceiling is reached,
- evidence admitted before the deadline survives.

Kept scoped to these two tests only; no product code changed. Left PR #5809's unrelated row-selection change untouched per issue #6036's instruction.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-method '*OperationContext_OperationTimeoutIsTerminalAcrossAuthorities' --filter-method '*OperationContext_RequestTimeoutContinuesToLaterAuthorityWithinCeiling'` -- run 5x, all green, no flakes.
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class DotnetInspector.Tests.SourceScopedRoutingTests` -- 91/91 passed.

Closes #6036.
