### PR TITLE
Refine Member Facts Calls presentation

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -355,8 +355,28 @@ moves above the type. Long types, offsets, and property values wrap within
 their occurrence. This trades some vertical density for complete visible
 evidence without horizontal scrolling. A successful empty result retains
 the section and its explicit absence message; loading and failure remain
-separate top-level Facts states. Calls and subsequent detail sections retain
-their existing presentation.
+separate top-level Facts states.
+
+Calls follows the same readable measure and separator treatment. Each returned
+site retains its IL offset, opcode, callee, multiplicity, and loop flag. The
+callee is the primary row text, with offset and opcode beside it and compact
+Multiplicity and Loop properties below. At constrained pane widths provenance
+moves above the callee; long signatures, offsets, and property values wrap
+within the site rather than widening the scroller.
+
+The returned order and repeated callees remain intact. The section count
+describes static call sites, not executions or distinct callees. Loop membership
+uses explicit `yes` and `no`; opcode and multiplicity retain their returned
+values without a stronger dispatch or execution claim. Callee text and offsets
+remain non-interactive evidence rather than inferred navigation identities.
+The existing typed `kind` value remains undisplayed.
+
+This presentation trades some vertical density for visible evidence without
+horizontal scrolling; it does not hide, group, or truncate sites to reduce
+height. A successful empty Calls result retains the section, zero count, and
+explicit absence message. Loading and failure remain separate top-level Facts
+states. Safety facts and subsequent detail sections retain their existing
+presentation.
 
 #### Graph Explore
 

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -42,7 +42,7 @@ import {
 } from "../src/type-panel.ts";
 import { renderMemberContractSections } from "../src/member-overview.ts";
 import { renderMemberFacts } from "../src/member-facts.ts";
-import { allocationFactsFixture, memberFactsFixture } from "../test/member-facts-fixture.ts";
+import { allocationFactsFixture, callFactsFixture, memberFactsFixture } from "../test/member-facts-fixture.ts";
 import {
   bindWorkspaceSubject,
   focusWorkspace,
@@ -105,6 +105,7 @@ const packageMode =
 const memberMode = params.has("member");
 const memberFactsMode = params.get("member-facts");
 const allocationFactsMode = params.get("allocation-facts");
+const callFactsMode = params.get("call-facts");
 const memberDocumentationMode = params.get("member-docs") ?? "missing";
 const longSignatureMode = params.has("long-signature");
 const emptyMode = params.has("empty");
@@ -229,7 +230,7 @@ let activeTypeLens: TypeLens = sourceMode
     : "api";
 let activeMemberSection: MemberSection = sourceMode
   ? "source"
-  : memberFactsMode || allocationFactsMode ? "facts" : "overview";
+  : memberFactsMode || allocationFactsMode || callFactsMode ? "facts" : "overview";
 let contentFramePane: ContentFramePane = "detail";
 let contentFrameFocusOwner: ContentFrameFocusOwner = null;
 let contentFrameReplacementFocusOwner: ContentFrameFocusOwner = null;
@@ -398,7 +399,9 @@ function detailHtml() {
         : "populated";
       const facts = allocationFactsMode
         ? allocationFactsFixture(allocationFactsMode === "long" ? "long" : "populated")
-        : memberFactsFixture(mode);
+        : callFactsMode
+          ? callFactsFixture(callFactsMode === "long" ? "long" : "populated")
+          : memberFactsFixture(mode);
       return `<section class="member-surface" aria-labelledby="member-surface-title">
         <header class="api-surface-head member-surface-head">
           <h1 id="member-surface-title">DeserializeSync</h1>

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { callFactsFixture } from "../test/member-facts-fixture.ts";
 
 async function box(page: Page, selector: string) {
   const value = await page.locator(selector).boundingBox();
@@ -455,9 +456,15 @@ test("Member Facts keeps zero, loading, and failure states distinct", async ({
       await expect(page.locator(".allocation-empty"))
         .toHaveText("No allocation occurrences were found in this method.");
       await expect(page.locator(".allocation-row")).toHaveCount(0);
+      await expect(page.locator(".call-facts > header > span"))
+        .toHaveText("0 call sites");
+      await expect(page.locator(".call-empty"))
+        .toHaveText("No direct call sites were found in this method.");
+      await expect(page.locator(".call-row")).toHaveCount(0);
     } else {
       await expect(page.locator(".facts-summary")).toHaveCount(0);
       await expect(page.locator(".allocation-facts")).toHaveCount(0);
+      await expect(page.locator(".call-facts")).toHaveCount(0);
       await expect(page.locator(".member-surface-scroll h2"))
         .toHaveText(mode === "loading" ? "Analyzing method…" : "Facts query failed");
       if (mode === "error") {
@@ -524,7 +531,7 @@ test("Member Facts allocation rows preserve all nine fields in occurrence order"
   }
   await expect(page.locator(".allocation-facts a, .allocation-facts button, .allocation-facts details"))
     .toHaveCount(0);
-  await expect(page.locator(".fact-group h2"))
+  await expect(page.locator(".call-facts h2, .fact-group h2"))
     .toHaveText(["Calls", "Safety facts", "Exception regions"]);
   const section = await box(page, ".allocation-facts");
   const summary = await box(page, ".facts-summary");
@@ -562,6 +569,65 @@ test("Member Facts allocation rows reflow by pane width without hiding long valu
     await expect(page.locator(".allocation-type").last()).toHaveText("Type unavailable");
     await expect(page.locator(".allocation-row").nth(1).locator("dd").last())
       .toHaveText("2147483647 B");
+  }
+});
+
+test("Member Facts call rows preserve all five fields and repeated callees", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto("/browser/workspace-titlebar.html?member=1&call-facts=populated");
+  const facts = callFactsFixture();
+  await expect(page.locator(".call-facts > header > span")).toHaveText("4 call sites");
+  await expect(page.locator(".facts-summary-value").nth(1)).toHaveText("4");
+  await expect(page.locator(".call-row")).toHaveCount(4);
+  for (const [index, call] of facts.calls.entries()) {
+    const row = page.locator(".call-row").nth(index);
+    await expect(row.locator(".call-location code")).toHaveText([call.offset, call.opcode]);
+    await expect(row.locator(".call-callee")).toHaveText(call.callee);
+    await expect(row.locator("dt")).toHaveText(["Multiplicity", "Loop"]);
+    await expect(row.locator("dd")).toHaveText([call.multiplicity, call.inLoop ? "yes" : "no"]);
+  }
+  await expect(page.locator(".call-facts a, .call-facts button, .call-facts details"))
+    .toHaveCount(0);
+  await expect(page.locator(".fact-group h2")).toHaveText(["Safety facts", "Exception regions"]);
+  const calls = await box(page, ".call-facts");
+  const allocations = await box(page, ".allocation-facts");
+  expect(calls.width).toBeCloseTo(allocations.width, 0);
+  expect(calls.height).toBeLessThanOrEqual(310);
+  expect(calls.y - (allocations.y + allocations.height)).toBeCloseTo(20, 0);
+});
+
+test("Member Facts call rows reflow by pane width without hiding long values", async ({
+  page,
+}) => {
+  const facts = callFactsFixture("long");
+  for (const width of [1440, 900, 600, 360]) {
+    await page.setViewportSize({ width, height: 1000 });
+    await page.goto("/browser/workspace-titlebar.html?member=1&call-facts=long");
+    const location = await box(page, ".call-row:first-child .call-location");
+    const callee = await box(page, ".call-row:first-child .call-callee");
+    if (width === 900 || width === 360) {
+      expect(callee.y).toBeGreaterThanOrEqual(location.y + location.height);
+      expect(callee.x).toBeCloseTo(location.x, 0);
+    } else {
+      expect(callee.x).toBeGreaterThan(location.x + location.width);
+    }
+    for (const selector of [
+      ".call-facts", ".call-row", ".call-location", ".call-main",
+      ".call-callee", ".call-properties", ".call-properties > div",
+      ".call-properties dd", ".member-surface-scroll",
+    ]) {
+      expect(await page.locator(selector).evaluateAll(elements =>
+        elements.every(element => element.scrollWidth <= element.clientWidth)),
+      `${selector} at ${width}px`).toBe(true);
+    }
+    await expect(page.locator(".call-callee")).toHaveText(facts.calls.map(call => call.callee));
+    await expect(page.locator(".call-location code").last()).toHaveText("call");
+    await expect(page.locator(".call-location").last().locator("code").first())
+      .toHaveText("IL_12345678");
+    await expect(page.locator(".call-properties").first().locator("dd"))
+      .toHaveText(["Unknown", "no"]);
   }
 });
 

--- a/prototypes/inspect-web/src/member-facts.ts
+++ b/prototypes/inspect-web/src/member-facts.ts
@@ -53,10 +53,7 @@ export function renderMemberFacts(
       <p class="facts-metadata-identity"><span>Metadata token</span><code>${escapeHtml(`0x${facts.metadataToken.toString(16).padStart(8, "0")}`)}</code></p>
     </section>
     ${renderAllocationFacts(facts.allocations)}
-    ${renderFactTable("Calls", facts.calls, [
-      ["IL", "offset"], ["Opcode", "opcode"], ["Callee", "callee"],
-      ["Multiplicity", "multiplicity"], ["Loop", row => row.inLoop ? "yes" : ""]
-    ], "No direct call sites were found in this method.")}
+    ${renderCallFacts(facts.calls)}
     ${renderFactTable("Safety facts", facts.safety, [
       ["IL", row => row.offset || ""], ["Kind", "kind"], ["Operation", "operation"],
       ["Requirement", "requirement"], ["Evidence", "evidence"]
@@ -106,6 +103,25 @@ function renderAllocationFacts(allocations: MemberFacts["allocations"]) {
           </div>
         </li>`).join("")}</ol>`
       : '<p class="allocation-empty">No allocation occurrences were found in this method.</p>'}
+  </section>`;
+}
+
+function renderCallFacts(calls: MemberFacts["calls"]) {
+  return `<section class="call-facts" aria-labelledby="call-facts-title">
+    <header><h2 id="call-facts-title">Calls</h2><span>${calls.length} ${calls.length === 1 ? "call site" : "call sites"}</span></header>
+    ${calls.length
+      ? `<ol class="call-rows">${calls.map(call => `
+        <li class="call-row">
+          <div class="call-location"><code>${escapeHtml(call.offset)}</code><code>${escapeHtml(call.opcode)}</code></div>
+          <div class="call-main">
+            <div class="call-callee"><code>${escapeHtml(call.callee)}</code></div>
+            <dl class="call-properties">
+              <div><dt>Multiplicity</dt><dd><code>${escapeHtml(call.multiplicity)}</code></dd></div>
+              <div><dt>Loop</dt><dd><code>${call.inLoop ? "yes" : "no"}</code></dd></div>
+            </dl>
+          </div>
+        </li>`).join("")}</ol>`
+      : '<p class="call-empty">No direct call sites were found in this method.</p>'}
   </section>`;
 }
 

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1398,25 +1398,27 @@ kbd {
 .facts-metadata-identity { display: flex; flex-wrap: wrap; gap: 6px 12px; margin: 10px 0 0; font-size: 12px; }
 .facts-metadata-identity > span { color: var(--muted); }
 .facts-metadata-identity code { min-width: 0; color: var(--text); font: 12px var(--mono); overflow-wrap: anywhere; }
-.allocation-facts { max-width: 900px; margin-top: 20px; font-size: 13px; line-height: 1.5; }
-.allocation-facts > header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
-.allocation-facts h2 { margin: 0; font-size: 14px; font-weight: 600; }
-.allocation-facts > header > span { color: var(--muted); font-size: 12px; }
-.allocation-rows { list-style: none; padding: 0; margin: 0; border-top: 1px solid var(--line); }
-.allocation-row { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: 14px; padding: 10px 0; border-bottom: 1px solid var(--line); }
-.allocation-location { display: flex; flex-direction: column; align-items: flex-start; gap: 5px; min-width: 0; }
-.allocation-location code { color: var(--muted); font: 12px/1.5 var(--mono); overflow-wrap: anywhere; }
+.allocation-facts, .call-facts { max-width: 900px; margin-top: 20px; font-size: 13px; line-height: 1.5; }
+.allocation-facts > header, .call-facts > header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
+.allocation-facts h2, .call-facts h2 { margin: 0; font-size: 14px; font-weight: 600; }
+.allocation-facts > header > span, .call-facts > header > span { color: var(--muted); font-size: 12px; }
+.allocation-rows, .call-rows { list-style: none; padding: 0; margin: 0; border-top: 1px solid var(--line); }
+.allocation-row, .call-row { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: 14px; padding: 10px 0; border-bottom: 1px solid var(--line); }
+.allocation-location, .call-location { display: flex; flex-direction: column; align-items: flex-start; gap: 5px; min-width: 0; }
+.allocation-location code, .call-location code { color: var(--muted); font: 12px/1.5 var(--mono); overflow-wrap: anywhere; }
 .allocation-location > span { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; }
-.allocation-main { min-width: 0; }
+.allocation-main, .call-main { min-width: 0; }
 .allocation-type { margin-bottom: 7px; overflow-wrap: anywhere; }
-.allocation-type code { color: var(--text); font: 13px/1.5 var(--mono); }
+.allocation-type code, .call-callee code { color: var(--text); font: 13px/1.5 var(--mono); }
 .allocation-properties { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 5px 16px; margin: 0; }
-.allocation-properties > div { display: flex; flex-wrap: wrap; align-items: baseline; gap: 2px 7px; min-width: 0; }
-.allocation-properties dt { color: var(--muted); font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
-.allocation-properties dd { min-width: 0; margin: 0; font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
-.allocation-properties code { color: var(--text); font: 12px/1.5 var(--mono); }
+.allocation-properties > div, .call-properties > div { display: flex; flex-wrap: wrap; align-items: baseline; gap: 2px 7px; min-width: 0; }
+.allocation-properties dt, .call-properties dt { color: var(--muted); font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
+.allocation-properties dd, .call-properties dd { min-width: 0; margin: 0; font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
+.allocation-properties code, .call-properties code { color: var(--text); font: 12px/1.5 var(--mono); }
 .allocation-unavailable { color: var(--muted); font-size: 12px; }
-.allocation-empty { margin: 0; padding: 10px 0; border-top: 1px solid var(--line); color: var(--muted); font-size: 13px; }
+.allocation-empty, .call-empty { margin: 0; padding: 10px 0; border-top: 1px solid var(--line); color: var(--muted); font-size: 13px; }
+.call-callee { margin-bottom: 5px; overflow-wrap: anywhere; }
+.call-properties { display: flex; flex-wrap: wrap; gap: 4px 24px; margin: 0; }
 @container member-surface (max-width: 760px) {
   .allocation-properties { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 5px 14px; }
 }
@@ -1424,8 +1426,8 @@ kbd {
   .facts-summary-list > div { grid-template-columns: minmax(0, 48%) minmax(0, 1fr); gap: 12px; }
   .facts-summary-list dd { flex-direction: column; gap: 4px; }
   .facts-summary-value { flex-basis: auto; max-width: 100%; }
-  .allocation-row { grid-template-columns: minmax(0, 1fr); gap: 6px; }
-  .allocation-location { flex-direction: row; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
+  .allocation-row, .call-row { grid-template-columns: minmax(0, 1fr); gap: 6px; }
+  .allocation-location, .call-location { flex-direction: row; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
 }
 .assembly-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
 .assembly-grid .assembly-cell { display: flex; flex-direction: column; gap: 6px; padding: 14px 12px; background: var(--panel); min-width: 0; }

--- a/prototypes/inspect-web/test/member-facts-fixture.ts
+++ b/prototypes/inspect-web/test/member-facts-fixture.ts
@@ -119,3 +119,48 @@ export function allocationFactsFixture(
     ],
   };
 }
+
+export function callFactsFixture(
+  mode: "populated" | "long" = "populated",
+): MemberFacts {
+  const long = mode === "long";
+  return {
+    ...memberFactsFixture(),
+    calls: [
+      {
+        offset: "IL_0014",
+        opcode: "callvirt",
+        kind: "CallVirtual",
+        callee: long
+          ? "Example.Serialization.BufferedDocumentReader<System.Collections.Generic.Dictionary<System.String, System.Collections.Generic.List<System.Text.Json.JsonElement>>>.Read<System.Collections.Generic.KeyValuePair<System.String, System.Text.Json.JsonElement>>(System.ReadOnlySpan<System.Byte>, System.Text.Json.Serialization.Metadata.JsonTypeInfo<System.Text.Json.JsonElement>)"
+          : "System.Text.Json.Serialization.JsonConverter<System.Text.Json.JsonElement>.Read(System.Text.Json.Utf8JsonReader&, System.Type, System.Text.Json.JsonSerializerOptions)",
+        multiplicity: long ? "Unknown" : "Once",
+        inLoop: false,
+      },
+      {
+        offset: "IL_0020",
+        opcode: "newobj",
+        kind: "NewObject",
+        callee: "System.Text.Json.JsonException..ctor(System.String)",
+        multiplicity: "Conditional",
+        inLoop: false,
+      },
+      {
+        offset: "IL_0048",
+        opcode: "call",
+        kind: "Call",
+        callee: "System.Text.Json.Utf8JsonReader.Read()",
+        multiplicity: "Loop",
+        inLoop: true,
+      },
+      {
+        offset: long ? "IL_12345678" : "IL_0074",
+        opcode: "call",
+        kind: "Call",
+        callee: "System.Text.Json.Utf8JsonReader.Read()",
+        multiplicity: "Once",
+        inLoop: false,
+      },
+    ],
+  };
+}

--- a/prototypes/inspect-web/test/member-facts.test.ts
+++ b/prototypes/inspect-web/test/member-facts.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { renderMemberFacts } from "../src/member-facts.ts";
 import type { MemberFacts } from "../src/member-detail-inspection.ts";
-import { allocationFactsFixture, memberFactsFixture } from "./member-facts-fixture.ts";
+import { allocationFactsFixture, callFactsFixture, memberFactsFixture } from "./member-facts-fixture.ts";
 
 function render(facts: MemberFacts = memberFactsFixture()) {
   return renderMemberFacts({
@@ -67,6 +67,8 @@ test("member Facts keeps explicit zero results distinct from loading and failure
   assert.match(summaryRow(html, "Unsafe"), />no<\/code>/);
   assert.doesNotMatch(html, /class="fact-evidence"/);
   assert.match(html, /No direct call sites were found/);
+  assert.match(html, /<h2 id="call-facts-title">Calls<\/h2><span>0 call sites<\/span>/);
+  assert.doesNotMatch(html, /<ol class="call-rows">/);
   assert.match(html, /0 occurrences/);
   assert.match(html, /No allocation occurrences were found in this method\./);
   assert.doesNotMatch(html, /<ol class="allocation-rows">/);
@@ -77,7 +79,7 @@ test("member Facts keeps explicit zero results distinct from loading and failure
     memberFactsError: "",
   });
   assert.match(loading, /Analyzing method/);
-  assert.doesNotMatch(loading, /facts-summary|Metadata token|allocation-facts/);
+  assert.doesNotMatch(loading, /facts-summary|Metadata token|allocation-facts|call-facts/);
 
   const failure = renderMemberFacts({
     memberFacts: null,
@@ -86,7 +88,7 @@ test("member Facts keeps explicit zero results distinct from loading and failure
   });
   assert.match(failure, /Facts query failed/);
   assert.match(failure, /Could not decode &lt;method&gt;\./);
-  assert.doesNotMatch(failure, /facts-summary|No direct call sites|allocation-facts/);
+  assert.doesNotMatch(failure, /facts-summary|No direct call sites|allocation-facts|call-facts/);
   assert.match(renderMemberFacts({
     memberFacts: null,
     memberFactsLoading: false,
@@ -98,7 +100,10 @@ test("member Facts escapes summary evidence and all relocated detail sections", 
   const facts = memberFactsFixture();
   const html = render({
     ...facts,
-    calls: [{ ...facts.calls[0]!, offset: "<offset>\"", callee: "<callee>" }],
+    calls: [{
+      ...facts.calls[0]!, offset: "<offset>\"", callee: "<callee>",
+      opcode: "<opcode>", multiplicity: "<call-multiplicity>",
+    }],
     allocations: [{
       ...facts.allocations[0]!, type: "<type>", offset: "<allocation-offset>",
       kind: "<allocation-kind>", multiplicity: "<multiplicity>",
@@ -114,6 +119,7 @@ test("member Facts escapes summary evidence and all relocated detail sections", 
     "clause", "try", "handler", "filter", "caught", "shape", "fix",
     "confidence", "caveat", "finding", "provenance", "diagnostic",
     "allocation-offset", "allocation-kind", "multiplicity", "path", "escape",
+    "opcode", "call-multiplicity",
   ]) {
     assert.ok(html.includes(`&lt;${value}&gt;`));
     assert.ok(!html.includes(`<${value}>`));
@@ -160,4 +166,38 @@ test("allocation facts distinguish unavailable type and size from an estimated z
   assert.match(html, /class="allocation-unavailable">Type unavailable<\/span>/);
   assert.match(html, /<dt>Est. size<\/dt><dd><span class="allocation-unavailable">not available<\/span>/);
   assert.match(html, /<dt>Est. size<\/dt><dd><code>0 B<\/code>/);
+});
+
+test("call facts preserve every site and distinguish repeated callees", () => {
+  const facts = callFactsFixture();
+  const html = render(facts);
+  assert.match(summaryRow(html, "Calls"), />4<\/code>/);
+  assert.match(html, /<h2 id="call-facts-title">Calls<\/h2><span>4 call sites<\/span>/);
+  const rows = [...html.matchAll(/<li class="call-row">([\s\S]*?)<\/li>/g)]
+    .map(match => match[1]!);
+  assert.equal(rows.length, 4);
+  for (const [index, call] of facts.calls.entries()) {
+    const row = rows[index]!;
+    assert.ok(row.includes(`<code>${call.offset}</code><code>${call.opcode}</code>`));
+    assert.ok(summaryRow(row, "Multiplicity").includes(`>${call.multiplicity}</code>`));
+    assert.ok(summaryRow(row, "Loop").includes(`>${call.inLoop ? "yes" : "no"}</code>`));
+  }
+  assert.match(rows[0]!, /JsonConverter&lt;System.Text.Json.JsonElement&gt;.Read\(System.Text.Json.Utf8JsonReader&amp;/);
+  assert.match(rows[1]!, /System.Text.Json.JsonException\.\.ctor\(System.String\)/);
+  for (const row of rows.slice(2)) {
+    assert.match(row, /<code>System.Text.Json.Utf8JsonReader.Read\(\)<\/code>/);
+  }
+  assert.doesNotMatch(rows.join(""), /<a\b|<button\b|<details\b/);
+  assert.match(render({ ...facts, calls: [facts.calls[0]!] }), /<span>1 call site<\/span>/);
+});
+
+test("call facts retain the returned order instead of sorting by offset", () => {
+  const facts = callFactsFixture();
+  const calls = [...facts.calls.slice(2), ...facts.calls.slice(0, 2)];
+  const html = render({ ...facts, calls });
+  assert.deepEqual(
+    [...html.matchAll(/class="call-location"><code>([^<]+)<\/code>/g)]
+      .map(match => match[1]),
+    calls.map(call => call.offset),
+  );
 });


### PR DESCRIPTION
Make static call evidence readable without losing individual sites or implying
runtime execution counts. This implements the approved Calls proposal in #6050
and advances the top-down Inspect Web refinement.

Closes #6050.

## Demo

The production renderer keeps IL offset and opcode beside the callee, followed
by compact Multiplicity and Loop properties. It preserves the five displayed
fields, returned order, and repeated callees at different offsets.

For the same four-site fixture at a 1440px window, the old section is 245px tall
with another 643px of horizontal table scrolling; the new section is 306px tall
with all fields visible in the established 900px readable measure. The two
`Utf8JsonReader.Read()` sites remain separate, with different loop flags and
multiplicities. Four sites are not three unique callees or four executions.

Before and after screenshots execute their respective production renderers,
not a mockup replacement, against the same illustrative typed fixture. They
are not live inspection results for the member shown by the shell harness.
The baseline renderer is from
`4e518d23f085b86bd1c92a6b8d7db4f2a70be94c`; after screenshots correspond to
implementation commit `09fbded73`. The final integration of Type Metadata
Explore (#5949) leaves Calls rendering and its layout declarations unchanged.

### Before: 1440px

![Before: production Calls table](https://github.com/user-attachments/assets/02b671cf-b739-4df1-a234-737ae5e1fdd8)

### After: 1440px

![After: production Calls rows](https://github.com/user-attachments/assets/754bc22c-817e-434c-8257-cc8ee4569c8f)

### Constrained pane: 900px window

![Calls in a constrained detail pane](https://github.com/user-attachments/assets/38296c21-5af8-48ba-aad3-2eb46dc79cbf)

### Narrow window: 600px

![Calls with navigation collapsed](https://github.com/user-attachments/assets/4a7cb92b-0633-4a37-8ddb-69be57fa37ae)

### Long signature and offset: 360px

![Long returned callee and offset at 360px](https://github.com/user-attachments/assets/f36fe1a9-9add-4ac9-b645-fe906fb0fb59)

### Successful empty result

![Explicit empty Calls result](https://github.com/user-attachments/assets/7813dbb5-0bfc-4f3b-891a-2b74f58f5334)

## Design basis and scope

**Normative owner:** `docs/design/inspect-web-surface-composition.md`,
**Working surfaces > Type and Member API**. The claim is pane-responsive
call-site presentation preserving all five displayed fields and returned order.

Supporting roles: `BrowserCallFact` in
`prototypes/inspect-web/src/facades/inspect-web-analysis.d.ts` supplies the
unchanged typed input; `member-detail-inspection.ts` supplies query state;
`member-facts.ts` consumes the records and lowers them to DOM; the existing
shell owns identity and scrolling; CSS owns reflow.

The complexity basis is complete, readable evidence in constrained panes,
without sideways scanning or hidden rows. Landed Allocation facts and Member
Overview rows are the local convention and comparison. This extends that
composition rather than adopting a new overall application model. It trades
some vertical density for visibility and does not claim a denser result for
methods with many calls.

This is browser-specific DOM/CSS presentation, continuing the existing renderer
instead of adding a shared substrate, host path, or Markout rendering path.
The typed record survives to the private Calls renderer. Identical CSS rules
are shared with Allocation facts through grouped selectors; the existing
allocation declarations and appearance remain unchanged.

Issue #6050 is the focused end-to-end tracker. The user approved the browser
presentation scope with "Looks good" on 2026-09-05. Production-host adoption
is one step, completed here: replace the Calls generic-table invocation in
the existing Member Facts renderer. That invocation is retired; the generic
table remains for Safety facts and Exception regions. There is no later
adoption or retirement step required for this slice's correctness.

Loop membership now has explicit `yes` / `no`. Opcode and multiplicity retain
their returned values without implying stronger dispatch or execution facts.
The existing undisplayed `kind` stays undisplayed. Callees and offsets remain
inert display evidence, not inferred navigation identities.

No query, DTO, analysis, CLI, or Finding-navigation changes. #5517 retains
Finding-instance navigation ownership and #5516 retains identity transport.
The summary, Allocation facts, Safety facts, Exception regions, Performance
opportunities, and diagnostics retain their behavior. Loading and failure
remain distinct from a successful empty Calls result.

## Validation

- Focused four-file Node suite:
  `node --test --test-reporter=dot test/member-facts.test.ts test/member-detail-inspection.test.ts test/type-panel.test.ts test/spotlight-identity.test.ts`.
- `npm run build`, including frontend/test/config type checking.
- `npm run analyze`.
- `npx --no-install playwright test --config <session Calls config> --project=firefox --workers=1 --reporter=dot workspace-titlebar.spec.ts --grep 'Member Facts'`:
  seven Member Facts cases passed. The session config imports the existing
  config and changes only paths and the isolated port to 4188.
- `npx --no-install markdownlint-cli docs/design/inspect-web-surface-composition.md`.
- Production before/after capture compares every non-Calls section's DOM
  against the baseline and records wide, constrained, narrow, long-value,
  and empty-result cases.

The outcome-level tests cover field preservation, repeated callees, site counts,
singular counts, returned order even when offsets are not sorted, explicit
loop flags, escaped text, empty/loading/failure states, pane-based reflow,
long-value containment, and the wide fixture's 310px height bound. Existing
Allocation facts browser coverage remains included.

After the final base integration, the four-file suite, production build and
type checks, analysis, all seven Member Facts browser cases, and Markdown
gate passed again. No Calls implementation changes were needed after integration.

## Review state

Round 1 is **review-clean**: GPT-5.6 Sol and Claude Opus 5 both returned
**CLEAN** with no findings. No review-driven fixes were needed, and the
reviewed head remains unchanged.

- Frozen candidate: `b0a33a0762a154d2577a90946321d7918852a3ab`.
- Effective base: `d817fb6348d193f870a679c72a957255275b2d5f`.
- Authored implementation: `09fbded73`; integration commit: `b0a33a076`.
- The authored diff is seven files, 223 insertions and 31 deletions.
- Current-head `ci-required` concluded success at `2026-09-06T03:20:55Z`,
  confirmed again at `03:38:34Z`.
- The landed range from the effective base through
  `ac100a901f06a4347b9e10b24ae94a317fc6f10e` is **no interaction**:
  package acquisition, CLI/discovery, metadata decoding, documentation, and
  test timing do not change this slice's Calls renderer, typed input contract,
  or layout. None of the seven authored files is touched. Preserve the
  reviewed head; no integration, new CI run, or additional round is needed.
- `review-clean` records exact-head review evidence, not live merge readiness
  or authorization.
- No merge authorization has been given.
