### PR TITLE
Path-gate fast decompiler unit tests behind decompiler routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,7 +727,15 @@ jobs:
       # and fidelity tests are tagged [Trait("Speed", "Slow")] and excluded here;
       # the full suite (including those) runs in Deep Inspect. Mark any
       # new Roslyn-heavy/recompile test Slow so it stays out of the PR gate.
+      #
+      # Path-gated on the same `decompilerGates` selection as the separate,
+      # heavier decompiler-gates job: both are driven by the
+      # ILInspector.Decompiler.Tests project-reference closure, so a PR that
+      # cannot affect that project skips this ~8 minute step. A PR that does
+      # touch it still gets both the fast unit tests here and the slow
+      # pre-merge gate preset in decompiler-gates.
       - name: Run decompiler unit tests (fast)
+        if: fromJSON(needs.changes.outputs.plan).validations.decompilerGates
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
 
       - name: Run analysis tests (fast)

--- a/eng/CiChangeDetection/WorkflowContract.Consumers.cs
+++ b/eng/CiChangeDetection/WorkflowContract.Consumers.cs
@@ -169,6 +169,7 @@ internal static partial class WorkflowContract
         {
             "test/Restore vendored ILAssembler",
             "test/Run IL round-trip tests (fast)",
+            "test/Run decompiler unit tests (fast)",
         };
         var allowedContinueOnError = new HashSet<string>(
             StringComparer.Ordinal)


### PR DESCRIPTION
## Demo

Before: `test`'s `Run decompiler unit tests (fast)` step ran on every PR touching any code, unconditionally, at ~8.3 minutes measured on a recent run -- even for PRs with no decompiler-related changes at all.

After: the step only runs when `validations.decompilerGates` is selected (the same project-reference-closure-based selection that already path-gates the separate, heavier `decompiler-gates` job). A PR that cannot affect `ILInspector.Decompiler.Tests` now skips this step; a PR that does touch it still runs both the fast unit tests here and the slow gate preset in `decompiler-gates`.

## Motivation

Investigating why the Linux `test` leg takes ~30 minutes. Step-level timing from a recent completed run (`test (ubuntu-24.04, linux-x64)`, 36m23s wall):

```
884s (14.7min)  Run CLI tests (fast)
496s (8.3min)   Run decompiler unit tests (fast)
211s (3.5min)   Run analysis tests (fast)
167s (2.8min)   Build
113s (1.9min)   NuGetFetch tests (offline)
```

`Run decompiler unit tests (fast)` was the clearest, lowest-risk win: it duplicates path-routing logic that already exists and is exercised for the separate `decompiler-gates` job, but the in-job fast copy had no equivalent gate. This mirrors the existing precedent for `Run IL round-trip tests (fast)`, which is already gated on `validations.ilRoundTrip`.

This does not by itself get the leg to 5-10 minutes -- `Run CLI tests (fast)` is the larger remaining cost and isn't decompiler-specific -- but it removes ~8 minutes for the (majority of) PRs that don't touch decompiler code, at effectively zero risk since it reuses an already-proven routing selection.

## Validation

- `dotnet run eng/test-ci-change-detection.cs -c Release` -- passes (validates the workflow YAML against `PromotionWorkflowContract`/`WorkflowContract` expectations, including the updated step-guard allowlist).
- `dotnet build dotnet-inspect.slnx -c Release` -- succeeds.

No product code changed; this is CI workflow/self-test infrastructure only.
