### PR TITLE
Make Inspect Web startup reads async-ready

### DIFF
--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -2,8 +2,9 @@
 
 Status: **implemented** for issue
 [#4497](https://github.com/richlander/dotnet-inspect/issues/4497).
-The [page-facing engine client](#page-facing-engine-client) is **design-only,
-not implemented**, preparing the single-runtime Worker cutover for
+The [page-facing engine client](#page-facing-engine-client) is **partially
+implemented**: startup reads have Promise-valued main-thread bindings.
+The single-runtime Worker cutover remains unimplemented, tracked by
 [#5987](https://github.com/richlander/dotnet-inspect/issues/5987) and its Source
 consumer [#5420](https://github.com/richlander/dotnet-inspect/issues/5420).
 
@@ -567,6 +568,24 @@ survives an awaited engine call; its navigation owner retains that interaction
 constraint.
 
 ### Adoption and evidence
+
+The first caller-adoption slice uses
+[`engine-startup.ts`](../../prototypes/inspect-web/src/engine-startup.ts) for
+Promise-valued build identity, vocabulary, home demo, Package Query facet, and
+Gallery discovery reads. Its three facade groups retain generated types;
+`engine-facades.ts` still owns the existing single page runtime and readiness.
+The application awaits each read in its existing startup error boundary:
+build identity remains fatal, vocabulary and home demo failures remain
+independent, and the two Package Query catalogs retain their shared failure
+path. This is asynchronous caller preparation, not Worker execution or a
+responsiveness claim.
+
+`test/engine-startup.test.ts` exercises deferred invocation, exact result and
+failure forwarding, and independent neighboring reads;
+`test/engine-facades.test.ts` retains the existing readiness/one-runtime
+composition evidence. Both use the existing inspect-web Node test runner, and
+the TypeScript gate checks the application's awaited DTO use.
+Other caller classes and Worker activation remain outstanding.
 
 The user-approved
 [five-milestone plan](https://github.com/richlander/dotnet-inspect/issues/5420#issuecomment-5549528380)

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -60,6 +60,10 @@ import {
   uniqueTypeByQueryId,
   workspaceCoordinatesMatch
 } from "./data.ts";
+import {
+  createMainThreadStartupClient,
+  type EngineStartupClient,
+} from "./engine-startup.ts";
 import type {
   MemberSection,
   PackageLens,
@@ -452,7 +456,6 @@ import type {
 // Each generated module publishes its own operations and its own wire declarations, so the
 // application binds every operation through the module that owns it. There is no aggregate
 // facade: a binding below names the facade it came from.
-type HostFacade = typeof import("./facades/inspect-web-host.d.ts");
 type PackageFacade = typeof import("./facades/inspect-web-package.d.ts");
 type MetadataFacade = typeof import("./facades/inspect-web-metadata.d.ts");
 type AnalysisFacade = typeof import("./facades/inspect-web-analysis.d.ts");
@@ -462,11 +465,9 @@ type CatalogFacade = typeof import("./facades/inspect-web-catalog.d.ts");
 type EngineCoordinator = typeof import("./engine-facades.ts");
 
 let startEngine: EngineCoordinator["startEngine"];
-let inspectBuildIdentity: HostFacade["buildIdentity"];
+let engineStartup: EngineStartupClient;
 let cancelPackageQuery: PackageFacade["cancelPackageQuery"];
 let inspectPackageDocument: PackageFacade["getPackageDocument"];
-let inspectListPackageQueryFacets: PackageFacade["listPackageQueryFacets"];
-let inspectListGalleryDiscoveryCatalog: PackageFacade["listGalleryDiscoveryCatalog"];
 let inspectLoadRuntimePack: PackageFacade["loadRuntimePack"];
 let inspectLoadRuntimePackAssembly: PackageFacade["loadRuntimePackAssembly"];
 let matchPackageDependencyCoordinate:
@@ -517,8 +518,6 @@ let inspectExpandPlatformCallGraph: CallGraphFacade["expandPlatformCallGraph"];
 let inspectMemberCallGraph: CallGraphFacade["queryMemberCallGraph"];
 let inspectDecodeWorkspaceShareState: CatalogFacade["decodeWorkspaceShareState"];
 let inspectEncodeWorkspaceShareState: CatalogFacade["encodeWorkspaceShareState"];
-let inspectListHomeDemos: CatalogFacade["listHomeDemos"];
-let inspectVocabulary: CatalogFacade["listVocabulary"];
 let inspectResolveHomeDemo: CatalogFacade["resolveHomeDemo"];
 let inspectRunHomeDemo: CatalogFacade["runHomeDemo"];
 let productHomeDemoCatalogError = "";
@@ -547,12 +546,14 @@ async function loadEngineModule() {
     import("./engine-facades.ts"),
   ]);
   ({ startEngine } = coordinator);
-  ({ buildIdentity: inspectBuildIdentity } = hostFacade);
+  engineStartup = createMainThreadStartupClient({
+    host: hostFacade,
+    package: packageFacade,
+    catalog: catalogFacade,
+  });
   ({
     cancelPackageQuery,
     getPackageDocument: inspectPackageDocument,
-    listPackageQueryFacets: inspectListPackageQueryFacets,
-    listGalleryDiscoveryCatalog: inspectListGalleryDiscoveryCatalog,
     loadRuntimePack: inspectLoadRuntimePack,
     loadRuntimePackAssembly: inspectLoadRuntimePackAssembly,
     matchPackageDependencyCoordinate,
@@ -609,8 +610,6 @@ async function loadEngineModule() {
   ({
     decodeWorkspaceShareState: inspectDecodeWorkspaceShareState,
     encodeWorkspaceShareState: inspectEncodeWorkspaceShareState,
-    listHomeDemos: inspectListHomeDemos,
-    listVocabulary: inspectVocabulary,
     resolveHomeDemo: inspectResolveHomeDemo,
     runHomeDemo: inspectRunHomeDemo,
   } = catalogFacade);
@@ -12585,10 +12584,10 @@ async function bootstrap() {
     reportEngineStatus("Loading .NET WebAssembly…");
     await startEngine(window.location.origin);
     reportEngineStatus("Reading package assemblies…");
-    state.buildIdentity = inspectBuildIdentity();
+    state.buildIdentity = await engineStartup.host.buildIdentity();
     const tEngine = performance.now();
     try {
-      const vocabulary = inspectVocabulary();
+      const vocabulary = await engineStartup.catalog.listVocabulary();
       const sections = vocabulary?.sections || [];
       state.styleTiers = (
         sections.find(section => section.id === "csharp.style-tiers")?.values
@@ -12609,7 +12608,7 @@ async function bootstrap() {
       state.styleCatalogError = errorMessage(error);
     }
     try {
-      setProductHomeDemoCatalog(inspectListHomeDemos().demos ?? []);
+      setProductHomeDemoCatalog((await engineStartup.catalog.listHomeDemos()).demos ?? []);
       productHomeDemoCatalogError = "";
     } catch (error) {
       setProductHomeDemoCatalog([]);
@@ -12618,8 +12617,9 @@ async function bootstrap() {
     }
     try {
       state.packageQueryFacets =
-        packageQueryFacets(inspectListPackageQueryFacets());
-      state.packageQuerySourceCatalog = inspectListGalleryDiscoveryCatalog();
+        packageQueryFacets(await engineStartup.package.listPackageQueryFacets());
+      state.packageQuerySourceCatalog =
+        await engineStartup.package.listGalleryDiscoveryCatalog();
     } catch (error) {
       state.packageQueryFacets = [];
       state.packageQuerySourceCatalog = null;

--- a/prototypes/inspect-web/src/engine-startup.ts
+++ b/prototypes/inspect-web/src/engine-startup.ts
@@ -1,0 +1,42 @@
+type HostFacade = typeof import("./facades/inspect-web-host.d.ts");
+type PackageFacade = typeof import("./facades/inspect-web-package.d.ts");
+type CatalogFacade = typeof import("./facades/inspect-web-catalog.d.ts");
+
+interface StartupFacades {
+  readonly host: Pick<HostFacade, "buildIdentity">;
+  readonly package: Pick<
+    PackageFacade,
+    "listPackageQueryFacets" | "listGalleryDiscoveryCatalog"
+  >;
+  readonly catalog: Pick<CatalogFacade, "listVocabulary" | "listHomeDemos">;
+}
+
+// These Promise-valued bindings still dispatch on the current thread.
+// Runtime readiness and each read's error policy stay with the caller.
+export function createMainThreadStartupClient(facades: StartupFacades) {
+  return {
+    host: {
+      async buildIdentity() {
+        return facades.host.buildIdentity();
+      },
+    },
+    package: {
+      async listPackageQueryFacets() {
+        return facades.package.listPackageQueryFacets();
+      },
+      async listGalleryDiscoveryCatalog() {
+        return facades.package.listGalleryDiscoveryCatalog();
+      },
+    },
+    catalog: {
+      async listVocabulary() {
+        return facades.catalog.listVocabulary();
+      },
+      async listHomeDemos() {
+        return facades.catalog.listHomeDemos();
+      },
+    },
+  };
+}
+
+export type EngineStartupClient = ReturnType<typeof createMainThreadStartupClient>;

--- a/prototypes/inspect-web/test/engine-startup.test.ts
+++ b/prototypes/inspect-web/test/engine-startup.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMainThreadStartupClient } from "../src/engine-startup.ts";
+import type { BrowserBuildIdentity } from "../src/facades/inspect-web-host.d.ts";
+import type {
+  BrowserHomeDemoCatalog,
+  BrowserVocabularyDocument,
+} from "../src/facades/inspect-web-catalog.d.ts";
+import type {
+  BrowserGalleryDiscoveryCatalog,
+  BrowserPackageQueryFacetCatalog,
+} from "../src/facades/inspect-web-package.d.ts";
+
+const identity: BrowserBuildIdentity = {
+  version: "1.0.0",
+  commit: null,
+  builtAtUtc: null,
+  commitUrl: null,
+};
+const vocabulary: BrowserVocabularyDocument = {
+  schema_version: 1,
+  sections: [],
+};
+const demos: BrowserHomeDemoCatalog = {
+  demos: [{ id: "example", title: "Example", summary: "A startup catalog entry." }],
+};
+const facets: BrowserPackageQueryFacetCatalog = { facets: [] };
+const gallery: BrowserGalleryDiscoveryCatalog = {
+  packageType: {
+    id: "package-type",
+    label: "Package type",
+    summary: "Gallery package types.",
+    suggestions: [{ value: "DotnetTool", label: ".NET Tool" }],
+  },
+  orders: [{ id: "downloads", label: "Downloads", summary: "Most downloaded first." }],
+};
+
+function createFacades(calls: string[] = []) {
+  return {
+    host: {
+      buildIdentity() {
+        calls.push("buildIdentity");
+        return identity;
+      },
+    },
+    catalog: {
+      listVocabulary() {
+        calls.push("listVocabulary");
+        return vocabulary;
+      },
+      listHomeDemos() {
+        calls.push("listHomeDemos");
+        return demos;
+      },
+    },
+    package: {
+      listPackageQueryFacets() {
+        calls.push("listPackageQueryFacets");
+        return facets;
+      },
+      listGalleryDiscoveryCatalog() {
+        calls.push("listGalleryDiscoveryCatalog");
+        return gallery;
+      },
+    },
+  };
+}
+
+test("startup bindings defer reads until called and preserve generated results in Promises", async () => {
+  const calls: string[] = [];
+  const client = createMainThreadStartupClient(createFacades(calls));
+  assert.deepEqual(calls, []);
+
+  const reads = [
+    { invoke: () => client.host.buildIdentity(), expected: identity },
+    { invoke: () => client.catalog.listVocabulary(), expected: vocabulary },
+    { invoke: () => client.catalog.listHomeDemos(), expected: demos },
+    { invoke: () => client.package.listPackageQueryFacets(), expected: facets },
+    { invoke: () => client.package.listGalleryDiscoveryCatalog(), expected: gallery },
+  ];
+  for (const read of reads) {
+    const result = read.invoke();
+    assert.ok(result instanceof Promise);
+    assert.equal(await result, read.expected);
+  }
+  assert.deepEqual(calls, [
+    "buildIdentity",
+    "listVocabulary",
+    "listHomeDemos",
+    "listPackageQueryFacets",
+    "listGalleryDiscoveryCatalog",
+  ]);
+});
+
+test("each startup binding turns a thrown failure into the same Promise rejection", async () => {
+  for (const failure of [new Error("Facade read failed."), new Error("")]) {
+    const fail = (): never => { throw failure; };
+    const client = createMainThreadStartupClient({
+      host: { buildIdentity: fail },
+      catalog: { listVocabulary: fail, listHomeDemos: fail },
+      package: { listPackageQueryFacets: fail, listGalleryDiscoveryCatalog: fail },
+    });
+    const reads = [
+      () => client.host.buildIdentity(),
+      () => client.catalog.listVocabulary(),
+      () => client.catalog.listHomeDemos(),
+      () => client.package.listPackageQueryFacets(),
+      () => client.package.listGalleryDiscoveryCatalog(),
+    ];
+    for (const read of reads) {
+      const result = read();
+      assert.ok(result instanceof Promise);
+      await assert.rejects(result, (error: unknown) => error === failure);
+    }
+  }
+});
+
+test("a rejected startup read does not poison neighboring catalog bindings", async () => {
+  const facades = createFacades();
+  const failure = new Error("Style vocabulary unavailable.");
+  facades.catalog.listVocabulary = () => { throw failure; };
+  const client = createMainThreadStartupClient(facades);
+
+  await assert.rejects(client.catalog.listVocabulary(), error => error === failure);
+  assert.equal(await client.catalog.listHomeDemos(), demos);
+  assert.equal(await client.package.listPackageQueryFacets(), facets);
+  assert.equal(await client.package.listGalleryDiscoveryCatalog(), gallery);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2407,7 +2407,7 @@ test("dependency graph render identity includes truncation and navigation", () =
 });
 
 test("ready status shows versioned linked build provenance", () => {
-  assert.match(appSource, /state\.buildIdentity = inspectBuildIdentity\(\)/);
+  assert.match(appSource, /state\.buildIdentity = await engineStartup\.host\.buildIdentity\(\)/);
   assert.match(
     appSource,
     /<\/main>[\s\S]{0,700}\$\{statusBarHtml\(\{/);


### PR DESCRIPTION
## Purpose and claim

Prepare a conventionally sound foundation for responsive Inspect Web: startup
consumers now await typed engine results without changing runtime ownership or
their existing failure semantics.

Advances #5987, step 2 of the five-step single-runtime adoption plan under
#5418 and #5420. This is only the startup-read slice, not the full caller
migration or Worker cutover.

**Design basis:** `docs/design/inspect-web-jsexport-partitioning.md`,
**Page-facing engine client / Composition contract** owns consumer bindings
that preserve generated results and visible failures across an asynchronous
boundary. The existing facade coordinator supplies readiness and single-runtime
composition; generated declarations supply operation and DTO types.

## Demo

Before, bootstrap directly consumed synchronous facade results:

```ts
state.buildIdentity = inspectBuildIdentity();
const vocabulary = inspectVocabulary();
```

After, the actual startup path consumes Promise-valued bindings:

```ts
state.buildIdentity = await engineStartup.host.buildIdentity();
const vocabulary = await engineStartup.catalog.listVocabulary();
```

The same handoff covers home demos, Package Query facets, and Gallery discovery.
Gallery discovery landed after the original four-read inventory and shares the
Package Query catalog failure boundary, so leaving it synchronous would leave
that startup stage only partly prepared.

Reproduce the binding-level scenario and neighboring readiness case:

```sh
cd prototypes/inspect-web
node --test test/engine-startup.test.ts test/engine-facades.test.ts
```

Actual output, omitting timings:

```text
✔ startup initializes every facade once, in order, serially
✔ concurrent callers share one initialization and one entry point
✔ the first initialization failure is the failure every caller observes
✔ the coordinator publishes composition only
✔ startup bindings defer reads until called and preserve generated results in Promises
✔ each startup binding turns a thrown failure into the same Promise rejection
✔ a rejected startup read does not poison neighboring catalog bindings
tests 7; pass 7; fail 0
```

Notice that vocabulary failure does not poison the home-demo or Package Query
bindings. Bootstrap still owns the existing separate catches; build identity
failure remains fatal, and facets/Gallery retain their shared failure path.
This is a real adapter test using typed facade fixtures, not a browser
responsiveness or managed-runtime deployment demo.

## Implementation and scope

- A small consumer-owned `engine-startup.ts` adapter groups five reads under
  their three owning facades. Inputs and results derive from generated
  declarations; no duplicate DTOs or generic RPC framework.
- The existing page runtime, serial startup ordering, readiness barrier,
  generated exports, and `engine-facades.ts` composition surface are retained.
- Managed dispatch still runs on the current thread. The remaining computed,
  mutable, control, callback, and query callers need their later slices before
  the atomic Worker switch and retirement of direct page dispatch.
- #5911's library-selected query bindings are untouched. Its neighboring
  bootstrap change sets `atLibraryRoot` in a later navigation block.
  #6052 owns durable Worker transport; this PR does not edit its protocol,
  tests, model, package manifest, or README surfaces.

The complexity basis is a typed async consumer boundary with unchanged error
policy. It uses the already approved Inspect-Web-only scope and five-step
adoption/retirement plan; it adds no shared product substrate, rendering
domain, platform dependency, or CLI runtime migration. Existing typed data
still reaches the existing browser rendering owners.

## Validation

- `npm run build`: all three TypeScript programs, Vite, and site-artifact gate.
- `npm run analyze`: existing lint, HTML, and unused-code checks.
- `node --test test/engine-startup.test.ts test/engine-facades.test.ts test/package-query-source.test.ts`:
  29 passed.
- `npm test`: all 1,380 frontend tests passed after updating the existing
  build-provenance wiring assertion to the awaited binding.
- `npx markdownlint-cli docs/design/inspect-web-jsexport-partitioning.md`.
- Focused startup/facade scenario repeated on the integrated candidate: 7 passed.

Base integrations brought only unrelated CLI test corrections and ts-jsexport
documentation; no frontend source or configuration changed in those ranges.

The first CI attempt exposed one stale source-wiring assertion requiring the
retired synchronous call. It was reproduced at the exact head and corrected;
round 1 restarts on the replacement candidate, without any review spent.

Candidate head: `91ca0eedd6ea06910eae0d77b1939592c700cefe`.
Effective base: `ac100a901f06a4347b9e10b24ae94a317fc6f10e`.
Two-seat adversarial review follows successful current-head `ci-required`.
