### PR TITLE
Reuse custom-attribute generic-context prefixes per decode

### DIFF
--- a/docs/design/custom-attribute-value-decoding.md
+++ b/docs/design/custom-attribute-value-decoding.md
@@ -958,6 +958,35 @@ I1 offset seam and generated guard-approval assertions are retired, not carried
 as additional D3 requirements. Exhaustive grammar coverage, D1/D2 enumeration,
 and real-package certification are not established by this fixture gate.
 
+### Generic-context lookup gate
+
+Within one attribute decode, locating repeated, alternating, or increasing
+`VAR` indices must reuse the generic prefix already traversed (#5098). This is
+an operation-local lookup claim, not a bound on selected-type decoding, enum
+resolution, output materialization, or work across attribute rows. Existing CLI
+and browser/Wasm consumers receive the repair through the shared decoder.
+
+Reuse preserves the existing structural skipper's cursor semantics and does not
+inspect unused trailing arguments. Storage grows from traversed argument starts,
+not declared generic arity. Substitution still has an empty generic context;
+selected types, resolver calls, charges, and per-argument defaulted-width flags
+retain their existing behavior rather than being cached as decoded values.
+
+`CustomAttributeGenericContextTests` is the focused Release gate. Its
+compiler-produced samples vary constructor parameter count, generic arity, and
+index order, with mixed scalar/array values and unused-context neighbors. An
+optional internal counter records bytes advanced by the actual prefix skipper;
+the assertions measure traversal, not elapsed time or allocation. The public
+facade remains unchanged, and the counter is absent from ordinary calls.
+
+At pre-repair head `b830af9b4901912f6e17a1e7e346822d0e1b6342` (the unchanged
+lookup loop plus the counter and initial samples), eight of nine cases failed
+only their skipped-byte assertions. For example, four/eight repetitions of the
+last argument in a four-argument context skipped 12/24 bytes; both now skip
+three. Values and charges already matched, and the unused-tail case passed.
+This gate establishes the local reuse regression, **not full D1**; #5733 still
+owns the generative joint-dimension cost gate.
+
 ## Known gaps
 
 Each row is a **verified** divergence between the contract above and the
@@ -971,7 +1000,6 @@ component.
 | 4 | `A` attribute rows sharing one `B`-byte blob are decoded independently, costing `Θ(A × B)` from `Θ(A + B)` metadata. | D1 | #5132 |
 | 7 | Building the type-definition index costs `Θ(P × L)` for `P` definitions sharing an `L`-character namespace. | D1 | #5757 |
 | 8 | A definition scan performs `O(L)` work per row on a loop-invariant name, costing `Θ(T × L)`. | D1 | #5758 |
-| I2 → D1 | Each `VAR` fixed argument re-skips its generic context, so `P` arguments over a `G`-node context cost `Θ(P × G)`. | D1 | #5098 |
 
 Gap 4 is deliberately excluded from that grouping: it is cross-row, so no per-walk
 memo can address it.
@@ -988,9 +1016,9 @@ place it.
 
 | Former gap | Was | Disposition |
 | --- | --- | --- |
-| SRM re-derived each fixed argument's type from the generic context, costing `Θ(P × G)`; the guard memoized the offset and never experienced it. | I2 (#5098) | **Transferred to D1.** SRM no longer runs, but the owned decoder currently re-skips the generic context per `VAR` argument and retains the same cost shape. |
+| SRM re-derived each fixed argument's type from the generic context, costing `Θ(P × G)`; the owned decoder initially retained that prefix-rescan cost. | I2 → D1 (#5098) | **Repaired.** Operation-local lazy prefix reuse is covered by the [generic-context lookup gate](#generic-context-lookup-gate), including alternating and increasing indices. |
 | `SZARRAY` replay re-parsed one element type per value. | D1 gap 2 (#5047) | **Repaired.** The owned decoder resolves one `ArgumentType` before the array value loop and reuses it for every element. |
-| Four single-slot memos admitted alternating-input amplification. | D1 gap 3 (#5130) | **Repaired.** Those memos were deleted with the paired walker. The remaining generic-context re-skip is #5098 above. |
+| Four single-slot memos admitted alternating-input amplification. | D1 gap 3 (#5130) | **Repaired.** Those memos were deleted with the paired walker. The generic-context cost transferred to #5098 is also repaired. |
 | The resolver-less `IsSafeToDecode` overload resolves widths in a different order, so its `true` does not carry I1. | I1 scope (#5120) | **Moot.** There is no alignment claim to carry. |
 | The guard and `ArgTypeProvider` each apply their own `"System.Type"` comparison, so the predicate can diverge. | I1 (#5393) | **Moot.** One decoder, one predicate. Recorded as a fidelity caution under [Classification](#classification-is-a-display-name-comparison-not-an-identity-test). |
 | Whether the #4914 width-alignment collapse remains reachable on the blob-authored name path. | I1 (#4992) | **Moot as an alignment question.** The name path's own collapse risk is retained as a D3 concern under [The two resolution paths are not symmetric](#the-two-resolution-paths-are-not-symmetric). |
@@ -1032,11 +1060,11 @@ slice 2. Both are now settled.
 | --- | --- |
 | #5288 | This inversion. Slice 2 landed in #5815 and the fixtures-first slice 3 gate in #5148. Slice 4 retires the legacy bridge; broader package certification remains outstanding. |
 | #5047 | Repaired in #5815: each array element type is resolved once. |
-| #5098 | Per-`VAR` generic-context re-skip retains `Θ(P × G)` work in the owned decoder. |
+| #5098 | Repaired: operation-local generic-prefix reuse; the focused Release gate measures skipped bytes, not full D1. |
 | #5065 | D3 fidelity and producer certification; the fixture subset landed in #5148. It is not D1's gate. |
 | #5085 | Repaired in #5815: observer-exception provenance is preserved. |
 | #5091 | Quadratic work across declared parameter count and type-definition count. Gap 1. |
-| #5130 | #5815 retired the paired walk's single-slot memos; the remaining generic-context cost is tracked by #5098. |
+| #5130 | #5815 retired the paired walk's single-slot memos; #5098 repairs the transferred generic-context cost. |
 | #5132 | Quadratic cost across attribute rows sharing one value blob. Gap 4. |
 | #5148 | Merged: fixtures-first D3 value equality and retained-image producer truth. Broader package certification remains outstanding in #5065. |
 | #5304 | Stage 2 exhaustive per-position enumeration. |

--- a/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
@@ -69,7 +69,8 @@ internal static class CustomAttributeValueDecoder
         AttributeDecoder.EnumWidthResolver? enumUnderlyingType,
         out CustomAttributeValue<string> value,
         out ImmutableArray<bool> fixedArgumentWidthDefaulted,
-        out ImmutableArray<bool> namedArgumentWidthDefaulted)
+        out ImmutableArray<bool> namedArgumentWidthDefaulted,
+        GenericContextWork? genericContextWork = null)
     {
         value = default;
         fixedArgumentWidthDefaulted = default;
@@ -84,7 +85,8 @@ internal static class CustomAttributeValueDecoder
                 preserveSerializedTypeNames,
                 captureDefaultedWidths,
                 beforeMaterialize,
-                enumUnderlyingType);
+                enumUnderlyingType,
+                genericContextWork);
             return decoder.Run(
                 attribute,
                 out value,
@@ -108,6 +110,11 @@ internal static class CustomAttributeValueDecoder
         }
     }
 
+    internal sealed class GenericContextWork
+    {
+        public long BytesSkipped { get; internal set; }
+    }
+
     /// <summary>
     /// One decode of one attribute value. Fixed arguments are read from the
     /// constructor signature interleaved with their values from the value blob,
@@ -121,7 +128,8 @@ internal static class CustomAttributeValueDecoder
         bool preserveSerializedTypeNames,
         bool captureDefaultedWidths,
         Action<int>? beforeMaterialize,
-        AttributeDecoder.EnumWidthResolver? enumUnderlyingType)
+        AttributeDecoder.EnumWidthResolver? enumUnderlyingType,
+        GenericContextWork? genericContextWork)
     {
         readonly MetadataReader _reader = reader;
         readonly EntityHandle _constructor = constructor;
@@ -362,7 +370,11 @@ internal static class CustomAttributeValueDecoder
                         throw new BadImageFormatException();
                     for (int skip = 0; skip < parameterIndex; skip++)
                     {
-                        if (!SrmType.TrySkip(ref arguments))
+                        int start = arguments.Offset;
+                        bool skipped = SrmType.TrySkip(ref arguments);
+                        if (genericContextWork is not null)
+                            genericContextWork.BytesSkipped += arguments.Offset - start;
+                        if (!skipped)
                             throw new BadImageFormatException();
                     }
 

--- a/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
@@ -143,6 +143,9 @@ internal static class CustomAttributeValueDecoder
         readonly Stack<ValueJob> _work = new();
 
         BlobReader _value;
+        BlobReader _genericArgumentCursor;
+        List<int>? _genericArgumentOffsets;
+        int _genericParameterCount;
         bool _currentArgumentDefaulted;
         CustomAttributeTypedArgument<string> _rootResult;
 
@@ -295,6 +298,36 @@ internal static class CustomAttributeValueDecoder
             return context;
         }
 
+        BlobReader LocateGenericArgument(BlobReader genericContext, int parameterIndex)
+        {
+            if (_genericArgumentOffsets is null)
+            {
+                _genericArgumentCursor = genericContext;
+                _genericParameterCount = _genericArgumentCursor.ReadCompressedInteger();
+            }
+            if (parameterIndex >= _genericParameterCount)
+                throw new BadImageFormatException();
+
+            // Retain only visited starts, never storage sized by declared arity.
+            // Leave unused suffixes alone and preserve the existing skipper's
+            // cursor semantics rather than decoding types into the index.
+            _genericArgumentOffsets ??= [_genericArgumentCursor.Offset];
+            while (_genericArgumentOffsets.Count <= parameterIndex)
+            {
+                int start = _genericArgumentCursor.Offset;
+                bool skipped = SrmType.TrySkip(ref _genericArgumentCursor);
+                if (genericContextWork is not null)
+                    genericContextWork.BytesSkipped += _genericArgumentCursor.Offset - start;
+                if (!skipped)
+                    throw new BadImageFormatException();
+                _genericArgumentOffsets.Add(_genericArgumentCursor.Offset);
+            }
+
+            BlobReader arguments = genericContext;
+            arguments.Offset = _genericArgumentOffsets[parameterIndex];
+            return arguments;
+        }
+
         // Reads one fixed-argument type from the constructor signature. Renders
         // the type name and resolves any enum width exactly once; array element
         // types are read here once and the value loop never re-reads them.
@@ -364,19 +397,8 @@ internal static class CustomAttributeValueDecoder
                     int parameterIndex = signature.ReadCompressedInteger();
                     if (parameterIndex < 0)
                         throw new BadImageFormatException();
-                    BlobReader arguments = genericContext;
-                    int genericParameterCount = arguments.ReadCompressedInteger();
-                    if (parameterIndex >= genericParameterCount)
-                        throw new BadImageFormatException();
-                    for (int skip = 0; skip < parameterIndex; skip++)
-                    {
-                        int start = arguments.Offset;
-                        bool skipped = SrmType.TrySkip(ref arguments);
-                        if (genericContextWork is not null)
-                            genericContextWork.BytesSkipped += arguments.Offset - start;
-                        if (!skipped)
-                            throw new BadImageFormatException();
-                    }
+                    BlobReader arguments = LocateGenericArgument(
+                        genericContext, parameterIndex);
 
                     // Substitute once, then decode with an empty generic
                     // context so a self-referential VAR cannot recurse.

--- a/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextSamples.cs
+++ b/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextSamples.cs
@@ -1,0 +1,68 @@
+namespace ILInspector.Metadata.Tests;
+
+internal static class CustomAttributeGenericContextSamples
+{
+    [Pair<int, int>(1, 2, 3, 4)]
+    public sealed class PairFour;
+
+    [Pair<int, int>(1, 2, 3, 4, 5, 6, 7, 8)]
+    public sealed class PairEight;
+
+    [Repeated<int, int, int, int>(1, 2, 3, 4)]
+    public sealed class RepeatedFour;
+
+    [Repeated<int, int, int, int>(1, 2, 3, 4, 5, 6, 7, 8)]
+    public sealed class RepeatedEight;
+
+    [Alternating<int, int, int, int>(1, 2, 3, 4, 5, 6, 7, 8)]
+    public sealed class AlternatingEight;
+
+    [Ascending<int, int, int, int>(1, 2, 3, 4)]
+    public sealed class AscendingFour;
+
+    [Descending<int, int, int, int>(1, 2, 3, 4)]
+    public sealed class DescendingFour;
+
+    [Unused<int, Dictionary<string, int>>(1)]
+    public sealed class UnusedTail;
+
+    [Mixed<int, long[], string>("first", new long[] { 2, 3 }, 4, "last")]
+    public sealed class MixedValues;
+
+    sealed class PairAttribute<T0, T1> : Attribute
+    {
+        public PairAttribute(T1 a, T0 b, T1 c, T0 d) { }
+        public PairAttribute(T1 a, T0 b, T1 c, T0 d, T1 e, T0 f, T1 g, T0 h) { }
+    }
+
+    sealed class RepeatedAttribute<T0, T1, T2, T3> : Attribute
+    {
+        public RepeatedAttribute(T3 a, T3 b, T3 c, T3 d) { }
+        public RepeatedAttribute(T3 a, T3 b, T3 c, T3 d, T3 e, T3 f, T3 g, T3 h) { }
+    }
+
+    sealed class AlternatingAttribute<T0, T1, T2, T3> : Attribute
+    {
+        public AlternatingAttribute(T3 a, T0 b, T3 c, T0 d, T3 e, T0 f, T3 g, T0 h) { }
+    }
+
+    sealed class AscendingAttribute<T0, T1, T2, T3> : Attribute
+    {
+        public AscendingAttribute(T0 a, T1 b, T2 c, T3 d) { }
+    }
+
+    sealed class DescendingAttribute<T0, T1, T2, T3> : Attribute
+    {
+        public DescendingAttribute(T3 a, T2 b, T1 c, T0 d) { }
+    }
+
+    sealed class UnusedAttribute<T0, T1> : Attribute
+    {
+        public UnusedAttribute(T0 value) { }
+    }
+
+    sealed class MixedAttribute<T0, T1, T2> : Attribute
+    {
+        public MixedAttribute(T2 first, T1 second, T0 third, T2 last) { }
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextSamples.cs
+++ b/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextSamples.cs
@@ -26,8 +26,15 @@ internal static class CustomAttributeGenericContextSamples
     [Unused<int, Dictionary<string, int>>(1)]
     public sealed class UnusedTail;
 
+    [NoLookup<Dictionary<string, int>>(1)]
+    public sealed class NoGenericParameters;
+
     [Mixed<int, long[], string>("first", new long[] { 2, 3 }, 4, "last")]
     public sealed class MixedValues;
+
+    [Repeated<int, int, int, DayOfWeek>(
+        DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Sunday, DayOfWeek.Monday)]
+    public sealed class RepeatedEnum;
 
     sealed class PairAttribute<T0, T1> : Attribute
     {
@@ -59,6 +66,11 @@ internal static class CustomAttributeGenericContextSamples
     sealed class UnusedAttribute<T0, T1> : Attribute
     {
         public UnusedAttribute(T0 value) { }
+    }
+
+    sealed class NoLookupAttribute<T> : Attribute
+    {
+        public NoLookupAttribute(int value) { }
     }
 
     sealed class MixedAttribute<T0, T1, T2> : Attribute

--- a/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+using Samples = ILInspector.Metadata.Tests.CustomAttributeGenericContextSamples;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class CustomAttributeGenericContextTests
+{
+    [Theory]
+    [InlineData(typeof(Samples.PairFour), 4, 1)]
+    [InlineData(typeof(Samples.PairEight), 8, 1)]
+    [InlineData(typeof(Samples.RepeatedFour), 4, 3)]
+    [InlineData(typeof(Samples.RepeatedEight), 8, 3)]
+    [InlineData(typeof(Samples.AlternatingEight), 8, 3)]
+    [InlineData(typeof(Samples.AscendingFour), 4, 3)]
+    [InlineData(typeof(Samples.DescendingFour), 4, 3)]
+    [InlineData(typeof(Samples.UnusedTail), 1, 0)]
+    public void GenericArgumentLookup_ReusesVisitedPrefix(
+        Type sample,
+        int parameterCount,
+        long expectedBytesSkipped)
+    {
+        using var pe = new PEReader(File.OpenRead(sample.Assembly.Location));
+        MetadataReader reader = pe.GetMetadataReader();
+        CustomAttribute attribute = SampleAttribute(reader, sample);
+        var work = new CustomAttributeValueDecoder.GenericContextWork();
+
+        Assert.True(CustomAttributeValueDecoder.TryDecode(
+            reader,
+            attribute,
+            preserveSerializedTypeNames: false,
+            captureDefaultedWidths: false,
+            beforeMaterialize: null,
+            enumUnderlyingType: null,
+            out var measured,
+            out _,
+            out _,
+            genericContextWork: work));
+        var ordinary = AttributeDecoder.TryDecode(reader, attribute);
+
+        Assert.NotNull(ordinary);
+        Assert.Equal(parameterCount, measured.FixedArguments.Length);
+        Assert.Equal(parameterCount, ordinary.Value.FixedArguments.Length);
+        Assert.Empty(measured.NamedArguments);
+        Assert.Empty(ordinary.Value.NamedArguments);
+        for (int i = 0; i < parameterCount; i++)
+        {
+            Assert.Equal("int", measured.FixedArguments[i].Type);
+            Assert.Equal(i + 1, measured.FixedArguments[i].Value);
+            Assert.Equal(measured.FixedArguments[i], ordinary.Value.FixedArguments[i]);
+        }
+        Assert.Equal(expectedBytesSkipped, work.BytesSkipped);
+    }
+
+    [Fact]
+    public void GenericArgumentLookup_PreservesMixedValuesAndCharges()
+    {
+        Type sample = typeof(Samples.MixedValues);
+        using var pe = new PEReader(File.OpenRead(sample.Assembly.Location));
+        MetadataReader reader = pe.GetMetadataReader();
+        CustomAttribute attribute = SampleAttribute(reader, sample);
+        var work = new CustomAttributeValueDecoder.GenericContextWork();
+        var measuredCharges = new List<int>();
+        var ordinaryCharges = new List<int>();
+
+        Assert.True(CustomAttributeValueDecoder.TryDecode(
+            reader,
+            attribute,
+            preserveSerializedTypeNames: false,
+            captureDefaultedWidths: true,
+            beforeMaterialize: measuredCharges.Add,
+            enumUnderlyingType: null,
+            out var measured,
+            out var fixedFlags,
+            out var namedFlags,
+            genericContextWork: work));
+        var ordinary = AttributeDecoder.TryDecode(reader, attribute, ordinaryCharges.Add);
+
+        Assert.NotNull(ordinary);
+        AssertValues(measured);
+        AssertValues(ordinary.Value);
+        Assert.Equal([false, false, false, false], fixedFlags);
+        Assert.Empty(namedFlags);
+        Assert.Equal([64, 5, 32, 4], measuredCharges);
+        Assert.Equal(measuredCharges, ordinaryCharges);
+        Assert.Equal(3, work.BytesSkipped);
+    }
+
+    static void AssertValues(CustomAttributeValue<string> value)
+    {
+        Assert.Equal(["string", "long[]", "int", "string"],
+            value.FixedArguments.Select(argument => argument.Type));
+        Assert.Equal("first", value.FixedArguments[0].Value);
+        var array = Assert.IsType<ImmutableArray<CustomAttributeTypedArgument<string>>>(
+            value.FixedArguments[1].Value);
+        Assert.Equal(["long", "long"], array.Select(argument => argument.Type));
+        Assert.Equal([2L, 3L], array.Select(argument => Assert.IsType<long>(argument.Value)));
+        Assert.Equal(4, value.FixedArguments[2].Value);
+        Assert.Equal("last", value.FixedArguments[3].Value);
+        Assert.Empty(value.NamedArguments);
+    }
+
+    static CustomAttribute SampleAttribute(MetadataReader reader, Type sample)
+    {
+        var handle = (TypeDefinitionHandle)MetadataTokens.EntityHandle(sample.MetadataToken);
+        return Assert.Single(reader.GetTypeDefinition(handle).GetCustomAttributes()
+            .Select(reader.GetCustomAttribute),
+            attribute =>
+                attribute.Constructor.Kind == HandleKind.MemberReference
+                && reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor)
+                    .Parent.Kind == HandleKind.TypeSpecification);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CustomAttributeGenericContextTests.cs
@@ -18,6 +18,7 @@ public sealed class CustomAttributeGenericContextTests
     [InlineData(typeof(Samples.AscendingFour), 4, 3)]
     [InlineData(typeof(Samples.DescendingFour), 4, 3)]
     [InlineData(typeof(Samples.UnusedTail), 1, 0)]
+    [InlineData(typeof(Samples.NoGenericParameters), 1, 0)]
     public void GenericArgumentLookup_ReusesVisitedPrefix(
         Type sample,
         int parameterCount,
@@ -53,6 +54,32 @@ public sealed class CustomAttributeGenericContextTests
             Assert.Equal(measured.FixedArguments[i], ordinary.Value.FixedArguments[i]);
         }
         Assert.Equal(expectedBytesSkipped, work.BytesSkipped);
+    }
+
+    [Fact]
+    public void GenericArgumentLookup_DoesNotCacheResolvedEnumWidths()
+    {
+        Type sample = typeof(Samples.RepeatedEnum);
+        using var pe = new PEReader(File.OpenRead(sample.Assembly.Location));
+        MetadataReader reader = pe.GetMetadataReader();
+        int resolutions = 0;
+
+        var decoded = AttributeDecoder.TryDecodeDetailed(
+            reader,
+            SampleAttribute(reader, sample),
+            enumUnderlyingType: (string name, out PrimitiveTypeCode width) =>
+            {
+                Assert.Equal("System.DayOfWeek", name);
+                width = PrimitiveTypeCode.Int32;
+                return ++resolutions % 2 == 0;
+            });
+
+        Assert.NotNull(decoded);
+        Assert.Equal(4, resolutions);
+        Assert.Equal([true, false, true, false],
+            decoded.Value.FixedArgumentEnumWidthDefaulted);
+        Assert.Equal([0, 1, 0, 1], decoded.Value.Value.FixedArguments
+            .Select(argument => Assert.IsType<int>(argument.Value)));
     }
 
     [Fact]


### PR DESCRIPTION
# Reliable custom-attribute generic lookup

Reliable custom-attribute inspection should not repeatedly traverse the same
generic prefix just because a constructor has more parameters. This repairs
issue #5098 in the shared decoder without changing decoded values or the public API.

## Demo

These small compiler-produced attributes exercise the ordinary decoder:

```csharp
[Repeated<int, int, int, int>(1, 2, 3, 4)]
public sealed class RepeatedFour;

[Repeated<int, int, int, int>(1, 2, 3, 4, 5, 6, 7, 8)]
public sealed class RepeatedEight;
```

Their constructor parameters all use the last generic argument. Public decoded
values remain `[1, 2, 3, 4]` and `[1, 2, 3, 4, 5, 6, 7, 8]`; actual generic-prefix
bytes skipped change as follows. `Expected` is the prefix-byte count to reach
the highest requested generic argument once:

| Compiler-produced case | Before | After | Expected |
| --- | ---: | ---: | ---: |
| Two generic arguments, four alternating parameters | 2 | 1 | 1 |
| Two generic arguments, eight alternating parameters | 4 | 1 | 1 |
| Four generic arguments, four repeated parameters | 12 | 3 | 3 |
| Four generic arguments, eight repeated parameters | 24 | 3 | 3 |
| Four generic arguments, eight alternating parameters | 12 | 3 | 3 |
| Four generic arguments, ascending indices | 6 | 3 | 3 |
| Four generic arguments, descending indices | 6 | 3 | 3 |
| Unused trailing generic argument | 0 | 0 | 0 |
| Mixed scalar/array parameters | 7 | 3 | 3 |

The mixed neighbor decodes `["first", long[] { 2, 3 }, 4, "last"]`, with
charges `[64, 5, 32, 4]` both before and after. An external-enum neighbor
preserves four independent resolver calls and alternating per-argument
defaulted-width flags. A constructor with no `VAR` parameters does no prefix
skipping.

## Design and scope

**Normative owner:** `docs/design/custom-attribute-value-decoding.md#d1--bounded`,
with the focused claim and gate in `#generic-context-lookup-gate`.
Within one attribute decode, generic argument lookup reuses the already
traversed prefix for repeated, alternating, and increasing indices.

The conventional repair is a lazy argument-start index. It grows from actual
prefix progress, not declared arity; does not inspect unused suffixes; preserves
the existing structural skipper; and caches positions rather than decoded
types. Selected-type decoding, enum resolution, materialization charges,
empty-context substitution, and defaulted-width reporting stay on their
existing paths. There is no new public metrics API.

SRM's historical prefix walk is comparative evidence, not a new oracle or a
dependency being introduced. Its existing cursor behavior remains pinned by the
neighboring regressions; changing that grammar is not part of this repair.

This is one independently complete repair under #5288. CLI and browser/Wasm
already consume the same shared decoder: one implementation step benefits both,
with no new host integration, architecture, dependency, platform exception, or
rendering surface. The optional internal traversal counter is consumed only by
the existing metadata test runner.

Full D1 is **not** established: #5733 retains the generative joint-dimension
gate, including selected-type resolution and cross-row work. #5065's broader
D3 certification and #5397's dedicated internal-OOM evidence remain separate.

## Validation

SDK: `11.0.100-preview.7.26381.103`; Release configuration.

Pre-repair commit `b830af9b4901912f6e17a1e7e346822d0e1b6342` preserves the old
lookup algorithm with an optional read-only work counter and the initial nine
compiler-produced cases. Eight fail only their skipped-byte assertions;
decoded-value and charge assertions already pass. The unused-tail case passes.
This is measured traversal, not a timing or allocation proxy.

```bash
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- \
  --filter-class ILInspector.Metadata.Tests.CustomAttributeGenericContextTests \
  --no-progress
```

Final focused gate: **259 passed, 0 failed, 0 skipped**, including the eleven
new cases and the existing refusal, earlier-generic-argument cursor, enum width,
fidelity, bounds, and materialization-index cases:

```bash
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- \
  --filter-class \
  ILInspector.Metadata.Tests.CustomAttributeGenericContextTests \
  ILInspector.Metadata.Tests.CustomAttributeValueDecoderTests \
  ILInspector.Metadata.Tests.TypeResolutionEnumWidthTests \
  ILInspector.Metadata.Tests.CustomAttributeFidelityTests \
  ILInspector.Metadata.Tests.ApiSurfaceExtractorBoundsTests \
  ILInspector.Metadata.Tests.MemorySafetyMetadataIndexTests \
  --no-progress
```

The owner documentation passes `markdownlint`. The second base integration
adds only unrelated export-count documentation; it does not affect these gates.
Round 1 is **review-clean, 2/2** at
`3087ea40dd6af668eee80528a0a451bc85de5e6e`: GPT-6 Astra and Claude Opus 5 each
independently passed the same 259 cases and returned no findings. Current-head
`ci-required` succeeded. Main through `d119594d9553804591761f30f7f0de5a2749c905`
was classified no interaction; the reviewed head is unchanged.
[Public reconciliation](https://github.com/richlander/dotnet-inspect/pull/6085#issuecomment-5556979317)
records the exact scope and evidence. Merge remains separately authorized.

Fixes #5098.
