### PR TITLE
Retain native C# union JSON wire evidence

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -64,6 +64,7 @@
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.ScalarFixtures/ILInspector.JsExportSurface.ScalarFixtures.csproj" />
     <Project Path="fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/ILInspector.JsExportSurface.TypeScriptFixtures.csproj" />
+    <Project Path="fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/ILInspector.JsExportSurface.UnionFixtures.csproj" />
     <Project Path="fixtures/js-export/TsJsExport.ContextFixtures.Alpha/TsJsExport.ContextFixtures.Alpha.csproj" />
     <Project Path="fixtures/js-export/TsJsExport.ContextFixtures.Beta/TsJsExport.ContextFixtures.Beta.csproj" />
     <Project Path="fixtures/js-export/TsJsExport.ContextFixtures.Host/TsJsExport.ContextFixtures.Host.csproj" />

--- a/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/ILInspector.JsExportSurface.UnionFixtures.csproj
+++ b/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/ILInspector.JsExportSurface.UnionFixtures.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <!-- Ambiguous read cases intentionally retain the source-generator warning. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);SYSLIB1227</WarningsNotAsErrors>
+  </PropertyGroup>
+</Project>

--- a/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/README.md
+++ b/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/README.md
@@ -1,0 +1,24 @@
+# JSON union wire fixture
+
+This assembly owns the native-union export inventory used by
+`JsonUnionWireTests`. Its assembly boundary keeps reached unions, which the
+TypeScript generator must currently reject, out of the canonical supported
+facade fixture. Resolve it through `FixtureIds.JsExportUnions`.
+
+The source-generated context covers scalar, DTO, generic, nested, collection,
+and custom-converted unions, alongside an ordinary object and a raw string
+export. The tests select an export from the extracted metadata while preserving
+its compiler-generated runtime registration and serializer body evidence.
+
+`ObjectUnion` and `NumberUnion` deliberately produce `SYSLIB1227`: their
+alternatives can be serialized, but the default read classifier is ambiguous.
+Only that warning is exempted from warnings-as-errors in this fixture project;
+it remains visible. Other source-generator warnings are not suppressed.
+
+The runtime oracle uses SDK `11.0.100-preview.7.26381.103`, with System.Text.Json
+source pinned to
+[`e2c1e00b3d0f96afb892fb261d5921565b400246`](https://github.com/dotnet/dotnet/tree/e2c1e00b3d0f96afb892fb261d5921565b400246/src/runtime/src/libraries/System.Text.Json).
+Generated union metadata selects the actual case and writes its own contract
+inline; its null arm accounts for the default value. A nested scalar union's
+number case and the ambiguous unions are negative read controls, not evidence
+that all successfully written unions can be deserialized.

--- a/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/UnionWireSamples.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/UnionWireSamples.cs
@@ -1,0 +1,122 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.UnionFixtures;
+
+public union ScalarUnion(int, string);
+public union NullableUnion(int?, string);
+public union DtoUnion(PackageSummary, string);
+public union GenericUnion<T>(T, string);
+public union NestedUnion(ScalarUnion, bool);
+public union ObjectUnion(PackageSummary, PackageProblem);
+public union NumberUnion(int, double);
+
+[JsonConverter(typeof(CustomUnionConverter))]
+public union CustomUnion(int, string);
+
+public sealed record PackageSummary(string Id);
+public sealed record PackageProblem(int Code);
+public sealed record UnionEnvelope(DtoUnion Result, ScalarUnion[] Items);
+public sealed record OrdinaryValue(int Value);
+
+public static partial class UnionExports
+{
+    [JSExport]
+    public static string GetScalar(int choice) =>
+        JsonSerializer.Serialize(
+            choice == 0 ? new ScalarUnion(42)
+                : choice == 1 ? new ScalarUnion("hello") : default,
+            UnionJsonContext.Default.ScalarUnion);
+
+    [JSExport]
+    public static string GetDto() =>
+        JsonSerializer.Serialize(
+            new DtoUnion(new PackageSummary("Example.Package")),
+            UnionJsonContext.Default.DtoUnion);
+
+    [JSExport]
+    public static string GetNullable() =>
+        JsonSerializer.Serialize(
+            new NullableUnion((int?)42),
+            UnionJsonContext.Default.NullableUnion);
+
+    [JSExport]
+    public static string GetGeneric() =>
+        JsonSerializer.Serialize(
+            new GenericUnion<int>(7),
+            UnionJsonContext.Default.GenericUnionInt32);
+
+    [JSExport]
+    public static string GetNested() =>
+        JsonSerializer.Serialize(
+            new NestedUnion(new ScalarUnion(42)),
+            UnionJsonContext.Default.NestedUnion);
+
+    [JSExport]
+    public static string GetObjects() =>
+        JsonSerializer.Serialize(
+            new ObjectUnion(new PackageProblem(404)),
+            UnionJsonContext.Default.ObjectUnion);
+
+    [JSExport]
+    public static string GetNumbers() =>
+        JsonSerializer.Serialize(
+            new NumberUnion(1.5),
+            UnionJsonContext.Default.NumberUnion);
+
+    [JSExport]
+    public static string GetEnvelope() =>
+        JsonSerializer.Serialize(
+            new UnionEnvelope(
+                new DtoUnion("missing"),
+                [new ScalarUnion(7), new ScalarUnion("ok"), default]),
+            UnionJsonContext.Default.UnionEnvelope);
+
+    [JSExport]
+    public static string GetCustom() =>
+        JsonSerializer.Serialize(
+            new CustomUnion(42),
+            UnionJsonContext.Default.CustomUnion);
+
+    [JSExport]
+    public static string GetOrdinary() =>
+        JsonSerializer.Serialize(
+            new OrdinaryValue(42),
+            UnionJsonContext.Default.OrdinaryValue);
+
+    [JSExport]
+    public static string GetPlain() => "plain";
+
+    [JSExport]
+    public static void ReadScalar(string json) =>
+        _ = JsonSerializer.Deserialize(json, UnionJsonContext.Default.ScalarUnion);
+
+    [JSExport]
+    public static void ReadObjects(string json) =>
+        _ = JsonSerializer.Deserialize(json, UnionJsonContext.Default.ObjectUnion);
+}
+
+public sealed class CustomUnionConverter : JsonConverter<CustomUnion>
+{
+    public override CustomUnion Read(
+        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        new(reader.GetString() ?? throw new JsonException());
+
+    public override void Write(
+        Utf8JsonWriter writer, CustomUnion value, JsonSerializerOptions options) =>
+        writer.WriteStringValue($"custom:{value.Value}");
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ScalarUnion))]
+[JsonSerializable(typeof(NullableUnion))]
+[JsonSerializable(typeof(DtoUnion))]
+[JsonSerializable(typeof(GenericUnion<int>))]
+[JsonSerializable(typeof(NestedUnion))]
+[JsonSerializable(typeof(ObjectUnion))]
+[JsonSerializable(typeof(NumberUnion))]
+[JsonSerializable(typeof(CustomUnion))]
+[JsonSerializable(typeof(UnionEnvelope))]
+[JsonSerializable(typeof(OrdinaryValue))]
+public sealed partial class UnionJsonContext : JsonSerializerContext;

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -31,6 +31,8 @@ public sealed class JsExportSurface
     /// </summary>
     public IReadOnlyList<ApiType> Enums { get; init; } = [];
 
+    public IReadOnlyList<JsExportUnion> Unions { get; init; } = [];
+
     /// <summary>
     /// Complete extracted same-assembly type inventory available when the
     /// surface came from <see cref="JsExportSurfaceBuilder"/> rather than a
@@ -47,21 +49,48 @@ public sealed class JsExportSurface
     /// <summary>
     /// The wire directions each declared type was reached in, keyed by the
     /// <see cref="ApiType"/> instances published in <see cref="Records"/> and
-    /// <see cref="Enums"/>.
+    /// <see cref="Enums"/> and <see cref="Unions"/>.
     /// </summary>
     /// <remarks>
     /// Directions are composed here rather than stored on <see cref="ApiType"/>
     /// because they are a property of how an export uses a type, not a metadata
-    /// fact the type itself carries. A type absent from this map — a
-    /// hand-composed surface, or a registered shape no export references — is
-    /// treated as <see cref="JsonWireDirection.Both"/> by consumers, which is
-    /// the conservative reading. Gated by
+    /// fact the type itself carries. Body-backed surfaces mark unreached types
+    /// as <see cref="JsonWireDirection.None"/>. A type absent from this map on
+    /// a declaration-only or hand-composed surface is conservatively treated
+    /// as <see cref="JsonWireDirection.Both"/> by consumers. Gated by
     /// <c>JsExportSurfaceBuilderTests.Build_RecordsSerializeOnlyDirectionForReturnOnlyDto</c>.
     /// </remarks>
     [JsonIgnore]
     public IReadOnlyDictionary<ApiType, JsonWireDirection> WireDirections
         { get; init; } =
         new Dictionary<ApiType, JsonWireDirection>();
+}
+
+/// <summary>
+/// The source-generated union convention, distinct from an object-property
+/// contract. Case types retain generic parameter positions; a consumer must
+/// instantiate them for a closed use and honor each case's own wire contract.
+/// </summary>
+public sealed class JsExportUnion
+{
+    public required ApiType Definition { get; init; }
+
+    [JsonIgnore]
+    public IReadOnlyList<TypeRef> CaseTypes { get; init; } = [];
+
+    /// <summary>
+    /// Null means the convention was not established. True includes the
+    /// default union state independently of constructor parameter annotations.
+    /// </summary>
+    public bool? IncludesNull { get; init; }
+
+    public string? SerializationUnsupportedReason { get; init; }
+
+    /// <summary>
+    /// Writing alternatives do not establish a case classifier for reading.
+    /// </summary>
+    public string DeserializationUnsupportedReason { get; init; } =
+        "union deserialization case classification is not modeled";
 }
 
 /// <summary>

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -189,6 +189,7 @@ public static class JsExportSurfaceBuilder
 
         var records = new List<ApiType>();
         var enums = new List<ApiType>();
+        var unionTypes = new List<ApiType>();
         var discovered = new HashSet<ApiType>();
         var policiesByType = new Dictionary<ApiType, HashSet<JsonWireNamingPolicy>>();
         var registeredJsonTypeInfoGetterModes =
@@ -480,7 +481,9 @@ public static class JsExportSurfaceBuilder
 
             if (discovered.Add(type))
             {
-                if (type.Kind == "enum")
+                if (type.HasUnionAttribute == true)
+                    unionTypes.Add(type);
+                else if (type.Kind == "enum")
                     enums.Add(type);
                 else
                     records.Add(type);
@@ -489,6 +492,19 @@ public static class JsExportSurfaceBuilder
             if (type.Kind == "enum"
                 || type.JsonConverterAttributeCount > 0)
                 continue;
+
+            if (type.HasUnionAttribute == true)
+            {
+                foreach (ApiMember constructor in JsonUnionWireRules.CaseConstructors(type))
+                {
+                    foreach (ApiTypeReferenceIdentity reference
+                        in constructor.SignatureModel!.Parameters[0].TypeReferences)
+                    {
+                        queue.Enqueue((null, reference, namingPolicy));
+                    }
+                }
+                continue;
+            }
 
             foreach (ApiMember member in type.Members)
             {
@@ -557,7 +573,8 @@ public static class JsExportSurfaceBuilder
                 functions,
                 surface.AssemblyIdentity,
                 typesByScopedIdentity,
-                discovered);
+                discovered,
+                bodyEvidenceAvailable: bodyIndex is not null);
         RejectReachedContextRelativeValueTypeAccessibility(
             functions,
             wireDirections,
@@ -572,9 +589,24 @@ public static class JsExportSurfaceBuilder
             Functions = functions,
             Records = records,
             Enums = enums,
+            Unions = DescribeUnions(unionTypes, bodyIndex),
             AllTypes = surface.Types,
             WireDirections = wireDirections,
         };
+    }
+
+    static IReadOnlyList<JsExportUnion> DescribeUnions(
+        IReadOnlyList<ApiType> unionTypes,
+        LibraryBodyIndex? bodyIndex)
+    {
+        if (unionTypes.Count == 0)
+            return [];
+
+        IReadOnlyDictionary<int, MethodIdentity> methods = bodyIndex is null
+            ? new Dictionary<int, MethodIdentity>()
+            : bodyIndex.DeclaredMethods.ToDictionary(method => method.MetadataToken);
+        return [.. unionTypes.Select(type =>
+            JsonUnionWireRules.Describe(type, bodyIndex, methods))];
     }
 
     /// <summary>
@@ -598,7 +630,8 @@ public static class JsExportSurfaceBuilder
         List<JsExportFunction> functions,
         ApiAssemblyIdentity? assemblyIdentity,
         Dictionary<ApiTypeReferenceIdentity, ApiType> typesByScopedIdentity,
-        HashSet<ApiType> discovered)
+        HashSet<ApiType> discovered,
+        bool bodyEvidenceAvailable)
     {
         var directions = new Dictionary<ApiType, JsonWireDirection>();
         var queue = new Queue<(ApiType Type, JsonWireDirection Direction)>();
@@ -641,6 +674,13 @@ public static class JsExportSurfaceBuilder
             if (type.Kind == "enum" || type.JsonConverterAttributeCount > 0)
                 continue;
 
+            if (type.HasUnionAttribute == true)
+            {
+                foreach (ApiMember constructor in JsonUnionWireRules.CaseConstructors(type))
+                    Seed(constructor.SignatureModel!.Parameters[0].TypeReferences, direction);
+                continue;
+            }
+
             foreach (ApiMember member in type.Members)
             {
                 if (!JsonWireMemberRules.IsSerialized(
@@ -658,7 +698,7 @@ public static class JsExportSurfaceBuilder
             }
         }
 
-        if (directions.Count > 0)
+        if (bodyEvidenceAvailable || directions.Count > 0)
         {
             foreach (ApiType type in discovered)
                 directions.TryAdd(type, JsonWireDirection.None);
@@ -702,6 +742,7 @@ public static class JsExportSurfaceBuilder
             if (!wireDirections.TryGetValue(type, out JsonWireDirection directions)
                 || directions == JsonWireDirection.None
                 || type.Kind == "enum"
+                || type.HasUnionAttribute == true
                 || type.JsonConverterAttributeCount > 0)
             {
                 continue;
@@ -818,6 +859,18 @@ public static class JsExportSurfaceBuilder
 
             if (type.Kind == "enum" || type.JsonConverterAttributeCount > 0)
                 continue;
+
+            if (type.HasUnionAttribute == true)
+            {
+                foreach (ApiMember constructor in JsonUnionWireRules.CaseConstructors(type))
+                {
+                    Seed(
+                        constructor.SignatureModel!.Parameters[0].TypeReferences,
+                        [contextScopeKey],
+                        direction);
+                }
+                continue;
+            }
 
             foreach (ApiMember member in type.Members)
             {

--- a/src/ILInspector.JsExportSurface/JsonUnionWireRules.cs
+++ b/src/ILInspector.JsExportSurface/JsonUnionWireRules.cs
@@ -1,0 +1,137 @@
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+
+namespace ILInspector.JsExportSurface;
+
+internal static class JsonUnionWireRules
+{
+    internal static IEnumerable<ApiMember> CaseConstructors(ApiType type) =>
+        type.Members.Where(member =>
+            member.Kind == "constructor"
+            && !member.IsStatic
+            && member.Accessibility is null or "public"
+            && member.SignatureModel is { Parameters.Count: 1 } signature
+            && signature.Parameters[0].Modifier is not ("ref" or "in" or "out"));
+
+    internal static JsExportUnion Describe(
+        ApiType type,
+        LibraryBodyIndex? bodyIndex,
+        IReadOnlyDictionary<int, MethodIdentity> methods)
+    {
+        JsExportUnion Unsupported(string reason) => new()
+        {
+            Definition = type,
+            SerializationUnsupportedReason = reason,
+        };
+
+        if (bodyIndex is null)
+            return Unsupported("union case signature evidence is unavailable");
+        if (type.Kind != "struct")
+            return Unsupported("only value-type union conventions are supported");
+        if (type.JsonConverterAttributeCount > 0
+            || type.HasUnsupportedJsonWireAttributes)
+        {
+            return Unsupported("union has unsupported wire-shaping attributes");
+        }
+        if (type.JsonPropertyNamingPolicy == JsonWireNamingPolicy.Unsupported)
+            return Unsupported("union serializer context options are unsupported");
+        if (type.Members.Any(member =>
+            member.Kind == "constructor"
+            && !member.IsStatic
+            && member.Accessibility is null or "public"
+            && (member.SignatureModel is null
+                || member.SignatureDecodeStatus == SignatureDecodeStatus.Degraded)))
+        {
+            return Unsupported("union constructor signature metadata is unavailable or degraded");
+        }
+
+        ApiMember[] valueProperties =
+        [
+            .. type.Members.Where(member =>
+                member.Kind == "property"
+                && member.Name == "Value"
+                && !member.IsStatic
+                && member.Accessibility is null or "public"
+                && member.HasGetter == true
+                && member.GetterAccessibility is null or "public"
+                && member.SignatureModel is { ParameterCount: 0 }),
+        ];
+        if (valueProperties is not [var value]
+            || value.GetterToken is not { } getterToken
+            || !methods.TryGetValue(getterToken, out MethodIdentity? getter)
+            || !IsOwnMethod(getter, type, bodyIndex)
+            || getter.IsStatic
+            || !getter.ParameterTypes.IsEmpty
+            || !IsSystemObject(getter.ReturnType)
+            || value.SignatureDecodeStatus == SignatureDecodeStatus.Degraded)
+        {
+            return Unsupported("union has no supported public object Value getter");
+        }
+
+        var cases = new List<TypeRef>();
+        foreach (ApiMember constructor in CaseConstructors(type))
+        {
+            if (constructor.SignatureDecodeStatus == SignatureDecodeStatus.Degraded
+                || constructor.MetadataToken is not { } token
+                || !methods.TryGetValue(token, out MethodIdentity? method)
+                || !IsOwnMethod(method, type, bodyIndex)
+                || method.Name != ".ctor"
+                || method.IsStatic
+                || method.ParameterTypes is not [var caseType]
+                || !IsSupportedCaseShape(caseType))
+            {
+                return Unsupported("union case signature evidence is unsupported");
+            }
+            cases.Add(caseType);
+        }
+
+        return cases.Count == 0
+            ? Unsupported("union has no supported case constructors")
+            : new JsExportUnion
+            {
+                Definition = type,
+                CaseTypes = cases,
+                IncludesNull = true,
+            };
+    }
+
+    static bool IsOwnMethod(
+        MethodIdentity method,
+        ApiType type,
+        LibraryBodyIndex bodyIndex) =>
+        method.ModuleVersionId == bodyIndex.ModuleIdentity.ModuleVersionId
+        && method.DeclaringType.Resolution is
+        {
+            Origin: TypeReferenceOrigin.CurrentAssembly,
+            Type: { } definition,
+        }
+        && definition == type.DefinitionName;
+
+    static bool IsSystemObject(TypeRef type) =>
+        type.Kind == TypeRefKind.Definition
+        && type.Namespace == "System"
+        && type.Name == "Object"
+        && type.TrustedFrameworkAssembly
+        && type.Assembly == TypeRef.CoreLibrary;
+
+    static bool IsSupportedCaseShape(TypeRef type)
+    {
+        var pending = new Stack<TypeRef>();
+        pending.Push(type);
+        while (pending.TryPop(out TypeRef? current))
+        {
+            if (current.Kind is not (TypeRefKind.Definition
+                or TypeRefKind.GenericInstance
+                or TypeRefKind.GenericParameter
+                or TypeRefKind.SzArray))
+            {
+                return false;
+            }
+            if (current.ElementType is { } element)
+                pending.Push(element);
+            foreach (TypeRef argument in current.TypeArguments)
+                pending.Push(argument);
+        }
+        return true;
+    }
+}

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -317,6 +317,60 @@ are the gates. `Build_RejectsAuthenticJsExportOperatorBeforePublication` and
 `SourceGeneratedJsExport_EmitsOnlyOrdinaryMethodWrappers` gate the
 ordinary-method boundary.
 
+## JSON union alternatives
+
+This section owns slice 2 of
+[#5892](https://github.com/richlander/dotnet-inspect/issues/5892), tracked by
+[#6078](https://github.com/richlander/dotnet-inspect/issues/6078).
+The consumer remains `ts-jsexport`, followed by inspect-web adoption in the
+four-slice tracker. It does not change raw JSExport marshalling.
+
+`Unions` separates a union's case contracts from `Records`: the public `Value`
+property is not an object wire member. Recognition consumes Metadata's typed
+`HasUnionAttribute` fact. The supported convention is a value type with public
+single-argument, by-value case constructors and a public instance,
+parameterless `object Value` getter. Exact case signature trees come from
+Analysis's same-module declared MethodDefs, joined to the Metadata declaration
+by token and structured declaring-type identity. They are not reconstructed
+from rendered attributes, parameter names, or C# type spelling.
+
+For a supported convention, `CaseTypes` retains the constructor alternatives
+and `IncludesNull` is true: the default union state writes JSON null even if no
+constructor parameter is nullable. A case writes its own effective serializer
+contract inline, without a `Value` wrapper or an invented discriminator.
+The case's existing converter, naming, member, and unsupported-type rules
+still apply; case types are not a replacement JSON schema. This is a statement
+about successful serialization, not a guarantee that arbitrary getter code or
+every possible producer value succeeds.
+
+Case discovery carries naming policy, reached wire directions, and context
+scope through constructor edges rather than through the `Value` getter.
+Generic alternatives retain their parameter positions; the authenticated
+closed root shape supplies their type arguments. Unused registrations stay
+unreached, and unsupported declaration-only or union conventions retain a
+`SerializationUnsupportedReason` with unavailable null evidence.
+
+Deserialization classification is deliberately not modeled in this slice.
+`DeserializationUnsupportedReason` remains explicit even when the runtime can
+read a simple scalar union. Writing two object cases or nested unions does not
+prove that a default reader can select the right case. Classifier support and
+its direction-specific admission require their own evidence before that
+boundary can expand.
+
+`JsonUnionWireTests` gates these facts with compiler-produced native unions,
+real source-generated serialization, ambiguous and nested read boundaries,
+case discovery, direction propagation, closed generic signatures, and
+unsupported converter evidence. Its neighboring ordinary DTO remains an
+object. The same suite checks that TypeScript generation rejects a reached
+union until slice 3 implements lowering, rather than emitting a misleading
+interface.
+
+The serializer oracle is bounded to SDK `11.0.100-preview.7.26381.103` and
+[its System.Text.Json source](https://github.com/dotnet/dotnet/tree/e2c1e00b3d0f96afb892fb261d5921565b400246/src/runtime/src/libraries/System.Text.Json).
+It uses the authenticated default source-generated context property. Explicit
+resolver results, `WithAddedModifier`, and custom-options context instances
+are not interchangeable with that path and do not inherit its evidence.
+
 Run its test suite in Release:
 
 ```bash

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -121,12 +121,22 @@ static class DtsEmitter
             includeRawReturnType);
 
     static ApiType[] GetDeclarationTypes(
-        ILInspector.JsExportSurface.JsExportSurface surface) =>
-        [
+        ILInspector.JsExportSurface.JsExportSurface surface)
+    {
+        JsExportUnion? union = surface.Unions.FirstOrDefault(
+            union => ShouldEmit(surface, union.Definition));
+        if (union is not null)
+        {
+            throw new UnsupportedWireContractException(
+                union.Definition.FullName,
+                "native C# union TypeScript lowering is not implemented");
+        }
+        return [
             .. surface.Records
                 .Concat(surface.Enums)
                 .Where(type => ShouldEmit(surface, type)),
         ];
+    }
 
     static IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
         DeclaredTypesByScopedIdentity(

--- a/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
+++ b/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
@@ -52,6 +52,7 @@ public static class FixtureGroupExtensions
 
 public static class FixtureIds
 {
+    public const string JsExportUnions = "js-export.unions";
     public const string MetadataAttributeEnums = "metadata.attribute-enums";
     public const string DiffV1 = "diff.v1";
     public const string DiffV2 = "diff.v2";
@@ -142,6 +143,13 @@ public static class FixtureIds
 
 public static class FixtureCatalog
 {
+    public static readonly FixtureDefinition JsExportUnions = Fixture(
+        FixtureIds.JsExportUnions,
+        "ILInspector.JsExportSurface.UnionFixtures",
+        "ILInspector.JsExportSurface.UnionFixtures.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity),
+        "js-export", "json", "union");
+
     public static readonly FixtureDefinition MetadataAttributeEnums = Fixture(
         FixtureIds.MetadataAttributeEnums,
         "ILInspector.Metadata.AttributeEnumFixtures",
@@ -679,6 +687,7 @@ public static class FixtureCatalog
 
     public static readonly IReadOnlyList<FixtureDefinition> All =
     [
+        JsExportUnions,
         MetadataAttributeEnums,
         InspectWebMethodBodies,
         DecompilerAuthoredRebuild,
@@ -1030,6 +1039,8 @@ public static class FixtureCatalog
     static string RepositoryProjectDirectory(string projectName)
         => projectName switch
         {
+            "ILInspector.JsExportSurface.UnionFixtures" =>
+                "fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures",
             "ILInspector.Metadata.AttributeEnumFixtures" =>
                 "fixtures/metadata/ILInspector.Metadata.AttributeEnumFixtures",
             "InspectWeb.MethodBodyFixtures" => "fixtures/inspect-web/InspectWeb.MethodBodyFixtures",

--- a/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
+++ b/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
@@ -21,6 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../DotnetInspector.FixtureInfrastructure/DotnetInspector.FixtureInfrastructure.csproj" />
+    <ProjectReference Include="../../fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/ILInspector.JsExportSurface.UnionFixtures.csproj" />
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
     <ProjectReference Include="../../src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
     <ProjectReference Include="../../src/ILInspector.JsExportSurface/ILInspector.JsExportSurface.csproj" />

--- a/tests/ILInspector.JsExportSurface.Tests/JsonUnionWireTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonUnionWireTests.cs
@@ -1,0 +1,214 @@
+using System.Reflection.PortableExecutable;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
+using ILInspector.JsExportSurface.UnionFixtures;
+using ILInspector.Metadata;
+
+namespace ILInspector.JsExportSurface.Tests;
+
+public sealed class JsonUnionWireTests
+{
+    static readonly Lazy<LibraryBodyIndex> Bodies = new(() =>
+        LibraryBodyIndex.Open(
+            FixtureCatalog.AssemblyPath(FixtureIds.JsExportUnions),
+            LibraryBodyAnalysisFeatures.MethodEvidence
+                | LibraryBodyAnalysisFeatures.JsonWireContractFlow));
+
+    [Fact]
+    public void Build_RetainsScalarCasesAndDefaultNullRatherThanValueWrapper()
+    {
+        var surface = Build(nameof(UnionExports.GetScalar));
+        JsExportUnion union = Find(surface, nameof(ScalarUnion));
+
+        Assert.Null(union.SerializationUnsupportedReason);
+        Assert.True(union.IncludesNull);
+        Assert.Equal(["int", "string"], union.CaseTypes.Select(type => type.ToDisplayString()));
+        Assert.DoesNotContain(surface.Records, type => type.HasUnionAttribute == true);
+        Assert.Equal(JsonWireDirection.Serialize, surface.WireDirections[union.Definition]);
+        Assert.Equal(JsonTypeInfoKind.Union, UnionJsonContext.Default.ScalarUnion.Kind);
+        Assert.Equal("42", UnionExports.GetScalar(0));
+        Assert.Equal("\"hello\"", UnionExports.GetScalar(1));
+        Assert.Equal("null", UnionExports.GetScalar(2));
+    }
+
+    [Fact]
+    public void Build_FollowsDtoCasesWithTheirContextNamingAndDirection()
+    {
+        var surface = Build(nameof(UnionExports.GetDto));
+        JsExportUnion union = Find(surface, nameof(DtoUnion));
+        ApiType dto = Assert.Single(surface.Records, type => type.Name == nameof(PackageSummary));
+
+        Assert.Equal(
+            typeof(PackageSummary).FullName,
+            union.CaseTypes[0].Resolution?.Type?.ToMetadataFullName());
+        Assert.Equal(JsonWireNamingPolicy.CamelCase, dto.JsonPropertyNamingPolicy);
+        Assert.Equal(JsonWireDirection.Serialize, surface.WireDirections[dto]);
+        Assert.Equal("{\"id\":\"Example.Package\"}", UnionExports.GetDto());
+        Assert.NotEmpty(Assert.Single(surface.Functions).ReturnWireContextScopeKeys);
+    }
+
+    [Fact]
+    public void Build_PreservesGenericCasePositionsAndClosedRootArguments()
+    {
+        var surface = Build(nameof(UnionExports.GetGeneric));
+        JsExportUnion union = Assert.Single(
+            surface.Unions, item => item.Definition.Name.StartsWith("GenericUnion", StringComparison.Ordinal));
+        Assert.Equal(TypeRefKind.GenericParameter, union.CaseTypes[0].Kind);
+        Assert.Equal(0, union.CaseTypes[0].GenericParameterIndex);
+        ApiTypeShape root = Assert.IsType<ApiTypeShape>(
+            Assert.Single(surface.Functions).ReturnWireTypeShape);
+        Assert.Equal(ApiPrimitiveType.Int32, Assert.Single(root.TypeArguments).Primitive);
+        Assert.Equal(typeof(int), UnionJsonContext.Default.GenericUnionInt32.UnionCases[0].CaseType);
+        Assert.Equal("7", UnionExports.GetGeneric());
+    }
+
+    [Fact]
+    public void Build_PreservesNullableValueCasesSeparatelyFromDefaultNull()
+    {
+        var surface = Build(nameof(UnionExports.GetNullable));
+        JsExportUnion union = Find(surface, nameof(NullableUnion));
+        Assert.Null(union.SerializationUnsupportedReason);
+        Assert.Equal(TypeRefKind.GenericInstance, union.CaseTypes[0].Kind);
+        Assert.Equal("Nullable`1", union.CaseTypes[0].ElementType?.Name);
+        Assert.True(union.IncludesNull);
+        Assert.Equal("42", UnionExports.GetNullable());
+        Assert.Equal("null", JsonSerializer.Serialize(
+            new NullableUnion((int?)null), UnionJsonContext.Default.NullableUnion));
+    }
+
+    [Fact]
+    public void Build_FollowsNestedAndCollectionUnionEdges()
+    {
+        var nested = Build(nameof(UnionExports.GetNested));
+        Assert.Equal(JsonWireDirection.Serialize,
+            nested.WireDirections[Find(nested, nameof(ScalarUnion)).Definition]);
+        Assert.Equal("42", UnionExports.GetNested());
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize("42", UnionJsonContext.Default.NestedUnion));
+
+        var envelope = Build(nameof(UnionExports.GetEnvelope));
+        Assert.Equal(JsonWireDirection.Serialize,
+            envelope.WireDirections[Find(envelope, nameof(ScalarUnion)).Definition]);
+        Assert.Equal(JsonWireDirection.Serialize,
+            envelope.WireDirections[Find(envelope, nameof(DtoUnion)).Definition]);
+        Assert.Equal(
+            "{\"result\":\"missing\",\"items\":[7,\"ok\",null]}",
+            UnionExports.GetEnvelope());
+    }
+
+    [Fact]
+    public void Build_DoesNotPromoteWritingEvidenceToReadClassification()
+    {
+        var surface = Build(nameof(UnionExports.ReadObjects));
+        JsExportUnion union = Find(surface, nameof(ObjectUnion));
+        Assert.Null(union.SerializationUnsupportedReason);
+        Assert.NotEmpty(union.DeserializationUnsupportedReason);
+        Assert.Equal(JsonWireDirection.Deserialize, surface.WireDirections[union.Definition]);
+        Assert.Equal("{\"code\":404}", UnionExports.GetObjects());
+        Assert.Throws<JsonException>(() => UnionExports.ReadObjects("{\"code\":404}"));
+        Assert.Equal("1.5", UnionExports.GetNumbers());
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize("1.5", UnionJsonContext.Default.NumberUnion));
+    }
+
+    [Fact]
+    public void Build_TracksBothDirectionsWithoutClaimingReaderSupport()
+    {
+        var surface = Build(nameof(UnionExports.GetScalar), nameof(UnionExports.ReadScalar));
+        JsExportUnion union = Find(surface, nameof(ScalarUnion));
+        Assert.Equal(JsonWireDirection.Both, surface.WireDirections[union.Definition]);
+        Assert.NotEmpty(union.DeserializationUnsupportedReason);
+        UnionExports.ReadScalar("42");
+    }
+
+    [Fact]
+    public void Build_RetainsUnsupportedCustomUnionConverter()
+    {
+        var surface = Build(nameof(UnionExports.GetCustom));
+        JsExportUnion union = Find(surface, nameof(CustomUnion));
+        Assert.NotNull(union.SerializationUnsupportedReason);
+        Assert.Null(union.IncludesNull);
+        Assert.Empty(union.CaseTypes);
+        Assert.Equal("\"custom:42\"", UnionExports.GetCustom());
+    }
+
+    [Fact]
+    public void Build_DeclarationOnlyDoesNotInventSignatureEvidence()
+    {
+        var surface = JsExportSurfaceBuilder.Build(Extract(nameof(UnionExports.GetScalar)));
+        JsExportUnion union = Find(surface, nameof(ScalarUnion));
+        Assert.NotNull(union.SerializationUnsupportedReason);
+        Assert.Null(union.IncludesNull);
+    }
+
+    [Fact]
+    public void Build_DoesNotDropAnUnreadableConstructorFromTheCaseSet()
+    {
+        ApiSurface api = Extract(nameof(UnionExports.GetScalar));
+        ApiType type = Assert.Single(api.Types, type => type.Name == nameof(ScalarUnion));
+        ApiMember constructor = type.Members.First(member => member.Kind == "constructor");
+        constructor.SignatureDecodeStatus = SignatureDecodeStatus.Degraded;
+        constructor.SignatureModel = null;
+
+        var surface = JsExportSurfaceBuilder.Build(api, Bodies.Value);
+        JsExportUnion union = Find(surface, nameof(ScalarUnion));
+        Assert.NotNull(union.SerializationUnsupportedReason);
+        Assert.Empty(union.CaseTypes);
+        Assert.Null(union.IncludesNull);
+    }
+
+    [Theory]
+    [InlineData(nameof(UnionExports.GetOrdinary))]
+    [InlineData(nameof(UnionExports.GetPlain))]
+    public void Emit_UnreachedUnionsRemainInert(string method)
+    {
+        var surface = Build(method);
+        Assert.All(surface.Unions, union =>
+            Assert.Equal(JsonWireDirection.None, surface.WireDirections[union.Definition]));
+        var diagnostics = new TypeScriptGenerationDiagnostics();
+        string output = DtsEmitter.Emit(surface, diagnostics);
+        Assert.False(diagnostics.HasUnmappedTypes);
+        Assert.DoesNotContain("ScalarUnion", output, StringComparison.Ordinal);
+        if (method == nameof(UnionExports.GetOrdinary))
+        {
+            Assert.Contains("interface OrdinaryValue", output, StringComparison.Ordinal);
+            Assert.Equal("{\"value\":42}", UnionExports.GetOrdinary());
+        }
+    }
+
+    [Fact]
+    public void Emit_ReachedUnionFailsUntilTypeScriptLoweringIsImplemented()
+    {
+        var surface = Build(nameof(UnionExports.GetScalar));
+        var exception = Assert.Throws<UnsupportedWireContractException>(
+            () => DtsEmitter.Emit(surface));
+        Assert.Contains("union TypeScript lowering", exception.Message, StringComparison.Ordinal);
+        Assert.Throws<UnsupportedWireContractException>(
+            () => TypeScriptFacadeEmitter.Emit(surface, "./dotnet.js"));
+    }
+
+    static JsExportUnion Find(JsExportSurface surface, string name) =>
+        Assert.Single(surface.Unions, union => union.Definition.Name == name);
+
+    static JsExportSurface Build(params string[] methods) =>
+        JsExportSurfaceBuilder.Build(Extract(methods), Bodies.Value);
+
+    static ApiSurface Extract(params string[] methods)
+    {
+        using var stream = File.OpenRead(FixtureCatalog.AssemblyPath(FixtureIds.JsExportUnions));
+        using var pe = new PEReader(stream);
+        ApiSurface surface = ApiSurfaceExtractor.Extract(pe, includeAll: true);
+        foreach (ApiMember member in surface.Types.SelectMany(type => type.Members))
+        {
+            if (member.HasRuntimeJsExport && !methods.Contains(member.Name, StringComparer.Ordinal))
+            {
+                member.HasRuntimeJsExport = false;
+                member.RuntimeJsExportAttributeCount = 0;
+                member.HasMalformedRuntimeJsExportAttribute = false;
+            }
+        }
+        return surface;
+    }
+}


### PR DESCRIPTION
# Native C# JSON union evidence

## Purpose

Build a sound C#/TypeScript boundary by retaining the JSON alternatives of
native C# unions rather than treating their `Value` property as an object
contract. This is slice 2 of the four-step adoption plan in #5892.

Fixes #6078. Builds on the Metadata prerequisite merged in #5896.
TypeScript lowering and inspect-web adoption remain separate follow-up slices.

**Design basis:** the sole normative owner is
[`ILInspector.JsExportSurface`'s JSON union alternatives contract](src/ILInspector.JsExportSurface/README.md#json-union-alternatives).
Its claim is structured, same-module case-constructor evidence, default-null
evidence, and reached direction/context propagation for the supported
source-generated JSON union convention. Metadata supplies the marker and
declarations; Analysis supplies exact signature trees and existing authenticated
serializer provenance. The pinned SDK serializer is the behavioral oracle.

The production consumer is `ts-jsexport`, then the shared browser/Wasm facade
used by inspect-web. The tracker enumerates all four adoption steps. This adds
typed host-neutral evidence, not another transport or rendering path; no
architecture is being replaced. TypeScript declaration/facade rendering stays
with its existing owner and rejects reached unions until lowering is implemented.

## Demo

The independently compiled fixture contains actual native C# unions and
source-generated serializer contexts:

```csharp
public union ScalarUnion(int, string);
public union NullableUnion(int?, string);
public union DtoUnion(PackageSummary, string);
public sealed record PackageSummary(string Id);
```

The runtime outputs, not a proposed wrapper format:

| Producer value | JSON |
| --- | --- |
| `new ScalarUnion(42)` | `42` |
| `new ScalarUnion("hello")` | `"hello"` |
| `default(ScalarUnion)` | `null` |
| `new NullableUnion((int?)null)` | `null` |
| `new DtoUnion(new PackageSummary("Example.Package"))` | `{"id":"Example.Package"}` |

Before this slice, the general object inventory had no union-case contract.
Now the surface keeps `ScalarUnion` in `Unions`, not `Records`, with structured
`int` and `string` alternatives and `IncludesNull = true`. DTO alternatives
inherit the authenticated context's camel-case policy and reached wire direction.
Generic alternatives retain parameter positions rather than parsing type names.

The neighboring ordinary `record OrdinaryValue(int Value)` still writes
`{"value":42}` and generates an ordinary interface. Unused union registrations
do not prevent that declaration or a raw-string export from publishing.

Writing is not proof of reading: two object cases write inline, but the default
reader cannot disambiguate them; nested union cases can also fail default
classification. The model therefore retains an explicit deserialization
unsupported reason even for simpler cases the runtime can read.

Until slice 3, both declaration and facade generation visibly reject a reached
union with `native C# union TypeScript lowering is not implemented`.

## Implementation and boundaries

- Discover and propagate union constructor edges instead of the `Value` getter.
- Join Metadata member tokens and structured declaring identities to Analysis's
  same-module MethodDefs; retain complete case signature trees.
- Keep unavailable, degraded, unsupported-converter, and unsupported-context
  evidence explicit rather than silently shrinking the case set.
- Keep each case's own converter/member/naming contract authoritative. Case
  alternatives are not a complete JSON schema or a promise every value can
  serialize successfully.
- Use the existing authenticated default source-generated context property.
  Arbitrary resolver results, modifiers, and custom-options context instances
  do not inherit that evidence.

The source oracle is SDK `11.0.100-preview.7.26381.103`, with System.Text.Json
source pinned to `dotnet/dotnet@e2c1e00b3d0f96afb892fb261d5921565b400246`.
The separate fixture preserves the export-inventory assembly boundary.
Ambiguous-read fixtures intentionally retain `SYSLIB1227` as a warning rather
than suppressing it or converting it to a build error.

## Validation

Release, using the exact repository SDK:

```sh
dotnet run --project tests/ILInspector.JsExportSurface.Tests -c Release -- \
  --filter-class '*JsonUnionWireTests' '*JsExportSurfaceBuilderTests' \
    '*JsonWireContractResolverTests' '*DtsEmitterTests' \
    '*TypeScriptFacadeEmitterTests' \
  --minimum-expected-tests 338 --no-progress
```

338 passed, including 13 union cases and the existing neighboring contracts.

```sh
dotnet run --project tests/DotnetInspector.FixtureInfrastructure.Tests \
  -c Release --no-build -- \
  -method '*All_FixtureIdsAreUnique' \
  -method '*All_ProjectDirectoriesAreExplicitRepositoryRelativePaths' \
  -method '*Groups_ReferenceRegisteredFixtures'
```

3 passed. The unfiltered catalog run initially had seven missing-artifact
failures because this focused worktree has not built unrelated fixture
assemblies/assets; those are not reported as passing. The new union fixture's
actual catalog resolution and compiled assembly are exercised by the union suite.

Changed Markdown passes `markdownlint`; `git diff --check` is clean.
Current-head `ci-required` succeeded. Round 1 was clean from GPT-6 Astra and
Claude Opus 5 at `926e7bb75ce60f5cdee68afee1c46a7b1b7c8026`; Opus also ran the
full JsExportSurface suite with 524 passing tests in Release. No merge is
authorized.
