### PR TITLE
Preserve reporting authorities for selected package payloads

### DIFF
--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -489,10 +489,10 @@ can report an observed exact coordinate with peer failures disclosed, but
 cannot infer absence from unreadable peers. Failed operations, including the
 terminal operation deadline, publish no query rows.
 
-Online caller-pinned extraction now adopts configured authorities as described
-below. Offline version queries and extraction, payload-selecting
-latest/wildcard/range resolution, metadata, search, and other payload consumers
-remain on the legacy composition until their package-owned adoption slices land.
+Online caller-pinned extraction and the discovered-coordinate acquisition seam
+now adopt configured authorities as described below. Offline version queries
+and extraction, metadata, search, and unmigrated payload consumers remain on the
+legacy composition until their package-owned adoption slices land.
 The process-global authentication decorator therefore
 also remains solely for those legacy paths; it cannot be removed until they no
 longer depend on it. This first live slice does not read or publish the legacy
@@ -601,6 +601,64 @@ and namespace/provenance separation), and
 (derived-index isolation). Existing source-routing, store-publication,
 legacy extraction/concurrency, and payload-admission suites retain their
 contracts.
+
+### Discovered-coordinate payload acquisition
+
+The production consumer in step 5 is ordinary online single-package inspection
+with an omitted version, `@latest`, `--preview`, or a wildcard version. The
+package layer also supplies an authority-preserving range-address acquisition
+seam. Its named CLI consumers, API inspection and timeline, adopt that seam in
+step 6 together with their remaining payload and replay paths. This slice does
+not add `package --at` or claim those hosts have migrated.
+
+Selection consumes complete, current candidate evidence from every eligible
+configured authority. Each retained observation preserves its configured
+authority, normalized coordinate, discovery contract, listing state, and
+producer provenance. Per-feed display rows and legacy source-URL restrictions
+are not selection receipts. Partial evidence, failed discovery, or an expired
+operation cannot reach payload-cache lookup or acquisition.
+
+Latest selects the highest listed version, excluding prereleases unless
+requested. Wildcards retain the existing case-insensitive version-prefix
+semantics, including matching prereleases. Range addresses retain
+`PackageVersionVector`'s inclusive endpoints, caller direction, prerelease
+rules, and explicit address selection. Metadata-only range enumeration stays
+separate from acquisition.
+
+Only authorities whose admitted observations reported the selected coordinate
+under that selection contract may supply its payload, including cache hits.
+Another eligible authority's warm cache is not a substitute for reporting
+evidence. Among reporters, the existing cache-first and cold-local-before-HTTP
+rules apply. Selection, acquisition, and tool-wrapper traversal share one
+operation context; each redirected package independently reapplies its own
+package-ID authority rather than inheriting the root's reporting set.
+
+This path does not consult legacy producer-keyed candidate caches or use
+payload-directory scans as candidate evidence. Selection therefore performs
+fresh bounded discovery, including when an omitted-version request previously
+used a legacy version-cache hit. `@latest` keeps its fresh-discovery meaning.
+Authority-safe candidate caching remains deferred; local payload caching and
+HTTP temporary ownership reuse the caller-pinned path unchanged.
+
+The same six-step plan and recorded CLI-only approval apply. Multi-package
+inspection, API/timeline host adoption, offline behavior, and corresponding
+legacy retirement remain step 6. Existing Markout-backed package views and
+file/content projection remain the rendering boundary; no new default output
+section is introduced.
+
+The Release gates in `ConfiguredPayloadAcquisitionTests` cover this contract:
+`PackageCommand_LocalSelectionPrintsSelectedPayload` and
+`PackageCommand_SelectionRefreshesWithWarmLocalPayload` exercise the live
+consumer and fresh discovery; `AcquireSelected_PartialDiscoveryDoesNotProbePayloadCaches`,
+`AcquireSelected_NonReportingWarmCacheCannotSupplySelectedVersion`,
+`AcquireSelected_QueryDistinctAuthoritiesDoNotShareReportingEvidence`, and
+`AcquireSelected_GalleryListingEvidenceControlsAuthorization` distinguish
+reporting authority from availability, producer identity, and listing state.
+`AcquireSelected_RangeRetainsAddressDirectionAndReporter` gates the range seam.
+The external-operation deadline, commit-lifetime, caller-cancellation, and
+selected-wrapper tests gate the shared operation and temporary ownership.
+Existing caller-pinned acquisition and authority-store gates remain applicable
+to their shared implementation.
 
 ### Metadata-only version queries
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -1,8 +1,12 @@
 # Version resolution
 
-dotnet-inspect uses Docker-style version tags to balance freshness against
-latency. Version discovery is cached briefly; package contents are cached
-permanently by exact version.
+dotnet-inspect uses Docker-style version tags to separate version selection
+from exact payload acquisition. Online single-package CLI inspection uses the
+[configured-authority acquisition contract](package-source-model.md#discovered-coordinate-payload-acquisition):
+automatic selection performs fresh bounded discovery, local payload caches
+are authority-scoped, and HTTP payloads use temporary materialization.
+Unmigrated consumers retain the candidate and producer-payload caches described
+below.
 
 The command modes, listing rules, source-scoped candidate caches, and
 payload-provenance rules describe current behavior. Package source mapping and
@@ -16,17 +20,17 @@ implementation-ready syntax.
 
 ## Four modes
 
-| Syntax | Behavior | Network I/O |
+| Syntax | Behavior | Online single-package CLI discovery |
 | --- | --- | --- |
-| `Name@2.0.3` | **Pinned** — use the exact version from cache; download only if missing | Never, if cached |
-| `Name` | **Latest stable** — resolve the latest stable version, then use/download that exact package | Only on version-cache miss |
-| `Name --preview` | **Latest prerelease** — resolve the latest version including prerelease/preview versions | Only on version-cache miss |
-| `Name@latest` | **Always check** — query NuGet for the latest version every time | Always |
-| `Name@A..B` | **Addressable vector** — resolve the inclusive published-version range without downloading package payloads | Only on version-list cache miss |
+| `Name@2.0.3` | **Pinned** — acquire the caller's exact version | No candidate discovery |
+| `Name` | **Latest stable** — resolve the latest stable version, then acquire that exact package | Fresh eligible-source discovery |
+| `Name --preview` | **Latest prerelease** — include prerelease/preview versions in selection | Fresh eligible-source discovery |
+| `Name@latest` | **Always check** — resolve the latest version every time | Fresh eligible-source discovery |
+| `Name@A..B` | **Addressable vector** — enumerate the inclusive published-version range with `--versions`, without payload acquisition | Fresh eligible-source discovery |
 
 ### Pinned (`Name@version`)
 
-Online caller-pinned CLI extraction now follows the
+Online single-package caller-pinned CLI extraction follows the
 [configured-authority acquisition contract](package-source-model.md#caller-pinned-payload-acquisition):
 local authority caches may answer immediately, while HTTP payloads currently
 use temporary authority-scoped materialization rather than persistent
@@ -42,7 +46,13 @@ and cached permanently under that producer.
 
 ### Latest stable (`Name`)
 
-This is the default and the most common case. Resolution follows this order:
+This is the default and the most common case. Online single-package CLI
+inspection requires complete discovery from all eligible configured
+authorities, then acquires only from authorities that reported the chosen
+version. It does not consult legacy candidate caches or use their shortened
+stale-cache request budget. Folder-only selection performs no HTTP work.
+
+Unmigrated consumers follow this legacy order:
 
 1. **Version cache** — check each eligible feed's version-resolution cache
    (1-hour TTL) for a source-scoped candidate list.
@@ -157,6 +167,11 @@ dotnet-inspect timeline \
 Resolving the vector reads version metadata only. The command downloads or
 opens a package only after the caller selects an address, so an agent can probe
 previous, midpoint, or adjacent versions without triggering an unbounded scan.
+
+The configured-authority range-acquisition seam is available in the package
+layer. API and timeline adoption, including their payload replay paths, remains
+step 6 of the [source adoption plan](package-source-model.md#implementation-boundary).
+Ordinary `package` payload inspection does not accept a range or `--at`.
 
 `timeline` uses the same vector without changing that authorization rule. With
 no `--at`, it renders every address as `Unevaluated` and recommends a probe

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -125,10 +125,10 @@ dnx dotnet-inspect -y -- library System.Text.Json -S Switches
 
 ## Which versions to compare
 
-Version resolution is source-scoped. Use `Foo --version` for the best-known
-listed version: it reuses each source's matching latest entry and queries
-sources without one. Use `Foo --latest-version` to bypass those caches and
-refresh the newest version across all eligible configured sources, and
+Version resolution is source-scoped. Online `Foo --version` and
+`Foo --latest-version` resolve the newest listed version from fresh, complete
+discovery across all eligible configured sources, without legacy candidate
+cache reuse. Use
 `Foo --versions [N]` (add `--preview`) to list published versions. Unlisted
 versions are hidden unless
 `--include-unlisted` is explicit. `--versions-with-feed` retains each

--- a/skills/private-feeds/SKILL.md
+++ b/skills/private-feeds/SKILL.md
@@ -71,7 +71,7 @@ use the non-Gallery `listed` convention.
 
 These version queries are metadata-only and do not use `--offline`.
 
-### Inspect an exact package from a folder feed
+### Inspect a package from a folder feed
 
 Pin one coordinate to inspect its payload through the configured folder source:
 
@@ -79,19 +79,31 @@ Pin one coordinate to inspect its payload through the configured folder source:
 dnx dotnet-inspect -y -- package MyCompany.Widget@1.2.3 --source ./feed
 dnx dotnet-inspect -y -- package MyCompany.Widget@1.2.3 --source ./feed \
   --path @readme --content --bare
+dnx dotnet-inspect -y -- package MyCompany.Widget --source ./feed
+dnx dotnet-inspect -y -- package 'MyCompany.Widget@1.*' --source ./feed \
+  --path @readme --content --bare
 ```
 
-Online caller-pinned acquisition tries local sources before HTTP sources.
+Online single-package inspection also supports latest, `--preview`, and
+wildcard payload selection. It freshly queries every eligible source and
+requires complete evidence before choosing a version; a failed peer blocks
+automatic selection even when another source has a warm payload cache.
+Only sources that reported the selected version may supply its payload.
+Wildcards use a case-insensitive version prefix and may match prereleases.
+
+Caller-pinned acquisition tries local sources before HTTP sources.
 Declaration order is not precedence within a tier. One eligible source can
 supply the exact package even when an earlier peer fails; `--verbose` retains
 those diagnostics. Tool-wrapper redirects independently reapply mapping.
 
 Local payload caches are scoped to the canonical configured folder, not just
-package ID/version or producer identity. HTTP pins currently use temporary
+package ID/version or producer identity. HTTP payloads currently use temporary
 authority-scoped materialization and do not reuse persistent payload caches.
-Multi-package inspection, local-feed latest/wildcard/range payload selection,
-package-scoped API and dependency commands, offline extraction, symbols, and
-manifest-only requests have not migrated yet.
+Automatic selection does not reuse legacy candidate caches. Multi-package
+inspection, range-addressed payload commands, package-scoped API and dependency
+commands, and offline extraction have not migrated yet. `package --versions`
+can enumerate a range, but ordinary `package` payload inspection does not
+accept a range or `--at`.
 
 ### Restrict package ids to feeds
 
@@ -174,8 +186,8 @@ Missing or mismatched provenance is a cache miss, and installed payloads do not
 introduce version candidates. Use `--no-nuget-cache` to exclude that layer.
 `--offline` forbids network access and does not start credential plugins, so it
 succeeds only from producer-authorized caches. Online version queries bypass
-these legacy caches. Online caller-pinned extraction uses the new authority
-cache instead: old producer-keyed entries cannot authorize it, and HTTP
+these legacy caches. Online single-package extraction uses authority-scoped
+payload storage instead: old producer-keyed entries cannot authorize it, and HTTP
 global-packages entries are not reused. A local global-packages entry must
 name the same canonical configured folder in `.nupkg.metadata.source`.
 Other unmigrated paths still skip configured folder feeds; `--verbose`

--- a/src/DotnetInspector.Packages/ConfiguredPackageExtractionSession.cs
+++ b/src/DotnetInspector.Packages/ConfiguredPackageExtractionSession.cs
@@ -39,8 +39,8 @@ internal sealed class ConfiguredPackageExtractionSession(
             includePrerelease, rangeAddress, operationContext: _operation).ConfigureAwait(false);
 
         return ConvertResult(result,
-            $"Package '{packageId}' selection '{versionSelector ?? "latest"}'",
-            "No eligible source reported a matching version.", log);
+            $"Package '{packageId}' selection '{(string.IsNullOrEmpty(versionSelector) ? "latest" : versionSelector)}'",
+            "No eligible reporting source supplied a matching payload.", log);
     }
 
     private DesktopPackageSourceComposition GetComposition() =>

--- a/src/DotnetInspector.Packages/ConfiguredPackageExtractionSession.cs
+++ b/src/DotnetInspector.Packages/ConfiguredPackageExtractionSession.cs
@@ -2,7 +2,7 @@ using NuGetFetch;
 
 namespace DotnetInspector.Packages;
 
-internal sealed class PinnedPackageExtractionSession(
+internal sealed class ConfiguredPackageExtractionSession(
     TimeSpan requestTimeout,
     string tempDirPrefix,
     Func<DesktopPackageSourceComposition>? createComposition) : IAsyncDisposable
@@ -16,25 +16,53 @@ internal sealed class PinnedPackageExtractionSession(
         string packageId, string version,
         NuGetSourceOptions? sourceOptions, Action<string>? log)
     {
-        TimeSpan timeout = requestTimeout == Timeout.InfiniteTimeSpan
-            ? NuGetFetchOptions.DefaultRequestTimeout
-            : requestTimeout;
-        _composition ??= createComposition?.Invoke() ?? new DesktopPackageSourceComposition(timeout);
-        _operation ??= _composition.CreateOperationContext();
-        ConfiguredPackagePayloadResult result = await _composition.AcquirePinnedAsync(
+        DesktopPackageSourceComposition composition = GetComposition();
+        _operation ??= composition.CreateOperationContext();
+        ConfiguredPackagePayloadResult result = await composition.AcquirePinnedAsync(
             packageId, version, GetStore, sourceOptions, log,
             operationContext: _operation).ConfigureAwait(false);
 
+        return ConvertResult(result,
+            $"Package '{packageId}' version '{version}'",
+            "No eligible source supplied this exact coordinate.", log);
+    }
+
+    public async Task<PackageExtractionOutcome> AcquireSelectedAsync(
+        string packageId, string? versionSelector,
+        NuGetSourceOptions? sourceOptions, Action<string>? log,
+        bool includePrerelease, string? rangeAddress)
+    {
+        DesktopPackageSourceComposition composition = GetComposition();
+        _operation ??= composition.CreateOperationContext();
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            packageId, versionSelector, GetStore, sourceOptions, log,
+            includePrerelease, rangeAddress, operationContext: _operation).ConfigureAwait(false);
+
+        return ConvertResult(result,
+            $"Package '{packageId}' selection '{versionSelector ?? "latest"}'",
+            "No eligible source reported a matching version.", log);
+    }
+
+    private DesktopPackageSourceComposition GetComposition() =>
+        _composition ??= createComposition?.Invoke() ?? new DesktopPackageSourceComposition(
+            requestTimeout == Timeout.InfiniteTimeSpan
+                ? NuGetFetchOptions.DefaultRequestTimeout
+                : requestTimeout);
+
+    private static PackageExtractionOutcome ConvertResult(
+        ConfiguredPackagePayloadResult result, string request,
+        string noMatch, Action<string>? log)
+    {
         foreach (PackageAuthorityFailure failure in result.Failures)
             log?.Invoke($"{failure.Authority}: {failure.Message}");
         if (result.Payload is not { } payload)
         {
             string reason = result.Failures.Count == 0
-                ? "No eligible source supplied this exact coordinate."
+                ? noMatch
                 : string.Join(Environment.NewLine,
                     result.Failures.Select(failure => $"{failure.Authority}: {failure.Message}"));
             return PackageExtractionOutcome.Error(
-                $"Package '{packageId}' version '{version}' could not be acquired. {reason}");
+                $"{request} could not be acquired. {reason}");
         }
 
         return new PackageExtractionResult(

--- a/src/DotnetInspector.Packages/DesktopPackageSourceComposition.Payloads.cs
+++ b/src/DotnetInspector.Packages/DesktopPackageSourceComposition.Payloads.cs
@@ -58,7 +58,23 @@ public sealed partial class DesktopPackageSourceComposition
         NuGetOperationContext operation = operationContext ?? ownedOperation!;
         _ = operation.ResolveInvocationToken(cancellationToken);
         PackageSourceCoordinate coordinate = PackageSourceCoordinate.Create(packageId, normalizedVersion);
+        return await AcquireCoordinateAsync(
+            packageId, coordinate, createStore, sourceOptions, log, operation,
+            limits, transferPolicy, failures).ConfigureAwait(false);
+    }
 
+    private async Task<ConfiguredPackagePayloadResult> AcquireCoordinateAsync(
+        string packageId,
+        PackageSourceCoordinate coordinate,
+        Func<ConfiguredPackageAuthority, PackageProducerIdentity, IPackageStore> createStore,
+        NuGetSourceOptions? sourceOptions,
+        Action<string>? log,
+        NuGetOperationContext operation,
+        PackagePayloadLimits? limits,
+        IPackagePayloadTransferPolicy? transferPolicy,
+        List<PackageAuthorityFailure> failures,
+        HashSet<ConfiguredPackageAuthority>? reportingAuthorities = null)
+    {
         try
         {
             operation.ThrowIfExpired();
@@ -73,6 +89,9 @@ public sealed partial class DesktopPackageSourceComposition
                 if (TryGetEligibleAuthority(source, failures) is not { } entry)
                     continue;
                 RequireAuthority(entry.Client.Source, entry);
+                if (reportingAuthorities is not null
+                    && !reportingAuthorities.Contains(entry.Authority))
+                    continue;
                 IPackageStore store = createStore(entry.Authority, entry.Client.Source.Producer);
                 entries.Add((entry, store));
             }
@@ -142,7 +161,7 @@ public sealed partial class DesktopPackageSourceComposition
         }
         catch (NuGetOperationTimeoutException)
         {
-            return TimedOut();
+            return PayloadOperationTimedOut(operation, failures);
         }
         catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
         {
@@ -150,19 +169,21 @@ public sealed partial class DesktopPackageSourceComposition
         }
         catch (OperationCanceledException) when (operation.OperationToken.IsCancellationRequested)
         {
-            return TimedOut();
+            return PayloadOperationTimedOut(operation, failures);
         }
+    }
 
-        ConfiguredPackagePayloadResult TimedOut()
+    private static ConfiguredPackagePayloadResult PayloadOperationTimedOut(
+        NuGetOperationContext operation,
+        List<PackageAuthorityFailure> failures)
+    {
+        failures.Add(new PackageAuthorityFailure(
+            InertString.Empty, PackageAuthorityFailureKind.Timeout,
+            "The package payload operation deadline expired before acquisition completed.")
         {
-            failures.Add(new PackageAuthorityFailure(
-                InertString.Empty, PackageAuthorityFailureKind.Timeout,
-                "The package payload operation deadline expired before acquisition completed.")
-            {
-                Timeout = new(PackageSourceTimeoutKind.Operation, operation.OperationTimeout),
-            });
-            return new(null, null, failures);
-        }
+            Timeout = new(PackageSourceTimeoutKind.Operation, operation.OperationTimeout),
+        });
+        return new(null, null, failures);
     }
 
     private static PackageAuthorityFailure DescribePayloadFailure(

--- a/src/DotnetInspector.Packages/DesktopPackageSourceComposition.Selection.cs
+++ b/src/DotnetInspector.Packages/DesktopPackageSourceComposition.Selection.cs
@@ -1,0 +1,147 @@
+using InertText;
+using NuGet.Versioning;
+using NuGetFetch;
+
+namespace DotnetInspector.Packages;
+
+public sealed partial class DesktopPackageSourceComposition
+{
+    /// <summary>
+    /// Selects a coordinate from complete current discovery and acquires it only
+    /// from authorities whose admitted observations reported that coordinate.
+    /// An external operation remains caller-owned through payload consumption.
+    /// </summary>
+    public async Task<ConfiguredPackagePayloadResult> AcquireSelectedAsync(
+        string packageId,
+        string? versionSelector,
+        Func<ConfiguredPackageAuthority, PackageProducerIdentity, IPackageStore> createStore,
+        NuGetSourceOptions? sourceOptions = null,
+        Action<string>? log = null,
+        bool includePrerelease = false,
+        string? rangeAddress = null,
+        CancellationToken cancellationToken = default,
+        NuGetOperationContext? operationContext = null,
+        PackagePayloadLimits? limits = null,
+        IPackagePayloadTransferPolicy? transferPolicy = null)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ArgumentNullException.ThrowIfNull(createStore);
+        if (!PackageExtractor.IsValidPackageId(packageId))
+            return InvalidSelection("The package ID must use the NuGet package ID grammar.");
+        if (sourceOptions?.AuthorizedSourceKeys is not null
+            || sourceOptions?.ResolvedSources is not null)
+            return InvalidSelection("Selected payload acquisition requires configured sources, not legacy producer or resolved-source restrictions.");
+
+        PackageVersionRange? range = null;
+        string? prefix = null;
+        if (versionSelector?.Contains("..", StringComparison.Ordinal) == true)
+        {
+            if (!PackageVersionRange.TryParse(
+                    $"{packageId}@{versionSelector}", out range, out string? rangeError))
+                return InvalidSelection(rangeError ?? "A valid package version range is required.");
+            if (range!.PackageId != packageId)
+                return InvalidSelection("The version selector must contain only the range endpoints.");
+            if (!IsRangeAddressSyntaxValid(rangeAddress))
+                return InvalidSelection("A package range address must be an exact version, #N, first, or last.");
+        }
+        else
+        {
+            if (rangeAddress is not null)
+                return InvalidSelection("A range address requires a package version range.");
+            if (versionSelector?.Contains('*') == true)
+                prefix = versionSelector.Replace("*", "");
+            else if (!string.IsNullOrEmpty(versionSelector)
+                     && !versionSelector.Equals("latest", StringComparison.OrdinalIgnoreCase))
+                return InvalidSelection("Selected payload acquisition requires latest, a wildcard, or a range; use pinned acquisition for an exact version.");
+        }
+
+        using NuGetOperationContext? ownedOperation = operationContext is null
+            ? CreateOperationContext(cancellationToken)
+            : null;
+        NuGetOperationContext operation = operationContext ?? ownedOperation!;
+        cancellationToken = operation.ResolveInvocationToken(cancellationToken);
+        var failures = new List<PackageAuthorityFailure>();
+        try
+        {
+            operation.ThrowIfExpired();
+            PackageVersionDiscoveryResult discovery = await GetVersionsAsync(
+                packageId,
+                includePrerelease || prefix is not null || range?.IncludesPrerelease == true,
+                limit: null, sourceOptions, log, cancellationToken,
+                includeUnlisted: false, operationContext: operation).ConfigureAwait(false);
+            failures.AddRange(discovery.Failures);
+            if (discovery.State != PackageVersionDiscoveryState.Authoritative)
+                return new(null, null, failures);
+            operation.ThrowIfExpired();
+
+            PackageSourceCoordinate? coordinate;
+            if (range is not null)
+            {
+                PackageVersionVector vector;
+                try
+                {
+                    vector = PackageVersionVector.Create(
+                        range,
+                        discovery.Candidates.Select(candidate => candidate.Observation.Coordinate.Version),
+                        includePrerelease);
+                }
+                catch (ArgumentException exception)
+                {
+                    return InvalidSelection(exception.Message);
+                }
+                if (!vector.TrySelect(rangeAddress!, out PackageVersionAddress? address, out string? addressError))
+                    return InvalidSelection(addressError!);
+                coordinate = PackageSourceCoordinate.Create(packageId, address!.Version.ToNormalizedString());
+            }
+            else
+            {
+                coordinate = discovery.Candidates
+                    .Select(candidate => candidate.Observation.Coordinate)
+                    .Where(candidate => prefix is null || candidate.Version.StartsWith(
+                        prefix, StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(candidate => NuGetVersion.Parse(candidate.Version))
+                    .FirstOrDefault();
+            }
+
+            operation.ThrowIfExpired();
+            if (coordinate is null)
+                return new(null, null, failures);
+
+            var reporters = new HashSet<ConfiguredPackageAuthority>(ReferenceEqualityComparer.Instance);
+            foreach (ConfiguredPackageCandidateObservation candidate in discovery.Candidates)
+            {
+                if (candidate.Observation.Coordinate == coordinate)
+                    reporters.Add(candidate.Authority);
+            }
+            return await AcquireCoordinateAsync(
+                packageId, coordinate, createStore, sourceOptions, log, operation,
+                limits, transferPolicy, failures, reporters).ConfigureAwait(false);
+        }
+        catch (NuGetOperationTimeoutException)
+        {
+            return PayloadOperationTimedOut(operation, failures);
+        }
+        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(operation.CancellationToken);
+        }
+        catch (OperationCanceledException) when (operation.OperationToken.IsCancellationRequested)
+        {
+            return PayloadOperationTimedOut(operation, failures);
+        }
+    }
+
+    private static bool IsRangeAddressSyntaxValid(string? address) =>
+        !string.IsNullOrWhiteSpace(address)
+        && (address.Equals("first", StringComparison.OrdinalIgnoreCase)
+            || address.Equals("last", StringComparison.OrdinalIgnoreCase)
+            || (address[0] == '#'
+                ? int.TryParse(address.AsSpan(1), out int ordinal) && ordinal > 0
+                : NuGetVersion.TryParse(address, out _)));
+
+    private static ConfiguredPackagePayloadResult InvalidSelection(string message) =>
+        new(null, null,
+        [
+            new PackageAuthorityFailure(InertString.Empty, PackageAuthorityFailureKind.Input, message),
+        ]);
+}

--- a/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
+++ b/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
@@ -41,6 +41,10 @@ public sealed record PackageAuthorityFailure(
     public PackageSourceTimeout? Timeout { get; init; }
 }
 
+internal sealed record ConfiguredPackageCandidateObservation(
+    ConfiguredPackageAuthority Authority,
+    PackageCandidateObservation Observation);
+
 /// <summary>
 /// The package-owned aggregate of version evidence from every eligible
 /// configured authority.
@@ -51,7 +55,8 @@ public sealed class PackageVersionDiscoveryResult
         PackageVersionDiscoveryState state,
         IReadOnlyList<PackageVersionSourceInfo> sourceListings,
         IReadOnlyList<PackageAuthorityFailure> failures,
-        bool hasAnyCandidate)
+        bool hasAnyCandidate,
+        IReadOnlyList<ConfiguredPackageCandidateObservation>? candidates = null)
     {
         State = state;
         SourceListings = new ReadOnlyCollection<PackageVersionSourceInfo>([.. sourceListings]);
@@ -63,6 +68,8 @@ public sealed class PackageVersionDiscoveryResult
         Failures =
             new ReadOnlyCollection<PackageAuthorityFailure>([.. failures]);
         HasAnyCandidate = hasAnyCandidate;
+        Candidates = new ReadOnlyCollection<ConfiguredPackageCandidateObservation>(
+            candidates is null ? [] : [.. candidates]);
     }
 
     public PackageVersionDiscoveryState State { get; }
@@ -73,6 +80,7 @@ public sealed class PackageVersionDiscoveryResult
     public IReadOnlyList<PackageVersionSourceInfo> SourceListings { get; }
     public IReadOnlyList<PackageAuthorityFailure> Failures { get; }
     public bool HasAnyCandidate { get; }
+    internal IReadOnlyList<ConfiguredPackageCandidateObservation> Candidates { get; }
 }
 
 /// <summary>
@@ -127,6 +135,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
     /// <summary>
     /// Enumerates versions from every configured authority eligible for one
     /// package ID and adopts their results through exact association lookup.
+    /// A supplied operation context remains caller-owned.
     /// </summary>
     public async Task<PackageVersionDiscoveryResult> GetVersionsAsync(
         string packageId,
@@ -135,7 +144,8 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
         NuGetSourceOptions? sourceOptions = null,
         Action<string>? log = null,
         CancellationToken cancellationToken = default,
-        bool includeUnlisted = false)
+        bool includeUnlisted = false,
+        NuGetOperationContext? operationContext = null)
     {
         ObjectDisposedException.ThrowIf(
             Volatile.Read(ref _disposed) != 0,
@@ -167,9 +177,14 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
                 PackageVersionDiscoveryState.Failed, [], failures, hasAnyCandidate: false);
         }
 
-        using var operation = CreateOperationContext(cancellationToken);
+        using NuGetOperationContext? ownedOperation = operationContext is null
+            ? CreateOperationContext(cancellationToken)
+            : null;
+        NuGetOperationContext operation = operationContext ?? ownedOperation!;
+        cancellationToken = operation.ResolveInvocationToken(cancellationToken);
         IReadOnlyList<InertString> feedLabels = PackageSourceDisplay.ForVersionListings(sources);
         var versions = new Dictionary<string, List<PackageVersionSourceInfo>>(StringComparer.OrdinalIgnoreCase);
+        var candidates = new List<ConfiguredPackageCandidateObservation>();
         bool hasAnyCandidate = false;
         bool operationTimedOut = false;
 
@@ -185,7 +200,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
             catch (NuGetOperationTimeoutException)
             {
                 operationTimedOut = true;
-                AddOperationTimeoutFailure(failures);
+                AddOperationTimeoutFailure(failures, operation);
                 for (int remainingIndex = sourceIndex;
                      remainingIndex < sources.Count;
                      remainingIndex++)
@@ -255,6 +270,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
                     if ((listed || includeUnlisted)
                         && (includePrerelease || !parsed.IsPrerelease))
                     {
+                        candidates.Add(new(authority.Authority, candidate));
                         string version = candidate.Coordinate.Version;
                         if (!versions.TryGetValue(version, out var rows))
                         {
@@ -274,7 +290,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
             catch (NuGetOperationTimeoutException)
             {
                 operationTimedOut = true;
-                AddOperationTimeoutFailure(failures);
+                AddOperationTimeoutFailure(failures, operation);
                 for (int remainingIndex = sourceIndex + 1;
                      remainingIndex < sources.Count;
                      remainingIndex++)
@@ -307,7 +323,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
         catch (NuGetOperationTimeoutException)
         {
             operationTimedOut = true;
-            AddOperationTimeoutFailure(failures);
+            AddOperationTimeoutFailure(failures, operation);
         }
 
         PackageVersionDiscoveryState state = operationTimedOut
@@ -323,7 +339,8 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
             state,
             ordered,
             failures,
-            hasAnyCandidate);
+            hasAnyCandidate,
+            candidates);
     }
 
     private static IReadOnlyList<PackageSource> ResolveEligibleSources(
@@ -639,7 +656,11 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
                 $"Package source {authority} could not be reached while enumerating versions.",
             _ => failure.Message,
         };
-        return new PackageAuthorityFailure(authority, kind, message);
+        return new PackageAuthorityFailure(authority, kind, message)
+        {
+            SourceFailure = failure,
+            ResultSource = failure.Source,
+        };
     }
 
     private static PackageVersionDiscoveryResult Failed(
@@ -651,7 +672,8 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
             hasAnyCandidate: false);
 
     private static void AddOperationTimeoutFailure(
-        List<PackageAuthorityFailure> failures)
+        List<PackageAuthorityFailure> failures,
+        NuGetOperationContext operation)
     {
         if (failures.Any(failure =>
                 failure.Authority == InertString.Empty
@@ -663,7 +685,10 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
         failures.Add(new PackageAuthorityFailure(
             InertString.Empty,
             PackageAuthorityFailureKind.Timeout,
-            "The package version operation deadline expired before the aggregate completed."));
+            "The package version operation deadline expired before the aggregate completed.")
+        {
+            Timeout = new(PackageSourceTimeoutKind.Operation, operation.OperationTimeout),
+        });
     }
 
     public async ValueTask DisposeAsync()

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -282,7 +282,7 @@ public static class PackageExtractor
         bool includePrerelease = false) =>
         ExtractPackageCoreAsync(
             client, packageSource, log, tempDirPrefix, sourceOptions,
-            version, forceLatest, includePrerelease, pinnedSession: null);
+            version, forceLatest, includePrerelease, authoritySession: null);
 
     /// <summary>Extracts an online caller-pinned package through configured authorities.</summary>
     public static async Task<PackageExtractionOutcome> ExtractPinnedPackageAsync(
@@ -301,12 +301,51 @@ public static class PackageExtractor
             return PackageExtractionOutcome.Error(
                 "Configured-authority extraction requires online mode, a valid package ID, and an exact version.");
         }
-        await using var session = new PinnedPackageExtractionSession(
+        await using var session = new ConfiguredPackageExtractionSession(
             client.Timeout, tempDirPrefix, createComposition);
         return await ExtractPackageCoreAsync(
             client, packageId, log, tempDirPrefix, sourceOptions,
             normalizedVersion, forceLatest: false, includePrerelease: false, session)
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Selects and extracts an online package using current configured-authority
+    /// evidence. Range selectors require an explicit address.
+    /// </summary>
+    public static async Task<PackageExtractionOutcome> ExtractSelectedPackageAsync(
+        HttpClient client,
+        string packageId,
+        string? versionSelector = null,
+        Action<string>? log = null,
+        string tempDirPrefix = "inspect-pkg",
+        NuGetSourceOptions? sourceOptions = null,
+        bool includePrerelease = false,
+        string? rangeAddress = null,
+        Func<DesktopPackageSourceComposition>? createComposition = null)
+    {
+        if (HttpClientFactory.IsOffline || !IsValidPackageId(packageId))
+        {
+            return PackageExtractionOutcome.Error(
+                "Configured-authority selection requires online mode and a valid package ID.");
+        }
+
+        await using var session = new ConfiguredPackageExtractionSession(
+            client.Timeout, tempDirPrefix, createComposition);
+        PackageExtractionOutcome selected;
+        using (FeedFailureTelemetry.Scope())
+        {
+            selected = await session.AcquireSelectedAsync(
+                packageId, versionSelector, sourceOptions, log,
+                includePrerelease, rangeAddress).ConfigureAwait(false);
+        }
+        if (!selected.IsSuccess)
+            return selected;
+
+        return await ExtractPackageCoreAsync(
+            client, packageId, log, tempDirPrefix, sourceOptions,
+            selected.Result!.Version, forceLatest: false, includePrerelease: false,
+            session, selected).ConfigureAwait(false);
     }
 
     private static async Task<PackageExtractionOutcome> ExtractPackageCoreAsync(
@@ -318,9 +357,11 @@ public static class PackageExtractor
         string? version,
         bool forceLatest,
         bool includePrerelease,
-        PinnedPackageExtractionSession? pinnedSession)
+        ConfiguredPackageExtractionSession? authoritySession,
+        PackageExtractionOutcome? initialOutcome = null)
     {
-        bool isLocalFile = packageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
+        bool isLocalFile = authoritySession is null
+            && packageSource.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
 
         if (isLocalFile)
         {
@@ -347,7 +388,7 @@ public static class PackageExtractor
             PackageExtractionOutcome outcome;
             using (FeedFailureTelemetry.Scope())
             {
-                outcome = await DownloadAndExtractPackageAsync(
+                outcome = initialOutcome ?? await DownloadAndExtractPackageAsync(
                     client,
                     currentPackageSource,
                     log,
@@ -356,7 +397,8 @@ public static class PackageExtractor
                     currentVersion,
                     currentForceLatest,
                     currentIncludePrerelease,
-                    pinnedSession).ConfigureAwait(false);
+                    authoritySession).ConfigureAwait(false);
+                initialOutcome = null;
             }
 
             if (!outcome.IsSuccess)
@@ -374,7 +416,7 @@ public static class PackageExtractor
                     {
                         ToolWrapperChain = wrapperPackages.ToArray()
                     };
-                return pinnedSession?.Complete(completed) ?? completed;
+                return authoritySession?.Complete(completed) ?? completed;
             }
 
             if (string.IsNullOrWhiteSpace(result.PackageName))
@@ -468,21 +510,23 @@ public static class PackageExtractor
         string? explicitVersion = null,
         bool forceLatest = false,
         bool includePrerelease = false,
-        PinnedPackageExtractionSession? pinnedSession = null)
+        ConfiguredPackageExtractionSession? authoritySession = null)
     {
-        var (packageName, parsedVersion) = ParsePackageReference(packageSource);
+        (string packageName, string? parsedVersion) = authoritySession is null
+            ? ParsePackageReference(packageSource)
+            : (packageSource, null);
         var version = explicitVersion ?? parsedVersion;
 
         // A legacy selector's producer restriction is not an authority receipt.
         // Those discovered-coordinate paths migrate with their resolver.
         if (!HttpClientFactory.IsOffline
-            && pinnedSession is not null
+            && authoritySession is not null
             && sourceOptions?.AuthorizedSourceKeys is null
             && sourceOptions?.ResolvedSources is null
             && version is not null
             && TryNormalizePackageVersion(version, out string pinnedVersion))
         {
-            return await pinnedSession.AcquireAsync(
+            return await authoritySession.AcquireAsync(
                 packageName, pinnedVersion, sourceOptions, log).ConfigureAwait(false);
         }
 

--- a/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.Selection.cs
+++ b/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.Selection.cs
@@ -276,6 +276,28 @@ public sealed partial class ConfiguredPayloadAcquisitionTests
     }
 
     [Fact]
+    public async Task ExtractSelected_ReportedVersionWithoutPayloadReturnsAcquisitionFailure()
+    {
+        const string Id = "Selected.Unavailable";
+        var requests = new ConcurrentQueue<string>();
+        using var client = new HttpClient(new RejectNetworkHandler(new HttpClientHandler()));
+
+        PackageExtractionOutcome outcome = await DesktopPackageExtractor.ExtractSelectedPackageAsync(
+            client, Id, "",
+            sourceOptions: new NuGetSourceOptions { Sources = [FirstFeed] },
+            createComposition: () => CreateComposition((source, _) =>
+                new SelectionFeedHandler(source.Url, Id, [Version],
+                    _ => CreatePackage(Id, "unavailable"), requests, missingPayload: true)));
+
+        Assert.False(outcome.IsSuccess);
+        Assert.Null(outcome.Result);
+        Assert.Contains("selection 'latest'", outcome.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("No eligible reporting source supplied a matching payload.",
+            outcome.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains(requests, request => request.EndsWith(".nupkg", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ExtractSelected_WrapperReauthorizesTargetAndTransfersOwnedTemporary()
     {
         const string Wrapper = "Selected.Wrapper";

--- a/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.Selection.cs
+++ b/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.Selection.cs
@@ -1,0 +1,468 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text.Json;
+
+using DotnetInspector.Packages;
+using NuGetFetch;
+
+using CoreHttpClientFactory = DotnetInspector.Core.HttpClientFactory;
+using DesktopPackageExtractor = DotnetInspector.Packages.PackageExtractor;
+
+namespace DotnetInspector.Tests;
+
+public sealed partial class ConfiguredPayloadAcquisitionTests
+{
+    [Theory]
+    [InlineData(null, false, false, "2.0.0")]
+    [InlineData("latest", false, true, "2.0.0")]
+    [InlineData(null, true, false, "3.0.0-preview.2")]
+    [InlineData("1.*", false, true, "1.5.0")]
+    [InlineData("*", false, false, "3.0.0-preview.2")]
+    [InlineData("3.0.0-preview*", false, true, "3.0.0-preview.2")]
+    public async Task PackageCommand_LocalSelectionPrintsSelectedPayload(
+        string? selector, bool preview, bool fileUri, string expectedVersion)
+    {
+        string id = $"Selected.Local.{Guid.NewGuid():N}";
+        string source = Path.Combine(_root, "selection-feed");
+        foreach (string version in new[] { "1.0.0", "1.5.0", "2.0.0", "3.0.0-preview.1", "3.0.0-preview.2" })
+            WriteLocalPackage(source, id, $"payload {version}", hierarchical: fileUri, version: version);
+        CoreHttpClientFactory.SetPackageSourceHandlerForTesting(_ =>
+            throw new InvalidOperationException("Local selection created an HTTP transport."));
+
+        List<string> args = ["package", selector is null ? id : $"{id}@{selector}",
+            "--source", fileUri ? new Uri(source).AbsoluteUri : source,
+            "--path", "@readme", "--content", "--bare"];
+        if (preview)
+            args.Add("--preview");
+        var (exit, output, error) = await RunCommandAsync([.. args]);
+
+        Assert.True(exit == 0, $"Exit {exit}: {error}");
+        Assert.Equal($"payload {expectedVersion}", output.Trim());
+        Assert.Empty(error);
+    }
+
+    [Theory]
+    [InlineData("latest")]
+    [InlineData("*")]
+    [InlineData(Version)]
+    public async Task PackageCommand_ExplicitPackageReferenceWithArchiveSuffixIsNotAFile(string selector)
+    {
+        const string Id = "Selected.Package.nupkg";
+        string source = Path.Combine(_root, "suffix");
+        WriteLocalPackage(source, Id, "package identity, not a file path");
+
+        var (exit, output, error) = await RunCommandAsync(
+            ["package", $"{Id}@{selector}", "--source", source,
+                "--path", "@readme", "--content", "--bare"]);
+
+        Assert.True(exit == 0, error);
+        Assert.Equal("package identity, not a file path", output.Trim());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("*")]
+    public async Task AcquireSelected_PartialDiscoveryDoesNotProbePayloadCaches(string? selector)
+    {
+        const string Id = "Selected.Partial";
+        string source = Path.Combine(_root, "healthy");
+        string missing = Path.Combine(_root, "missing");
+        WriteLocalPackage(source, Id, "not a complete selection");
+        await using var composition = LocalComposition();
+
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            Id, selector,
+            (_, _) => throw new InvalidOperationException("Incomplete discovery reached a payload store."),
+            new NuGetSourceOptions { Sources = [source, missing] },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Null(result.Payload);
+        Assert.Null(result.Authority);
+        Assert.Contains(result.Failures, failure =>
+            failure.Kind == PackageAuthorityFailureKind.Transport
+            && failure.Authority.ToString().Contains(missing, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AcquireSelected_NonReportingWarmCacheCannotSupplySelectedVersion(bool reporterMissing)
+    {
+        const string Id = "Selected.NonReporter";
+        const string SelectedVersion = "2.0.0";
+        var requests = new ConcurrentQueue<string>();
+        var stores = new Dictionary<ConfiguredPackageAuthority, IPackageStore>();
+        await using var composition = CreateComposition((source, _) =>
+            new SelectionFeedHandler(source.Url, Id,
+                source.Url == FirstFeed ? [SelectedVersion] : [Version],
+                version => CreatePackage(Id, source.Url, version: version), requests,
+                missingPayload: source.Url == FirstFeed && reporterMissing));
+        IPackageStore GetStore(ConfiguredPackageAuthority authority, PackageProducerIdentity _)
+        {
+            if (!stores.TryGetValue(authority, out IPackageStore? store))
+                stores.Add(authority, store = new InMemoryPackageStore());
+            return store;
+        }
+
+        ConfiguredPackagePayloadResult warm = await composition.AcquirePinnedAsync(
+            Id, SelectedVersion, GetStore, new NuGetSourceOptions { Sources = [SecondFeed] },
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(warm.Payload);
+        Assert.Equal(SecondFeed, ReadReadme(warm.Payload.Content));
+        int nonReporterStoreReads = 0;
+
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            Id, null,
+            (authority, producer) =>
+            {
+                if (ReferenceEquals(authority, warm.Authority))
+                    nonReporterStoreReads++;
+                return GetStore(authority, producer);
+            },
+            new NuGetSourceOptions { Sources = [SecondFeed, FirstFeed] },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, nonReporterStoreReads);
+        if (reporterMissing)
+        {
+            Assert.Null(result.Payload);
+            Assert.Null(result.Authority);
+        }
+        else
+        {
+            Assert.NotNull(result.Payload);
+            Assert.Equal(SelectedVersion, result.Payload.Coordinate.Version);
+            Assert.Equal(FirstFeed, ReadReadme(result.Payload.Content));
+            Assert.Equal(FirstFeed, result.Authority!.Source.Url);
+        }
+    }
+
+    [Fact]
+    public async Task AcquireSelected_QueryDistinctAuthoritiesDoNotShareReportingEvidence()
+    {
+        const string Id = "Selected.QueryAuthority";
+        const string Older = "https://query-selection.invalid/v3/index.json?channel=older";
+        const string Newer = "https://query-selection.invalid/v3/index.json?channel=newer";
+        var requests = new ConcurrentQueue<string>();
+        await using var composition = CreateComposition((source, _) =>
+            new SelectionFeedHandler(source.Url, Id,
+                source.Url == Older ? [Version] : ["2.0.0"],
+                version => CreatePackage(Id, source.Url, version: version), requests));
+        ConfiguredPackagePayloadResult older = await composition.AcquirePinnedAsync(
+            Id, Version, (_, _) => new InMemoryPackageStore(),
+            new NuGetSourceOptions { Sources = [Older] },
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(older.Payload);
+
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            Id, "*", (authority, _) =>
+            {
+                Assert.Equal(Newer, authority.Source.Url);
+                return new InMemoryPackageStore();
+            },
+            new NuGetSourceOptions { Sources = [Older, Newer] },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Payload);
+        Assert.Equal("2.0.0", result.Payload.Coordinate.Version);
+        Assert.Equal(Newer, ReadReadme(result.Payload.Content));
+        Assert.Equal(Newer, result.Authority!.Source.Url);
+        Assert.Equal(older.Payload.ProducerKey, result.Payload.ProducerKey);
+        Assert.NotSame(older.Authority, result.Authority);
+        Assert.Empty(result.Failures);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AcquireSelected_GalleryListingEvidenceControlsAuthorization(bool missingListingState)
+    {
+        const string Id = "selected.gallery";
+        const string Gallery = "https://api.nuget.org/v3/index.json";
+        var requests = new ConcurrentQueue<string>();
+        await using var composition = CreateComposition((source, isGallery) =>
+            new SelectionFeedHandler(source.Url, Id, [Version],
+                _ => CreatePackage(Id, source.Url), requests,
+                listed: !isGallery, missingListingState: isGallery && missingListingState));
+
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            Id, null, (authority, _) =>
+            {
+                Assert.False(missingListingState, "Incomplete listing metadata reached a payload store.");
+                Assert.Equal(FirstFeed, authority.Source.Url);
+                return new InMemoryPackageStore();
+            },
+            new NuGetSourceOptions { Sources = [Gallery, FirstFeed] },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        if (missingListingState)
+        {
+            Assert.Null(result.Payload);
+            Assert.Contains(result.Failures,
+                failure => failure.Kind == PackageAuthorityFailureKind.IncompleteMetadata);
+        }
+        else
+        {
+            Assert.Equal(FirstFeed, ReadReadme(AssertPayload(result, Id).Content));
+            Assert.Equal(FirstFeed, result.Authority!.Source.Url);
+            Assert.Empty(result.Failures);
+        }
+    }
+
+    [Fact]
+    public async Task PackageCommand_SelectionRefreshesWithWarmLocalPayload()
+    {
+        const string Id = "Selected.Fresh";
+        string source = Path.Combine(_root, "fresh");
+        WriteLocalPackage(source, Id, "first version");
+        string[] args = ["package", Id, "--source", source, "--path", "@readme", "--content", "--bare"];
+        var first = await RunCommandAsync(args);
+        Assert.True(first.Exit == 0, first.Error);
+        Assert.Equal("first version", first.Output.Trim());
+
+        WriteLocalPackage(source, Id, "newer version", version: "2.0.0");
+        var next = await RunCommandAsync(args);
+        Assert.True(next.Exit == 0, next.Error);
+        Assert.Equal("newer version", next.Output.Trim());
+    }
+
+    [Theory]
+    [InlineData("1.0.0..3.0.0", "first", "1.0.0")]
+    [InlineData("1.0.0..3.0.0", "#2", "2.0.0")]
+    [InlineData("1.0.0..3.0.0", "last", "3.0.0")]
+    [InlineData("3.0.0..1.0.0", "#1", "3.0.0")]
+    [InlineData("3.0.0..1.0.0", "last", "1.0.0")]
+    [InlineData("3.0.0..1.0.0", "2.0.0", "2.0.0")]
+    public async Task AcquireSelected_RangeRetainsAddressDirectionAndReporter(
+        string range, string address, string expectedVersion)
+    {
+        const string Id = "Selected.Range";
+        string source = Path.Combine(_root, "range");
+        string peer = Path.Combine(_root, "outside-range");
+        foreach (string version in new[] { "1.0.0", "2.0.0", "3.0.0" })
+            WriteLocalPackage(source, Id, $"range {version}", version: version);
+        WriteLocalPackage(peer, Id, "outside range", version: "4.0.0");
+        await using var composition = LocalComposition();
+
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            Id, range, (_, _) => new InMemoryPackageStore(),
+            new NuGetSourceOptions { Sources = [peer, source] },
+            rangeAddress: address,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Payload);
+        Assert.Equal(expectedVersion, result.Payload.Coordinate.Version);
+        Assert.Equal($"range {expectedVersion}", ReadReadme(result.Payload.Content));
+        Assert.Equal(source, result.Authority!.Source.Url);
+        Assert.Empty(result.Failures);
+    }
+
+    [Theory]
+    [InlineData("1.0.0..bad", "first")]
+    [InlineData("1.0.0..2.0.0", null)]
+    [InlineData(null, "first")]
+    public async Task AcquireSelected_InvalidSelectorFailsBeforeTransport(string? selector, string? address)
+    {
+        await using var composition = LocalComposition();
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            "Selected.Invalid", selector,
+            (_, _) => throw new InvalidOperationException("Invalid selection reached a store."),
+            new NuGetSourceOptions { Sources = [FirstFeed] },
+            rangeAddress: address,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Null(result.Payload);
+        Assert.Contains(result.Failures, failure => failure.Kind == PackageAuthorityFailureKind.Input);
+    }
+
+    [Fact]
+    public async Task ExtractSelected_WrapperReauthorizesTargetAndTransfersOwnedTemporary()
+    {
+        const string Wrapper = "Selected.Wrapper";
+        const string Target = "Selected.Target";
+        string source = Path.Combine(_root, "target");
+        WriteLocalPackage(source, Target, "target bytes");
+        string config = WriteConfig([("wrapper", FirstFeed, Wrapper), ("target", source, Target)]);
+        using var client = new HttpClient(new RejectNetworkHandler(new HttpClientHandler()));
+        var options = new NuGetSourceOptions { ConfigFile = config };
+        PackageExtractionOutcome warm = await DesktopPackageExtractor.ExtractPinnedPackageAsync(
+            client, Target, Version, sourceOptions: options);
+        Assert.True(warm.IsSuccess, warm.ErrorMessage);
+        DesktopPackageExtractor.Cleanup(warm.Result!.TempDir);
+        var requests = new ConcurrentQueue<string>();
+        PackageExtractionOutcome outcome = await DesktopPackageExtractor.ExtractSelectedPackageAsync(
+            client, Wrapper, sourceOptions: options,
+            createComposition: () => CreateComposition((authority, _) =>
+                new SelectionFeedHandler(authority.Url, Wrapper, [Version],
+                    _ => CreatePackage(Wrapper, "wrapper", Target), requests)));
+        string? temporaryRoot = outcome.Result?.TempDir;
+        try
+        {
+            Assert.True(outcome.IsSuccess, outcome.ErrorMessage);
+            Assert.Equal(Target, outcome.Result!.PackageName, ignoreCase: true);
+            Assert.True(outcome.Result.FromCache);
+            Assert.Equal(ConfiguredPackageAuthorityKind.LocalFolder, outcome.Result.Authority!.Kind);
+            Assert.NotNull(temporaryRoot);
+            Assert.True(Directory.Exists(temporaryRoot));
+            Assert.Equal(FirstFeed, Assert.Single(outcome.Result.ToolWrapperChain).Authority!.Source.Url);
+            Assert.DoesNotContain(requests, request => request.Contains(Target.ToLowerInvariant(), StringComparison.Ordinal));
+        }
+        finally
+        {
+            DesktopPackageExtractor.Cleanup(temporaryRoot);
+        }
+        Assert.False(Directory.Exists(temporaryRoot));
+    }
+
+    [Fact]
+    public async Task AcquireSelected_ExternalOperationSurvivesDiscoveryThroughCommit()
+    {
+        const string Id = "Selected.Operation";
+        var requests = new ConcurrentQueue<string>();
+        await using var composition = CreateComposition((source, _) =>
+            new SelectionFeedHandler(source.Url, Id, [Version],
+                _ => CreatePackage(Id, "one operation"), requests));
+        using var operation = new NuGetOperationContext(
+            TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+        var store = new GatedCommitStore(operation);
+        Task<ConfiguredPackagePayloadResult> acquisition = composition.AcquireSelectedAsync(
+            Id, null, (_, _) => store, new NuGetSourceOptions { Sources = [FirstFeed] },
+            cancellationToken: TestContext.Current.CancellationToken, operationContext: operation);
+        try
+        {
+            await store.Entered.Task.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+            Assert.False(acquisition.IsCompleted);
+            operation.ThrowIfExpired();
+        }
+        finally
+        {
+            store.Release.TrySetResult();
+        }
+
+        ConfiguredPackagePayloadResult result = await acquisition;
+        Assert.Equal("one operation", ReadReadme(AssertPayload(result, Id).Content));
+        Assert.True(store.Committed);
+        operation.ThrowIfExpired();
+    }
+
+    [Fact]
+    public async Task AcquireSelected_ExternalOperationDeadlineBoundsDiscovery()
+    {
+        const string Id = "selected.deadline";
+        var requests = new ConcurrentQueue<string>();
+        await using var composition = CreateComposition((source, _) =>
+            new SelectionFeedHandler(source.Url, Id, [Version],
+                _ => throw new InvalidOperationException("Expired discovery reached payload transport."),
+                requests, beforeResponse: async (url, token) =>
+                {
+                    if (url.EndsWith($"/{Id}/index.json", StringComparison.Ordinal))
+                        await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }),
+            requestTimeout: TimeSpan.FromSeconds(30));
+        using var operation = new NuGetOperationContext(
+            TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+
+        ConfiguredPackagePayloadResult result = await composition.AcquireSelectedAsync(
+            Id, null,
+            (_, _) => throw new InvalidOperationException("Expired discovery reached a payload store."),
+            new NuGetSourceOptions { Sources = [FirstFeed] },
+            cancellationToken: TestContext.Current.CancellationToken, operationContext: operation)
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        Assert.Null(result.Payload);
+        Assert.Contains(result.Failures, failure => failure.Kind == PackageAuthorityFailureKind.Timeout);
+        Assert.Contains(requests, url => url.EndsWith($"/{Id}/index.json", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AcquireSelected_DiscoveryCancellationPreservesCallerToken()
+    {
+        const string Id = "selected.cancel";
+        var requests = new ConcurrentQueue<string>();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        await using var composition = CreateComposition((source, _) =>
+            new SelectionFeedHandler(source.Url, Id, [Version],
+                _ => throw new InvalidOperationException("Cancelled discovery reached payload transport."),
+                requests, beforeResponse: async (url, token) =>
+                {
+                    if (url.EndsWith($"/{Id}/index.json", StringComparison.Ordinal))
+                    {
+                        cancellation.Cancel();
+                        await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    }
+                }));
+        using var operation = composition.CreateOperationContext(cancellation.Token);
+
+        OperationCanceledException exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => composition.AcquireSelectedAsync(
+                Id, null,
+                (_, _) => throw new InvalidOperationException("Cancelled discovery reached a payload store."),
+                new NuGetSourceOptions { Sources = [FirstFeed] },
+                cancellationToken: cancellation.Token, operationContext: operation));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+    }
+
+    private sealed class SelectionFeedHandler(
+        string source, string id, IReadOnlyList<string> versions,
+        Func<string, byte[]> payload, ConcurrentQueue<string> requests,
+        bool missingPayload = false, bool listed = true, bool missingListingState = false,
+        Func<string, CancellationToken, Task>? beforeResponse = null) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string url = request.RequestUri!.AbsoluteUri;
+            requests.Enqueue(url);
+            if (beforeResponse is not null)
+                await beforeResponse(url, cancellationToken);
+            string flat = new Uri(new Uri(source), "flat2/").AbsoluteUri;
+            HttpContent content;
+            HttpStatusCode status = HttpStatusCode.OK;
+            if (url == source)
+            {
+                content = new StringContent($$"""
+                    {"version":"3.0.0","resources":[
+                      {"@id":"{{flat}}","@type":"PackageBaseAddress/3.0.0"}
+                    ]}
+                    """);
+            }
+            else if (url == $"{flat}{id.ToLowerInvariant()}/index.json"
+                || url == $"https://globalcdn.nuget.org/v3-flatcontainer/{id}/index.json")
+            {
+                content = new StringContent(JsonSerializer.Serialize(new { versions }));
+            }
+            else if (url == $"https://globalcdn.nuget.org/v3/registration5-gz-semver2/{id}/index.json")
+            {
+                status = missingListingState ? HttpStatusCode.NotFound : HttpStatusCode.OK;
+                content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    items = new[] { new { items = versions.Select(version => new
+                    {
+                        catalogEntry = new { version, listed },
+                    }) } },
+                }));
+            }
+            else if (url.StartsWith($"{flat}{id.ToLowerInvariant()}/", StringComparison.Ordinal)
+                && url.EndsWith(".nupkg", StringComparison.Ordinal))
+            {
+                status = missingPayload ? HttpStatusCode.NotFound : HttpStatusCode.OK;
+                string version = request.RequestUri.Segments[^2].TrimEnd('/');
+                content = new ByteArrayContent(missingPayload ? [] : payload(version));
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unexpected selected-payload request: {url}");
+            }
+            return new HttpResponseMessage(status)
+            {
+                Content = content,
+                RequestMessage = request,
+            };
+        }
+    }
+}

--- a/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.cs
+++ b/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.cs
@@ -18,7 +18,7 @@ using DesktopPackageExtractor = DotnetInspector.Packages.PackageExtractor;
 namespace DotnetInspector.Tests;
 
 [Collection("Console")]
-public sealed class ConfiguredPayloadAcquisitionTests : IDisposable
+public sealed partial class ConfiguredPayloadAcquisitionTests : IDisposable
 {
     private const string Version = "1.0.0";
     private const string FirstFeed = "https://first-payload.invalid/v3/index.json";
@@ -547,26 +547,28 @@ public sealed class ConfiguredPayloadAcquisitionTests : IDisposable
     }
 
     private static void WriteLocalPackage(
-        string root, string id, string readme, bool hierarchical = false, string? redirectId = null)
+        string root, string id, string readme, bool hierarchical = false,
+        string? redirectId = null, string version = Version)
     {
-        string directory = hierarchical ? Path.Combine(root, id.ToLowerInvariant(), Version) : root;
+        string directory = hierarchical ? Path.Combine(root, id.ToLowerInvariant(), version) : root;
         Directory.CreateDirectory(directory);
         File.WriteAllBytes(
-            Path.Combine(directory, $"{id.ToLowerInvariant()}.{Version}.nupkg"),
-            CreatePackage(id, readme, redirectId));
+            Path.Combine(directory, $"{id.ToLowerInvariant()}.{version}.nupkg"),
+            CreatePackage(id, readme, redirectId, version));
     }
 
     private static HttpContent PackageContent(string id, string readme) =>
         new ByteArrayContent(CreatePackage(id, readme));
 
-    private static byte[] CreatePackage(string id, string readme, string? redirectId = null)
+    private static byte[] CreatePackage(
+        string id, string readme, string? redirectId = null, string version = Version)
     {
         using var buffer = new MemoryStream();
         using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
         {
             WriteEntry(archive, $"{id}.nuspec", $"""
                 <package><metadata>
-                  <id>{id}</id><version>{Version}</version>
+                  <id>{id}</id><version>{version}</version>
                   <authors>Payload tests</authors><description>Exact-pin fixture</description>
                   <readme>README.md</readme>
                 </metadata></package>

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -830,14 +830,23 @@ public class PackageCommand
 
         try
         {
-            PackageExtractionOutcome outcome = !target.IsLocalFile
-                && !Core.HttpClientFactory.IsOffline
-                && PackageExtractor.TryNormalizePackageVersion(version, out string pinnedVersion)
-                ? await PackageExtractor.ExtractPinnedPackageAsync(
-                    client, packageName, pinnedVersion, logger.Log,
-                    sourceOptions: options.SourceOptions,
-                    createComposition: context.CreatePackageSourceComposition)
-                : await PackageExtractor.ExtractPackageAsync(
+            PackageExtractionOutcome outcome;
+            if (!target.IsLocalFile && !Core.HttpClientFactory.IsOffline)
+            {
+                outcome = PackageExtractor.TryNormalizePackageVersion(version, out string pinnedVersion)
+                    ? await PackageExtractor.ExtractPinnedPackageAsync(
+                        client, packageName, pinnedVersion, logger.Log,
+                        sourceOptions: options.SourceOptions,
+                        createComposition: context.CreatePackageSourceComposition)
+                    : await PackageExtractor.ExtractSelectedPackageAsync(
+                        client, packageName, version.Length > 0 ? version : null, logger.Log,
+                        sourceOptions: options.SourceOptions,
+                        includePrerelease: options.IncludePrerelease,
+                        createComposition: context.CreatePackageSourceComposition);
+            }
+            else
+            {
+                outcome = await PackageExtractor.ExtractPackageAsync(
                     client,
                     target.IsLocalFile ? target.OriginalArgument : packageName,
                     logger.Log,
@@ -845,6 +854,7 @@ public class PackageCommand
                     version: target.IsLocalFile ? null : (version.Length > 0 ? version : null),
                     forceLatest: options.ForceLatest,
                     includePrerelease: options.IncludePrerelease);
+            }
 
             if (!outcome.IsSuccess)
             {

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Online single-package inspection now selects latest and wildcard versions
+  from configured local and HTTP authorities, including `--preview`.
+  Selection requires fresh, complete discovery and acquires only from sources
+  that reported the chosen version, even on a payload-cache hit. Local payload
+  caches and HTTP temporary ownership match exact-pin inspection. API/timeline
+  range hosts, multi-package commands, and offline extraction remain on their
+  existing paths (#5400).
 - **Breaking:** Renames `match --implementation` to `match --body`, with
   a `Method Body Diff` view. Body comparison now consumes the shared Queries
   designated-pair path and retains native endpoint and failure outcomes.


### PR DESCRIPTION
## Summary

Make ordinary local-feed inspection a robust CLI capability: latest and wildcard
requests now reach the selected package's payload while retaining the configured
authorities that reported it, rather than substituting producer identity.

Step **5 of 6** for #5400, under end-to-end tracker #3759. This follows merged
exact-pin adoption in #5971.

- Preserve admitted candidate observations with their exact configured authority
  before projecting version-list display rows.
- Require complete discovery before any selected-payload cache probe; only
  reporting authorities can supply the selected coordinate.
- Reuse the pinned acquisition core, authority-scoped stores, operation context,
  and wrapper traversal. Explicit package IDs ending in `.nupkg` remain package
  identities rather than being reparsed as filenames.
- Enable ordinary online single-package omitted/latest/wildcard inspection,
  including `--preview`. Provide the shared range-address acquisition seam
  without adding `package --at`.

## Demo

The fixture folder contains `Selection.Demo` versions `1.0.0`, `1.5.0`,
`2.0.0`, and `3.0.0-preview.1`, each with a version-identifying README.
These are real child-process CLI invocations. Before evidence used the previous
exact-pin-only CLI dispatch against the same fixture.

Before:

```text
> dotnet-inspect package Selection.Demo --source ./feed --path @readme --content --bare --no-nuget-cache
Error: Package 'selection.demo' not found.
Exit: 1

> dotnet-inspect package Selection.Demo@1.* --source ./feed --path @readme --content --bare --no-nuget-cache
Error: No version matching pattern found for 'selection.demo'.
Exit: 1
```

After:

```text
> dotnet-inspect package Selection.Demo --source ./feed --path @readme --content --bare --no-nuget-cache
Selected local payload: 2.0.0
Exit: 0

> dotnet-inspect package Selection.Demo@1.* --source ./feed --path @readme --content --bare --no-nuget-cache
Selected local payload: 1.5.0
Exit: 0

> dotnet-inspect package Selection.Demo --preview --source ./feed --path @readme --content --bare --no-nuget-cache
Selected local payload: 3.0.0-preview.1
Exit: 0
```

The neighboring failure case adds `--add-source ./missing` to the first
invocation. It exits 1, reports that the missing source could not be reached
while enumerating versions, and emits no payload—even after the healthy
source's payload has been cached. A healthy subset is not a complete selection.

## Design basis and scope

**Normative owner:** `docs/design/package-source-model.md`, Exact payload
acquisition and Discovered-coordinate payload acquisition: a discovered
coordinate can be acquired only from an authority that reported it under the
selection contract.

Supporting roles are the existing version-selector semantics in
`docs/design/version-resolution.md`, `PackageVersionVector`'s inclusive range
and address algorithms, NuGetFetch's bounded operations and source observations,
and the existing authority-store publication/lifetime contract. Existing legacy
selection is comparative evidence for wildcard and highest-version behavior,
not authority for carrying source URLs as receipts.

The added observation/authority pairing serves one correctness requirement:
preserve reporting authority across discovery, cache lookup, and acquisition.
The CLI remains a thin consumer. Existing typed package results and
Markout-backed views remain the rendering boundary; there is no new default
section or broad rendering domain.

**Intentional divergence:** automatic single-package acquisition performs fresh,
bounded discovery rather than consulting legacy producer-keyed candidate caches
or their shortened stale-cache request budget. Those caches cannot supply the
new authority evidence. Existing local payload caching and HTTP temporary
ownership are reused.

The supported caller is an ordinary CLI/package-API consumer; varying inputs
are its selected source policy, published candidate metadata, and package
payloads. Incomplete discovery, an eligible non-reporting warm cache,
same-producer/different-authority feeds, and Gallery listing-state disagreement
are the defining boundaries. Local interference and hostile trusted callers
are not added to the threat model.

The six-step adoption path is: configured authorities; ordinary version
listing; metadata-only version queries; caller-pinned payload/cache authority;
discovered-coordinate acquisition (this PR); remaining CLI consumers and legacy
retirement. API/timeline range hosts and their replay paths migrate in step 6,
as do remaining multi-package and other legacy consumers. Local-file and
offline extraction remain unchanged. The recorded
[CLI-only approval](https://github.com/richlander/dotnet-inspect/issues/5400#issuecomment-5547738490)
applies to this workstream; this PR adds no browser filesystem registration and
does not claim release or deployment.

## Validation

Required SDK: `11.0.100-preview.7.26381.103`, installed under this worktree's
ignored artifacts. `DOTNET_ROOT` and `DOTNET_HOST_PATH` both select that SDK's
host; no central installation or PATH was changed.

- **354 passed:** configured acquisition/selection, authority stores,
  source-scoped routing, version vectors, version commands, source-policy
  authorization, and shipped skill cases in Release.
- **226 passed, 1 existing private-feed skip:** package command, package routing,
  projection, content, and neighboring command cases in Release.
- **45 passed on replacement head `ef4cd367d`:** the affected configured
  acquisition/selection class, including a new case where a reported version's
  payload is unavailable. The broader runs above preceded this diagnostic-only
  correction; their implementation surfaces are otherwise unchanged.
- The CLI and Packages Release builds completed without warnings or errors.
- All five changed Markdown files pass `markdownlint`.
- Before/after demo and decisive local logs are preserved in the session
  artifacts; the owning design names the committed outcome-level gates.

## Review

Current-head `ci-required` passed. GPT-6 Astra and Claude Opus 5 both returned
**CLEAN** at `ef4cd367d80bbd3ec54c4f6a238085c6956733ea`; their reported Release
evidence totals 219 and 525 passing cases respectively (Opus also reports one
existing skip).

[Round-1 reconciliation and no-interaction carry-forward](https://github.com/richlander/dotnet-inspect/pull/6090#issuecomment-5557170955)
preserve the unchanged candidate through analyzed base `060b41b78`. No review
evidence from #5971 was inherited. Merge still requires explicit authorization.
