### PR TITLE
Separate package-prefix declarations from consumer limits

### DIFF
--- a/docs/design/search-scope-domain.md
+++ b/docs/design/search-scope-domain.md
@@ -40,11 +40,14 @@ The end-to-end tracker is #5602. Six adoption stages are:
 5. Inventory and focused adoption of other CLI source-policy families.
 6. Retirement of obsolete adapter shapes when their migrations are complete.
 
-The catalog consumes `PackagePrefixRequest`; CLI and Browser can independently
-consume `SourceIntent` and `SearchSourceNormalizer`. Neither host must apply
-search defaulting merely to construct or inspect a declaration. The source
-production changes in #5954 and the catalog hints/priorities in #6028 remain
-separate. This slice introduces no universal realization protocol.
+The catalog-facing currency is `PackagePrefixDeclaration`; a consumer adds its
+policy when constructing a `PackagePrefixRequest`. This separation is
+implemented under #6092; the catalog's planned prefix slot remains a separate
+adoption. CLI and Browser can independently consume `SourceIntent` and
+`SearchSourceNormalizer`. Neither host must apply search defaulting merely to
+construct or inspect a declaration. The source-production changes in #5954 and
+the catalog hints/priorities in #6028 remain separate. This slice introduces no
+universal realization protocol.
 
 ## Declaration contract
 
@@ -93,9 +96,11 @@ continue to put Extensions before ASP.NET Core regardless of token order.
 
 ## Package-prefix request
 
-`PackagePrefixRequest` is an immutable request with original prefix spelling,
-a positive `MaxPackages` integer, and `IncludePrerelease`. All three are
-inspectable independently of a declaration or search normalization.
+Prefix declaration and consumer policy are separate immutable values.
+`PackagePrefixDeclaration` retains only the original validated prefix spelling.
+It can be constructed and inspected without a request, source access, or search
+normalization. It carries neither expected nor maximum package counts;
+prerelease policy also belongs to the consumer request, not the declaration.
 
 The prefix is a nonempty literal beginning of a package ID accepted by
 `PackageCoordinateResolver.IsCanonicalPackageId`. It may be a complete valid
@@ -105,17 +110,33 @@ is no trimming, wildcard, query syntax, or case folding at construction.
 Matching semantics, source ordering, and the meaning of returned versions
 remain source-owned.
 
-The bound is required and must be positive; the request does not invent a
-universal provider maximum. Command policy chooses bounds such as the existing
+`PackagePrefixRequest` combines that declaration with a positive `MaxPackages`
+integer and `IncludePrerelease`. It retains the exact supplied declaration;
+different consumers can apply different policies to that same value without
+changing it. A prefix-only declaration is not an unbounded execution request.
+`SourceSelector.PackagePrefix` continues to retain the bounded request, and
+normalization preserves both the request and its declaration.
+
+The bound is required and must be positive; request construction does not invent
+a universal provider maximum. Command policy chooses bounds such as the existing
 500-package type-search limit. A realization adapter must preserve the requested
 bound or visibly reject unsupported intent, rather than silently clamp it.
 Source-work/page limits, deadlines, source configuration, authentication, and
 completion are not request fields. Prerelease eligibility is explicit, with
 `false` as the construction default.
 
-An accepted request proves intrinsic well-formedness only. Catalog discovery
-may retain and return it; it does not prove that the prefix exists, that a
-provider supports it, that a query is complete, or that traversal is permitted.
+The existing string-based request constructor remains a convenience for
+consumers that already have both prefix text and policy. It uses the same
+declaration validation. `PackagePrefixRequest.Create` accepts an existing
+declaration; using a named factory instead of a second public reference-typed
+constructor keeps existing null-input calls unambiguous. Request equality still
+distinguishes original prefix spelling, bound, and prerelease policy, not the
+allocation identity of the declaration.
+
+Construction of either value proves intrinsic well-formedness only. Neither
+proves that the prefix exists, that a provider supports it, that a query is
+complete, or that traversal is permitted. Catalog registration, source
+production, and host adoption remain outside this prerequisite.
 
 ## Search interpretation
 
@@ -147,13 +168,18 @@ not accept an acquisition result as a replacement declaration.
 
 ## Demo
 
-An ordinary consumer can retain a catalog-ready request before running search:
+An ordinary consumer can retain a catalog-ready declaration without choosing
+a package limit. Consumers then apply their own request policy:
 
 ```csharp
-var request = new PackagePrefixRequest("Aspire.", maxPackages: 500);
+var prefix = new PackagePrefixDeclaration("Aspire.");
+var request = PackagePrefixRequest.Create(prefix, maxPackages: 5);
+var broader = PackagePrefixRequest.Create(prefix, maxPackages: 250, includePrerelease: true);
 var intent = SourceIntent.Empty.Append(new SourceSelector.PackagePrefix(request));
 var normalized = SearchSourceNormalizer.Normalize(intent);
 
+// request.Declaration and broader.Declaration are the same prefix
+// request.MaxPackages == 5; broader.MaxPackages == 250
 // intent.Selectors.Count == 1
 // normalized.UsesImplicitPlatform == false
 // normalized.Frameworks.Count == 0
@@ -173,8 +199,8 @@ executable, run in Release in normal CI. Its public-consumer gates cover:
 | Gate | Claim |
 | --- | --- |
 | `SourceIntentTests` | Empty inspection, each typed variant, intrinsic rejection, independent snapshot/append, immutable collections, and package-owner validation |
-| `PackagePrefixRequestTests` | Retained bounded request, malformed prefix/bound rejection, separator and maximum-length boundaries |
-| `SearchSourceNormalizerTests` | Complete finite platform/group truth table, every direct source, stable package precedence/deduplication, retained prefix, and empty-group non-fallback |
+| `PackagePrefixRequestTests` | Declaration-only construction/inspection, independent consumer policies on one declaration, equivalent text-based/composed requests, malformed prefix/bound rejection, separator and maximum-length boundaries |
+| `SearchSourceNormalizerTests` | Complete finite platform/group truth table, every direct source, stable package precedence/deduplication, retained prefix declaration and distinct consumer requests, and empty-group non-fallback |
 
 The tests use product construction and normalization, not replacement
 algorithms or manufactured acquisition evidence. Browser execution, CLI

--- a/src/DotnetInspector.SourceSelection/PackagePrefixDeclaration.cs
+++ b/src/DotnetInspector.SourceSelection/PackagePrefixDeclaration.cs
@@ -1,0 +1,28 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.SourceSelection;
+
+/// <summary>A validated literal package prefix, independent of consumer request policy.</summary>
+public sealed record PackagePrefixDeclaration
+{
+    public PackagePrefixDeclaration(string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        if (!IsPackagePrefix(prefix))
+        {
+            throw new ArgumentException(
+                "A package prefix must be a nonempty literal beginning of a valid package ID.",
+                nameof(prefix));
+        }
+
+        Prefix = prefix;
+    }
+
+    public string Prefix { get; }
+
+    private static bool IsPackagePrefix(string prefix) =>
+        PackageCoordinateResolver.IsCanonicalPackageId(prefix)
+        || (prefix.Length is > 1 and < PackageCoordinateResolver.MaxPackageIdLength
+            && prefix[^1] is '.' or '-'
+            && PackageCoordinateResolver.IsCanonicalPackageId(prefix[..^1]));
+}

--- a/src/DotnetInspector.SourceSelection/PackagePrefixRequest.cs
+++ b/src/DotnetInspector.SourceSelection/PackagePrefixRequest.cs
@@ -1,5 +1,3 @@
-using DotnetInspector.Packages;
-
 namespace DotnetInspector.SourceSelection;
 
 /// <summary>Inert, bounded package-prefix intent; construction does not authorize source access.</summary>
@@ -9,28 +7,31 @@ public sealed record PackagePrefixRequest
         string prefix,
         int maxPackages,
         bool includePrerelease = false)
+        : this(new PackagePrefixDeclaration(prefix), maxPackages, includePrerelease)
     {
-        ArgumentNullException.ThrowIfNull(prefix);
-        if (!IsPackagePrefix(prefix))
-        {
-            throw new ArgumentException(
-                "A package prefix must be a nonempty literal beginning of a valid package ID.",
-                nameof(prefix));
-        }
+    }
 
+    private PackagePrefixRequest(
+        PackagePrefixDeclaration declaration,
+        int maxPackages,
+        bool includePrerelease)
+    {
+        ArgumentNullException.ThrowIfNull(declaration);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPackages);
-        Prefix = prefix;
+        Declaration = declaration;
         MaxPackages = maxPackages;
         IncludePrerelease = includePrerelease;
     }
 
-    public string Prefix { get; }
+    /// <summary>Applies consumer policy while retaining the exact supplied declaration.</summary>
+    public static PackagePrefixRequest Create(
+        PackagePrefixDeclaration declaration,
+        int maxPackages,
+        bool includePrerelease = false) =>
+        new(declaration, maxPackages, includePrerelease);
+
+    public PackagePrefixDeclaration Declaration { get; }
+    public string Prefix => Declaration.Prefix;
     public int MaxPackages { get; }
     public bool IncludePrerelease { get; }
-
-    private static bool IsPackagePrefix(string prefix) =>
-        PackageCoordinateResolver.IsCanonicalPackageId(prefix)
-        || (prefix.Length is > 1 and < PackageCoordinateResolver.MaxPackageIdLength
-            && prefix[^1] is '.' or '-'
-            && PackageCoordinateResolver.IsCanonicalPackageId(prefix[..^1]));
 }

--- a/tests/DotnetInspector.SourceSelection.Tests/PackagePrefixRequestTests.cs
+++ b/tests/DotnetInspector.SourceSelection.Tests/PackagePrefixRequestTests.cs
@@ -13,8 +13,15 @@ public sealed class PackagePrefixRequestTests
     [InlineData("Contoso_Core")]
     public void PublicConsumerRetainsExactBoundedRequest(string prefix)
     {
+        var declaration = new PackagePrefixDeclaration(prefix);
+        Assert.Equal(prefix, declaration.Prefix);
+
         var request = new PackagePrefixRequest(prefix, 500, includePrerelease: true);
+        var composed = PackagePrefixRequest.Create(declaration, 500, includePrerelease: true);
+        Assert.Same(declaration, composed.Declaration);
+        Assert.Equal(request, composed);
         Assert.Equal(prefix, request.Prefix);
+        Assert.Equal(prefix, request.Declaration.Prefix);
         Assert.Equal(500, request.MaxPackages);
         Assert.True(request.IncludePrerelease);
         Assert.False(new PackagePrefixRequest(prefix, 1).IncludePrerelease);
@@ -40,8 +47,11 @@ public sealed class PackagePrefixRequestTests
     [InlineData("Contoso\u00e9")]
     [InlineData("Contoso\0")]
     [InlineData("Contoso\n")]
-    public void MalformedPrefixesAreRejected(string prefix) =>
+    public void MalformedPrefixesAreRejected(string prefix)
+    {
+        Assert.Throws<ArgumentException>(() => new PackagePrefixDeclaration(prefix));
         Assert.Throws<ArgumentException>(() => new PackagePrefixRequest(prefix, 500));
+    }
 
     [Fact]
     public void PrefixLengthMustAllowACompletePackageId()
@@ -49,21 +59,58 @@ public sealed class PackagePrefixRequestTests
         int maximum = PackageCoordinateResolver.MaxPackageIdLength;
         string fullId = new('a', maximum);
         string extendable = new string('a', maximum - 2) + ".";
-        Assert.Equal(fullId, new PackagePrefixRequest(fullId, 1).Prefix);
-        Assert.Equal(extendable, new PackagePrefixRequest(extendable, 1).Prefix);
-        Assert.Throws<ArgumentException>(() => new PackagePrefixRequest(fullId + "a", 1));
-        Assert.Throws<ArgumentException>(() =>
-            new PackagePrefixRequest(new string('a', maximum - 1) + ".", 1));
+        foreach (string prefix in new[] { fullId, extendable })
+        {
+            Assert.Equal(prefix, new PackagePrefixDeclaration(prefix).Prefix);
+            Assert.Equal(prefix, new PackagePrefixRequest(prefix, 1).Prefix);
+        }
+
+        foreach (string prefix in new[] { fullId + "a", new string('a', maximum - 1) + "." })
+        {
+            Assert.Throws<ArgumentException>(() => new PackagePrefixDeclaration(prefix));
+            Assert.Throws<ArgumentException>(() => new PackagePrefixRequest(prefix, 1));
+        }
     }
 
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
     [InlineData(int.MinValue)]
-    public void NonpositiveBoundsAreRejected(int maximum) =>
+    public void NonpositiveBoundsAreRejected(int maximum)
+    {
+        var declaration = new PackagePrefixDeclaration("Contoso.");
+        Assert.Throws<ArgumentOutOfRangeException>(() => PackagePrefixRequest.Create(declaration, maximum));
         Assert.Throws<ArgumentOutOfRangeException>(() => new PackagePrefixRequest("Contoso.", maximum));
+        Assert.Equal("Contoso.", declaration.Prefix);
+    }
 
     [Fact]
-    public void NullPrefixIsRejected() =>
+    public void OneDeclarationSupportsIndependentConsumerPolicies()
+    {
+        var declaration = new PackagePrefixDeclaration("Aspire.");
+        var small = PackagePrefixRequest.Create(declaration, 5);
+        var large = PackagePrefixRequest.Create(declaration, int.MaxValue, includePrerelease: true);
+
+        Assert.Same(declaration, small.Declaration);
+        Assert.Same(declaration, large.Declaration);
+        Assert.Equal("Aspire.", small.Prefix);
+        Assert.Equal("Aspire.", large.Prefix);
+        Assert.Equal(5, small.MaxPackages);
+        Assert.False(small.IncludePrerelease);
+        Assert.Equal(int.MaxValue, large.MaxPackages);
+        Assert.True(large.IncludePrerelease);
+        Assert.NotEqual(small, large);
+        Assert.NotEqual(small, PackagePrefixRequest.Create(declaration, 5, includePrerelease: true));
+        Assert.NotEqual(small, PackagePrefixRequest.Create(declaration, 6));
+        Assert.NotEqual(small, new PackagePrefixRequest("aspire.", 5));
+        Assert.Equal("Aspire.", declaration.Prefix);
+    }
+
+    [Fact]
+    public void NullInputsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => new PackagePrefixDeclaration(null!));
         Assert.Throws<ArgumentNullException>(() => new PackagePrefixRequest(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => PackagePrefixRequest.Create(null!, 1));
+    }
 }

--- a/tests/DotnetInspector.SourceSelection.Tests/SearchSourceNormalizerTests.cs
+++ b/tests/DotnetInspector.SourceSelection.Tests/SearchSourceNormalizerTests.cs
@@ -152,6 +152,31 @@ public sealed class SearchSourceNormalizerTests
     }
 
     [Fact]
+    public void SharedPrefixDeclarationRetainsIndependentRequests()
+    {
+        var declaration = new PackagePrefixDeclaration("Aspire.");
+        var small = PackagePrefixRequest.Create(declaration, 5);
+        var large = PackagePrefixRequest.Create(declaration, 250, includePrerelease: true);
+        SourceIntent intent = SourceIntent.Create(
+        [
+            new SourceSelector.PackagePrefix(small),
+            new SourceSelector.PackagePrefix(large),
+        ]);
+
+        SearchSourceSelection result = SearchSourceNormalizer.Normalize(intent);
+
+        Assert.False(result.UsesImplicitPlatform);
+        Assert.Empty(result.Frameworks);
+        Assert.Empty(result.Packages);
+        Assert.Collection(result.OtherSources,
+            source => Assert.Same(small, Assert.IsType<SourceSelector.PackagePrefix>(source).Request),
+            source => Assert.Same(large, Assert.IsType<SourceSelector.PackagePrefix>(source).Request));
+        Assert.All(result.OtherSources, source => Assert.Same(
+            declaration, Assert.IsType<SourceSelector.PackagePrefix>(source).Request.Declaration));
+        Assert.Equal("Aspire.", declaration.Prefix);
+    }
+
+    [Fact]
     public void OtherSelectorsRetainRelativeOrderAndOccurrences()
     {
         var library = new SourceSelector.Library("first.dll");


### PR DESCRIPTION
Build a robust foundation for ecosystem discovery through the conventional
separation of a declaration from request policy: a catalog can name a package
prefix without inventing an operational limit.

Closes #6092. Focused prerequisite under #5602 for #5728/#6012.

## Demo

Previously, the only typed prefix required `MaxPackages` at construction:

```csharp
var request = new PackagePrefixRequest("Aspire.", maxPackages: 500);
```

That remains useful for a consumer with a concrete request, but is the wrong
currency for a static catalog. A catalog-facing declaration now needs only
the prefix:

```csharp
var prefix = new PackagePrefixDeclaration("Aspire.");
var small = PackagePrefixRequest.Create(prefix, maxPackages: 5);
var broader = PackagePrefixRequest.Create(prefix, maxPackages: 250, includePrerelease: true);
var intent = SourceIntent.Create(
[
    new SourceSelector.PackagePrefix(small),
    new SourceSelector.PackagePrefix(broader),
]);
var normalized = SearchSourceNormalizer.Normalize(intent);
```

Actual Release API walkthrough output:

```text
Declaration: Aspire.
Request: Aspire., max=5, prerelease=False
  Same declaration: True
Request: Aspire., max=250, prerelease=True
  Same declaration: True
Normalized requests: 2
Implicit platform: False
Empty neighbor uses implicit platform: True
```

The two consumers share the exact declaration but retain independent policies.
The neighboring empty source intent still selects the implicit platform;
an unrealized prefix does not become empty intent.

## Design basis

**Sole normative owner:**
[`docs/design/search-scope-domain.md#package-prefix-request`](docs/design/search-scope-domain.md#package-prefix-request).
The claim is independently constructible, immutable prefix intent with consumer
policy applied only when forming a bounded request; request construction and
normalization retain the exact declaration.

Packages remains the supporting owner of package-ID validation and maximum
ID length. Source production retains authorization, matching, ordering, paging,
completion, and realization. Catalog registration and host adoption remain
separate owners and stages.

The implementation reuses the existing intrinsic prefix validation and moves
it into `PackagePrefixDeclaration`. `PackagePrefixRequest.Create` accepts that
typed value with required positive `MaxPackages` and optional prerelease policy.
The existing string constructor uses the same validation, and existing
`Prefix`, `MaxPackages`, `IncludePrerelease`, and request equality behavior
remain supported. A named factory avoids making existing null-input constructor
calls ambiguous. `SourceSelector` and normalization algorithms are unchanged.

## Scope and adoption

**Complexity basis:** one prefix-only value and bounded request composition
remove the need for a static catalog to choose execution policy. This uses the
existing immutable-value/separate-interpretation pattern; it introduces no
new registry or universal realization protocol. The local RowSelection pattern
and Gallery request shape remain comparative evidence, not additional owners.

**Production consumers and six-stage path:** #5602 tracks the shared component
and public consumer, catalog prefix handoff, four CLI search adapters, Browser
adoption, remaining CLI policy families, and retirement of obsolete adapter
shapes. This repairs the stage-1 currency for stage 2. CLI and Browser remain
planned consumers through stages 3 and 4; this PR does not claim host adoption.
The current source-selection architecture is retained rather than replaced.
Rendering is unchanged; this is typed intent, not a new output domain.

**Boundary evidence:** standalone prefix construction; maximum package-ID and
trailing-separator limits; malformed/null inputs; independently chosen bounds
including `int.MaxValue`; default versus explicit prerelease policy; equivalent
text-based and composed requests; case-sensitive original spelling; and exact
request/declaration retention through normalization.

**Non-actions:** no expected/max count or prerelease field on the declaration;
no catalog registration/content, tool-prefix discovery, source paging,
installation/execution, population admission, Workspace/editor, or host UI
changes. #6075's package-selection forms and #5954's demand-driven production
remain separate; coordination is recorded on #6075 and #5728.

## Validation

- `dotnet run --project tests/DotnetInspector.SourceSelection.Tests -c Release`:
  **60 passed**, no failures or skips, after integrating the effective base.
- Actual public API walkthrough executed in Release with
  `EnablePreviewFeatures=true`.
- `npx --no-install markdownlint-cli docs/design/search-scope-domain.md`: passed.
- `git diff --check`: passed.

The existing non-friend xUnit/MTP suite runs in normal CI. No new testing
tooling, CI expansion, or feature-specific platform exception is introduced.

## Candidate

- Head: `6552e338ac4b6935e840df2dc806526acae1c3d6`.
- Effective base: `d119594d9553804591761f30f7f0de5a2749c905`.
- Branch: `feat/package-prefix-declarations`, targeting `main`.
- Round 1: **CLEAN** from GPT-6 Astra, Claude Opus 5, and GPT-5.6 Sol.
- [Reconciliation and no-interaction carry-forward](https://github.com/richlander/dotnet-inspect/pull/6094#issuecomment-5557203971).
- Catalog adoption remains the explicit stage-2 follow-on; no source-prerequisite fixes were required.
