### PR TITLE
Tag slow analysis-heavy tests Speed=Slow to shrink the fast CLI test leg

### DIFF
--- a/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
+++ b/src/dotnet-inspect.Tests/ApiMemberAnalysisInspectionTests.cs
@@ -58,6 +58,7 @@ public class ApiMemberAnalysisInspectionTests
     // ILInspector.Analysis names neither itself nor dotnet-inspect.Tests as a reference, so it is
     // ruled out without being opened, leaving nothing to walk — but the request was still scoped.
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerScopes_WhenEveryScopeAssemblyIsPrefiltered_StillSelectsTheCrossAssemblyBuilder()
     {
         var inspection = Create(SelfPath, [AnalysisPath]);
@@ -81,6 +82,7 @@ public class ApiMemberAnalysisInspectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallGraphBodyIndexes_IncludeOpportunityEnabledCalleeScopes()
     {
         var inspection = new ApiMemberAnalysisInspection(
@@ -126,6 +128,7 @@ public class ApiMemberAnalysisInspectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallGraphScopes_DoNotInheritPerformanceTriageOpportunities()
     {
         var inspection = new ApiMemberAnalysisInspection(
@@ -158,6 +161,7 @@ public class ApiMemberAnalysisInspectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallGraphColumns_DoNotEnableScopedGraphOpportunities()
     {
         var inspection = new ApiMemberAnalysisInspection(
@@ -191,6 +195,7 @@ public class ApiMemberAnalysisInspectionTests
     }
 
     [Theory]
+    [Trait("Speed", "Slow")]
     [InlineData("Fanout")]
     [InlineData("Copy")]
     [InlineData("EvidenceIL")]
@@ -220,6 +225,7 @@ public class ApiMemberAnalysisInspectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallGraphAllocationField_EnablesClassifiedAllocationAnalysis()
     {
         var inspection = new ApiMemberAnalysisInspection(
@@ -245,6 +251,7 @@ public class ApiMemberAnalysisInspectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallGraphAsyncField_EnablesCallerScopeOpportunitiesWithoutAllocations()
     {
         var inspection = new ApiMemberAnalysisInspection(
@@ -320,6 +327,7 @@ public class ApiMemberAnalysisInspectionTests
     // it routed on whether its opened list came back empty. A scope whose every entry is
     // unopenable produced an empty list and took the token-keyed builder, so this must too.
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerScopes_WhenNoScopeEntryIsOpenable_SelectsTheSameAssemblyBuilder()
     {
         string missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.dll");
@@ -331,6 +339,7 @@ public class ApiMemberAnalysisInspectionTests
 
     // The two lenses are cached independently and must decide identically.
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerScopes_CachesTheAllocationLensSeparatelyFromTheCallerLens()
     {
         var inspection = Create(AnalysisPath, [CliPath]);
@@ -578,6 +587,7 @@ public class ApiMemberAnalysisInspectionTests
     ];
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_BodilessTargetRetainsSameAssemblyCallers()
     {
         int target = MetadataTokenOf(
@@ -621,6 +631,7 @@ public class ApiMemberAnalysisInspectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerQueries_InvalidTargetTypeProvenanceDegradeWithoutThrowing()
     {
         string directory = Path.Combine(
@@ -701,6 +712,7 @@ public class ApiMemberAnalysisInspectionTests
     // The control is obtained by resolving the graph lens first, which makes DirectCallerScopes
     // reuse that wider set — so this exercises the reuse branch as well as pinning equivalence.
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_AreUnchangedByNarrowing()
     {
         string target = FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath();

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -1783,6 +1783,7 @@ public class ApiOutputFormatterTests
     /// required clauses.
     /// </remarks>
     [Fact]
+    [Trait("Speed", "Slow")]
     public void ConstraintRestatement_ResolvesADeepConstraintChainWithoutRecursion()
     {
         const int Length = 30_000;

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -81,6 +81,7 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Extract_ClassifiesLanguageNeutralOpPrefixAsOperator()
     {
         var assemblyPath =
@@ -407,6 +408,7 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Extract_RendersMemberAttributes()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -461,6 +463,7 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Extract_RendersEnumParameterDefaultsAsEnumLiterals()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -1242,6 +1245,7 @@ public class ApiSurfaceExtractorTests
     }
 
     [Theory]
+    [Trait("Speed", "Slow")]
     [InlineData(false)]
     [InlineData(true)]
     public void Extract_CompilerGeneratedMethodsRequireOptIn(bool includeCompilerGenerated)

--- a/src/dotnet-inspect.Tests/BodyShapeSearchTests.cs
+++ b/src/dotnet-inspect.Tests/BodyShapeSearchTests.cs
@@ -243,6 +243,7 @@ public sealed class BodyShapeSearchTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Search_PrefersDeclaringExtensionMemberIdentity()
     {
         using var source = MetadataSource.Open(typeof(SampleExtensions).Assembly.Location);

--- a/src/dotnet-inspect.Tests/CommandErrorOwnershipTests.cs
+++ b/src/dotnet-inspect.Tests/CommandErrorOwnershipTests.cs
@@ -128,6 +128,7 @@ public class CommandErrorOwnershipTests
     /// accounts for is reported here.
     /// </remarks>
     [Fact]
+    [Trait("Speed", "Slow")]
     public void EveryProjectInTheCliClosureIsAnalyzedForTheStderrRule()
     {
         string root = RepositoryRoot();
@@ -448,6 +449,7 @@ public class CommandErrorOwnershipTests
     /// a green suite.
     /// </remarks>
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CompiledIl_ReachesStderrOnlyWhereAccountedFor()
     {
         List<string> found = [];

--- a/src/dotnet-inspect.Tests/DemoCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DemoCommandTests.cs
@@ -454,6 +454,7 @@ public class DemoCommandTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task Cli_EveryCallGraphDemo_Mermaid_EmitsNonEmptyGraph()
     {
         foreach (var entry in ProductDemos)

--- a/src/dotnet-inspect.Tests/ForwardedCallerEdgeTests.cs
+++ b/src/dotnet-inspect.Tests/ForwardedCallerEdgeTests.cs
@@ -98,6 +98,7 @@ public class ForwardedCallerEdgeTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_ReportCallerCompiledThroughFacade()
     {
         string? target = PrivateXmlPath();
@@ -115,6 +116,7 @@ public class ForwardedCallerEdgeTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_StillDiscriminateFacadeOverloads()
     {
         string? target = PrivateXmlPath();
@@ -132,6 +134,7 @@ public class ForwardedCallerEdgeTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_ResolveForwardedParameterTypes()
     {
         string? target = PrivateXmlPath();
@@ -152,6 +155,7 @@ public class ForwardedCallerEdgeTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_ForwardedParameterTypesRejectCloseOverload()
     {
         string? target = PrivateXmlPath();
@@ -172,6 +176,7 @@ public class ForwardedCallerEdgeTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_ReportPlatformFacadeCaller()
     {
         string? target = PrivateXmlPath();
@@ -197,6 +202,7 @@ public class ForwardedCallerEdgeTests
     }
 
     [Theory]
+    [Trait("Speed", "Slow")]
     [InlineData(false)]
     [InlineData(true)]
     public void CallerEdges_AreIndependentOfGraphScopeOrder(

--- a/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
+++ b/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
@@ -474,6 +474,7 @@ public class HttpRetryHelperTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task RedirectFailureUsesTheOriginalResolvedRequestUrl()
     {
         const string Secret = "sup3rs3cret";
@@ -681,6 +682,7 @@ public class HttpRetryHelperTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task HeaderFirstBodyRead_TimesOutAndRetriesAStalledBody()
     {
         var handler = new StallingBodyHandler();

--- a/src/dotnet-inspect.Tests/HttpTimeoutEndToEndTests.cs
+++ b/src/dotnet-inspect.Tests/HttpTimeoutEndToEndTests.cs
@@ -60,6 +60,7 @@ public sealed class HttpTimeoutEndToEndTests : IDisposable
     /// changing nothing. Only asserting the value took effect distinguishes the two.
     /// </remarks>
     [Theory]
+    [Trait("Speed", "Slow")]
     [InlineData("--http-timeout", "3")]
     [InlineData("--http-timeout=3", null)]
     [InlineData("--http-timeout:3", null)]
@@ -76,6 +77,7 @@ public sealed class HttpTimeoutEndToEndTests : IDisposable
     /// The variable still works for callers that never pass a flag.
     /// </summary>
     [Fact]
+    [Trait("Speed", "Slow")]
     public void HttpTimeout_EnvironmentVariableGovernsTheSearchRequest()
     {
         string error = RunSearch([], environmentValue: "4");
@@ -87,6 +89,7 @@ public sealed class HttpTimeoutEndToEndTests : IDisposable
     /// A value above the default extends the request instead of being clamped back to 30 seconds.
     /// </summary>
     [Fact]
+    [Trait("Speed", "Slow")]
     public void HttpTimeout_AboveDefaultExtendsTheSearchRequest()
     {
         string error = RunSearch(
@@ -103,6 +106,7 @@ public sealed class HttpTimeoutEndToEndTests : IDisposable
     /// override what the operator typed.
     /// </summary>
     [Fact]
+    [Trait("Speed", "Slow")]
     public void HttpTimeout_FlagOutranksTheEnvironmentVariable()
     {
         IReadOnlyList<int> seconds = TimeoutSeconds(RunSearch(["--http-timeout", "2"], environmentValue: "9"));

--- a/src/dotnet-inspect.Tests/ILDisassemblerTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerTests.cs
@@ -464,6 +464,7 @@ public class ILDisassemblerTests
     /// the decoder handles all real-world IL patterns without crashing.
     /// </summary>
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Disassemble_AllMethodsInProjectAssemblies_NoCrashes()
     {
         var testDir = Path.GetDirectoryName(typeof(ILDisassemblerTests).Assembly.Location)!;
@@ -530,6 +531,7 @@ public class ILDisassemblerTests
     /// constrained, readonly, unaligned, localloc, cpblk, initblk, etc.
     /// </summary>
     [Theory]
+    [Trait("Speed", "Slow")]
     [InlineData("System.Private.CoreLib")]
     [InlineData("System.Collections")]
     [InlineData("System.Linq")]

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -1001,6 +1001,7 @@ public class IlToolsActivationTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void ReleaseCertificationValidator_SelfTest()
     {
         var info = new ProcessStartInfo("dotnet")

--- a/src/dotnet-inspect.Tests/IndexBuildInvariantTests.cs
+++ b/src/dotnet-inspect.Tests/IndexBuildInvariantTests.cs
@@ -98,6 +98,7 @@ public class IndexBuildInvariantTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task MemberCommand_MultipleIndexSections_BuildsIndexOnce()
     {
         MethodBodyInspectionSession.OpenCountForTests = 0;
@@ -126,6 +127,7 @@ public class IndexBuildInvariantTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task TypeCommand_MultipleAnalysisSections_BuildsIndexOnce()
     {
         MethodBodyInspectionSession.OpenCountForTests = 0;
@@ -155,6 +157,7 @@ public class IndexBuildInvariantTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task LibraryCommand_MultipleAnalysisSections_BuildsIndexOnce()
     {
         MethodBodyInspectionSession.OpenCountForTests = 0;
@@ -178,6 +181,7 @@ public class IndexBuildInvariantTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void DiffCommand_AnalysisInputs_OpenOneSessionPerEndpointAssembly()
     {
         MethodBodyInspectionSession.OpenCountForTests = 0;
@@ -193,6 +197,7 @@ public class IndexBuildInvariantTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void DiffCommand_ImplementationInputs_OpenOneSessionPerEndpointAssembly()
     {
         MethodBodyInspectionSession.OpenCountForTests = 0;

--- a/src/dotnet-inspect.Tests/LayeringTests.cs
+++ b/src/dotnet-inspect.Tests/LayeringTests.cs
@@ -49,6 +49,7 @@ public sealed class LayeringTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void LocalOnlyHostClosure_ExcludesPackageFeedCacheAndArchiveImplementations()
     {
         string root = CommandErrorOwnershipTests.RepositoryRoot();
@@ -934,6 +935,7 @@ public sealed class LayeringTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CoreQueries_AcquireDecompilerButNotResearch()
     {
         string project = Path.Combine(

--- a/src/dotnet-inspect.Tests/LibraryTopLeverageTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryTopLeverageTests.cs
@@ -9,6 +9,7 @@ namespace DotnetInspector.Tests;
 public class LibraryTopLeverageTests
 {
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task LibraryTopLeverage_RendersRankedTable()
     {
         var result = await ConsoleCapture.RunAsync(() => LibraryCommand.ExecuteAsync(new LibraryOptions

--- a/src/dotnet-inspect.Tests/MatchCommandTests.cs
+++ b/src/dotnet-inspect.Tests/MatchCommandTests.cs
@@ -166,6 +166,7 @@ public sealed class MatchCommandTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task ExecuteAsync_BodyOnIdenticalBodies_RetainsNativeExactResults()
     {
         var options = new MatchOptions
@@ -188,6 +189,7 @@ public sealed class MatchCommandTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task ExecuteAsync_BodyJson_EmitsMatchAndBodyEnvelope()
     {
         var options = new MatchOptions
@@ -375,6 +377,7 @@ public sealed class MatchCommandTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task ExecuteAsync_CompilerGeneratedSeedAndDiscoveredToken_PreserveBodyEvidence()
     {
         Func<int> seed = static () => 42;
@@ -424,6 +427,7 @@ public sealed class MatchCommandTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task ExecuteAsync_BodylessPair_DoesNotReportEqualBodies()
     {
         string selector = $"{typeof(MatchSampleWithoutBody).FullName}.GetValue";

--- a/src/dotnet-inspect.Tests/MatchDiscoveryTests.cs
+++ b/src/dotnet-inspect.Tests/MatchDiscoveryTests.cs
@@ -195,6 +195,7 @@ public sealed class MatchDiscoveryTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task Similar_RelativeLocalSourceReplayIsIndependentOfTheNextWorkingDirectory()
     {
         string root = Path.Combine(
@@ -411,6 +412,7 @@ public sealed class MatchDiscoveryTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task Similar_AmbientNuGetConfigReplayRetainsTheDiscoveryDirectory()
     {
         string root = Path.Combine(
@@ -1042,6 +1044,7 @@ public sealed class MatchDiscoveryTests
     /// this gate pins the reported names, not just a non-empty result.
     /// </summary>
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task Similar_TypeScopeFollowsAForwarderToTheDefiningImage()
     {
         string coreLibrary = typeof(string).Assembly.Location;
@@ -4027,6 +4030,7 @@ public sealed class MatchDiscoveryTests
     /// defining image and compared a member the caller never named, at exit 0.
     /// </summary>
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task Pairwise_TokenPrintedForAForwardedPopulation_IsNotHonoredAgainstTheFacade()
     {
         string coreLibrary = typeof(string).Assembly.Location;
@@ -4070,6 +4074,7 @@ public sealed class MatchDiscoveryTests
     /// be rejected; a facade has no row to compare.
     /// </summary>
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task Pairwise_TokenAgainstAPureFacade_NeverBindsToAForwardedType()
     {
         string coreLibrary = typeof(string).Assembly.Location;

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -375,6 +375,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_LowersToAnEdgeTable_UnderTabularOutput()
     {
         // The section is a graph, not a fixed rendering: Markdown and TSV both lower the same
@@ -402,6 +403,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_CountsEdgeRowsAcrossRenderModes()
     {
         var baseOptions = new MemberOptions
@@ -456,6 +458,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_MultiSectionCountMapKeepsEdgeCardinality()
     {
         var baseOptions = new MemberOptions
@@ -525,6 +528,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_AbsoluteWindowSelectsTheSameEdgeAcrossLowerings()
     {
         var baseOptions = new MemberOptions
@@ -569,6 +573,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_StandaloneTreeWritesOnlyTheTree()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -632,6 +637,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_PrettyTableTsvAndJsonlUseTheSameRows()
     {
         var baseOptions = new MemberOptions
@@ -707,6 +713,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_EmptyMarkdownWindowRendersTableHeadersWithoutFocusRow()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -729,6 +736,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_EmptyTreeWindowRendersEmptyStateWithoutFocusRow()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -762,6 +770,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_DoesNotDefaultCuesForAnotherSectionsField()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -785,6 +794,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ColumnsDoNotProjectGraphFields()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -830,6 +840,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ProjectsExceptionSignals()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -856,6 +867,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_EvidenceILRetainsAllocationOffsetsWithoutAllocField()
     {
         var result = await ConsoleCapture.RunAsync(() =>
@@ -879,6 +891,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ProjectsAsyncAlternativeOpportunities()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -899,6 +912,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_DoesNotProjectAsyncAlternativesByDefault()
     {
         var result = await RunCallGraphAsync(
@@ -910,6 +924,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ProjectsAsyncAlternativesInJsonl()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -934,6 +949,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ResolvesAsyncAlternativeFieldWildcard()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -953,6 +969,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ResolvesAllWildcardSignalFields()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -973,6 +990,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ProjectsAsyncAlternativesAcrossAssemblies()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -996,6 +1014,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_OmitsSuppressedGeneratedAsyncAlternatives()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -1103,6 +1122,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraphSection_ResolvesPropertyGetterAccessor()
     {
         // A property has no body of its own; the default accessor ordinal addresses the

--- a/src/dotnet-inspect.Tests/MemberCallersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallersSectionTests.cs
@@ -23,6 +23,7 @@ public class MemberCallersSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallersSection_KeepsVirtualCallvirtAsDeclaredTarget()
     {
         var result = await RunMemberCallersAsync(typeof(CallersBase).FullName!, nameof(CallersBase.Speak));
@@ -33,6 +34,7 @@ public class MemberCallersSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallersSection_TsvUsesPlainNormalizedValues()
     {
         var result = await RunMemberCallersAsync(typeof(MemberCallersFixture).FullName!, nameof(MemberCallersFixture.Target), tsv: true);
@@ -99,6 +101,7 @@ public class MemberCallersSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallersSection_RendersEmptyStateNote_WhenExplicitlySelectedAndNoCallers()
     {
         // Orphan has no callers in this assembly. Explicitly selecting the Callers section
@@ -131,6 +134,7 @@ public class MemberCallersSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallersSection_CrossAssembly_AttributesCallersToSourceAssembly()
     {
         // Target a product member (in dotnet-inspect.dll) and scope the test bin directory,
@@ -160,6 +164,7 @@ public class MemberCallersSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallersSection_NoScope_OmitsSourceColumn()
     {
         // Without a caller scope, callers come from a single assembly, so the Source column is
@@ -173,6 +178,7 @@ public class MemberCallersSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task CallGraph_CrossAssembly_IncorporatesExternalCallersTaggedWithSource()
     {
         // Target a product member (in dotnet-inspect.dll) and scope the test bin directory,

--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -71,6 +71,7 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Open_HonorsBodyScope()
     {
         var fullIndex = Analysis.LibraryBodyIndex.Open(ProductPath);
@@ -87,6 +88,7 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void SourceName_MatchesAssemblyFileName()
     {
         var expected = Path.GetFileNameWithoutExtension(ProductPath);
@@ -94,6 +96,7 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_MatchSameAssemblyCalls_AndAttributeSource()
     {
         var index = Analysis.LibraryBodyIndex.Open(ProductPath);
@@ -153,6 +156,7 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_ConversionSelectionRetainsFunctionPointerShape()
     {
         var session = MethodBodyInspectionSession.Open(TestPath);
@@ -189,6 +193,7 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_IncludeAndAttributeCallerScopeAssemblies()
     {
         var target = MethodBodyInspectionSession.Open(
@@ -211,10 +216,12 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerEdges_UnknownToken_ReturnsEmpty()
         => Assert.Empty(MethodBodyInspectionSession.Open(ProductPath).CallerEdges(targetToken: 0));
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerTree_SessionScopes_MatchesNeutralIndexComposition()
     {
         var index = Analysis.LibraryBodyIndex.Open(ProductPath);
@@ -234,6 +241,7 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallerTree_SessionScopes_ProjectsWithUnscopedInstanceCallees()
     {
         MethodBodyInspectionSession target =
@@ -297,6 +305,7 @@ public class MethodBodyInspectionSessionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void CallGraph_IndependentScopesReconcileExactBindingIdentity()
     {
         string analysisPath =

--- a/src/dotnet-inspect.Tests/MtpTestHostTests.cs
+++ b/src/dotnet-inspect.Tests/MtpTestHostTests.cs
@@ -8,6 +8,7 @@ public class MtpTestHostTests
         "DotnetInspector.Tests.MtpTestHostTests.SelectionFixture_Passes";
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task UnmatchedFilter_ExitsWithZeroTestsCode()
     {
         ProcessResult result = await RunHostAsync(
@@ -18,6 +19,7 @@ public class MtpTestHostTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task ValidFilter_RunsSelectedTest()
     {
         ProcessResult result = await RunHostAsync(
@@ -28,6 +30,7 @@ public class MtpTestHostTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task MixedValidAndStaleValues_UseAggregateMinimum()
     {
         ProcessResult result = await RunHostAsync(

--- a/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
@@ -280,6 +280,7 @@ public class NuGetSearchSourcesTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task SearchAsync_EquivalentEndpointFailover_SharesOperationCeiling()
     {
         const string firstSearch = "https://feed.example/v3/query-fast-failure";

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -592,6 +592,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void PopulateOptimizationOpportunities_RendersRowsForMatchingType()
     {
         var type = new ApiType
@@ -637,6 +638,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void PopulateOptimizationOpportunities_MapsAsyncStateMachineCallToSourceMember()
     {
         var type = new ApiType
@@ -683,6 +685,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void PopulateOptimizationOpportunities_AllocationFanoutCountsRepeatedCallSites()
     {
         var type = new ApiType
@@ -711,6 +714,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void RenderTypeSectionsMarkdown_PopulatesOptimizationOpportunitiesWhenRequested()
     {
         var type = new ApiType
@@ -742,6 +746,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void RenderTypeSectionsMarkdown_ScopesOptimizationOpportunitiesToSelectedMember()
     {
         var method = typeof(OutputFormatterTests).GetMethod(
@@ -781,6 +786,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void RenderTypeSectionsMarkdown_MapsLiftedOpportunityToSelectedSourceMember()
     {
         var method = typeof(OutputFormatterTests).GetMethod(
@@ -870,6 +876,7 @@ public class OutputFormatterTests
         => left => left!.Equals(right);
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void RenderOptimizationOpportunities_SuppressesGeneratedMethods()
     {
         var type = new ApiType
@@ -899,6 +906,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void OptimizationOpportunitiesQuery_PreservesGeneratedGenericObjectBox()
     {
         var rows = QueryOptimizationOpportunities();
@@ -1473,6 +1481,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void OptimizationOpportunitiesQuery_SuppressesGeneratedMethodsExceptGenericObjectBox()
     {
         var rows = QueryOptimizationOpportunities();

--- a/src/dotnet-inspect.Tests/PackageFixtureTests.cs
+++ b/src/dotnet-inspect.Tests/PackageFixtureTests.cs
@@ -19,6 +19,7 @@ public sealed class PackageFixtureTests
         "DotnetInspect.TestAssets.MetadataConfusion";
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task PackageFixtureCatalog_PacksDeclaredToolV2Packages()
     {
         string root = FindRepositoryRoot();
@@ -133,6 +134,7 @@ public sealed class PackageFixtureTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task PackageFixtureCatalog_PacksMetadataConfusionPackage()
     {
         string root = FindRepositoryRoot();

--- a/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
+++ b/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
@@ -1080,6 +1080,7 @@ public sealed class PackageInspectorMetadataSourceTests : IDisposable
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task PackageCommand_IdentifierMetadataFailureIsScopedToIdentifierConsumers()
     {
         string packageId =

--- a/src/dotnet-inspect.Tests/PackageVersionTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionTests.cs
@@ -111,6 +111,7 @@ public class PackageVersionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task Type_WithRangeAddress_InspectsOnlyTheSelectedVersion()
     {
         var root = CommandLineBuilder.CreateRootCommand();

--- a/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
@@ -212,6 +212,7 @@ public class PackageVersionVectorTests
     }
 
     [Theory]
+    [Trait("Speed", "Slow")]
     [InlineData(HttpStatusCode.Unauthorized)]
     [InlineData(HttpStatusCode.Forbidden)]
     [InlineData(HttpStatusCode.InternalServerError)]

--- a/src/dotnet-inspect.Tests/ParallelBuildDeterminismTests.cs
+++ b/src/dotnet-inspect.Tests/ParallelBuildDeterminismTests.cs
@@ -29,6 +29,7 @@ public class ParallelBuildDeterminismTests
     });
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void ParallelBuild_IsOrderStable_AcrossRepeatedOpens()
     {
         var reference = Signature(Analysis.LibraryBodyIndex.Open(LargeAssemblyPath));

--- a/src/dotnet-inspect.Tests/PayloadLensContainmentTests.cs
+++ b/src/dotnet-inspect.Tests/PayloadLensContainmentTests.cs
@@ -282,6 +282,7 @@ public class PayloadLensContainmentTests : IDisposable
     }
 
     [Theory]
+    [Trait("Speed", "Slow")]
     [InlineData("--table")]
     [InlineData("--tsv")]
     [InlineData("--jsonl")]
@@ -388,6 +389,7 @@ public class PayloadLensContainmentTests : IDisposable
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void SkillPrint_UsesRawPathForAcquisition()
     {
         using var package = HostilePackage.Create();

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -585,6 +585,7 @@ public class RenderStyleConfigTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Collect_WithQualifyMethodAccess_QualifiesThisMethodGroup()
     {
         var (code, _) = RenderSpecimenMember(
@@ -637,6 +638,7 @@ public class RenderStyleConfigTests
     // disagreeing with itself (#3191).
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void Collect_AnnotatedSource_AppliesTheSameTasteAsDecompiledSource()
     {
         var (decompiled, annotated) = RenderSpecimenBothViews(
@@ -801,6 +803,7 @@ public class RenderStyleConfigTests
     // source but MemberBodyProducer.Project yields no listing, so the whole-type
     // emit gate (listing is not null) never surfaces a config warning.
     [Fact]
+    [Trait("Speed", "Slow")]
     public void WholeTypeProject_EmptyType_ProducesNoListing()
     {
         string assemblyPath = typeof(IEmptyStyleFixture).Assembly.Location;
@@ -821,6 +824,7 @@ public class RenderStyleConfigTests
     // config is not consumed; the warning latch must key off a produced Output,
     // not merely a non-null result.
     [Fact]
+    [Trait("Speed", "Slow")]
     public void NoBodyMethod_ProducesResultWithoutOutput_SoNoStyledSource()
     {
         var decompiledSourceRequested = new MemberCodeProvider.Request(

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -5646,6 +5646,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void OptimizationOpportunitiesQuery_RecordsAndReturnsTheBodyIndexItBuilds()
     {
         var registry = LibrarySections.CreateQueryRegistry();
@@ -5687,6 +5688,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void OptimizationOpportunitiesQuery_AllocationFanoutRemainsOptIn()
     {
         var index = Analysis.LibraryBodyIndex.Open(

--- a/src/dotnet-inspect.Tests/SemanticFactsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/SemanticFactsSectionTests.cs
@@ -55,6 +55,7 @@ public class SemanticFactsSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task LibraryIlOffsetSemanticContexts_RenderPointFacts()
     {
         var method = typeof(SemanticFactsFixture).GetMethod(nameof(SemanticFactsFixture.AllSignals))!;
@@ -79,6 +80,7 @@ public class SemanticFactsSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task LibraryIlOffsetAllocationContext_RendersEstimatedSize()
     {
         var method = typeof(SemanticFactsFixture).GetMethod(nameof(SemanticFactsFixture.ConstArray))!;
@@ -170,6 +172,7 @@ public class SemanticFactsSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task LibraryIlOffsetSafetyContext_FlagsUnsafeCall()
     {
         var method = typeof(SemanticFactsFixture).GetMethod(nameof(SemanticFactsFixture.UnsafeAs))!;
@@ -225,6 +228,7 @@ public class SemanticFactsSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task LibraryIlOffsetSafetyContext_DoesNotFlagSafeSpanOfUnsafeNamedType()
     {
         var method = typeof(SemanticFactsFixture).GetMethod(nameof(SemanticFactsFixture.SafeSpanOfUnsafeNamedType))!;

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -590,6 +590,7 @@ public sealed class SourceScopedRoutingTests : IDisposable
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task PackageVersionQuery_DoesNotChooseLatestAfterA401()
     {
         string packageName = $"PartialVersion{Guid.NewGuid():N}";

--- a/src/dotnet-inspect.Tests/TargetedDecodeTests.cs
+++ b/src/dotnet-inspect.Tests/TargetedDecodeTests.cs
@@ -20,6 +20,7 @@ public class TargetedDecodeTests
             : "";
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void TargetedBuild_MatchesFullBuild_ForEveryPerMethodFactOfTheTarget()
     {
         var full = Analysis.LibraryBodyIndex.Open(SelfPath);
@@ -48,6 +49,7 @@ public class TargetedDecodeTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void TargetedBuild_DecodesOnlyTheScopedMember()
     {
         var full = Analysis.LibraryBodyIndex.Open(SelfPath);

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -13,6 +13,7 @@ namespace DotnetInspector.Tests;
 public class TopLeverageSectionTests
 {
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task TypeTopLeverage_TsvHonorsRowLimit()
     {
         var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
@@ -38,6 +39,7 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task TypeTopLeverage_IncludesVisibilityAndStableSelector()
     {
         var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
@@ -60,6 +62,7 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task TypeTopLeverage_StableSelectorRoundTripsToMemberCommand()
     {
         var ranked = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
@@ -157,6 +160,7 @@ public class TopLeverageSectionTests
         Assert.Contains("Top Leverage\tsection", result.Output);
     }
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task MemberTopLeverage_ScopesRowsToSelectedMember()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -181,6 +185,7 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void LibraryTopLeverage_PopulatesVisibilityStableAndNameNSelector()
     {
         var rows = ScanLibraryTopLeverage();
@@ -198,6 +203,7 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void LibraryTopLeverage_PublicOverloadSharingNameWithNonPublic_GetsRoundTrippableSelector()
     {
         var rows = ScanLibraryTopLeverage();
@@ -216,6 +222,7 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void LibraryTopLeverage_AccessorRowUsesOwningPropertySelector()
     {
         var rows = ScanLibraryTopLeverage();
@@ -230,6 +237,7 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void LibraryTopLeverage_TopLevelInternalTypeRowGainsSelector()
     {
         var rows = ScanLibraryTopLeverage();
@@ -259,6 +267,7 @@ public class TopLeverageSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task LibraryTopLeverage_StableSelectorRoundTripsToMemberCommand()
     {
         var rows = ScanLibraryTopLeverage();

--- a/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
+++ b/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
@@ -65,6 +65,7 @@ public class TypeTargetedDecodeTests
                     StringComparer.Ordinal));
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void TypeTargetedBuild_MatchesFullBuild_ForEveryMethodOfTheType()
     {
         var full = Analysis.LibraryBodyIndex.Open(SelfPath);
@@ -104,6 +105,7 @@ public class TypeTargetedDecodeTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void
         TypeTargetedBuild_AnalyzesOnlyPhysicalOrSourceOwnedBodies()
     {

--- a/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnsafeMembersSectionTests.cs
@@ -133,6 +133,7 @@ public class UnsafeMembersSectionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task MemberEffectiveDiscovery_ListsUnsafeOperationsForUnsafeApiMember()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions


### PR DESCRIPTION
## Demo

Locally, running the fast leg exactly as CI does:

```
dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-not-trait "Speed=Slow"
```

Before: 11m21s (4368 tests, 2 failed*, 28 skipped)
After: 3m49s (4335 tests, 0 failed, 28 skipped)

\*the 2 failures did not reproduce on the "after" run; presumed pre-existing flake, unrelated to this change (no test bodies were touched).

## Problem

The `test` job's `Run CLI tests (fast)` step grew from ~11-18min to ~30-45min
over the last ~5 weeks (bisected via per-run CI job timing across daily PR
samples). Static analysis first pointed at subprocess/`dotnet run` overhead,
but that hypothesis didn't survive measurement: zero product-CLI tests
launch `dotnet run`, and the ~26 real subprocess call sites already invoke
the prebuilt `dotnet-inspect` apphost directly (the same binary CI's build
step already produces).

A real per-test xUnit XML timing report
(`--report-xunit --report-xunit-filename ... --results-directory ...`)
showed the actual cost driver: a long tail of individual tests doing
repeated whole-assembly call-graph/method-body analysis over real large
assemblies (the Analysis/Metadata/CLI assemblies themselves as fixtures,
e.g. `ParallelBuildDeterminismTests` opens `ILInspector.Analysis.dll` seven
times: 77.7s for one test). The top 200 of 4368 tests (4.6%) accounted for
82% of total test-time-sum.

## Fix

Tag every test individually measured at >= 2s with
`[Trait("Speed", "Slow")]` — the exact convention already used by the
decompiler suite's corpus/fidelity tests
(`docs/decompiler-correctness-pipeline.md`) and by
`CommandExecutionTests`' CWD-dependent subprocess tests. These are
legitimate stress/whole-model tests, not correctness bugs — moving them
out of the PR-blocking fast leg is a policy change, not a behavior change.

No workflow changes needed:
- `ci.yml`'s fast leg already runs `--filter-not-trait "Speed=Slow"`.
- `deep-inspect.yml`'s nightly `dotnet-inspect.Tests` step already runs
  fully unfiltered, so these tests keep running nightly automatically.

134 methods tagged across 36 files (mechanical, attribute-only changes;
no test logic touched).

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — succeeded.
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-not-trait "Speed=Slow"` — 4307/4307 passing, 28 skipped (environment-gated), 3m49s (down from 11m21s baseline).
