### PR TITLE
Use module identity for legacy Research body-index association

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -35,6 +35,37 @@ family.
   members present on both sides. A disagreement is retained as a per-member
   `Failed` diagnostic; it does not abort healthy members in the same diff.
 
+### Legacy body-index association
+
+The retained assembly-comparison paths consume Analysis-issued
+`LibraryBodyIndex.ModuleIdentity`, not a sampled method or a display path.
+`ImplementationDiff.Compare` requires each supplied index to match its opened
+image's complete assembly-definition identity and MVID, including when the
+index is methodless or a selected capability produced no method rows.
+Metadata's `AssemblyReferenceIdentity.EquivalentComparer` defines assembly
+identity equivalence; Analysis owns the identity's image-derived issuance.
+
+This physical association is distinct from cross-version pairing.
+`ResearchDiff` retains its existing ordinal simple-assembly-name pairing rule,
+now taking that name from the issued identity. Versions and MVIDs are not
+pairing keys: different versions and generations of the same assembly must
+remain comparable. Multiple inputs with the same pairing key on one side
+remain rejected, not silently coalesced. This legacy rule is not the richer
+workspace correspondence-domain contract below.
+
+A standalone managed module has no assembly-definition identity, so it cannot
+acquire an assembly pairing key from its filename. Body-index assembly
+comparison rejects that unsupported association visibly. API-only netmodule
+comparison remains supported; this does not change Metadata or Analysis
+module inspection.
+
+`ResearchDiffTests.BodyIndexIdentity_*` gates full identity and MVID mismatch,
+matching and mismatched capability-limited or methodless inputs, label-independent
+pairing and union construction, and preserved cross-version comparison in
+Release. The existing API netmodule case gates that separate supported path.
+This retires the heuristics tracked by #5125, not the live legacy comparison
+APIs or their native C#/IL producers.
+
 ### Structural body comparison
 
 `CSharpBodyDiff.IssueCorrespondence` is the product correspondence owner for

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1927,6 +1927,227 @@ public class ResearchDiffTests
         Assert.StartsWith("ConstantValue~", changed.Subject.Id, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(LibraryBodyAnalysisFeatures.None)]
+    [InlineData(LibraryBodyAnalysisFeatures.MethodEvidence)]
+    public void BodyIndexIdentity_AcceptsMatchingImageRegardlessOfCapabilities(
+        LibraryBodyAnalysisFeatures features)
+    {
+        byte[] image = File.ReadAllBytes(FixtureCatalog.DiffPair.OldAssemblyPath());
+        var input = IdentityInput(image, image, features);
+
+        var result = ImplementationDiff.Compare(
+            [input], [input],
+            new ImplementationDiffOptions(ImplementationDiffMechanism.IlBody));
+
+        Assert.NotNull(result.Research);
+    }
+
+    [Theory]
+    [InlineData(LibraryBodyAnalysisFeatures.None)]
+    [InlineData(LibraryBodyAnalysisFeatures.MethodEvidence)]
+    public void BodyIndexIdentity_RejectsDifferentImageRegardlessOfCapabilities(
+        LibraryBodyAnalysisFeatures features)
+    {
+        byte[] image = File.ReadAllBytes(FixtureCatalog.DiffPair.OldAssemblyPath());
+        byte[] other = File.ReadAllBytes(FixtureCatalog.DiffPair.NewAssemblyPath());
+        var input = IdentityInput(image, other, features);
+
+        var error = Assert.Throws<ArgumentException>(() =>
+            ImplementationDiff.Compare([input], []));
+
+        Assert.Contains("does not match assembly content", error.Message);
+    }
+
+    [Theory]
+    [InlineData(LibraryBodyAnalysisFeatures.None)]
+    [InlineData(LibraryBodyAnalysisFeatures.MethodEvidence)]
+    public void BodyIndexIdentity_AcceptsMatchingMethodlessImage(
+        LibraryBodyAnalysisFeatures features)
+    {
+        byte[] image = BuildIdentityAssembly("Identity", Guid.NewGuid());
+        var input = IdentityInput(image, image, features);
+        Assert.Empty(input.BodyIndex.DeclaredMethods);
+        Assert.Empty(input.BodyIndex.Methods);
+
+        var result = ImplementationDiff.Compare([input], [input]);
+
+        Assert.Empty(result.Members);
+    }
+
+    [Theory]
+    [InlineData("name")]
+    [InlineData("version")]
+    [InlineData("culture")]
+    [InlineData("public-key")]
+    [InlineData("mvid")]
+    public void BodyIndexIdentity_RejectsMethodlessIdentityMismatch(string difference)
+    {
+        Guid mvid = Guid.NewGuid();
+        byte[] image = BuildIdentityAssembly("Identity", mvid);
+        byte[] other = BuildIdentityAssembly(
+            difference == "name" ? "Other" : "Identity",
+            difference == "mvid" ? Guid.NewGuid() : mvid,
+            version: difference == "version" ? new Version(2, 0, 0, 0) : null,
+            culture: difference == "culture" ? "fr" : null,
+            publicKey: difference == "public-key" ? [1, 2, 3, 4] : null);
+        var input = IdentityInput(image, other, LibraryBodyAnalysisFeatures.MethodEvidence);
+        Assert.Empty(input.BodyIndex.DeclaredMethods);
+
+        var error = Assert.Throws<ArgumentException>(() =>
+            ImplementationDiff.Compare([input], []));
+
+        Assert.Contains("does not match assembly content", error.Message);
+    }
+
+    [Theory]
+    [InlineData(ResearchChangeMechanism.BodySignals, false)]
+    [InlineData(ResearchChangeMechanism.IlBody, false)]
+    [InlineData(ResearchChangeMechanism.IlBody, true)]
+    public void BodyIndexIdentity_MethodlessGroupingIgnoresDisplayPaths(
+        ResearchChangeMechanism mechanism,
+        bool retainOperations)
+    {
+        byte[] firstImage = BuildIdentityAssembly("First", Guid.NewGuid());
+        byte[] secondImage = BuildIdentityAssembly("Second", Guid.NewGuid());
+        LibraryBodyIndex Index(byte[] image, string label) =>
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                label, [.. image], LibraryBodyAnalysisFeatures.MethodEvidence);
+        var oldInput = new ResearchDiffInput([])
+        {
+            BodyIndexes = [Index(firstImage, "shared.dll"), Index(secondImage, "shared.dll")],
+        };
+        var newInput = new ResearchDiffInput([])
+        {
+            BodyIndexes = [Index(firstImage, "renamed-first.dll"), Index(secondImage, "renamed-second.dll")],
+        };
+        var first = IdentityInput(firstImage, firstImage, LibraryBodyAnalysisFeatures.MethodEvidence);
+        var second = IdentityInput(secondImage, secondImage, LibraryBodyAnalysisFeatures.MethodEvidence);
+        using var firstSource = DecompilerMetadataSource.OpenWithoutSymbols(first.Assembly, first.Resolver);
+        using var secondSource = DecompilerMetadataSource.OpenWithoutSymbols(second.Assembly, second.Resolver);
+        if (mechanism == ResearchChangeMechanism.IlBody)
+        {
+            oldInput = oldInput with
+            {
+                AssemblyContents =
+                [
+                    new(firstSource, oldInput.BodyIndexes[0]),
+                    new(secondSource, oldInput.BodyIndexes[1]),
+                ],
+            };
+            newInput = newInput with
+            {
+                AssemblyContents =
+                [
+                    new(firstSource, newInput.BodyIndexes[0]),
+                    new(secondSource, newInput.BodyIndexes[1]),
+                ],
+            };
+        }
+
+        var result = ResearchDiff.Compare(oldInput, newInput, new ResearchDiffOptions(mechanism)
+        {
+            RetainedComparisonDescriptorIds = retainOperations
+                ? ImmutableHashSet.Create(IlFindings.OperationDescriptor.Id)
+                : ImmutableHashSet<string>.Empty,
+        });
+
+        Assert.Empty(result.Changes);
+    }
+
+    [Fact]
+    public void BodyIndexIdentity_StandaloneModuleDoesNotAcquireAKeyFromItsLabel()
+    {
+        LibraryBodyIndex index = LibraryBodyIndex.OpenFromPrefetchedImage(
+            "pretend-assembly.dll",
+            [.. BuildNetmodule("Widget")],
+            LibraryBodyAnalysisFeatures.MethodEvidence);
+        Assert.Null(index.ModuleIdentity.AssemblyIdentity);
+        var input = new ResearchDiffInput([], BodyIndexes: [index]);
+
+        var error = Assert.Throws<ArgumentException>(() => ResearchDiff.Compare(
+            input, input, new ResearchDiffOptions(ResearchChangeMechanism.BodySignals)));
+
+        Assert.Contains("standalone module has no assembly pairing key", error.Message);
+    }
+
+    [Fact]
+    public void BodyIndexIdentity_VersionAndMvidChangesRemainComparable()
+    {
+        byte[] oldImage = BuildIdentityAssembly(
+            "Versioned", Guid.NewGuid(), new Version(1, 0, 0, 0), returnValue: 1);
+        byte[] newImage = BuildIdentityAssembly(
+            "Versioned", Guid.NewGuid(), new Version(2, 0, 0, 0), returnValue: 2);
+        var before = IdentityInput(oldImage, oldImage, LibraryBodyAnalysisFeatures.MethodEvidence);
+        var after = IdentityInput(newImage, newImage, LibraryBodyAnalysisFeatures.MethodEvidence);
+        Assert.NotEqual(before.BodyIndex.ModuleIdentity.ModuleVersionId,
+            after.BodyIndex.ModuleIdentity.ModuleVersionId);
+        Assert.NotEqual(before.BodyIndex.ModuleIdentity.AssemblyIdentity!.Version,
+            after.BodyIndex.ModuleIdentity.AssemblyIdentity!.Version);
+
+        var result = ImplementationDiff.Compare(
+            [before], [after],
+            new ImplementationDiffOptions(ImplementationDiffMechanism.IlBody));
+
+        Assert.Contains(result.Members, member =>
+            member.Subject.MemberName == "Read"
+            && member.Changes.Any(change =>
+                change.Mechanism == ResearchChangeMechanism.IlBody
+                && change.Kind == ResearchChangeKind.Changed));
+    }
+
+    static ImplementationAssemblyInput IdentityInput(
+        byte[] image,
+        byte[] indexedImage,
+        LibraryBodyAnalysisFeatures features)
+    {
+        using var pe = new PEReader(new MemoryStream(image, writable: false));
+        AssemblyReferenceIdentity identity =
+            AssemblyReferenceIdentity.FromAssemblyDefinition(pe.GetMetadataReader());
+        var reference = ResolvedAssemblyReference.Create(
+            identity, "display-only.dll",
+            () => new MemoryStream(image, writable: false),
+            AssemblyResolutionProvenance.Local("Research body-index identity fixture"));
+        return new(
+            reference,
+            DecompilerMetadataSource.DefaultAssemblyReferenceResolver(
+                FixtureCatalog.DiffPair.OldAssemblyPath()),
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "unrelated-index-label.dll", [.. indexedImage], features));
+    }
+
+    static byte[] BuildIdentityAssembly(
+        string name,
+        Guid mvid,
+        Version? version = null,
+        string? culture = null,
+        byte[]? publicKey = null,
+        int? returnValue = null)
+    {
+        MetadataBuilder metadata = NewResearchMetadata(name, mvid, version, culture, publicKey);
+        AddResearchModuleType(metadata);
+        var il = new BlobBuilder();
+        if (returnValue is int value)
+        {
+            AddResearchType(metadata, "Value");
+            var code = new InstructionEncoder(new BlobBuilder());
+            code.LoadConstantI4(value);
+            code.OpCode(ILOpCode.Ret);
+            int offset = new MethodBodyStreamEncoder(il).AddMethodBody(code);
+            var signature = new BlobBuilder();
+            new BlobEncoder(signature).MethodSignature().Parameters(
+                0, result => result.Type().Int32(), parameters => { });
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Read"),
+                metadata.GetOrAddBlob(signature),
+                offset,
+                MetadataTokens.ParameterHandle(1));
+        }
+        return SerializeResearchMetadata(metadata, il);
+    }
+
     [Fact]
     public void ImplementationDiff_CompareAssemblies_GroupsCSharpAndIlEvidence()
     {
@@ -2461,7 +2682,12 @@ public class ResearchDiffTests
         return SerializeResearchMetadata(metadata);
     }
 
-    static MetadataBuilder NewResearchMetadata(string assemblyName)
+    static MetadataBuilder NewResearchMetadata(
+        string assemblyName,
+        Guid? mvid = null,
+        Version? version = null,
+        string? culture = null,
+        byte[]? publicKey = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -2469,15 +2695,15 @@ public class ResearchDiffTests
             moduleName:
                 metadata.GetOrAddString($"{assemblyName}.dll"),
             mvid:
-                metadata.GetOrAddGuid(Guid.NewGuid()),
+                metadata.GetOrAddGuid(mvid ?? Guid.NewGuid()),
             encId: default,
             encBaseId: default);
         metadata.AddAssembly(
             metadata.GetOrAddString(assemblyName),
-            new Version(1, 0, 0, 0),
-            culture: default,
-            publicKey: default,
-            flags: default,
+            version ?? new Version(1, 0, 0, 0),
+            culture: culture is null ? default : metadata.GetOrAddString(culture),
+            publicKey: publicKey is null ? default : metadata.GetOrAddBlob(publicKey),
+            flags: publicKey is null ? default : AssemblyFlags.PublicKey,
             hashAlgorithm: default);
         return metadata;
     }
@@ -2507,14 +2733,15 @@ public class ResearchDiffTests
                 MetadataTokens.MethodDefinitionHandle(1));
 
     static byte[] SerializeResearchMetadata(
-        MetadataBuilder metadata)
+        MetadataBuilder metadata,
+        BlobBuilder? il = null)
     {
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),
             new MetadataRootBuilder(
                 metadata,
                 suppressValidation: true),
-            new BlobBuilder(),
+            il ?? new BlobBuilder(),
             flags: CorFlags.ILOnly);
         var image = new BlobBuilder();
         pe.Serialize(image);

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -429,24 +429,22 @@ public static class ImplementationDiff
         MetadataSource source,
         LibraryBodyIndex bodyIndex)
     {
-        MethodIdentity? indexedMethod =
-            bodyIndex.DeclaredMethods.FirstOrDefault()
-            ?? bodyIndex.Methods.FirstOrDefault();
-        if (indexedMethod is null)
-            return;
-
+        LibraryBodyModuleIdentity indexedModule = bodyIndex.ModuleIdentity;
+        AssemblyReferenceIdentity? sourceIdentity = source.Reader.IsAssembly
+            ? AssemblyReferenceIdentity.FromAssemblyDefinition(source.Reader)
+            : null;
         Guid sourceMvid = source.Reader.GetGuid(
             source.Reader.GetModuleDefinition().Mvid);
-        if (StringComparer.OrdinalIgnoreCase.Equals(
-                source.AssemblyName,
-                indexedMethod.AssemblyName)
-            && sourceMvid == indexedMethod.ModuleVersionId)
+        if (AssemblyReferenceIdentity.EquivalentComparer.Equals(
+                sourceIdentity,
+                indexedModule.AssemblyIdentity)
+            && sourceMvid == indexedModule.ModuleVersionId)
         {
             return;
         }
 
         throw new ArgumentException(
-            $"The body index for '{indexedMethod.AssemblyName}' does not match "
+            $"The body index for '{indexedModule.AssemblyIdentity?.Name ?? "standalone module"}' does not match "
             + $"assembly content '{source.AssemblyName}'.",
             nameof(bodyIndex));
     }

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -1855,8 +1855,11 @@ public static class ResearchDiff
            && definition.Equals(TypeRef.Definition("System.Text.Json", "System.Text.Json.Serialization.Metadata", "JsonTypeInfo`1"));
 
     static string AssemblyKey(LibraryBodyIndex index)
-        => index.Methods.Select(method => method.AssemblyName).FirstOrDefault(name => !string.IsNullOrWhiteSpace(name))
-            ?? Path.GetFileNameWithoutExtension(index.Path);
+        => index.ModuleIdentity.AssemblyIdentity?.Name
+            ?? throw new ArgumentException(
+                "Body-index assembly comparison requires an assembly identity; "
+                + "a standalone module has no assembly pairing key.",
+                nameof(index));
 
     static string FormatOperations(IReadOnlyList<IlDiffRow> rows)
         => rows.Count == 0 ? "" : string.Join("; ", rows.Select(row => row.Operation.Display));


### PR DESCRIPTION
## Summary

Research now associates a supplied body index with its opened image using the
existing Analysis-issued module identity, including full assembly identity and
MVID. Methodless and capability-limited indexes no longer skip that check.
Legacy assembly grouping takes its name from the same issued identity instead
of method rows or a filename.

Closes #5125. Contributes to scoped Research retirement in #4706; it does not
close the broader retirement milestone or remove live comparison APIs.

## Why this improvement matters

The requested improvement analysis is preserved on the associated issue:
https://github.com/richlander/dotnet-inspect/issues/5125#issuecomment-5556965522.

The shared comparison infrastructure provides one reliable operation for CLI
and Browser, with exact input association, preserved non-success, explicit
borrowed lifetimes, and reusable structured native evidence. It is not a new
diff algorithm, a measured speedup, or a decompilation-quality improvement.
Both production hosts have landed; the strongest delivered payoff is Browser
Method Body Diff using the same query as CLI `match --body`.

Retirement collects the simplification benefit instead of keeping two
orchestration systems indefinitely. This slice retires a concrete identity
heuristic in legacy paths that still have callers. Tool migrations, supported
Source composition, and assembly/body-signal execution migration remain
separate obligations.

## Design basis and compatibility

- **Normative owner:** `docs/design/implementation-diff.md#legacy-body-index-association`.
  Research validates exact image/index association and retains its current
  cross-version assembly pairing semantics.
- **Supporting currency:** Analysis owns `LibraryBodyIndex.ModuleIdentity`;
  Metadata owns `AssemblyReferenceIdentity.EquivalentComparer`. This change
  consumes their existing contracts rather than issuing another identity.
- Physical validation uses complete assembly identity and MVID. Cross-version
  grouping deliberately retains the existing ordinal simple-name rule: versions
  and MVIDs must not become pairing keys. Duplicate keys on one side remain
  errors rather than being silently coalesced. This is not the newer workspace
  correspondence-domain contract.
- Standalone modules have no assembly-definition identity. Body-index assembly
  comparison now rejects that association explicitly instead of deriving a
  key from a filename. API-only netmodule comparison remains supported.
- `CompareMembers`, PDB-source composition, native C#/IL algorithms, and live
  legacy query contracts remain. No host rendering contract is changed.

The bounded production route remains 7/8 complete: sealing, designated-pair
session, publication, physical adapter, CLI, Browser, and scoped Queries
retirement are landed. This addresses the #5125 obligation within the remaining
Research milestone, not all its tool/Source/assembly caller obligations.

## Demo

This is a real public-API before/after probe, not a new host-adoption claim.
The same two compiled `DiffFixtureSample` images are indexed with
`LibraryBodyAnalysisFeatures.None`; both indexes have zero method rows.

Before, at base `d119594d9553804591761f30f7f0de5a2749c905`:

```text
Method rows: matching=0, foreign=0
Matching capability-limited index: accepted
Foreign capability-limited index: accepted
Distinct assemblies with the same display label: rejected - An item with the same key has already been added. Key: shared
```

After:

```text
Method rows: matching=0, foreign=0
Matching capability-limited index: accepted
Foreign capability-limited index: rejected - The body index for 'DiffFixtureSample' does not match assembly content 'DiffFixtureSample'. (Parameter 'bodyIndex')
Distinct assemblies with the same display label: accepted
```

Notice both sides of the fix: missing method rows no longer hide a foreign
image, and equal display labels no longer collide for distinct assemblies.
The matching-index neighbor still succeeds. "Accepted" here describes input
association, not a claim that incomplete body evidence proves exactness.

<details>
<summary>Reproduce the public-API probe</summary>

Save this as `artifacts/di-5125-identity-demo.cs`:

```csharp
#:project ../src/ILInspector.Research/ILInspector.Research.csproj
#:property EnablePreviewFeatures=true
#:property PublishAot=false
#:property PublishSingleFile=false

using ILInspector.Analysis;
using ILInspector.Decompiler.Pipeline;
using ILInspector.Metadata;
using ILInspector.Research;

if (args.Length != 2)
    throw new ArgumentException("Supply the old and new DiffFixtureSample assembly paths.");

LibraryBodyIndex Index(string path, string label) =>
    LibraryBodyIndex.OpenFromPrefetchedImage(
        label, [.. File.ReadAllBytes(path)], LibraryBodyAnalysisFeatures.None);

var reference = ResolvedAssemblyReference.CreateFromPath(
    args[0], AssemblyResolutionProvenance.Local("body-index association demo"));
var resolver = MetadataSource.DefaultAssemblyReferenceResolver(args[0]);
var matching = Index(args[0], "shared.dll");
var foreign = Index(args[1], "shared.dll");
Console.WriteLine($"Method rows: matching={matching.Methods.Length}, foreign={foreign.Methods.Length}");

Report("Matching capability-limited index", () =>
    ImplementationDiff.Compare(
        [new(reference, resolver, matching)],
        [new(reference, resolver, matching)],
        new(ImplementationDiffMechanism.IlBody)));
Report("Foreign capability-limited index", () =>
    ImplementationDiff.Compare(
        [new(reference, resolver, foreign)],
        [new(reference, resolver, matching)],
        new(ImplementationDiffMechanism.IlBody)));

var otherAssembly = Index(typeof(ResearchDiff).Assembly.Location, "shared.dll");
var population = new ResearchDiffInput([], BodyIndexes: [matching, otherAssembly]);
Report("Distinct assemblies with the same display label", () =>
    ResearchDiff.Compare(
        population, population, new(ResearchChangeMechanism.BodySignals)));

static void Report(string name, Action operation)
{
    try
    {
        operation();
        Console.WriteLine($"{name}: accepted");
    }
    catch (ArgumentException exception)
    {
        Console.WriteLine($"{name}: rejected - {exception.Message.Split('\n')[0]}");
    }
}
```

Run the Research command below once to build its existing versioned fixtures,
then:

```bash
dotnet build artifacts/di-5125-identity-demo.cs -c Release \
  -o artifacts/5125-demo
dotnet exec \
  --additional-deps artifacts/5125-demo/ILInspector.Research.deps.json \
  artifacts/5125-demo/di-5125-identity-demo.dll \
  "$PWD/artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll" \
  "$PWD/artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll"
```

The explicit additional-deps manifest is needed by the selected preview SDK's
file-app output: its own manifest omitted transitive project dependencies
despite copying their assemblies. Both before and after use the same runtime
setup; no product fallback or SDK modification was introduced.

</details>

## Validation

- Research comparison suite: 107 passed, including the new identity cases
  and the existing API netmodule case.
- Queries: 28 passed across the retained implementation/body-signal consumers
  and the modern direct-member query.
- CLI: 480 passed across `DiffCommandTests`, `SectionPipelineTests`, and
  `MatchCommandTests`, after building their existing RouteLearning fixture.
- Changed Markdown passed `markdownlint`; `git diff --check` passed.
- The initial regression run against unchanged Research code had 9 failing
  cases covering methodless/capability-limited mismatch and label collisions.
- The public-API demo above ran against the original base and this change.

```bash
dotnet run --project src/ILInspector.Research.Tests -c Release -- \
  --filter-class '*ResearchDiffTests' --no-progress

dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
  -class '*ImplementationComparisonQueryTests' \
  -class '*BodySignalComparisonQueryTests' \
  -class '*DirectMemberComparisonQueryTests'

dotnet run --project src/dotnet-inspect.Tests -c Release -- \
  --filter-class '*DiffCommandTests' '*SectionPipelineTests' \
  '*MatchCommandTests' --no-progress
```

## Review

Round 1 is complete: two independent GPT-6 Astra reviewers returned clean
results at `54b658b1ed6275386edfeb90c0d287eaf40ed6ea`. Current-head
`ci-required` completed successfully.
[Public reconciliation and base carry-forward](https://github.com/richlander/dotnet-inspect/pull/6099#issuecomment-5557297010)
record the exact evidence. Merge has not been authorized.
