### PR TITLE
Make retained package cache test process-isolated

### DIFF
--- a/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.cs
+++ b/src/dotnet-inspect.Tests/ConfiguredPayloadAcquisitionTests.cs
@@ -443,12 +443,15 @@ public sealed class ConfiguredPayloadAcquisitionTests : IDisposable
         string localFeed = Path.Combine(_root, "local-feed");
         string temporaryRoot = Directory.CreateDirectory(Path.Combine(_root, "command-temp")).FullName;
         WriteLocalPackage(localFeed, PayloadId, Readme);
-        using var client = new HttpClient();
         if (warmTarget)
         {
-            PackageExtractionOutcome warm = await AcquireTargetAsync();
-            Assert.True(warm.IsSuccess, warm.ErrorMessage);
-            Assert.False(warm.Result!.FromCache);
+            var (exit, output, error) = await RunIsolatedCommandAsync(temporaryRoot,
+                ["package", $"{PayloadId}@{Version}", "--source", localFeed,
+                    "--path", "@readme", "--content", "--bare", "--no-nuget-cache"]);
+            Assert.True(exit == 0, $"Exit {exit}: {error}");
+            Assert.Equal(Readme, output.Trim());
+            Assert.Empty(Directory.EnumerateDirectories(temporaryRoot, "inspect-pkg*"));
+            Directory.Delete(localFeed, recursive: true);
         }
 
         using var listener = new TcpListener(IPAddress.Loopback, 0);
@@ -467,6 +470,10 @@ public sealed class ConfiguredPayloadAcquisitionTests : IDisposable
         {
             for (int iteration = 1; iteration <= 2; iteration++)
             {
+                // With the source gone, success proves the isolated CLI retained the target.
+                if (warmTarget || iteration > 1)
+                    Assert.False(Directory.Exists(localFeed));
+
                 var (exit, output, error) = await RunIsolatedCommandAsync(temporaryRoot,
                     ["package", $"{WrapperId}@{Version}", "--source", localFeed,
                         "--source", source, "--path", "@readme", "--content", "--bare",
@@ -477,12 +484,8 @@ public sealed class ConfiguredPayloadAcquisitionTests : IDisposable
                     request.EndsWith(".nupkg", StringComparison.Ordinal)));
                 Assert.Empty(Directory.EnumerateDirectories(temporaryRoot, "inspect-pkg*"));
 
-                PackageExtractionOutcome retained = await AcquireTargetAsync();
-                Assert.True(retained.IsSuccess, retained.ErrorMessage);
-                Assert.True(retained.Result!.FromCache);
-                Assert.Null(retained.Result.TempDir);
-                Assert.Equal(Readme, File.ReadAllText(
-                    Path.Combine(retained.Result.ExtractPath, "README.md")));
+                if (!warmTarget && iteration == 1)
+                    Directory.Delete(localFeed, recursive: true);
             }
         }
         finally
@@ -496,11 +499,6 @@ public sealed class ConfiguredPayloadAcquisitionTests : IDisposable
             {
             }
         }
-
-        Task<PackageExtractionOutcome> AcquireTargetAsync() =>
-            DesktopPackageExtractor.ExtractPinnedPackageAsync(client, PayloadId, Version,
-                sourceOptions: new NuGetSourceOptions { Sources = [localFeed] },
-                createComposition: LocalComposition);
     }
 
     private static DesktopPackageSourceComposition CreateComposition(


### PR DESCRIPTION
Robust release certification should prove user-observable cache behavior without depending on mutable test-host globals. This change makes the retained-package proof process-isolated while preserving the production contract.

## Demo

Before, Deep Inspect Windows run `34008838669` failed `PackageCommand_HttpWrapperCleansTemporaryStorageAndKeepsLocalTarget(false)` because the isolated CLI populated its cache, then the test host consulted process-global `NuGetCache` state that other tests can replace:

```text
Assert.True() Failure
Expected: True
Actual:   False
ConfiguredPayloadAcquisitionTests.cs:482
```

After, both cold and pre-warmed scenarios use the isolated CLI throughout. The test deletes the local payload feed, then requires later wrapper resolution to return the retained README successfully. With the source absent, success is a direct non-vacuity proof that the target survived in the CLI-owned cache.

The neighboring temporary-storage and wrapper-download assertions remain unchanged.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- Targeted theory: 10 consecutive runs, 20/20 cases passed
- `ConfiguredPayloadAcquisitionTests`: 14/14 passed
- `git diff --check`

## Compatibility

Test-only change. Product acquisition, cache layout, command behavior, and release artifacts are unchanged.
