### PR TITLE
Add contributor guidance for classifying slow tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,9 @@ publishing mechanics (exact commands, `@agent_state` fields, `blocked` vs.
   as normal visible output first; only after it appears in the session log may
   you open an approval prompt containing just the concise decision question and
   answer labels — never the report, checkpoint, or evidence itself.
-- **Publish `@agent`/`@agent_state`** after every state change, and **signal
-  `HELP`** when blocked on a human decision; clear both once the window no
-  longer owns the work or the decision arrives.
+- **Publish `@agent`/`@agent_state`** after every state change; clear both
+  only when the window no longer owns the work. **Signal `HELP`** when
+  blocked on a human decision; clear only `HELP` once the decision arrives.
 
 ### Keep the review-clean label current
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,18 +95,12 @@ This section is tmux-specific and applies only inside a tmux pane — check
 `[ -n "$TMUX" ]` first; outside tmux there is no window to name or option to
 attach state to, so skip it entirely. Each window name must identify its work
 item, domain, and purpose; its pane title reports current activity, while
-window options carry structured state. Full mechanics live in
-[Agent session state](docs/agent-session-state.md).
+window options carry structured state. Full naming, pane-title, and state-
+publishing mechanics (exact commands, `@agent_state` fields, `blocked` vs.
+`waiting`) live in [Agent session state](docs/agent-session-state.md).
 
-- **Name the window** `PR <number> | <Domain> | <Short description>`, or
-  `Issue <number> | <Domain> | <Short description>` before a PR exists. Keep
-  Domain to one or two words, omit machine and tmux coordinates, and always
-  target `"${TMUX_PANE:?}"`.
-- **Update the pane title** with concise current activity, always targeting
-  `"${TMUX_PANE:?}"`. Accept Copilot's startup title only as the initial
-  fallback; replace it at the start of work, after every resume, and at
-  meaningful phase changes with
-  `tmux select-pane -t "${TMUX_PANE:?}" -T "<theme>: <current activity>"`.
+- **Name the window and title the pane**, always targeting `"${TMUX_PANE:?}"`,
+  at the start of work, after every resume, and at meaningful phase changes.
 - **Announce PR identity** — the literal token `PR #<number>` or `PR <number>`,
   plus branch or expected head — at the start of work, after every resume, and
   at every round start. Round completions use the
@@ -115,16 +109,9 @@ window options carry structured state. Full mechanics live in
   as normal visible output first; only after it appears in the session log may
   you open an approval prompt containing just the concise decision question and
   answer labels — never the report, checkpoint, or evidence itself.
-- **Publish `@agent` and `@agent_state`** after every state change, each as its
-  own single command (never inside `if`/`&&`/a loop). `@agent_state` carries
-  `theme`, `head`, and `pr`/`issue`, plus `round`, `reviews`, `blocked`,
-  `waiting`, and `rec` (`continue`, `wait`, `merge`, `split`, `approve`,
-  `stop`); clear both when the window no longer owns the work. `blocked` names
-  an issue/PR a person can act on; `waiting` names tool-evaluable predicates
-  (`check:<name>`, `checks`, `merge`, `review`).
-- **Signal `HELP`** with a persistent state plus one best-effort
-  `tmux display-message` nudge when blocked on a human decision; clear it once
-  the decision arrives.
+- **Publish `@agent`/`@agent_state`** after every state change, and **signal
+  `HELP`** when blocked on a human decision; clear both once the window no
+  longer owns the work or the decision arrives.
 
 ### Keep the review-clean label current
 
@@ -332,6 +319,12 @@ Build the normal graph with `dotnet build dotnet-inspect.slnx -c Release`.
 Tests are xUnit executables. **Use `dotnet run`, not `dotnet test`**;
 `dotnet test` silently executes no tests here. Always use Release because
 compiler-generated IL shapes differ in Debug.
+
+Tag a test `[Trait("Speed", "Slow")]` when its cost comes from exhaustive or
+whole-assembly analysis rather than ordinary unit-test setup, so it runs only
+in nightly Deep Inspect, not the PR-blocking fast leg. See
+[Classifying test cost](docs/testing-cost-classification.md) for the
+threshold, placement convention, and existing consumers.
 
 | Area | Command |
 | --- | --- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -177,6 +177,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Design Scope and Composition](../docs/design-scope.md) | Full mechanics for one-owner-per-design, broad-design gating, TLA+ modeling, and over-broad-design recovery. |
 | [Evidence and Validation](evidence-and-validation.md) | Matching evidence to claims, the style-oracle consultation procedure, and the harness/product boundary. |
 | [Fixture Governance](fixture-governance.md) | Placement, project-boundary axes, catalog metadata, consumer rules, and expectation ownership for compiled fixtures and test-local samples. |
+| [Classifying Test Cost](testing-cost-classification.md) | When and how to tag a test `Speed=Slow` so it runs nightly instead of in the PR-blocking fast leg. |
 | [Round Orchestration](round-orchestration.md) | Running an adversarial review round: status discovery, dispatch, reconciliation, carry-forward, and block boundaries. |
 | [Agent Model Mapping](agent-models.md) | Contributor-guidance model names, exact dispatch IDs, and runtime availability resolution. |
 | [GitHub Status Queries](github-status-queries.md) | Querying PR mergeability and CI status without wasting API quota. |

--- a/docs/testing-cost-classification.md
+++ b/docs/testing-cost-classification.md
@@ -75,10 +75,14 @@ public void SomeExpensiveTheory(string assemblyName)
   — a newly tagged test is automatically excluded.
 - `deep-inspect.yml`'s nightly `dotnet-inspect.Tests` step runs fully
   unfiltered — a newly tagged test automatically keeps running nightly.
-- The decompiler suite uses the same trait and the same
-  `--filter-not-trait "Speed=Slow"` / unfiltered split; see
+- The decompiler suite uses the same trait, but its native xUnit console
+  runner takes a different flag spelling than the CLI suite's Microsoft
+  Testing Platform runner: `dotnet run --project
+  src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
+  (fast) vs. `-trait "Speed=Slow"` (slow-only). See
   [`docs/decompiler-correctness-pipeline.md`](decompiler-correctness-pipeline.md)
-  for that suite's `Area`/`Speed` trait combination.
+  for that suite's full `Area`/`Speed` trait combination and its
+  `--gate fast`/`--gate slow` equivalents.
 
 Tagging a test is a policy change (when it runs), not a behavior change (what
 it asserts). It requires no `.github/workflows/*.yml` edits.

--- a/docs/testing-cost-classification.md
+++ b/docs/testing-cost-classification.md
@@ -1,0 +1,84 @@
+# Classifying test cost
+
+[AGENTS.md](../AGENTS.md#building-and-testing) states the binding rule: tag a
+test `[Trait("Speed", "Slow")]` when its cost comes from exhaustive or
+whole-assembly analysis rather than ordinary unit-test setup. This doc owns
+the threshold, placement convention, and existing consumers.
+
+## Why this exists
+
+PR CI's fast leg is a shared, PR-blocking resource. A test that repeatedly
+opens or analyzes a real large assembly (the product's own assemblies are a
+common and legitimate fixture source) can cost seconds where an ordinary
+unit test costs milliseconds. Left untagged, these accumulate silently and
+the fast leg's wall time creeps upward with no single commit to blame. PR
+[#6095](https://github.com/richlander/dotnet-inspect/pull/6095) found and
+tagged 134 such tests after the fast leg's `test` job grew from ~11-18min to
+~30-45min over about five weeks — almost entirely from this kind of
+untagged, individually-expensive test.
+
+## Threshold
+
+Tag a test `Speed=Slow` when it does one of the following:
+
+- Runs whole-assembly or whole-solution analysis (e.g. `LibraryBodyIndex.Open`
+  over a real multi-thousand-method assembly) more than once, or over more
+  than one large assembly, in a single test.
+- Is a corpus, fidelity, or determinism sweep whose entire purpose is
+  exhaustive coverage rather than a single targeted assertion (see the
+  decompiler suite's corpus/fidelity tests in
+  [`docs/decompiler-correctness-pipeline.md`](decompiler-correctness-pipeline.md)
+  for the established precedent).
+- Measures at or above **2 seconds** of real wall time in isolation. Do not
+  guess — measure with a real xUnit XML timing report:
+
+  ```sh
+  dotnet run --project src/dotnet-inspect.Tests -c Release -- \
+    --filter-not-trait "Speed=Slow" --report-xunit \
+    --report-xunit-filename fast-tests.xml --results-directory /tmp
+  ```
+
+  Static analysis (grepping for subprocess helpers, fixture size, etc.) is
+  unreliable for this call — a file matching a "slow-looking" helper can have
+  only a handful of genuinely slow tests among hundreds of cheap ones. Measure
+  the actual per-test time before tagging.
+
+Do not tag a whole test class merely because a few of its tests are slow;
+tag the individual `[Fact]`/`[Theory]` methods that actually measure above
+the threshold. Reserve class-level tagging (e.g.
+`CommandExecutionTests`) for classes where the slow cost is genuinely
+pervasive across nearly all of the class's tests.
+
+## Placement convention
+
+Place `[Trait("Speed", "Slow")]` as its own line directly after the
+`[Fact]`/`[Theory]` attribute, before any `[InlineData(...)]` rows:
+
+```csharp
+[Fact]
+[Trait("Speed", "Slow")]
+public void SomeExpensiveTest()
+```
+
+```csharp
+[Theory]
+[Trait("Speed", "Slow")]
+[InlineData("System.Private.CoreLib")]
+[InlineData("System.Collections")]
+public void SomeExpensiveTheory(string assemblyName)
+```
+
+## Existing consumers (no workflow changes needed to add a tag)
+
+- `ci.yml`'s PR-blocking fast leg runs
+  `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-not-trait "Speed=Slow"`
+  — a newly tagged test is automatically excluded.
+- `deep-inspect.yml`'s nightly `dotnet-inspect.Tests` step runs fully
+  unfiltered — a newly tagged test automatically keeps running nightly.
+- The decompiler suite uses the same trait and the same
+  `--filter-not-trait "Speed=Slow"` / unfiltered split; see
+  [`docs/decompiler-correctness-pipeline.md`](decompiler-correctness-pipeline.md)
+  for that suite's `Area`/`Speed` trait combination.
+
+Tagging a test is a policy change (when it runs), not a behavior change (what
+it asserts). It requires no `.github/workflows/*.yml` edits.


### PR DESCRIPTION
## Demo

Before: nothing told a contributor writing a new whole-assembly-analysis
test that it should be tagged `Speed=Slow` before it lands — only the
decompiler suite's own doc described that convention, for that suite only.
PR #6095 found 134 such tests had accumulated untagged, growing the fast
CI leg from ~11-18min to ~30-45min.

After: `AGENTS.md`'s "Building and testing" section states the rule in one
paragraph; [`docs/testing-cost-classification.md`](docs/testing-cost-classification.md)
owns the threshold (measure with `--report-xunit`; >= 2s individually, or
exhaustive/whole-assembly analysis), the placement convention, and the
existing zero-workflow-change consumers.

## Change

- `AGENTS.md`: add the binding rule to "Building and testing"; trim
  "Making your work findable"'s bullets to one-line summaries to offset
  the added lines (593/600 after; the trimmed detail was already fully
  present in `docs/agent-session-state.md` and is unchanged there).
- New `docs/testing-cost-classification.md`.
- `docs/README.md`: add the pointer row.

Documentation-only; every changed file is `*.md`.

## Validation

`npx markdownlint-cli AGENTS.md docs/README.md docs/testing-cost-classification.md` — clean.
`wc -l AGENTS.md` — 593 (<= 600 cap).
