### PR TITLE
Record virtual/interface modifier signature-shape flow

### DIFF
--- a/docs/design/member-signature-shape.md
+++ b/docs/design/member-signature-shape.md
@@ -145,6 +145,21 @@ MethodDef signature blobs are identical across the direction/readonly forms.
 Those examples do not demonstrate distinct metadata custom-modifier signatures.
 Modifier handling has its own evidence.
 
+`VirtualInterfaceModifierSignatureShapeFlowTests` adds compiler-produced virtual
+methods and interface declarations to that evidence. It records the required
+`System.Runtime.InteropServices.InAttribute` modifier on `in` and `ref readonly`,
+their distinct `IsReadOnlyAttribute`/`RequiresLocationAttribute` parameter
+markers, and the unmodified value/`ref`/`out` neighbors. Raw signatures are read
+before projection, without pinning metadata row numbers. Literal shapes and
+canonical transport preserve value/reference passing but erase the decoded
+modifier. A unique alternative source match is still only correspondence;
+multiple matching alternatives remain ambiguous, not interchangeable contracts.
+The [C# metadata encoding specification][readonly-parameter-encoding] supplies
+the comparative basis; existing unavailable-modifier refusal gates remain
+separate from this compiler-backed ledger.
+
+[readonly-parameter-encoding]: https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/ref-readonly-parameters.md#metadata-encoding
+
 ### Demo: distinguish overloads, retain ambiguity
 
 Within the compiled `Ref` group:

--- a/tests/ILInspector.Metadata.Tests/VirtualInterfaceModifierFlowSamples.cs
+++ b/tests/ILInspector.Metadata.Tests/VirtualInterfaceModifierFlowSamples.cs
@@ -1,0 +1,25 @@
+namespace ILInspector.Metadata.Tests;
+
+public class VirtualModifierFlowSamples
+{
+    public virtual void Ref(int value) { }
+    public virtual void Ref(ref int value) { }
+    public virtual void Out(int value) { }
+    public virtual void Out(out int value) => value = 0;
+    public virtual void In(int value) { }
+    public virtual void In(in int value) { }
+    public virtual void ReadOnly(int value) { }
+    public virtual void ReadOnly(ref readonly int value) { }
+}
+
+public interface IInterfaceModifierFlowSamples
+{
+    void Ref(int value);
+    void Ref(ref int value);
+    void Out(int value);
+    void Out(out int value);
+    void In(int value);
+    void In(in int value);
+    void ReadOnly(int value);
+    void ReadOnly(ref readonly int value);
+}

--- a/tests/ILInspector.Metadata.Tests/VirtualInterfaceModifierSignatureShapeFlowTests.cs
+++ b/tests/ILInspector.Metadata.Tests/VirtualInterfaceModifierSignatureShapeFlowTests.cs
@@ -1,0 +1,246 @@
+using CSharpText;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class VirtualInterfaceModifierSignatureShapeFlowTests
+{
+    const string IsReadOnlyAttribute = "System.Runtime.CompilerServices.IsReadOnlyAttribute";
+    const string RequiresLocationAttribute = "System.Runtime.CompilerServices.RequiresLocationAttribute";
+    const string ValueTransport = "mss1:0(1:vp12:System.Int32)n";
+    const string ReferenceTransport = "mss1:0(1:rp12:System.Int32)n";
+
+    static readonly MemberSignatureShape ValueShape = new(
+        0, new([new MemberParameterSignatureShape(
+            ParameterPassingKind.Value, new PrimitiveTypeSignatureShape("System.Int32"))]));
+    static readonly MemberSignatureShape ReferenceShape = new(
+        0, new([new MemberParameterSignatureShape(
+            ParameterPassingKind.ByReference, new PrimitiveTypeSignatureShape("System.Int32"))]));
+
+    static readonly Type[] FixtureTypes =
+        [typeof(VirtualModifierFlowSamples), typeof(IInterfaceModifierFlowSamples)];
+
+    static readonly Specimen[] Specimens =
+    [
+        new("RefValue", "Ref", "int value", typeof(int), ValueShape, ValueTransport),
+        new("RefReference", "Ref", "ref int value", typeof(int).MakeByRefType(),
+            ReferenceShape, ReferenceTransport),
+        new("OutValue", "Out", "int value", typeof(int), ValueShape, ValueTransport),
+        new("OutReference", "Out", "out int value", typeof(int).MakeByRefType(),
+            ReferenceShape, ReferenceTransport, Attributes: ParameterAttributes.Out),
+        new("InValue", "In", "int value", typeof(int), ValueShape, ValueTransport),
+        new("InReference", "In", "in int value", typeof(int).MakeByRefType(),
+            ReferenceShape, ReferenceTransport, RequiredInModifier: true,
+            Attributes: ParameterAttributes.In, MarkerAttribute: IsReadOnlyAttribute),
+        new("ReadOnlyValue", "ReadOnly", "int value", typeof(int), ValueShape, ValueTransport),
+        new("ReadOnlyReference", "ReadOnly", "ref readonly int value", typeof(int).MakeByRefType(),
+            ReferenceShape, ReferenceTransport, RequiredInModifier: true,
+            Attributes: ParameterAttributes.In, MarkerAttribute: RequiresLocationAttribute),
+    ];
+
+    public static TheoryData<Type, string> FlowCases => Cases(Specimens);
+
+    public static TheoryData<Type, string> ModifiedCases =>
+        Cases(Specimens.Where(specimen => specimen.RequiredInModifier));
+
+    [Theory]
+    [MemberData(nameof(FlowCases))]
+    public void ModifierFlow_RecordsMetadataShapeTransportAndCandidate(Type fixtureType, string specimenName)
+    {
+        Specimen specimen = FindSpecimen(specimenName);
+        using var peReader = OpenFixture();
+        MetadataReader reader = peReader.GetMetadataReader();
+        MethodDefinitionHandle expected = ExpectedHandle(fixtureType, specimen);
+        AssertCompilerEncoding(reader, expected, specimen);
+
+        var metadataCandidates = MetadataCandidates(reader, fixtureType, specimen.MethodName);
+        Assert.Equal(2, metadataCandidates.Length);
+        MemberSignatureShapeResult metadata = Assert.Single(
+            metadataCandidates, candidate => candidate.Candidate == expected).Shape;
+        MemberSignatureShapeResult restoredMetadata = AssertStages(metadata, specimen);
+        MemberSignatureShapeResult source = SourceShape(specimen);
+        MemberSignatureShapeResult restoredSource = AssertStages(source, specimen);
+        var restoredCandidates = metadataCandidates
+            .Select(candidate => (candidate.Candidate, Shape: Transport(candidate.Shape)))
+            .ToArray();
+
+        AssertUnique(MemberSignatureShapeMatcher.Match(source, metadataCandidates), expected);
+        AssertUnique(MemberSignatureShapeMatcher.Match(restoredSource, restoredCandidates), expected);
+        AssertUnique(MemberSignatureShapeMatcher.Match(restoredMetadata, restoredCandidates), expected);
+
+        var sourceCandidates = Specimens
+            .Where(candidate => candidate.MethodName == specimen.MethodName)
+            .Select(candidate => (
+                Candidate: candidate.Name, Shape: AssertStages(SourceShape(candidate), candidate)))
+            .ToArray();
+        AssertUnique(MemberSignatureShapeMatcher.Match(restoredMetadata, sourceCandidates), specimen.Name);
+
+        MemberSignatureCorrespondence<MethodDefinitionHandle> oppositePassing =
+            MemberSignatureShapeMatcher.Match(
+                restoredSource, restoredCandidates.Where(candidate => candidate.Candidate != expected).ToArray());
+        Assert.Equal(MemberSignatureCorrespondenceKind.Unavailable, oppositePassing.Kind);
+        Assert.True(oppositePassing.Match.IsNil);
+        Assert.Empty(oppositePassing.Candidates);
+        Assert.False(string.IsNullOrWhiteSpace(oppositePassing.UnavailableReason));
+    }
+
+    [Theory]
+    [MemberData(nameof(ModifiedCases))]
+    public void DistinctModifierEncoding_DoesNotBecomeSignatureIdentity(Type fixtureType, string specimenName)
+    {
+        Specimen modified = FindSpecimen(specimenName);
+        Specimen plainReference = FindSpecimen("RefReference");
+        using var peReader = OpenFixture();
+        MetadataReader reader = peReader.GetMetadataReader();
+        MethodDefinitionHandle modifiedHandle = ExpectedHandle(fixtureType, modified);
+        MethodDefinitionHandle plainHandle = ExpectedHandle(fixtureType, plainReference);
+        AssertCompilerEncoding(reader, modifiedHandle, modified);
+        AssertCompilerEncoding(reader, plainHandle, plainReference);
+        Assert.False(reader.GetBlobBytes(reader.GetMethodDefinition(modifiedHandle).Signature).AsSpan()
+            .SequenceEqual(reader.GetBlobBytes(reader.GetMethodDefinition(plainHandle).Signature)));
+
+        MemberSignatureShapeResult metadata = AssertStages(
+            MetadataMemberSignatureShape.Create(reader, modifiedHandle), modified);
+        MemberSignatureShapeResult plainMetadata = AssertStages(
+            MetadataMemberSignatureShape.Create(reader, plainHandle), plainReference);
+        Assert.Equal(plainMetadata.Shape, metadata.Shape);
+
+        MemberSignatureShapeResult original = AssertStages(SourceShape(modified), modified);
+        MemberSignatureShapeResult alternative = AssertStages(
+            SourceMemberSignatureShape.Create(
+                $"void {modified.MethodName}(ref int value);", SourceMemberSignatureKind.Method),
+            modified);
+        Specimen value = Specimens.Single(specimen =>
+            specimen.MethodName == modified.MethodName && specimen.RuntimeParameterType == typeof(int));
+        MemberSignatureShapeResult valueSource = AssertStages(SourceShape(value), value);
+
+        // Alternative source versions, not legal overloads differing only in direction/readonly.
+        AssertUnique(
+            MemberSignatureShapeMatcher.Match(metadata, [("value", valueSource), ("alternative", alternative)]),
+            "alternative");
+        MemberSignatureCorrespondence<string> ambiguous = MemberSignatureShapeMatcher.Match(
+            metadata, [("value", valueSource), ("original", original), ("alternative", alternative)]);
+        Assert.Equal(MemberSignatureCorrespondenceKind.Ambiguous, ambiguous.Kind);
+        Assert.Equal(["original", "alternative"], ambiguous.Candidates);
+        Assert.Null(ambiguous.Match);
+        Assert.Null(ambiguous.UnavailableReason);
+    }
+
+    static void AssertCompilerEncoding(
+        MetadataReader reader, MethodDefinitionHandle handle, Specimen specimen)
+    {
+        MethodDefinition method = reader.GetMethodDefinition(handle);
+        Assert.True((method.Attributes & MethodAttributes.Virtual) != 0);
+        BlobReader signature = reader.GetBlobReader(method.Signature);
+        Assert.Equal(0x20, signature.ReadByte()); // Instance, non-generic default calling convention.
+        Assert.Equal(1, signature.ReadCompressedInteger());
+        Assert.Equal(SignatureTypeCode.Void, signature.ReadSignatureTypeCode());
+        if (specimen.RequiredInModifier)
+        {
+            Assert.Equal(SignatureTypeCode.RequiredModifier, signature.ReadSignatureTypeCode());
+            EntityHandle modifier = signature.ReadTypeHandle();
+            Assert.Equal(HandleKind.TypeReference, modifier.Kind);
+            TypeReference modifierType = reader.GetTypeReference((TypeReferenceHandle)modifier);
+            Assert.Equal("System.Runtime.InteropServices", reader.GetString(modifierType.Namespace));
+            Assert.Equal("InAttribute", reader.GetString(modifierType.Name));
+        }
+        if (specimen.RuntimeParameterType.IsByRef)
+            Assert.Equal(SignatureTypeCode.ByReference, signature.ReadSignatureTypeCode());
+        Assert.Equal(SignatureTypeCode.Int32, signature.ReadSignatureTypeCode());
+        Assert.Equal(0, signature.RemainingBytes);
+
+        Parameter parameter = method.GetParameters().Select(reader.GetParameter)
+            .Single(parameter => parameter.SequenceNumber == 1);
+        Assert.Equal(specimen.Attributes, parameter.Attributes);
+        foreach (string marker in new[] { IsReadOnlyAttribute, RequiresLocationAttribute })
+        {
+            Assert.Equal(
+                specimen.MarkerAttribute == marker,
+                AttributeReader.HasAttribute(reader, parameter.GetCustomAttributes(), marker));
+        }
+    }
+
+    static TheoryData<Type, string> Cases(IEnumerable<Specimen> specimens)
+    {
+        var cases = new TheoryData<Type, string>();
+        foreach (Type fixtureType in FixtureTypes)
+            foreach (Specimen specimen in specimens)
+                cases.Add(fixtureType, specimen.Name);
+        return cases;
+    }
+
+    static (MethodDefinitionHandle Candidate, MemberSignatureShapeResult Shape)[] MetadataCandidates(
+        MetadataReader reader, Type fixtureType, string methodName)
+    {
+        var typeHandle = (TypeDefinitionHandle)MetadataTokens.EntityHandle(fixtureType.MetadataToken);
+        return reader.GetTypeDefinition(typeHandle).GetMethods()
+            .Where(handle => reader.StringComparer.Equals(reader.GetMethodDefinition(handle).Name, methodName))
+            .Select(handle => (
+                Candidate: handle, Shape: MetadataMemberSignatureShape.Create(reader, handle)))
+            .ToArray();
+    }
+
+    static MethodDefinitionHandle ExpectedHandle(Type fixtureType, Specimen specimen)
+    {
+        // Locate the compiled overload independently of the shape projection.
+        MethodInfo method = fixtureType
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Single(method => method.Name == specimen.MethodName
+                && method.GetParameters().Single().ParameterType == specimen.RuntimeParameterType);
+        return (MethodDefinitionHandle)MetadataTokens.EntityHandle(method.MetadataToken);
+    }
+
+    static MemberSignatureShapeResult SourceShape(Specimen specimen) =>
+        SourceMemberSignatureShape.Create(
+            $"void {specimen.MethodName}({specimen.ParameterDeclaration});", SourceMemberSignatureKind.Method);
+
+    static MemberSignatureShapeResult AssertStages(MemberSignatureShapeResult result, Specimen specimen)
+    {
+        Assert.True(result.IsAvailable, result.UnavailableReason);
+        Assert.Null(result.UnavailableReason);
+        Assert.Equal(specimen.ExpectedShape, result.Shape);
+        string text = MemberSignatureShapeCodec.Encode(result.Shape!);
+        Assert.Equal(specimen.ExpectedTransport, text);
+        MemberSignatureShapeResult restored = MemberSignatureShapeCodec.Decode(text);
+        Assert.True(restored.IsAvailable, restored.UnavailableReason);
+        Assert.Null(restored.UnavailableReason);
+        Assert.Equal(specimen.ExpectedShape, restored.Shape);
+        return restored;
+    }
+
+    static MemberSignatureShapeResult Transport(MemberSignatureShapeResult result)
+    {
+        Assert.True(result.IsAvailable, result.UnavailableReason);
+        MemberSignatureShapeResult restored =
+            MemberSignatureShapeCodec.Decode(MemberSignatureShapeCodec.Encode(result.Shape!));
+        Assert.True(restored.IsAvailable, restored.UnavailableReason);
+        return restored;
+    }
+
+    static void AssertUnique<T>(MemberSignatureCorrespondence<T> result, T expected)
+    {
+        Assert.Equal(MemberSignatureCorrespondenceKind.Unique, result.Kind);
+        Assert.Equal(expected, result.Match);
+        Assert.Empty(result.Candidates);
+        Assert.Null(result.UnavailableReason);
+    }
+
+    static Specimen FindSpecimen(string name) => Specimens.Single(specimen => specimen.Name == name);
+
+    static PEReader OpenFixture() =>
+        new(File.OpenRead(typeof(VirtualModifierFlowSamples).Assembly.Location));
+
+    sealed record Specimen(
+        string Name,
+        string MethodName,
+        string ParameterDeclaration,
+        Type RuntimeParameterType,
+        MemberSignatureShape ExpectedShape,
+        string ExpectedTransport,
+        bool RequiredInModifier = false,
+        ParameterAttributes Attributes = ParameterAttributes.None,
+        string? MarkerAttribute = null);
+}


### PR DESCRIPTION
## Summary

Make the signature-correspondence boundary concrete for compiler-produced
virtual and interface methods: distinct raw modifier/parameter evidence can
produce the same non-authoritative shape without becoming signature identity.

Closes #6100. Theme: **signature identity evidence**. This follows the focused
contract in #6080 and extends #5960's non-virtual static parameter ledger.
Product behavior is unchanged.

## Demo

The ledger records these facts for both a virtual class and an interface:

| Parameter | Required modifier in signature | Parameter flags / marker | Canonical shape |
| --- | --- | --- | --- |
| `int` | None | None | `mss1:0(1:vp12:System.Int32)n` |
| `ref int` | None | None | `mss1:0(1:rp12:System.Int32)n` |
| `out int` | None | `Out` | `mss1:0(1:rp12:System.Int32)n` |
| `in int` | `System.Runtime.InteropServices.InAttribute` | `In` / `IsReadOnlyAttribute` | `mss1:0(1:rp12:System.Int32)n` |
| `ref readonly int` | `System.Runtime.InteropServices.InAttribute` | `In` / `RequiresLocationAttribute` | `mss1:0(1:rp12:System.Int32)n` |

These rows compare evidence, not one legal C# overload set. Each compiled
`Ref`, `Out`, `In`, or `ReadOnly` group pairs its by-value and by-reference
overloads. The exact expected MethodDef remains uniquely distinguishable
within that complete same-type/same-name group; the opposite-passing-only
neighbor is unavailable.

For a compiled `In(in int)` target, an alternative source version containing
`In(int)` and `In(ref int)` still produces a unique *shape* match. Retaining
both alternative by-reference declarations yields **Ambiguous**, with both
candidates retained. Those alternatives cannot coexist as legal overloads.
The raw `in` signature differs from plain `ref`; equal projection does not
make their contracts interchangeable.

Before this slice, the static fixtures did not exercise this required-modifier
difference. The new ledger records it before projection, followed by literal
shape and transport expectations and candidate outcomes. `in` and
`ref readonly` share the required modifier; their parameter markers differ.

## Design basis and scope

Single owner:
`docs/design/member-signature-shape.md#projection-policy-and-rationale`.
The existing claim is deliberate erasure of successfully decoded modifiers
for correspondence, not direction/readonly/binary-compatibility evidence.
The decompiler pipeline remains the supporting consumer/attribution boundary,
not another owner for this slice.

The [C# metadata encoding specification](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/ref-readonly-parameters.md#metadata-encoding)
and the selected repository compiler supply the encoding basis. Direct SRM
blob reads establish modifier placement and type name without pinning metadata
row numbers. Reflection locates the known, compiled fixture overloads
independently of the shape projection; no inspected assembly is loaded by a
product path.

Three files: 16 compiled specimen methods beside their owning tests, 20
data-driven flow cases, and one focused design gate paragraph. Samples build
through the existing Metadata test project as required by fixture governance.
No new fixture project, compiler invocation, dependency, public API, product
algorithm, CI expansion, or runtime behavior.

Existing consumer: ReturnToSender non-authoritative lookup. The Metadata test
executable is the existing exercising host. Issue #6100 is the complete
one-step evidence-adoption tracker: the existing Release/CI suite discovers
this ledger. No new architecture, CLI/browser adoption, rendering path,
retirement plan, or later implementation slice is required.

## Validation

- Release Metadata selection `--filter-class '*SignatureShape*'`: 103 passed,
  including all 20 new cases and 83 adjacent cases. CTRF receipt confirms
  the new cases were discovered and passed.
- Includes the existing unavailable-modifier and bounded-erasure tests;
  this slice adds no duplicate malformed-metadata fixture.
- Changed design Markdown passes existing `markdownlint-cli`.
- Standard fixed-head review waits for current-head `ci-required`.
  No merge authorization is implied.
