### PR TITLE
Add raw custom-attribute resource-failure propagation coverage

### DIFF
--- a/docs/design/custom-attribute-value-decoding.md
+++ b/docs/design/custom-attribute-value-decoding.md
@@ -21,10 +21,11 @@ paired-walker hazards described under
 [How this design changed](#how-this-design-changed) are gone from the code.
 Slice 3's compiler-produced fixture gate landed in #5148; it does not establish
 real-package certification or a certified producer-SDK range. Slice 4 retires
-the temporary guard bridge and its validation-only mode. D1's generative cost
-gate (#5733), D2's internal-exhaustion evidence (#5397), and broader D3
-certification remain open, so the full invariants below remain targets rather
-than gated facts.
+the temporary guard bridge and its validation-only mode. D2 now has focused
+resource-failure propagation evidence (#5397), using deterministic fault
+injection rather than actual memory pressure. D1's generative cost gate
+(#5733), exhaustive D2 coverage, and broader D3 certification remain open, so
+the full invariants below remain targets rather than gated facts.
 
 ## Responsibility
 
@@ -318,8 +319,10 @@ observer and resolver instances.
 Resource exhaustion is a separate class. An `OutOfMemoryException` raised
 inside materialization crosses no caller boundary, so callback provenance
 cannot protect it. It propagates because it is not a malformed-input outcome.
-Slice 2 removed the catch that converted it to `null`; issue #5397 records that
-repair, while a dedicated internal-resource-exhaustion gate remains missing.
+Slice 2 removed the catch that converted it to `null`. The focused
+[resource-failure propagation gate](#resource-failure-propagation-gate)
+exercises that policy with a raw, injected failure beneath the public decoder,
+separately from callback-provenance tests (#5397).
 
 **D2 is outcome-shaped, and only that.** Its whole content is which of three
 outcomes a caller can observe: a complete value, `null`, or a propagated
@@ -834,7 +837,7 @@ remain `unverified`.**
 | Invariant | Gate | State |
 | --- | --- | --- |
 | **D1** | #5733 varies attacker-controlled dimensions jointly, measures work rather than allocation, samples capped dimensions past their cap, and must be shown red against the pre-repair head. | Does not exist; five open defects violate it. |
-| **D2** | Slice 2 classified and inverted the guard's deferral tests, and added explicit coverage for the defaulted-width signal, caller-boundary provenance (observer and resolver, including `BadImageFormatException` and `ArgumentOutOfRangeException`), and a malformed control. Slice 4 exercises those fixtures through `AttributeDecoder` directly. An internally originated `OutOfMemoryException` gate does not yet exist. | Partial, landed in #5815; resource-exhaustion propagation remains unverified. |
+| **D2** | Slice 2 classified and inverted the guard's deferral tests, and added explicit coverage for the defaulted-width signal, caller-boundary provenance (observer and resolver, including `BadImageFormatException` and `ArgumentOutOfRangeException`), and a malformed control. Slice 4 exercises those fixtures through `AttributeDecoder` directly. The [resource-failure propagation gate](#resource-failure-propagation-gate) covers raw `OutOfMemoryException` propagation from SRM string materialization. | Focused refusal, callback, width-signal, and injected resource-failure cases are gated; exhaustive D2 coverage remains unverified. |
 | **D3** | #5148's fixtures-first gate compares compiler-produced values with independent SRM results and source-owned cross-assembly enum expectations. `CustomAttributeFidelityTests.CompilerProducedValues_EqualIndependentSrm` and `RetainedCrossAssemblyEnums_EqualProducerTruth` enforce this fixture subset. | Partial fixture coverage; real-package certification and its producer range remain unverified. |
 | **Defaulted-width signal** | #5742 asserts that the out-of-band per-argument signal is set for a defaulted width and clear for a resolved width on the same decode path. `DetailedDecode_ReportsDefaultedAndResolvedWidths` and `DetailedDecode_LegacyFuncIsAuthoritative_ButUnresolvedDefaults` gate it. | Gated, landed in #5815. |
 
@@ -958,6 +961,35 @@ I1 offset seam and generated guard-approval assertions are retired, not carried
 as additional D3 requirements. Exhaustive grammar coverage, D1/D2 enumeration,
 and real-package certification are not established by this fixture gate.
 
+### Resource-failure propagation gate
+
+`CustomAttributeFailurePropagationTests.StringMaterializationOutOfMemory_PropagatesUnchanged`
+is the focused Release gate for #5397. It uses SRM's existing
+`MetadataStringDecoder` customization point to inject one
+`OutOfMemoryException` during type-name materialization inside a decode.
+The ordinary, serialized-name-preserving, and detailed public entry points must
+each propagate the original exception instance, rather than return `null` or a
+value.
+
+No `beforeMaterialize` observer or enum resolver is supplied. The failure
+therefore reaches the owned decoder as a raw dependency exception, not through
+its caller-callback provenance sentinel. This distinction is what the existing
+callback tests cannot establish. The compiler-produced `Types` sample already
+used by the fidelity gate supplies ordinary metadata; healthy decodes before
+and after the one-shot injection are controls for the test double.
+
+This follows the existing metadata tests' use of a custom SRM string decoder
+for observation and injected dependency failures for exception-identity checks.
+The metadata test runner is the evidence consumer; it exercises the same shared
+decoder already used by CLI and browser/Wasm. No product hook, new decoding
+path, or host integration is introduced.
+
+The evidence is **fault-injected propagation**, not a claim about actual heap
+exhaustion, recovery under memory pressure, every allocation site, or exhaustive
+D2 grammar coverage. Those stronger claims are not needed to check the decoder's
+exception policy. The test does not exhaust host memory or reproduce a malformed
+resource-amplifying input.
+
 ### Generic-context lookup gate
 
 Within one attribute decode, locating repeated, alternating, or increasing
@@ -1068,7 +1100,7 @@ slice 2. Both are now settled.
 | #5132 | Quadratic cost across attribute rows sharing one value blob. Gap 4. |
 | #5148 | Merged: fixtures-first D3 value equality and retained-image producer truth. Broader package certification remains outstanding in #5065. |
 | #5304 | Stage 2 exhaustive per-position enumeration. |
-| #5397 | Slice 2 no longer catches internal `OutOfMemoryException`; dedicated propagation evidence remains absent, so D2 stays partially unverified. |
+| #5397 | Gated: a one-shot SRM string-materialization fault propagates unchanged through all three public decode surfaces. This is fault-injection evidence, not actual memory-pressure testing or exhaustive D2 coverage. |
 | #5733 | The D1 generative bounded-cost gate; #5065 does not measure cost. |
 | #5742 | Implemented in #5815: the opt-in defaulted-width signal mitigates D3's row-three carve-out. |
 | #5755 | Retained-name evidence and the representation-bound revisit point if the output-shape hold is lifted. |

--- a/docs/design/custom-attribute-value-decoding.md
+++ b/docs/design/custom-attribute-value-decoding.md
@@ -978,6 +978,13 @@ callback tests cannot establish. The compiler-produced `Types` sample already
 used by the fidelity gate supplies ordinary metadata; healthy decodes before
 and after the one-shot injection are controls for the test double.
 
+Gate adequacy was checked at `6e076e9502645b2d0a01550f407bbc9deebb643f` with a
+temporary policy mutation that included `OutOfMemoryException` in the owned
+decoder's refusal filter. All three new cases failed because no exception
+escaped, while 110 neighboring cases still passed. The mutation was removed;
+it is a synthetic regression control, not a reproduction of historical memory
+exhaustion. The implementation repair already landed in #5815.
+
 This follows the existing metadata tests' use of a custom SRM string decoder
 for observation and injected dependency failures for exception-identity checks.
 The metadata test runner is the evidence consumer; it exercises the same shared

--- a/tests/ILInspector.Metadata.Tests/CustomAttributeFailurePropagationTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CustomAttributeFailurePropagationTests.cs
@@ -1,0 +1,80 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class CustomAttributeFailurePropagationTests
+{
+    [Theory]
+    [InlineData(DecodeSurface.Value)]
+    [InlineData(DecodeSurface.PreservingSerializedTypeNames)]
+    [InlineData(DecodeSurface.Detailed)]
+    public void StringMaterializationOutOfMemory_PropagatesUnchanged(DecodeSurface surface)
+    {
+        Type sample = typeof(CustomAttributeFidelitySamples.Types);
+        using var pe = new PEReader(File.OpenRead(sample.Assembly.Location));
+        var strings = new FaultingStringDecoder();
+        MetadataReader reader = pe.GetMetadataReader(
+            MetadataReaderOptions.Default, strings);
+        var type = (TypeDefinitionHandle)MetadataTokens.EntityHandle(sample.MetadataToken);
+        CustomAttribute attribute = reader.GetCustomAttribute(
+            Assert.Single(reader.GetTypeDefinition(type).GetCustomAttributes()));
+
+        Assert.NotNull(Decode(reader, attribute, surface));
+        var failure = new OutOfMemoryException("Synthetic SRM string-materialization failure.");
+        strings.FailNext(failure);
+
+        var propagated = Assert.Throws<OutOfMemoryException>(
+            () => Decode(reader, attribute, surface));
+
+        Assert.Same(failure, propagated);
+        Assert.Equal(1, strings.InjectedFailures);
+        Assert.NotNull(Decode(reader, attribute, surface));
+        Assert.Equal(1, strings.InjectedFailures);
+    }
+
+    static CustomAttributeValue<string>? Decode(
+        MetadataReader reader,
+        CustomAttribute attribute,
+        DecodeSurface surface)
+        => surface switch
+        {
+            DecodeSurface.Value =>
+                AttributeDecoder.TryDecode(reader, attribute),
+            DecodeSurface.PreservingSerializedTypeNames =>
+                AttributeDecoder.TryDecodePreservingSerializedTypeNames(reader, attribute),
+            DecodeSurface.Detailed =>
+                AttributeDecoder.TryDecodeDetailed(reader, attribute)?.Value,
+            _ => throw new ArgumentOutOfRangeException(nameof(surface)),
+        };
+
+    public enum DecodeSurface
+    {
+        Value,
+        PreservingSerializedTypeNames,
+        Detailed,
+    }
+
+    sealed class FaultingStringDecoder() : MetadataStringDecoder(Encoding.UTF8)
+    {
+        OutOfMemoryException? _failure;
+
+        public int InjectedFailures { get; private set; }
+
+        public void FailNext(OutOfMemoryException failure) => _failure = failure;
+
+        public override unsafe string GetString(byte* bytes, int byteCount)
+        {
+            if (_failure is { } failure)
+            {
+                _failure = null;
+                InjectedFailures++;
+                throw failure;
+            }
+            return base.GetString(bytes, byteCount);
+        }
+    }
+}


### PR DESCRIPTION
# Keep resource failures distinct from malformed attributes

Reliable custom-attribute inspection must not report a host resource failure as
an undecodable attribute. This adds the missing focused propagation evidence
for #5397 without changing product code or exhausting memory.

## Demo

The existing compiler-produced `CustomAttributeFidelitySamples.Types` attribute
decodes normally. SRM's existing `MetadataStringDecoder` customization point
then injects one synthetic `OutOfMemoryException` during type-name materialization,
beneath the public attribute decoder. No observer or enum resolver is supplied.

| Public surface | Observed with the injected fault | Expected |
| --- | --- | --- |
| `TryDecode` | Original `OutOfMemoryException` instance propagates | Original exception, not `null` or a value |
| `TryDecodePreservingSerializedTypeNames` | Original exception instance propagates | Original exception, not `null` or a value |
| `TryDecodeDetailed` | Original exception instance propagates | Original exception, not `null` or a value |

Healthy decodes before and after the one-shot injection succeed. These are
controls for the test double, not evidence of recovery from actual memory
pressure.

```bash
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- \
  --filter-class ILInspector.Metadata.Tests.CustomAttributeFailurePropagationTests \
  --no-progress
```

Result: **3 passed**. The product correction already landed in #5815; this PR
adds evidence, not a new exception-handling behavior.

## Design basis and scope

**Normative owner:**
`docs/design/custom-attribute-value-decoding.md#d2--fail-closed-visibly`.
Its outcome contract requires a resource failure beneath decoding to propagate
unchanged, rather than become a malformed-input refusal. The focused gate and
its limits are recorded in `#resource-failure-propagation-gate`.

The error reaches the owned decoder directly from SRM string materialization,
without the caller-callback provenance sentinel. This is the distinction the
observer/resolver tests do not establish.

This uses conventional dependency fault injection and an existing SRM extension
point. Prior art in the same test project includes `MetadataTypeNameBudgetTests`'
custom string decoder and `PdbContextDescriptorTests`' injected dependency
exceptions with identity assertions. No new product hook, dependency, public API,
allocator abstraction, or host path is needed.

The metadata test runner is the evidence consumer. The production decoder
already serves CLI and browser/Wasm; one test/documentation step adds this gate
without any further host adoption or retirement work. The existing value shape
and rendering boundaries are unchanged.

**Evidence boundary:** fault-injected raw exception propagation, not physical
heap exhaustion, recovery under memory pressure, every allocation site, or
exhaustive D2 grammar coverage. No malformed resource-amplifying input or
historical exhaustion reproduction is used. Full D1 (#5733), exhaustive D2
coverage, and broader D3 certification (#5065) remain separate.

## Validation

SDK `11.0.100-preview.7.26381.103`, Release configuration.

The gate's adequacy was checked at
`6e076e9502645b2d0a01550f407bbc9deebb643f` with a temporary local policy mutation:
include `OutOfMemoryException` in the owned decoder's refusal filter. That
mutation was removed and is not part of the PR.

| Policy | New cases | Neighboring cases | Expected |
| --- | --- | --- | --- |
| Existing correct product | 3 pass | 110 pass | Original exception escapes |
| Temporary refusal-policy mutation | 3 fail: no exception was thrown | 110 pass | The new gate rejects the regression |
| Restored product | 3 pass | 110 pass | Original exception escapes again |

The negative control demonstrates a raw, unprotected failure path rather than
recounting callback-propagation coverage. It is not a claim that the historical
memory-pressure scenario was reproduced.

Final focused gate: **113 passed, 0 failed, 0 skipped**:

```bash
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- \
  --filter-class \
  ILInspector.Metadata.Tests.CustomAttributeFailurePropagationTests \
  ILInspector.Metadata.Tests.CustomAttributeValueDecoderTests \
  ILInspector.Metadata.Tests.TypeResolutionEnumWidthTests \
  ILInspector.Metadata.Tests.CustomAttributeFidelityTests \
  --no-progress
```

The owning document passes `markdownlint`. The two-file diff contains only the
new test and the focused owner update. Round 1 reviews will follow green
current-head `ci-required`.

Fixes #5397. Part of #5288.
