### PR TITLE
Add bounded API comparison for selected library pairs

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -94,7 +94,12 @@ request binding, acquisition authorization, diagnostics, and format selection.
 The
 API-comparison seam
 retains Metadata-owned Finding correspondence and compatibility classification
-over two host-resolved surfaces. The body-signal seam consumes already-acquired
+over two host-resolved surfaces. Its
+[selected-library coordinator](../inspection-space.md#selected-library-api-comparison)
+also projects two explicit context participants under independent bounds and
+withholds comparison when either API surface is incomplete. Browser
+selection and inventory/detail adoption remain separate deliveries.
+The body-signal seam consumes already-acquired
 Analysis indexes and retains `ResearchComparison`; keeping that query in the
 companion assembly avoids imposing Research on core query consumers. Core L1
 now intentionally references Decompiler for `AssemblyContextSourceQuery`,

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1242,6 +1242,60 @@ acquisition, while a typed miss reaches a separately preflighted moderated PDB
 acquisition successor. Availability and integrity declare unbounded work and
 accept host-owned HTTP clients and an optional cache.
 
+### Selected-library API comparison
+
+Queries coordinates an ordered API comparison of two explicitly selected
+assembly-context participants. Each participant is projected inside its own
+existing binding group; selecting one library does not shrink that group's
+dependency-resolution context. The caller supplies the participants, visibility
+scope, and projection limits. Package-version choice, cross-version library
+selection, and presentation remain caller or adjacent-owner responsibilities.
+
+`AssemblyContextApiComparisonQuery` retains each side's
+`AssemblyContextSubject` and complete projection outcome, including a subject
+whose projection was omitted by a limit. Both sides are attempted independently.
+The same caller-declared budget applies separately to each endpoint, not to
+their combined population.
+
+The query compares only two fully projected surfaces. Rejection, failure,
+projection truncation, or an API-row inspection failure on either side prevents
+comparison, while retaining both endpoint outcomes and any available facts.
+In particular, a participant can be available while some API rows failed:
+`AssemblyContextApiSurfaceResult.IsComplete` alone does not establish that its
+surface is eligible for this comparison. The new endpoint's completion
+includes the row-failure check.
+
+A valid empty public surface is complete evidence and may be compared. An
+unavailable or incomplete surface is not an empty surface and must not produce
+apparent additions, removals, equality, or a negative compatibility conclusion.
+This stricter admission is deliberate: the Library Diff consumer in
+[#5083](https://github.com/richlander/dotnet-inspect/issues/5083) needs an
+exhaustive result within its advertised API scope, not a comparison of two
+potentially different healthy subsets.
+
+When admitted, the query delegates to `ApiComparisonQuery`, retaining its
+Metadata-owned type/member Finding correspondence, signature compatibility
+classification, and exactness. Visibility scope does not add attribute,
+implementation, IL, or authored-source comparison. The existing raw-surface
+query and its CLI consumer remain unchanged.
+
+`AssemblyContextApiComparisonQueryTests` gates ordered subject identity,
+selected-participant projection, complete and empty comparisons, independent
+budgets, unavailable neighbors, and row-level failure admission. The existing
+`AssemblyContextApiSurfaceQueryTests` owns extraction-bound enforcement;
+`ApiComparisonQueryTests` owns the Metadata-comparison seam.
+
+[#6119](https://github.com/richlander/dotnet-inspect/issues/6119) is the
+selected-library slice of
+[#5104](https://github.com/richlander/dotnet-inspect/issues/5104), not its
+whole-package root/asset correspondence contract. The browser adoption path
+has three remaining deliveries: this query, Package-scoped comparison
+selection/defaults, and a feature facade with its immediate Library API Diff
+inventory/detail consumer. The existing CLI already consumes the shared
+Metadata comparison through `ApiComparisonQuery`; migrating its path-based
+acquisition to retained contexts remains separate. This query does not claim
+that the browser inspector or immersive comparison viewer is implemented.
+
 ### Executor
 
 Sequential topological execution defines the baseline. It works in

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1258,12 +1258,15 @@ The same caller-declared budget applies separately to each endpoint, not to
 their combined population.
 
 The query compares only two fully projected surfaces. Rejection, failure,
-projection truncation, or an API-row inspection failure on either side prevents
-comparison, while retaining both endpoint outcomes and any available facts.
+projection truncation, an API-row inspection failure, or a degraded member
+signature on either side prevents comparison, while retaining both endpoint
+outcomes and any available facts.
 In particular, a participant can be available while some API rows failed:
 `AssemblyContextApiSurfaceResult.IsComplete` alone does not establish that its
-surface is eligible for this comparison. The new endpoint's completion
-includes the row-failure check.
+surface is eligible for this comparison. Guarded signature substitution is
+also retained separately as `ApiMember.SignatureDecodeStatus`, without
+necessarily producing a row failure. The endpoint's completion consumes both
+signals; a substituted signature is not complete comparison evidence.
 
 A valid empty public surface is complete evidence and may be compared. An
 unavailable or incomplete surface is not an empty surface and must not produce
@@ -1281,8 +1284,9 @@ query and its CLI consumer remain unchanged.
 
 `AssemblyContextApiComparisonQueryTests` gates ordered subject identity,
 selected-participant projection, complete and empty comparisons, independent
-budgets, unavailable neighbors, and row-level failure admission. The existing
-`AssemblyContextApiSurfaceQueryTests` owns extraction-bound enforcement;
+budgets, unavailable neighbors, row-level failure admission, and degraded
+signature admission. `AssemblyContextApiSurfaceQueryTests` owns
+extraction-bound enforcement;
 `ApiComparisonQueryTests` owns the Metadata-comparison seam.
 
 [#6119](https://github.com/richlander/dotnet-inspect/issues/6119) is the

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextApiComparisonQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextApiComparisonQueryTests.cs
@@ -1,0 +1,688 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using DotnetInspector.Fixtures;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+/// <summary>
+/// Gates the two-endpoint library comparison query: ordered before/after acquisition, each
+/// endpoint's independent bounded projection, and the Metadata-owned comparison the query
+/// retains only when both endpoints are exactly and completely projected.
+/// </summary>
+public sealed class AssemblyContextApiComparisonQueryTests(ITestOutputHelper output)
+{
+    static ApiSurfaceProjectionLimits GenerousLimits { get; } =
+        new(64, 1_000_000, 1_000_000, int.MaxValue, int.MaxValue, int.MaxValue);
+
+    // The same physical image registered in two distinct groups is the trivial A-vs-A case: an
+    // exact comparison, with an unselected decoy participant on each side that must never be
+    // opened or projected.
+    [Fact]
+    public void Execute_SameImageAcrossDistinctGroups_IsExactAndIgnoresDecoyParticipants()
+    {
+        byte[] bytes = File.ReadAllBytes(SelfPath);
+        AssemblyReferenceIdentity identity = IdentityOf(bytes);
+        var policy = new TestBindingPolicy();
+        int selectedBeforeOpens = 0;
+        int decoyBeforeOpens = 0;
+        int selectedAfterOpens = 0;
+        int decoyAfterOpens = 0;
+
+        var selectedBefore = Participant(
+            identity,
+            bytes,
+            () => Interlocked.Increment(ref selectedBeforeOpens),
+            "selected-before",
+            policy);
+        var decoyBefore = Participant(
+            identity with { Name = "DecoyBefore" },
+            bytes,
+            () => Interlocked.Increment(ref decoyBeforeOpens),
+            "decoy-before",
+            policy);
+        var selectedAfter = Participant(
+            identity,
+            bytes,
+            () => Interlocked.Increment(ref selectedAfterOpens),
+            "selected-after",
+            policy);
+        var decoyAfter = Participant(
+            identity with { Name = "DecoyAfter" },
+            bytes,
+            () => Interlocked.Increment(ref decoyAfterOpens),
+            "decoy-after",
+            policy);
+
+        using var workspace = new InspectionWorkspace();
+        // The decoy comes first in one group and second in the other, so selection cannot be
+        // relying on participant position within the group.
+        using AssemblyContextGroup beforeGroup =
+            workspace.CreateAssemblyContextGroup([decoyBefore, selectedBefore]);
+        using AssemblyContextGroup afterGroup =
+            workspace.CreateAssemblyContextGroup([selectedAfter, decoyAfter]);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            selectedBefore,
+            afterGroup,
+            selectedAfter,
+            ApiSurfaceScope.Public,
+            GenerousLimits);
+
+        Assert.True(result.IsComplete);
+        Assert.True(result.IsExact);
+        Assert.NotNull(result.Comparison);
+        Assert.True(result.Comparison.IsExact);
+        Assert.Same(
+            selectedBefore.Assembly.Registration,
+            result.Before.Subject.Registration);
+        Assert.Same(
+            selectedAfter.Assembly.Registration,
+            result.After.Subject.Registration);
+        Assert.Equal(1, Volatile.Read(ref selectedBeforeOpens));
+        Assert.Equal(1, Volatile.Read(ref selectedAfterOpens));
+        Assert.Equal(0, Volatile.Read(ref decoyBeforeOpens));
+        Assert.Equal(0, Volatile.Read(ref decoyAfterOpens));
+        WriteOutcome("Same image, distinct registrations", result);
+    }
+
+    // A real version pair retains Metadata's own type/member correspondence and its breaking and
+    // additive classification, exercising the actual product comparison rather than a
+    // success-shaped stand-in.
+    [Fact]
+    public void Execute_RealVersionPair_RetainsMetadataOwnedBreakingAndAdditiveClassification()
+    {
+        var policy = new TestBindingPolicy();
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup beforeGroup = SinglePathGroup(
+            workspace,
+            FixtureCatalog.DiffV1.AssemblyPath(),
+            "diff v1",
+            policy);
+        using AssemblyContextGroup afterGroup = SinglePathGroup(
+            workspace,
+            FixtureCatalog.DiffV2.AssemblyPath(),
+            "diff v2",
+            policy);
+        AssemblyContextParticipant beforeParticipant = Assert.Single(beforeGroup.Participants);
+        AssemblyContextParticipant afterParticipant = Assert.Single(afterGroup.Participants);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            beforeParticipant,
+            afterGroup,
+            afterParticipant,
+            ApiSurfaceScope.Public,
+            GenerousLimits);
+
+        Assert.True(result.IsComplete);
+        Assert.False(result.IsExact);
+        ApiFindingComparison comparison = Assert.IsType<ApiFindingComparison>(result.Comparison);
+        Assert.True(comparison.ApiDiff.TotalBreaking > 0);
+        Assert.True(comparison.ApiDiff.TotalAdditive > 0);
+
+        TypeDiff methodRemovalDiff = Assert.Single(
+            comparison.ApiDiff.TypeDiffs,
+            diff => diff.TypeFullName == "DiffFixtureSample.MethodRemovalSample");
+        Assert.Contains(
+            methodRemovalDiff.Changes,
+            change => change.Kind == ChangeKind.MemberRemoved
+                && change.Classification == ChangeClassification.Breaking
+                && change.Subject!.MemberName == "Removed");
+
+        TypeDiff bodyStateDiff = Assert.Single(
+            comparison.ApiDiff.TypeDiffs,
+            diff => diff.TypeFullName == "DiffFixtureSample.BodyStateSample");
+        Assert.Contains(
+            bodyStateDiff.Changes,
+            change => change.Kind == ChangeKind.AbstractRemoved
+                && change.Classification == ChangeClassification.Additive);
+
+        // MethodRemovalSample retains its type identity across the pair.
+        var types = Assert.IsType<FindingComparison<ApiTypeHandle>.Complete>(comparison.Types.Value);
+        Assert.Contains(
+            types.Pairs,
+            pair => pair is PairFinding<ApiTypeHandle>.Present present
+                && present.New.Payload.TypeFullName == "DiffFixtureSample.MethodRemovalSample");
+        WriteOutcome("Fixture version pair", result);
+        foreach (TypeDiff type in new[] { methodRemovalDiff, bodyStateDiff })
+        {
+            output.WriteLine($"{type.TypeFullName}: {string.Join(", ",
+                type.Changes.Select(change => $"{change.Classification}/{change.Kind}"))}");
+        }
+    }
+
+    // A valid empty public API is a completed comparison, not an unavailable one.
+    [Fact]
+    public void Execute_ValidEmptyPublicApi_IsCompleteAndExact()
+    {
+        byte[] bytes = BuildTypedApiSurfaceImage(typeCount: 0);
+        AssemblyReferenceIdentity identity = IdentityOf(bytes);
+        var policy = new TestBindingPolicy();
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextParticipant beforeParticipant = Participant(
+            identity,
+            bytes,
+            openedCallback: null,
+            "empty-before",
+            policy);
+        AssemblyContextParticipant afterParticipant = Participant(
+            identity,
+            bytes,
+            openedCallback: null,
+            "empty-after",
+            policy);
+        using AssemblyContextGroup beforeGroup =
+            workspace.CreateAssemblyContextGroup([beforeParticipant]);
+        using AssemblyContextGroup afterGroup =
+            workspace.CreateAssemblyContextGroup([afterParticipant]);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            beforeParticipant,
+            afterGroup,
+            afterParticipant,
+            ApiSurfaceScope.Public,
+            GenerousLimits);
+
+        Assert.True(result.Before.IsComplete);
+        Assert.True(result.After.IsComplete);
+        Assert.Empty(Available(result.Before.Projection.Assemblies).Surface.Types);
+        Assert.Empty(Available(result.After.Projection.Assemblies).Surface.Types);
+        Assert.True(result.IsComplete);
+        Assert.True(result.IsExact);
+        WriteOutcome("Empty public API", result);
+    }
+
+    // A rejected endpoint on either side must still attempt the opposite endpoint, retaining its
+    // complete facts rather than collapsing to an empty successful diff.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Execute_RejectedEndpoint_RetainsTheOppositeEndpointWithoutComparison(
+        bool rejectBefore)
+    {
+        byte[] bytes = File.ReadAllBytes(SelfPath);
+        AssemblyReferenceIdentity identity = IdentityOf(bytes);
+        var policy = new TestBindingPolicy();
+        AssemblyContextParticipant healthy = Participant(
+            identity,
+            bytes,
+            openedCallback: null,
+            "healthy",
+            policy);
+        AssemblyContextParticipant rejected = Participant(
+            identity with { Name = "WrongIdentity" },
+            bytes,
+            openedCallback: null,
+            "rejected",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup beforeGroup = workspace.CreateAssemblyContextGroup(
+            [rejectBefore ? rejected : healthy]);
+        using AssemblyContextGroup afterGroup = workspace.CreateAssemblyContextGroup(
+            [rejectBefore ? healthy : rejected]);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            Assert.Single(beforeGroup.Participants),
+            afterGroup,
+            Assert.Single(afterGroup.Participants),
+            ApiSurfaceScope.Public,
+            GenerousLimits);
+
+        Assert.Null(result.Comparison);
+        Assert.False(result.IsComplete);
+        AssemblyContextApiComparisonEndpoint rejectedEndpoint =
+            rejectBefore ? result.Before : result.After;
+        AssemblyContextApiComparisonEndpoint healthyEndpoint =
+            rejectBefore ? result.After : result.Before;
+        Assert.False(rejectedEndpoint.IsComplete);
+        Assert.Equal("WrongIdentity", rejectedEndpoint.Subject.Identity.Name);
+        Assert.IsType<AssemblyContextEntry<AssemblyApiSurface>.Rejected>(
+            Assert.Single(rejectedEndpoint.Projection.Assemblies.Assemblies));
+        Assert.True(healthyEndpoint.IsComplete);
+        Assert.NotEmpty(Available(healthyEndpoint.Projection.Assemblies).Surface.Types);
+        WriteOutcome(rejectBefore ? "Rejected Before" : "Rejected After", result);
+    }
+
+    // A row-level inspection failure can leave the owning projection's own IsComplete true (the
+    // surface is the healthy subset beside a recorded failure); the comparison endpoint must
+    // still be incomplete and the comparison must not run, so a healthy subset never yields false
+    // additions or removals.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Execute_RowLevelInspectionFailure_SuppressesComparisonButRetainsFactsAndDiagnostics(
+        bool failBefore)
+    {
+        byte[] partialImage = AssemblyContextApiSurfaceQueryTests.BuildPartialSurfaceImage();
+        AssemblyReferenceIdentity partialIdentity = IdentityOf(partialImage);
+        byte[] healthyBytes = File.ReadAllBytes(SelfPath);
+        var policy = new TestBindingPolicy();
+        AssemblyContextParticipant partialParticipant = Participant(
+            partialIdentity,
+            partialImage,
+            openedCallback: null,
+            "partial",
+            policy);
+        AssemblyContextParticipant healthyParticipant = Participant(
+            IdentityOf(healthyBytes),
+            healthyBytes,
+            openedCallback: null,
+            "healthy",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup beforeGroup =
+            workspace.CreateAssemblyContextGroup(
+                [failBefore ? partialParticipant : healthyParticipant]);
+        using AssemblyContextGroup afterGroup =
+            workspace.CreateAssemblyContextGroup(
+                [failBefore ? healthyParticipant : partialParticipant]);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            Assert.Single(beforeGroup.Participants),
+            afterGroup,
+            Assert.Single(afterGroup.Participants),
+            ApiSurfaceScope.PublicWithNonPublicTypes,
+            GenerousLimits);
+        AssemblyContextApiComparisonEndpoint partial =
+            failBefore ? result.Before : result.After;
+        AssemblyContextApiComparisonEndpoint healthy =
+            failBefore ? result.After : result.Before;
+
+        // The owning surface projection is complete by its own contract: no bound was exceeded
+        // and every participant is Available.
+        Assert.Null(partial.Projection.Truncation);
+        Assert.True(partial.Projection.IsComplete);
+        AssemblyApiSurface partialSurface = Available(partial.Projection.Assemblies);
+        Assert.NotEmpty(partialSurface.InspectionFailures);
+        Assert.Contains(partialSurface.Surface.Types, type => type.Name == "Sibling");
+
+        // But the comparison endpoint itself must not claim completeness over a subset.
+        Assert.False(partial.IsComplete);
+        Assert.True(healthy.IsComplete);
+        Assert.Null(result.Comparison);
+        Assert.False(result.IsComplete);
+        WriteOutcome(failBefore ? "Row failure Before" : "Row failure After", result);
+    }
+
+    // Extraction bounds are explicit and per-endpoint: the same nominal per-type budget lets a
+    // small enough endpoint complete even though the paired endpoint on the other side overflowed
+    // it, proving the budget is never shared or halved across the pair.
+    [Fact]
+    public void Execute_TightBudget_OmitsOverflowingEndpointButRetainsItsSubjectIdentity()
+    {
+        byte[] overflowBytes = BuildTypedApiSurfaceImage(typeCount: 2, assemblyName: "Overflow");
+        byte[] fittingBytes = BuildTypedApiSurfaceImage(typeCount: 1, assemblyName: "Fitting");
+        var policy = new TestBindingPolicy();
+        AssemblyContextParticipant beforeParticipant = Participant(
+            IdentityOf(overflowBytes),
+            overflowBytes,
+            openedCallback: null,
+            "overflow",
+            policy);
+        AssemblyContextParticipant afterParticipant = Participant(
+            IdentityOf(fittingBytes),
+            fittingBytes,
+            openedCallback: null,
+            "fitting",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup beforeGroup =
+            workspace.CreateAssemblyContextGroup([beforeParticipant]);
+        using AssemblyContextGroup afterGroup =
+            workspace.CreateAssemblyContextGroup([afterParticipant]);
+        var tightLimits = new ApiSurfaceProjectionLimits(
+            64, maxTypes: 1, 1_000_000, int.MaxValue, int.MaxValue, int.MaxValue);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            beforeParticipant,
+            afterGroup,
+            afterParticipant,
+            ApiSurfaceScope.Public,
+            tightLimits);
+
+        Assert.False(result.Before.IsComplete);
+        Assert.Empty(result.Before.Projection.Assemblies.Assemblies);
+        Assert.NotNull(result.Before.Projection.Truncation);
+        // The subject survives even though every row of its projection was omitted.
+        Assert.Same(
+            beforeParticipant.Assembly.Registration,
+            result.Before.Subject.Registration);
+        Assert.Equal("Overflow", result.Before.Subject.Identity.Name);
+
+        // The opposite endpoint, under the identical nominal per-type budget, still completes:
+        // the budget was never spent by the omitted attempt on the other side.
+        Assert.True(result.After.IsComplete);
+        Assert.Null(result.After.Projection.Truncation);
+        Assert.Null(result.Comparison);
+        Assert.False(result.IsComplete);
+        WriteOutcome("Before type limit", result);
+    }
+
+    // Both endpoints get their full declared budget independently: an exact per-type bound that
+    // matches each image's own type count admits both sides, rather than the pair sharing one
+    // combined budget.
+    [Fact]
+    public void Execute_ExactPerEndpointLimits_AdmitBothEndpointsIndependently()
+    {
+        const int typeCount = 3;
+        byte[] bytes = BuildTypedApiSurfaceImage(typeCount, assemblyName: "ExactBudget");
+        AssemblyReferenceIdentity identity = IdentityOf(bytes);
+        var policy = new TestBindingPolicy();
+        AssemblyContextParticipant beforeParticipant = Participant(
+            identity,
+            bytes,
+            openedCallback: null,
+            "exact-before",
+            policy);
+        AssemblyContextParticipant afterParticipant = Participant(
+            identity,
+            bytes,
+            openedCallback: null,
+            "exact-after",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup beforeGroup =
+            workspace.CreateAssemblyContextGroup([beforeParticipant]);
+        using AssemblyContextGroup afterGroup =
+            workspace.CreateAssemblyContextGroup([afterParticipant]);
+        var exactLimits = new ApiSurfaceProjectionLimits(
+            64, maxTypes: typeCount, 1_000_000, int.MaxValue, int.MaxValue, int.MaxValue);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            beforeParticipant,
+            afterGroup,
+            afterParticipant,
+            ApiSurfaceScope.Public,
+            exactLimits);
+
+        Assert.Null(result.Before.Projection.Truncation);
+        Assert.Null(result.After.Projection.Truncation);
+        Assert.True(result.Before.IsComplete);
+        Assert.True(result.After.IsComplete);
+        Assert.Equal(typeCount, Available(result.Before.Projection.Assemblies).Surface.Types.Count);
+        Assert.Equal(typeCount, Available(result.After.Projection.Assemblies).Surface.Types.Count);
+        Assert.True(result.IsComplete);
+        Assert.True(result.IsExact);
+    }
+
+    // The requested scope applies identically to both endpoints: an include-all request reaches
+    // each side's non-public types, and the result reports the scope it was asked for.
+    [Fact]
+    public void Execute_RetainsTheRequestedScopeForBothEndpoints()
+    {
+        var policy = new TestBindingPolicy();
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup beforeGroup = SinglePathGroup(
+            workspace, SelfPath, "scope-before", policy);
+        using AssemblyContextGroup afterGroup = SinglePathGroup(
+            workspace, SelfPath, "scope-after", policy);
+        AssemblyContextParticipant beforeParticipant = Assert.Single(beforeGroup.Participants);
+        AssemblyContextParticipant afterParticipant = Assert.Single(afterGroup.Participants);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            beforeParticipant,
+            afterGroup,
+            afterParticipant,
+            ApiSurfaceScope.IncludeAll,
+            GenerousLimits);
+
+        Assert.Equal(ApiSurfaceScope.IncludeAll, result.Scope);
+        Assert.Contains(
+            Available(result.Before.Projection.Assemblies).Surface.Types,
+            type => type.Name == nameof(ApiSurfaceInternalProbe));
+        Assert.Contains(
+            Available(result.After.Projection.Assemblies).Surface.Types,
+            type => type.Name == nameof(ApiSurfaceInternalProbe));
+        Assert.True(result.IsExact);
+    }
+
+    [Fact]
+    public void Execute_ThrowsForNullArguments()
+    {
+        var policy = new TestBindingPolicy();
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group = SinglePathGroup(
+            workspace, SelfPath, "null-args", policy);
+        AssemblyContextParticipant participant = Assert.Single(group.Participants);
+
+        Assert.Throws<ArgumentNullException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                null!, participant, group, participant, ApiSurfaceScope.Public, GenerousLimits));
+        Assert.Throws<ArgumentNullException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                group, null!, group, participant, ApiSurfaceScope.Public, GenerousLimits));
+        Assert.Throws<ArgumentNullException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                group, participant, null!, participant, ApiSurfaceScope.Public, GenerousLimits));
+        Assert.Throws<ArgumentNullException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                group, participant, group, null!, ApiSurfaceScope.Public, GenerousLimits));
+        Assert.Throws<ArgumentNullException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                group, participant, group, participant, ApiSurfaceScope.Public, null!));
+    }
+
+    [Fact]
+    public void Execute_ThrowsForUndefinedScope()
+    {
+        var policy = new TestBindingPolicy();
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group = SinglePathGroup(
+            workspace, SelfPath, "undefined-scope", policy);
+        AssemblyContextParticipant participant = Assert.Single(group.Participants);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                group,
+                participant,
+                group,
+                participant,
+                (ApiSurfaceScope)99,
+                GenerousLimits));
+    }
+
+    [Fact]
+    public void Execute_ThrowsWhenAParticipantIsNotAMemberOfItsGroup()
+    {
+        var policy = new TestBindingPolicy();
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup groupA = SinglePathGroup(
+            workspace, SelfPath, "membership-a", policy);
+        using AssemblyContextGroup groupB = SinglePathGroup(
+            workspace, SelfPath, "membership-b", policy);
+        AssemblyContextParticipant participantA = Assert.Single(groupA.Participants);
+        AssemblyContextParticipant participantB = Assert.Single(groupB.Participants);
+
+        Assert.Throws<ArgumentException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                groupA,
+                participantB,
+                groupB,
+                participantB,
+                ApiSurfaceScope.Public,
+                GenerousLimits));
+        Assert.Throws<ArgumentException>(
+            () => AssemblyContextApiComparisonQuery.Execute(
+                groupA,
+                participantA,
+                groupB,
+                participantA,
+                ApiSurfaceScope.Public,
+                GenerousLimits));
+    }
+
+    [Fact]
+    public void Definition_UsesTheDeclaredNameAndNetworkFreeCostThroughTheRegistry()
+    {
+        Assert.Equal(
+            "Assembly context API comparison",
+            AssemblyContextApiComparisonQuery.Definition.Name);
+        Assert.Equal(
+            InspectionCost.NetworkFree,
+            AssemblyContextApiComparisonQuery.Definition.Cost);
+
+        var policy = new TestBindingPolicy();
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group = SinglePathGroup(
+            workspace, SelfPath, "registry", policy);
+        AssemblyContextParticipant participant = Assert.Single(group.Participants);
+        var registry = new InspectionQueryRegistry<ComparisonContext>()
+            .Add(
+                AssemblyContextApiComparisonQuery.Definition,
+                static (context, _) => AssemblyContextApiComparisonQuery.Execute(
+                    context.BeforeGroup,
+                    context.BeforeParticipant,
+                    context.AfterGroup,
+                    context.AfterParticipant,
+                    context.Scope,
+                    context.Limits));
+
+        InspectionQueryResults results = registry.Run(
+            [AssemblyContextApiComparisonQuery.Definition],
+            new ComparisonContext(
+                group, participant, group, participant, ApiSurfaceScope.Public, GenerousLimits));
+
+        Assert.Same(
+            results.Get(AssemblyContextApiComparisonQuery.Definition),
+            results.Get(AssemblyContextApiComparisonQuery.Definition));
+        Assert.Equal(
+            InspectionCost.NetworkFree,
+            registry.CostOf(AssemblyContextApiComparisonQuery.Definition));
+    }
+
+    sealed record ComparisonContext(
+        AssemblyContextGroup BeforeGroup,
+        AssemblyContextParticipant BeforeParticipant,
+        AssemblyContextGroup AfterGroup,
+        AssemblyContextParticipant AfterParticipant,
+        ApiSurfaceScope Scope,
+        ApiSurfaceProjectionLimits Limits);
+
+    void WriteOutcome(string label, AssemblyContextApiComparisonResult result)
+        => output.WriteLine(
+            $"{label}: complete={result.IsComplete}, exact={result.IsExact}, "
+            + $"Before API complete={result.Before.IsComplete}, "
+            + $"After API complete={result.After.IsComplete}, "
+            + $"comparison={result.Comparison is not null}");
+
+    static string SelfPath =>
+        typeof(AssemblyContextApiComparisonQueryTests).Assembly.Location;
+
+    static AssemblyContextGroup SinglePathGroup(
+        InspectionWorkspace workspace,
+        string path,
+        string provenanceLabel,
+        IAssemblyBindingPolicy policy)
+        => workspace.CreateAssemblyContextGroup(
+            [
+                new AssemblyContextParticipant(
+                    ResolvedAssemblyReference.CreateFromPath(
+                        path,
+                        AssemblyResolutionProvenance.Local(provenanceLabel)),
+                    policy),
+            ]);
+
+    static AssemblyContextParticipant Participant(
+        AssemblyReferenceIdentity identity,
+        byte[] bytes,
+        Action? openedCallback,
+        string provenanceLabel,
+        IAssemblyBindingPolicy policy)
+        => new(
+            ResolvedAssemblyReference.Create(
+                identity,
+                path: null,
+                () =>
+                {
+                    openedCallback?.Invoke();
+                    return new MemoryStream(bytes, writable: false);
+                },
+                AssemblyResolutionProvenance.Local(provenanceLabel)),
+            policy);
+
+    static AssemblyReferenceIdentity IdentityOf(byte[] bytes)
+    {
+        using var reader = new PEReader(new MemoryStream(bytes, writable: false));
+        return AssemblyReferenceIdentity.FromAssemblyDefinition(reader.GetMetadataReader());
+    }
+
+    static AssemblyApiSurface Available(AssemblyContextResult<AssemblyApiSurface> result)
+        => Assert.IsType<AssemblyContextEntry<AssemblyApiSurface>.Available>(
+                Assert.Single(result.Assemblies))
+            .Value;
+
+    /// <summary>
+    /// A minimal public API surface with exactly <paramref name="typeCount"/> public types and no
+    /// forwarders, interfaces, or members. Deliberately smaller than
+    /// <c>AssemblyContextApiSurfaceQueryTests.BuildBoundedSurfaceImage</c> — this query's tests
+    /// only need explicit control over the projected type count, not that helper's forwarder and
+    /// interface shapes.
+    /// </summary>
+    static byte[] BuildTypedApiSurfaceImage(int typeCount, string assemblyName = "ComparisonBudget")
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString(assemblyName + ".dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        for (int index = 0; index < typeCount; index++)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("ComparisonBudgetTypes"),
+                metadata.GetOrAddString($"Type{index}"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    sealed class TestBindingPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+            => new(
+                Version,
+                AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind.CandidateUnavailable)));
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextApiComparisonQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextApiComparisonQueryTests.cs
@@ -313,6 +313,61 @@ public sealed class AssemblyContextApiComparisonQueryTests(ITestOutputHelper out
         WriteOutcome(failBefore ? "Row failure Before" : "Row failure After", result);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Execute_DegradedSignature_SuppressesComparisonButRetainsEndpointEvidence(
+        bool degradeBefore)
+    {
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).FieldSignature().Object();
+        var guardedSignature = new BlobBuilder();
+        SignatureTypeEncoder fieldType = new BlobEncoder(guardedSignature).FieldSignature();
+        for (int depth = 0; depth <= SignatureBlobGuard.DefaultMaxDepth; depth++)
+            fieldType = fieldType.SZArray();
+        fieldType.Object();
+        byte[] degradedImage = BuildTypedApiSurfaceImage(
+            1, "SignatureComparison", guardedSignature.ToArray());
+        byte[] healthyImage = BuildTypedApiSurfaceImage(
+            1, "SignatureComparison", signature.ToArray());
+        var policy = new TestBindingPolicy();
+        AssemblyContextParticipant degradedParticipant = Participant(
+            IdentityOf(degradedImage), degradedImage, null, "degraded", policy);
+        AssemblyContextParticipant healthyParticipant = Participant(
+            IdentityOf(healthyImage), healthyImage, null, "healthy", policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup beforeGroup = workspace.CreateAssemblyContextGroup(
+            [degradeBefore ? degradedParticipant : healthyParticipant]);
+        using AssemblyContextGroup afterGroup = workspace.CreateAssemblyContextGroup(
+            [degradeBefore ? healthyParticipant : degradedParticipant]);
+
+        AssemblyContextApiComparisonResult result = AssemblyContextApiComparisonQuery.Execute(
+            beforeGroup,
+            Assert.Single(beforeGroup.Participants),
+            afterGroup,
+            Assert.Single(afterGroup.Participants),
+            ApiSurfaceScope.Public,
+            GenerousLimits);
+        AssemblyContextApiComparisonEndpoint degraded =
+            degradeBefore ? result.Before : result.After;
+        AssemblyContextApiComparisonEndpoint healthy =
+            degradeBefore ? result.After : result.Before;
+        AssemblyApiSurface degradedSurface = Available(degraded.Projection.Assemblies);
+        Assert.True(degraded.Projection.IsComplete);
+        Assert.Empty(degradedSurface.InspectionFailures);
+        ApiType degradedType = Assert.Single(degradedSurface.Surface.Types);
+        ApiMember degradedMember = Assert.Single(degradedType.Members);
+        Assert.Equal(SignatureDecodeStatus.Degraded, degradedMember.SignatureDecodeStatus);
+        Assert.Same(degradedParticipant.Assembly.Registration, degraded.Subject.Registration);
+        WriteOutcome(degradeBefore ? "Degraded signature Before" : "Degraded signature After", result);
+
+        Assert.False(degraded.IsComplete);
+        Assert.True(healthy.IsComplete);
+        Assert.Null(result.Comparison);
+        Assert.False(result.IsComplete);
+        Assert.False(result.IsExact);
+    }
+
     // Extraction bounds are explicit and per-endpoint: the same nominal per-type budget lets a
     // small enough endpoint complete even though the paired endpoint on the other side overflowed
     // it, proving the budget is never shared or halved across the pair.
@@ -624,13 +679,13 @@ public sealed class AssemblyContextApiComparisonQueryTests(ITestOutputHelper out
             .Value;
 
     /// <summary>
-    /// A minimal public API surface with exactly <paramref name="typeCount"/> public types and no
-    /// forwarders, interfaces, or members. Deliberately smaller than
-    /// <c>AssemblyContextApiSurfaceQueryTests.BuildBoundedSurfaceImage</c> — this query's tests
-    /// only need explicit control over the projected type count, not that helper's forwarder and
-    /// interface shapes.
+    /// A minimal public API surface with exactly <paramref name="typeCount"/> public types,
+    /// an optional field on the last type, and no forwarders or interfaces.
     /// </summary>
-    static byte[] BuildTypedApiSurfaceImage(int typeCount, string assemblyName = "ComparisonBudget")
+    static byte[] BuildTypedApiSurfaceImage(
+        int typeCount,
+        string assemblyName = "ComparisonBudget",
+        byte[]? fieldSignature = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -662,6 +717,14 @@ public sealed class AssemblyContextApiComparisonQueryTests(ITestOutputHelper out
                 baseType: default,
                 fieldList: MetadataTokens.FieldDefinitionHandle(1),
                 methodList: MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        if (fieldSignature is not null)
+        {
+            metadata.AddFieldDefinition(
+                FieldAttributes.Public,
+                metadata.GetOrAddString("Value"),
+                metadata.GetOrAddBlob(fieldSignature));
         }
 
         var pe = new ManagedPEBuilder(

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextApiSurfaceQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextApiSurfaceQueryTests.cs
@@ -1183,7 +1183,9 @@ public sealed class AssemblyContextApiSurfaceQueryTests
                 Assert.Single(result.Assemblies))
             .Value;
 
-    static byte[] BuildPartialSurfaceImage(int cyclicTypeCount = 1)
+    // Internal (not private) so AssemblyContextApiComparisonQueryTests can reuse this synthetic
+    // partial-surface image instead of duplicating this builder.
+    internal static byte[] BuildPartialSurfaceImage(int cyclicTypeCount = 1)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(

--- a/src/DotnetInspector.Queries/AssemblyContextApiComparisonQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextApiComparisonQuery.cs
@@ -23,6 +23,8 @@ public sealed class AssemblyContextApiComparisonEndpoint
         && Projection.Assemblies.Assemblies is
             [AssemblyContextEntry<AssemblyApiSurface>.Available available]
         && available.Value.InspectionFailures.IsEmpty
+        && available.Value.Surface.Types.All(type =>
+            type.Members.All(member => member.SignatureDecodeStatus is null))
             ? available.Value.Surface
             : null;
 }

--- a/src/DotnetInspector.Queries/AssemblyContextApiComparisonQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextApiComparisonQuery.cs
@@ -1,0 +1,114 @@
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>One selected library and its bounded API projection.</summary>
+public sealed class AssemblyContextApiComparisonEndpoint
+{
+    internal AssemblyContextApiComparisonEndpoint(
+        AssemblyContextSubject subject,
+        AssemblyContextApiSurfaceResult projection)
+    {
+        Subject = subject;
+        Projection = projection;
+    }
+
+    public AssemblyContextSubject Subject { get; }
+    public AssemblyContextApiSurfaceResult Projection { get; }
+    public bool IsComplete => CompleteSurface is not null;
+
+    internal ApiSurface? CompleteSurface =>
+        Projection.Truncation is null
+        && Projection.Assemblies.Assemblies is
+            [AssemblyContextEntry<AssemblyApiSurface>.Available available]
+        && available.Value.InspectionFailures.IsEmpty
+            ? available.Value.Surface
+            : null;
+}
+
+/// <summary>
+/// The ordered endpoint evidence and, only for fully projected inputs, their
+/// Metadata-owned API comparison.
+/// </summary>
+public sealed class AssemblyContextApiComparisonResult
+{
+    internal AssemblyContextApiComparisonResult(
+        ApiSurfaceScope scope,
+        AssemblyContextApiComparisonEndpoint before,
+        AssemblyContextApiComparisonEndpoint after,
+        ApiFindingComparison? comparison)
+    {
+        Scope = scope;
+        Before = before;
+        After = after;
+        Comparison = comparison;
+    }
+
+    public ApiSurfaceScope Scope { get; }
+    public AssemblyContextApiComparisonEndpoint Before { get; }
+    public AssemblyContextApiComparisonEndpoint After { get; }
+    public ApiFindingComparison? Comparison { get; }
+    public bool IsComplete =>
+        Comparison is
+        {
+            Types.Value: FindingComparison<ApiTypeHandle>.Complete,
+            Members.Value: FindingComparison<ApiMemberHandle>.Complete,
+        };
+    public bool IsExact => IsComplete && Comparison is { IsExact: true };
+}
+
+/// <summary>
+/// Compares two explicitly selected libraries in retained contexts. Each side
+/// receives the full caller-declared projection budget independently.
+/// </summary>
+public static class AssemblyContextApiComparisonQuery
+{
+    public static InspectionQuery<AssemblyContextApiComparisonResult> Definition
+    { get; } = new(
+        "Assembly context API comparison",
+        InspectionCost.NetworkFree);
+
+    public static AssemblyContextApiComparisonResult Execute(
+        AssemblyContextGroup beforeGroup,
+        AssemblyContextParticipant beforeParticipant,
+        AssemblyContextGroup afterGroup,
+        AssemblyContextParticipant afterParticipant,
+        ApiSurfaceScope scope,
+        ApiSurfaceProjectionLimits perEndpointLimits)
+    {
+        ArgumentNullException.ThrowIfNull(beforeGroup);
+        ArgumentNullException.ThrowIfNull(beforeParticipant);
+        ArgumentNullException.ThrowIfNull(afterGroup);
+        ArgumentNullException.ThrowIfNull(afterParticipant);
+        ArgumentNullException.ThrowIfNull(perEndpointLimits);
+        if (!Enum.IsDefined(scope))
+            throw new ArgumentOutOfRangeException(nameof(scope));
+
+        AssemblyContextApiComparisonEndpoint before =
+            Project(beforeGroup, beforeParticipant, scope, perEndpointLimits);
+        AssemblyContextApiComparisonEndpoint after =
+            Project(afterGroup, afterParticipant, scope, perEndpointLimits);
+
+        ApiFindingComparison? comparison =
+            before.CompleteSurface is { } beforeSurface
+            && after.CompleteSurface is { } afterSurface
+                ? ApiComparisonQuery.Execute(beforeSurface, afterSurface)
+                : null;
+
+        return new(scope, before, after, comparison);
+    }
+
+    static AssemblyContextApiComparisonEndpoint Project(
+        AssemblyContextGroup group,
+        AssemblyContextParticipant participant,
+        ApiSurfaceScope scope,
+        ApiSurfaceProjectionLimits limits)
+        => new(
+            new AssemblyContextSubject(participant.Assembly),
+            AssemblyContextApiSurfaceQuery.ExecuteBounded(
+                group,
+                scope,
+                limits,
+                [participant]));
+}


### PR DESCRIPTION
# Selected-library API comparison

Add an ordered, bounded Queries operation for two explicitly selected library
participants in retained assembly contexts. Compare only when both API surfaces
are fully projected; retain both endpoint outcomes when either is unavailable,
limited, has failed API rows, or carries a degraded member signature.

Closes #6119. This is the selected-library producer slice of #5104 and the
Library Diff experience in #5083, not a browser inspector or whole-package
library-pairing implementation.

## Demo

The direct product query takes already-selected participants, not package
coordinates or display names:

```csharp
AssemblyContextApiComparisonResult result =
    AssemblyContextApiComparisonQuery.Execute(
        beforeGroup, beforeParticipant,
        afterGroup, afterParticipant,
        ApiSurfaceScope.Public,
        perEndpointLimits);
```

Run the committed query demo against the real DiffV1/DiffV2 fixture assemblies
and neighboring empty, rejected, row-failure, degraded-signature, and bounded
inputs:

```sh
dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
  -class DotnetInspector.Queries.Tests.AssemblyContextApiComparisonQueryTests \
  -showLiveOutput
```

Captured query output, with test-runner prefixes omitted:

```text
Fixture version pair: complete=True, exact=False, Before API complete=True, After API complete=True, comparison=True
DiffFixtureSample.MethodRemovalSample: Breaking/MemberRemoved, Breaking/MemberRemoved
DiffFixtureSample.BodyStateSample: Additive/AbstractRemoved, Breaking/VirtualRemoved, Additive/MemberAdded
Same image, distinct registrations: complete=True, exact=True, Before API complete=True, After API complete=True, comparison=True
Empty public API: complete=True, exact=True, Before API complete=True, After API complete=True, comparison=True
Rejected Before: complete=False, exact=False, Before API complete=False, After API complete=True, comparison=False
Before type limit: complete=False, exact=False, Before API complete=False, After API complete=True, comparison=False
Row failure Before: complete=False, exact=False, Before API complete=False, After API complete=True, comparison=False
```

Notice that compatibility classifications come from Metadata unchanged.
A truly empty public API remains comparable, while incomplete evidence does
not turn into apparent additions, removals, or equality. The row-failure case
is especially important: its underlying projection is Available and reports
its own extraction complete, but also carries a failed API row. The new
comparison admission checks that distinction and preserves the healthy
opposite endpoint. Both Before and After failure directions are covered.

This is a reproducible query-API demo, not a CLI command or website UI demo.

### Review-driven completeness fix

Round 1 identified that a guarded signature substitution can be retained as
`ApiMember.SignatureDecodeStatus.Degraded` without a row failure. The new
regression case uses product extraction and comparison, not a hand-constructed
comparison result.

Before the admission repair:

```text
Degraded signature Before: complete=True, exact=True, Before API complete=True, After API complete=True, comparison=True
Degraded signature After: complete=True, exact=True, Before API complete=True, After API complete=True, comparison=True
```

After the repair:

```text
Degraded signature Before: complete=False, exact=False, Before API complete=False, After API complete=True, comparison=False
Degraded signature After: complete=False, exact=False, Before API complete=True, After API complete=False, comparison=False
```

The endpoint still retains the available surface and its decode status, while
comparison no longer turns substituted evidence into apparent equality.
Healthy and genuinely empty comparisons remain unchanged.

## Design basis

**Normative owner:** `docs/inspection-space.md#selected-library-api-comparison`.
The owned claim is ordered, selected-participant comparison with independent
per-endpoint bounds and comparison admission only for fully projected APIs.

Supporting contracts and evidence:

- `AssemblyContextApiSurfaceQuery` owns selected-participant extraction,
  typed acquisition/projection outcomes, and extraction limits. The query
  reuses its bounded subset operation without shrinking binding context.
- `ApiComparisonQuery` and Metadata own signature-level type/member Finding
  correspondence, compatibility classification, and exactness.
- `AssemblyContextSubject` retains the selected registration, identity, and
  provenance even when its projection was omitted.
- `docs/design/inspection-layers.md` records implementation status and links
  the owner; it does not establish a second normative contract.
- The existing raw-surface comparator is the analogous implementation.
  Its intentional healthy-subset behavior remains unchanged. The deliberate
  stricter admission here serves the exhaustive Library API Diff contract.

The smallest sufficient composition is one coordinator and ordered endpoint
evidence. There is no new comparison algorithm or replacement architecture.
The supported caller supplies retained groups, exact participant objects,
visibility scope, and an explicit budget. It receives the original typed
outcomes rather than having failures normalized into empty surfaces.

## Consumer and delivery boundary

The end-to-end browser tracker is #5083, with three deliveries:

1. This selected-library API query.
2. Package-scoped comparison selection and defaults.
3. A feature facade with its immediate Library API Diff inventory/detail UI.

The production CLI already consumes the shared Metadata comparison through
`ApiComparisonQuery`. Its path-based acquisition and raw-surface behavior are
unchanged; moving CLI acquisition to retained contexts is a separate migration,
not an adopter claimed by this PR.

Package-version selection, cross-version library counterpart selection, JSON
transport, browser state, rendering, immersive type-pair viewing, and Clone
remain outside this slice. The result is scoped to API signatures, not
attributes, implementation bodies, IL, or authored-source changes.

Rendering strategy is not changed: this slice returns native typed query
evidence and introduces no renderer or host-specific presentation shape.

## Validation

The focused Release invocation passed all **44** cases:

```sh
dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
  -class DotnetInspector.Queries.Tests.AssemblyContextApiComparisonQueryTests \
  -class DotnetInspector.Queries.Tests.ApiComparisonQueryTests \
  -class DotnetInspector.Queries.Tests.AssemblyContextApiSurfaceQueryTests \
  -showLiveOutput
```

Coverage includes native fixture classifications, identical inputs in distinct
groups, unselected decoys, ordered identities, valid empty APIs, both rejected,
row-failed, and degraded-signature endpoint directions, independent exact-fit budgets, a limited
endpoint beside a complete one, visibility scope, and invalid caller arguments.
The existing extraction and comparator suites remain the owners of their
respective lower-level behavior.

```sh
npx --no-install markdownlint-cli \
  docs/inspection-space.md docs/design/inspection-layers.md
git diff --check
```
