### PR TITLE
Preserve source-client association in Browser package retention

### DIFF
--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -1380,6 +1380,10 @@ reuse and separation;
 independent reservations under the global package and byte limits; and
 `BrowserWorkspace_DistinctClientsKeepScopesAndArchiveLeasesSeparate` for
 workspace reuse, retirement, and archive leases across those acquisitions.
+The coordinate-only method-body exports resolve retained scopes through the
+production Gallery client association, not through a source-agnostic key.
+`BrowserMethodBodyOperationTests` gates that retained lookup, including missing
+contexts, removal-requested scopes, and ambiguous content generations.
 Configured-authority retirement and result admission remain separate
 obligations of the live registry adoption in [#5637][browser-adoption].
 

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -1354,6 +1354,37 @@ Symbol packages have independent provenance. NuGet Gallery's known symbol CDN
 is a Gallery capability. A custom v3 feed does not acquire symbols from
 NuGet.org merely because the same package ID exists there.
 
+### Browser retained-acquisition association
+
+The selected runtime-client association survives completion of a Browser
+acquisition. Payload-cache entries, download reservations, archive leases, and
+workspace reuse retain that association alongside the exact coordinate.
+Repeating an acquisition through the same client may reuse its retained
+content; a distinct client cannot answer from, overwrite, or join that content
+merely because the coordinate or producer matches.
+
+This consumes the same exact client-reference currency as pending acquisition.
+Any Browser-issued namespace needed by internal scope keys is session-local,
+not producer identity, a configured endpoint, or portable configuration.
+Package composition may supply one composed client when it establishes
+authority equivalence; Browser does not establish that equivalence itself.
+Package, byte, and scope limits remain aggregate session limits rather than
+separate allowances for each client.
+
+The Release `BrowserEngineBoundaryTests` gates are
+`PackageAcquisition_SameClientReusesCompletedPayload`,
+`PackageAcquisition_DistinctSameProducerClientsRetainTheirOwnPayloads`, and
+`PackageQueryContent_UsesTheSelectedClientsCompletedCache` for completed-cache
+reuse and separation;
+`PackageAcquisition_DistinctClientReservationsShareGlobalBudget` for
+independent reservations under the global package and byte limits; and
+`BrowserWorkspace_DistinctClientsKeepScopesAndArchiveLeasesSeparate` for
+workspace reuse, retirement, and archive leases across those acquisitions.
+Configured-authority retirement and result admission remain separate
+obligations of the live registry adoption in [#5637][browser-adoption].
+
+[browser-adoption]: https://github.com/richlander/dotnet-inspect/issues/5637
+
 ## Timeout ownership
 
 JavaScript cancellation is a host convenience, not the reliability boundary.
@@ -1702,6 +1733,13 @@ unavailable from a selected mirror is shown as a source-specific availability
 fact, not as a contradictory global package state.
 
 ## Implementation direction
+
+Production Browser adoption is tracked in [#5637][browser-adoption] in three
+steps: client-associated retained acquisition, live configured-authority and
+engine-operation adoption, and Settings integration with Browser/Wasm
+end-to-end coverage. The retained-acquisition step keeps Gallery as the
+production source; it does not expose configured feeds or session PATs before
+their complete configuration and operation paths are available.
 
 The existing NuGetFetch shape is a useful base:
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -129,6 +129,9 @@ A workspace is **keyed by its complete exact coordinate set and reused**. The
 package surface, a type projection, an annotated member, Integrations,
 Opportunities, and a composite call-graph workspace over several packages all
 reach the same open group rather than reacquiring every image.
+Retained packages and workspace reuse preserve the selected source-client
+association: matching package coordinates or producer identities do not merge
+distinct clients. Cache and scope limits remain aggregate session limits.
 `BrowserPackageWorkspace` keeps at most four scopes and disposes the least
 recently used one on eviction, which is what returns its retained image bytes.
 Opening, evicting, removing, and releasing the last protected use of a scope

--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -129,7 +129,9 @@ internal static class BrowserPackageWorkspace
                 RequestTimeout = GalleryOperationTimeout,
                 OperationTimeout = GalleryOperationTimeout,
             });
-    static readonly BrowserSessionPackageStore Store = new();
+    static readonly ConditionalWeakTable<IPackageSourceClient, BrowserSessionPackageStore>
+        SourceStores = new();
+    static readonly BrowserSessionPackageStore Store = StoreFor(Gallery);
     static readonly PackagePayloadLimits PayloadLimits = new()
     {
         MaxArchiveBytes = MaxCachedPackageBytes,
@@ -164,6 +166,9 @@ internal static class BrowserPackageWorkspace
     internal static IPackagePayloadTransferPolicy PackageTransferPolicy =>
         Store;
     internal static PackagePayloadLimits PackageLimits => PayloadLimits;
+
+    static BrowserSessionPackageStore StoreFor(IPackageSourceClient source) =>
+        SourceStores.GetValue(source, static _ => new BrowserSessionPackageStore());
 
     sealed record CacheEntry
     {
@@ -264,8 +269,11 @@ internal static class BrowserPackageWorkspace
             source,
             resolutionCancellation.Token).ConfigureAwait(false);
 
-        string key = PackageKey(coordinate.PackageId, coordinate.Version);
-        var pendingKey = new PendingAcquisitionKey(key, source);
+        BrowserSessionPackageStore store = StoreFor(source);
+        string key = store.PackageKey(coordinate.PackageId, coordinate.Version);
+        var pendingKey = new PendingAcquisitionKey(
+            CoordinateKey(coordinate.PackageId, coordinate.Version),
+            source);
         if (!PendingAcquisitions.TryGetValue(
                 pendingKey,
                 out Task<AcquiredPackageSourcePayload>? pending))
@@ -303,7 +311,8 @@ internal static class BrowserPackageWorkspace
         return new BrowserPackage(
             packageId,
             payload,
-            cached.Bytes);
+            cached.Bytes,
+            store);
     }
 
     static async Task<PackageSourceCoordinate> ResolveCoordinateAsync(
@@ -1029,13 +1038,24 @@ internal static class BrowserPackageWorkspace
                 request.Version,
                 cancellationToken)
             .ConfigureAwait(false);
+        return await OpenScopeAsync(package, request.TargetFramework, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    internal static async Task<BrowserScopeLease<BrowserInspectionScope>> OpenScopeAsync(
+        BrowserPackage package,
+        string? targetFramework,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        cancellationToken.ThrowIfCancellationRequested();
         string packageKey = PackageKey(package);
         using var acquired = new PackageLeaseSet();
         acquired.Lease(packageKey);
 
         var demand = new UnboundScopeDemand(
             packageKey,
-            SelectionRequestToken(request.TargetFramework),
+            SelectionRequestToken(targetFramework),
             package.Content.ProducerKey,
             package.Content.GenerationIdentity);
         ScopeAdmission admission = await ReserveScopeEntryAsync(
@@ -1055,7 +1075,7 @@ internal static class BrowserPackageWorkspace
         {
             coordinate = new BrowserPackageCoordinate(
                 package,
-                package.CreateRootBinding(request.TargetFramework));
+                package.CreateRootBinding(targetFramework));
             RetainCoordinatePackages([coordinate]);
         }
         catch
@@ -1132,6 +1152,7 @@ internal static class BrowserPackageWorkspace
         PackageSourceCoordinate coordinate,
         IPackageSourceClient source,
         PackageSourceIdentity configuredSourceIdentity,
+        BrowserSessionPackageStore store,
         CancellationToken cancellationToken,
         IPackagePayloadTransferPolicy transferPolicy)
     {
@@ -1140,7 +1161,7 @@ internal static class BrowserPackageWorkspace
             source,
             configuredSourceIdentity,
             coordinate,
-            Store,
+            store,
             limits: PayloadLimits,
             cancellationToken: cancellationToken,
             transferPolicy: transferPolicy).ConfigureAwait(false);
@@ -1181,6 +1202,7 @@ internal static class BrowserPackageWorkspace
         PackageSourceCoordinate coordinate = PackageSourceCoordinate.Create(
             package.PackageId,
             package.Version);
+        BrowserSessionPackageStore store = StoreFor(source);
 
         PackageSourcePayloadResult result;
         try
@@ -1189,12 +1211,12 @@ internal static class BrowserPackageWorkspace
                     source,
                     configuredSourceIdentity,
                     coordinate,
-                    Store,
+                    store,
                     limits: PayloadLimits,
                     cancellationToken: deadline.Token,
                     transferPolicy: new BrowserPackageQueryTransferPolicy(
                         new BrowserPackageOperationTransferPolicy(
-                            Store,
+                            store,
                             deadline)))
                 .ConfigureAwait(false);
         }
@@ -1285,17 +1307,21 @@ internal static class BrowserPackageWorkspace
         PackageSourceCoordinate coordinate,
         IPackageSourceClient source,
         PackageSourceIdentity configuredSourceIdentity,
-        TimeSpan timeout) =>
-        RunPackageOperationAsync(
+        TimeSpan timeout)
+    {
+        BrowserSessionPackageStore store = StoreFor(source);
+        return RunPackageOperationAsync(
             deadline => AcquirePayloadAsync(
                 coordinate,
                 source,
                 configuredSourceIdentity,
+                store,
                 deadline.Token,
                 new BrowserPackageOperationTransferPolicy(
-                    Store,
+                    store,
                     deadline)),
             timeout);
+    }
 
     internal static Task<string[]> GetVersionsAsync(string packageId) =>
         GetVersionsAsync(
@@ -2041,7 +2067,7 @@ internal static class BrowserPackageWorkspace
         BrowserPackage package)
     {
         ArgumentNullException.ThrowIfNull(package);
-        string key = PackageKey(package.PackageId, package.Version);
+        string key = PackageKey(package);
         Cache.Remove(key);
         while (!HasCacheRoom(package.RetainedBytes.LongLength, additionalEntries: 1))
         {
@@ -2072,12 +2098,15 @@ internal static class BrowserPackageWorkspace
     }
 
     static string PackageKey(BrowserPackageCoordinate coordinate) =>
-        PackageKey(coordinate.PackageId, coordinate.Version);
+        PackageKey(coordinate.Package);
 
     static string PackageKey(BrowserPackage package) =>
-        PackageKey(package.PackageId, package.Version);
+        package.CacheKey;
 
     internal static string PackageKey(string packageId, string version) =>
+        Store.PackageKey(packageId, version);
+
+    static string CoordinateKey(string packageId, string version) =>
         $"{packageId.ToLowerInvariant()}@{version.ToLowerInvariant()}";
 
     internal static string PackageScopeKey(
@@ -2113,9 +2142,16 @@ internal static class BrowserPackageWorkspace
         }
     }
 
-    sealed class BrowserSessionPackageStore
+    internal sealed class BrowserSessionPackageStore
         : IPackageStore, IPackagePayloadTransferPolicy
     {
+        // This namespace represents one exact runtime client, not its producer or endpoint.
+        // Only the adapter is per-client; all retained state and budgets remain session-wide.
+        readonly string _cacheNamespace = Guid.NewGuid().ToString("N");
+
+        internal string PackageKey(string packageId, string version) =>
+            CompositeKey(_cacheNamespace, CoordinateKey(packageId, version));
+
         public IPackageContent? TryGetCached(
             string packageName,
             string version,
@@ -2530,6 +2566,7 @@ internal sealed class BrowserPackage
         BrowserPackageWorkspace.ValidateArchive(retainedBytes);
         PackageId = packageId;
         Version = version;
+        CacheKey = BrowserPackageWorkspace.PackageKey(packageId, version);
         RetainedBytes = retainedBytes;
         Content = InMemoryPackageContent.CreateOwned(
             retainedBytes,
@@ -2541,11 +2578,13 @@ internal sealed class BrowserPackage
     internal BrowserPackage(
         string requestedPackageId,
         AcquiredPackageSourcePayload acquiredPayload,
-        byte[] retainedBytes)
+        byte[] retainedBytes,
+        BrowserPackageWorkspace.BrowserSessionPackageStore store)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(requestedPackageId);
         ArgumentNullException.ThrowIfNull(acquiredPayload);
         ArgumentNullException.ThrowIfNull(retainedBytes);
+        ArgumentNullException.ThrowIfNull(store);
         if (!requestedPackageId.Equals(
                 acquiredPayload.Coordinate.PackageId,
                 StringComparison.OrdinalIgnoreCase))
@@ -2564,6 +2603,7 @@ internal sealed class BrowserPackage
         BrowserPackageWorkspace.ValidateArchive(retainedBytes);
         PackageId = requestedPackageId;
         Version = acquiredPayload.Coordinate.Version;
+        CacheKey = store.PackageKey(PackageId, Version);
         RetainedBytes = retainedBytes;
         Content = content;
         _acquiredPayload = acquiredPayload;
@@ -2577,6 +2617,8 @@ internal sealed class BrowserPackage
     public InMemoryPackageContent Content { get; }
 
     internal byte[] RetainedBytes { get; }
+
+    internal string CacheKey { get; }
 
     public BrowserPackageIconPayload? Icon => _icon.Value;
 
@@ -2809,13 +2851,12 @@ internal sealed class BrowserPackageCoordinate
         ?? "";
 
     /// <summary>
-    /// The exact coordinate this workspace answers for. Each component is length-prefixed so
-    /// caller-controlled framework text cannot alter coordinate or workspace key boundaries.
+    /// The source-associated coordinate this workspace answers for. Each component is
+    /// length-prefixed so caller-controlled framework text cannot alter key boundaries.
     /// </summary>
     public string Key =>
         BrowserPackageWorkspace.CompositeKey(
-            PackageId.ToLowerInvariant(),
-            Version.ToLowerInvariant(),
+            Package.CacheKey,
             Framework.ToLowerInvariant());
 
     public bool HasExactContentAs(BrowserPackageCoordinate other)

--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -903,8 +903,9 @@ internal static class BrowserPackageWorkspace
         string version,
         string framework)
     {
-        string key = CompositeKey("packages", CompositeKey(
-            packageId.ToLowerInvariant(), version.ToLowerInvariant(), framework.ToLowerInvariant()));
+        string key = CompositeKey(
+            "packages",
+            PackageScopeCoordinateKey(PackageKey(packageId, version), framework));
         var demand = new KeyedScopeDemand(key);
         ScopeEntry[] candidates = Scopes.Where(demand.Joins).ToArray();
         if (candidates is not [{ Scope: BrowserInspectionScope scope }])
@@ -2109,6 +2110,9 @@ internal static class BrowserPackageWorkspace
     static string CoordinateKey(string packageId, string version) =>
         $"{packageId.ToLowerInvariant()}@{version.ToLowerInvariant()}";
 
+    internal static string PackageScopeCoordinateKey(string packageKey, string framework) =>
+        CompositeKey(packageKey, framework.ToLowerInvariant());
+
     internal static string PackageScopeKey(
         IReadOnlyList<BrowserPackageCoordinate> coordinates) =>
         CompositeKey(
@@ -2855,9 +2859,9 @@ internal sealed class BrowserPackageCoordinate
     /// length-prefixed so caller-controlled framework text cannot alter key boundaries.
     /// </summary>
     public string Key =>
-        BrowserPackageWorkspace.CompositeKey(
+        BrowserPackageWorkspace.PackageScopeCoordinateKey(
             Package.CacheKey,
-            Framework.ToLowerInvariant());
+            Framework);
 
     public bool HasExactContentAs(BrowserPackageCoordinate other)
     {

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -6410,6 +6410,306 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public async Task PackageAcquisition_SameClientReusesCompletedPayload()
+    {
+        string packageId = $"same.completed.package.{Guid.NewGuid():N}";
+        byte[] archive = PackageDocuments(1);
+        var handler = new GalleryPackageHandler(packageId, "1.0.0", archive);
+        using IPackageSourceClient source = Gallery(handler);
+
+        BrowserPackage first = await Acquire(source);
+        BrowserPackage repeated = await Acquire(source);
+
+        Assert.False(first.Content.FromCache);
+        Assert.True(repeated.Content.FromCache);
+        Assert.Same(first.RetainedBytes, repeated.RetainedBytes);
+        Assert.Same(first.Content.GenerationIdentity, repeated.Content.GenerationIdentity);
+        Assert.Equal(archive, repeated.RetainedBytes);
+        Assert.Single(handler.Requested);
+
+        Task<BrowserPackage> Acquire(IPackageSourceClient client) =>
+            BrowserPackageWorkspace.AcquireAsync(
+                packageId,
+                "1.0.0",
+                client,
+                PackageSourceIdentity.NuGetOrg,
+                TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task PackageAcquisition_DistinctSameProducerClientsRetainTheirOwnPayloads()
+    {
+        string packageId = $"distinct.completed.package.{Guid.NewGuid():N}";
+        byte[] firstArchive = PackageDocuments(1);
+        byte[] secondArchive = PackageDocuments(2);
+        var firstHandler = new GalleryPackageHandler(packageId, "1.0.0", firstArchive);
+        var secondHandler = new GalleryPackageHandler(packageId, "1.0.0", secondArchive);
+        using IPackageSourceClient firstSource = Gallery(firstHandler);
+        using IPackageSourceClient secondSource = Gallery(secondHandler);
+        Assert.Equal(firstSource.Source.Producer, secondSource.Source.Producer);
+        int downloaded = BrowserPackageWorkspace.Stats().Packages;
+
+        BrowserPackage first = await Acquire(firstSource);
+        BrowserPackage second = await Acquire(secondSource);
+        BrowserPackage firstAgain = await Acquire(firstSource);
+        BrowserPackage secondAgain = await Acquire(secondSource);
+
+        Assert.False(first.Content.FromCache);
+        Assert.False(second.Content.FromCache);
+        Assert.True(firstAgain.Content.FromCache);
+        Assert.True(secondAgain.Content.FromCache);
+        Assert.Equal(firstArchive, first.RetainedBytes);
+        Assert.Equal(secondArchive, second.RetainedBytes);
+        Assert.Same(first.RetainedBytes, firstAgain.RetainedBytes);
+        Assert.Same(second.RetainedBytes, secondAgain.RetainedBytes);
+        Assert.NotSame(first.Content.GenerationIdentity, second.Content.GenerationIdentity);
+        Assert.Same(first.Content.GenerationIdentity, firstAgain.Content.GenerationIdentity);
+        Assert.Same(second.Content.GenerationIdentity, secondAgain.Content.GenerationIdentity);
+        Assert.Single(firstAgain.Documents());
+        Assert.Equal(2, secondAgain.Documents().Count);
+        Assert.Single(firstHandler.Requested);
+        Assert.Single(secondHandler.Requested);
+        Assert.Equal(downloaded + 2, BrowserPackageWorkspace.Stats().Packages);
+
+        Task<BrowserPackage> Acquire(IPackageSourceClient client) =>
+            BrowserPackageWorkspace.AcquireAsync(
+                packageId,
+                "1.0.0",
+                client,
+                PackageSourceIdentity.NuGetOrg,
+                TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task PackageQueryContent_UsesTheSelectedClientsCompletedCache()
+    {
+        string packageId = $"distinct.query.package.{Guid.NewGuid():N}";
+        var firstHandler = new GalleryPackageHandler(
+            packageId, "1.0.0", PackageDocuments(1));
+        var secondHandler = new GalleryPackageHandler(
+            packageId, "1.0.0", PackageDocuments(2));
+        using IPackageSourceClient firstSource = Gallery(firstHandler);
+        using IPackageSourceClient secondSource = Gallery(secondHandler);
+        Assert.Equal(firstSource.Source.Producer, secondSource.Source.Producer);
+
+        BrowserPackage first = await BrowserPackageWorkspace.AcquireAsync(
+            packageId, "1.0.0", firstSource, PackageSourceIdentity.NuGetOrg,
+            TimeSpan.FromSeconds(5));
+        IPackageContent second = await QueryContent(secondSource);
+        IPackageContent firstAgain = await QueryContent(firstSource);
+        BrowserPackage secondAgain = await BrowserPackageWorkspace.AcquireAsync(
+            packageId, "1.0.0", secondSource, PackageSourceIdentity.NuGetOrg,
+            TimeSpan.FromSeconds(5));
+
+        Assert.False(second.FromCache);
+        Assert.True(firstAgain.FromCache);
+        Assert.True(secondAgain.Content.FromCache);
+        Assert.Same(first.Content.GenerationIdentity, firstAgain.GenerationIdentity);
+        Assert.NotSame(firstAgain.GenerationIdentity, second.GenerationIdentity);
+        Assert.Same(second.GenerationIdentity, secondAgain.Content.GenerationIdentity);
+        Assert.Single(firstAgain.EnumerateEntries());
+        Assert.Equal(2, second.EnumerateEntries().Count());
+        Assert.Single(firstHandler.Requested);
+        Assert.Single(secondHandler.Requested);
+
+        async Task<IPackageContent> QueryContent(IPackageSourceClient source)
+        {
+            PackageManifestFacts manifest = Assert.IsType<
+                PackageManifestFactsResult.Available>(
+                    PackageManifestFactsQuery.Execute(
+                        Encoding.UTF8.GetBytes(Nuspec(packageId, "1.0.0")),
+                        PackageSourceCoordinate.Create(packageId, "1.0.0"))).Value;
+            var package = new PackageQueryPackage(
+                packageId, "1.0.0", [], TotalDownloads: 0, Verified: false,
+                source.Source, manifest);
+            using var deadline =
+                new BrowserPackageWorkspace.BrowserPackageOperationDeadline(
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken);
+            return Assert.IsType<PackageQueryContentResult.Available>(
+                await BrowserPackageWorkspace.AcquirePackageQueryContentAsync(
+                    package, source, PackageSourceIdentity.NuGetOrg, deadline)).Content;
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PackageAcquisition_DistinctClientReservationsShareGlobalBudget(bool byteLimit)
+    {
+        using (await BrowserPackageWorkspace.ReservePackageDownloadAsync(
+            $"reservation.drain.{Guid.NewGuid():N}", 128L * MiB))
+        {
+        }
+
+        string packageId = $"distinct.reserved.package.{Guid.NewGuid():N}";
+        byte[] firstArchive = PackageDocuments(1);
+        byte[] secondArchive = PackageDocuments(2);
+        var firstRelease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondRelease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstHandler = new GalleryPackageHandler(
+            packageId, "1.0.0", firstArchive, payloadRelease: firstRelease.Task);
+        var secondHandler = new GalleryPackageHandler(
+            packageId, "1.0.0", secondArchive, payloadRelease: secondRelease.Task);
+        var rejectedHandler = new GalleryPackageHandler(
+            packageId, "1.0.0", PackageDocuments(1));
+        using IPackageSourceClient firstSource = Gallery(firstHandler);
+        using IPackageSourceClient secondSource = Gallery(secondHandler);
+        using IPackageSourceClient rejectedSource = Gallery(rejectedHandler);
+        Assert.Equal(firstSource.Source.Producer, secondSource.Source.Producer);
+        var held = new List<BrowserPackageWorkspace.PackageDownloadReservation>();
+        Task<BrowserPackage>? first = null;
+        Task<BrowserPackage>? second = null;
+        try
+        {
+            int count = byteLimit ? 1 : 10;
+            for (int index = 0; index < count; index++)
+            {
+                held.Add(await BrowserPackageWorkspace.ReservePackageDownloadAsync(
+                    $"reservation.holder.{index}.{Guid.NewGuid():N}",
+                    byteLimit ? 128L * MiB - firstArchive.Length - secondArchive.Length : 0));
+            }
+
+            first = Acquire(firstSource);
+            await firstHandler.PayloadReadStarted.Task.WaitAsync(
+                TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            second = Acquire(secondSource);
+            await secondHandler.PayloadReadStarted.Task.WaitAsync(
+                TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.False(first.IsCompleted);
+            Assert.False(second.IsCompleted);
+            Assert.Equal(
+                byteLimit ? 128L * MiB : firstArchive.Length + secondArchive.Length,
+                BrowserPackageWorkspace.Stats().ResidentBytes);
+
+            InvalidOperationException failure =
+                await Assert.ThrowsAsync<InvalidOperationException>(() => Acquire(rejectedSource));
+            Assert.Contains("package-cache limit", failure.Message, StringComparison.Ordinal);
+
+            firstRelease.SetResult();
+            BrowserPackage firstPackage = await first;
+            Assert.False(second.IsCompleted);
+            secondRelease.SetResult();
+            BrowserPackage secondPackage = await second;
+            Assert.Equal(firstArchive, firstPackage.RetainedBytes);
+            Assert.Equal(secondArchive, secondPackage.RetainedBytes);
+            Assert.NotSame(
+                firstPackage.Content.GenerationIdentity,
+                secondPackage.Content.GenerationIdentity);
+            Assert.Equal(2, BrowserPackageWorkspace.Stats().Resident);
+            Assert.Single(firstHandler.Requested);
+            Assert.Single(secondHandler.Requested);
+        }
+        finally
+        {
+            try
+            {
+                firstRelease.TrySetResult();
+                if (first is not null)
+                    await first;
+            }
+            finally
+            {
+                try
+                {
+                    secondRelease.TrySetResult();
+                    if (second is not null)
+                        await second;
+                }
+                finally
+                {
+                    foreach (BrowserPackageWorkspace.PackageDownloadReservation reservation in held)
+                        reservation.Dispose();
+                }
+            }
+        }
+
+        Task<BrowserPackage> Acquire(IPackageSourceClient source) =>
+            BrowserPackageWorkspace.AcquireAsync(
+                packageId, "1.0.0", source, PackageSourceIdentity.NuGetOrg,
+                TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task BrowserWorkspace_DistinctClientsKeepScopesAndArchiveLeasesSeparate()
+    {
+        using (await BrowserPackageWorkspace.ReservePackageDownloadAsync(
+            $"scope.drain.{Guid.NewGuid():N}", 128L * MiB))
+        {
+        }
+
+        string packageId = $"distinct.scope.package.{Guid.NewGuid():N}";
+        byte[] image = File.ReadAllBytes(typeof(MethodBodyFixtures.Left).Assembly.Location);
+        byte[] firstArchive = Package(image, "lib/net11.0/First.dll");
+        byte[] secondArchive = Package(image, "lib/net11.0/Second.dll");
+        var firstHandler = new GalleryPackageHandler(packageId, "1.0.0", firstArchive);
+        var secondHandler = new GalleryPackageHandler(packageId, "1.0.0", secondArchive);
+        using IPackageSourceClient firstSource = Gallery(firstHandler);
+        using IPackageSourceClient secondSource = Gallery(secondHandler);
+        Assert.Equal(firstSource.Source.Producer, secondSource.Source.Producer);
+
+        BrowserPackageCoordinate first = await Resolve(firstSource);
+        BrowserPackageCoordinate second = await Resolve(secondSource);
+        Assert.NotEqual(first.Key, second.Key);
+        Assert.NotEqual(
+            BrowserPackageWorkspace.PackageScopeKey([first]),
+            BrowserPackageWorkspace.PackageScopeKey([second]));
+        await using BrowserScopeLease<BrowserInspectionScope> firstLease =
+            await BrowserPackageWorkspace.OpenScopeAsync(
+                first.Package, first.Framework, TestContext.Current.CancellationToken);
+        await using BrowserScopeLease<BrowserInspectionScope> secondLease =
+            await BrowserPackageWorkspace.OpenScopeAsync(
+                second.Package, second.Framework, TestContext.Current.CancellationToken);
+        Assert.Equal("lib/net11.0/First.dll", Assert.Single(firstLease.Scope.SurfaceParticipants).Asset.Path);
+        Assert.Equal("lib/net11.0/Second.dll", Assert.Single(secondLease.Scope.SurfaceParticipants).Asset.Path);
+        Assert.True(BrowserPackageWorkspace.IsScopeRetained(firstLease.Scope));
+        Assert.True(BrowserPackageWorkspace.IsScopeRetained(secondLease.Scope));
+        Assert.InRange(BrowserPackageWorkspace.Stats().Workspaces, 2, 4);
+        BrowserPackage firstCached = await BrowserPackageWorkspace.AcquireAsync(
+            packageId, "1.0.0", firstSource, PackageSourceIdentity.NuGetOrg,
+            TimeSpan.FromSeconds(5));
+        Assert.True(firstCached.Content.FromCache);
+        Assert.Same(first.Package.Content.GenerationIdentity, firstCached.Content.GenerationIdentity);
+        Assert.Same(first.Package.RetainedBytes, firstCached.RetainedBytes);
+        await using (BrowserScopeLease<BrowserInspectionScope> repeated =
+            await BrowserPackageWorkspace.OpenScopeAsync(
+                firstCached, first.Framework, TestContext.Current.CancellationToken))
+        {
+            Assert.Same(firstLease.Scope, repeated.Scope);
+            Assert.NotSame(firstLease.Scope, secondLease.Scope);
+        }
+
+        await firstLease.DisposeAsync();
+        await BrowserPackageWorkspace.RemoveScopeAsync(firstLease.Scope);
+        Assert.True(BrowserPackageWorkspace.IsScopeRetained(secondLease.Scope));
+        using (await BrowserPackageWorkspace.ReservePackageDownloadAsync(
+            $"scope.pressure.{Guid.NewGuid():N}", 128L * MiB - secondArchive.Length))
+        {
+            Assert.DoesNotContain(first.Package.CacheKey, BrowserPackageWorkspace.ResidentPackageKeys());
+            Assert.Contains(second.Package.CacheKey, BrowserPackageWorkspace.ResidentPackageKeys());
+            Assert.Equal(128L * MiB, BrowserPackageWorkspace.Stats().ResidentBytes);
+        }
+
+        BrowserPackageCoordinate firstAgain = await Resolve(firstSource);
+        BrowserPackageCoordinate secondAgain = await Resolve(secondSource);
+        Assert.False(firstAgain.Package.Content.FromCache);
+        Assert.True(secondAgain.Package.Content.FromCache);
+        Assert.Same(second.Package.Content.GenerationIdentity, secondAgain.Package.Content.GenerationIdentity);
+        Assert.NotSame(first.Package.Content.GenerationIdentity, firstAgain.Package.Content.GenerationIdentity);
+        Assert.Equal(2, firstHandler.Requested.Count);
+        Assert.Single(secondHandler.Requested);
+        Assert.NotEmpty(secondLease.Scope.UseSurface(
+            group => AssemblyContextApiSurfaceQuery.Execute(group)).Assemblies.Assemblies);
+
+        Task<BrowserPackageCoordinate> Resolve(IPackageSourceClient source) =>
+            BrowserPackageWorkspace.ResolveAsync(
+                packageId, "1.0.0", "net11.0", source, PackageSourceIdentity.NuGetOrg,
+                TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public void PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent()
     {
         using var deadline =
@@ -8233,7 +8533,8 @@ public sealed class BrowserEngineBoundaryTests
         bool provideSearchResult = false,
         System.Net.HttpStatusCode packageStatus =
             System.Net.HttpStatusCode.OK,
-        bool omitContentLength = false)
+        bool omitContentLength = false,
+        Task? payloadRelease = null)
         : HttpMessageHandler
     {
         readonly string _packageUrl =
@@ -8241,6 +8542,8 @@ public sealed class BrowserEngineBoundaryTests
 
         public List<string> Requested { get; } = [];
         public bool PayloadDisposed { get; private set; }
+        public TaskCompletionSource PayloadReadStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -8272,12 +8575,17 @@ public sealed class BrowserEngineBoundaryTests
             var response = new HttpResponseMessage(packageStatus);
             if (packageStatus == System.Net.HttpStatusCode.OK)
             {
-                response.Content = omitContentLength
+                response.Content = payloadRelease is not null
+                    ? new StreamContent(new GatedPayloadStream(
+                        archive, PayloadReadStarted, payloadRelease))
+                    : omitContentLength
                     ? new StreamContent(
                         new TrackingPayloadStream(
                             archive,
                             () => PayloadDisposed = true))
                     : new ByteArrayContent(archive);
+                if (payloadRelease is not null)
+                    response.Content.Headers.ContentLength = archive.LongLength;
             }
 
             return Task.FromResult(response);
@@ -8453,6 +8761,23 @@ public sealed class BrowserEngineBoundaryTests
                 cancellationToken);
             throw new InvalidOperationException(
                 "The registration stall completed without cancellation.");
+        }
+    }
+
+    sealed class GatedPayloadStream(
+        byte[] bytes,
+        TaskCompletionSource started,
+        Task release) : MemoryStream(bytes, writable: false)
+    {
+        public override bool CanSeek => false;
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            started.TrySetResult();
+            await release.WaitAsync(cancellationToken);
+            return await base.ReadAsync(buffer, cancellationToken);
         }
     }
 

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -6667,6 +6667,9 @@ public sealed class BrowserEngineBoundaryTests
         Assert.True(BrowserPackageWorkspace.IsScopeRetained(firstLease.Scope));
         Assert.True(BrowserPackageWorkspace.IsScopeRetained(secondLease.Scope));
         Assert.InRange(BrowserPackageWorkspace.Stats().Workspaces, 2, 4);
+        Assert.Throws<InvalidOperationException>(() =>
+            BrowserPackageWorkspace.LeaseRetainedPackageScope(
+                packageId, "1.0.0", first.Framework));
         BrowserPackage firstCached = await BrowserPackageWorkspace.AcquireAsync(
             packageId, "1.0.0", firstSource, PackageSourceIdentity.NuGetOrg,
             TimeSpan.FromSeconds(5));


### PR DESCRIPTION
# Source-associated Browser package retention

Build robust Browser package inspection by preserving the selected source
client through completed acquisition, cache reuse, and workspace ownership.
Matching package coordinates or producer identities no longer collapse
distinct clients' retained content.

This is **step 1 of 3 for #5637**, following the completed CLI adoption
in #5654. It advances #4239 without claiming that configured feeds or PATs are
already supported in the Browser UI.

## Demo

Two real NuGetFetch Gallery clients report the same producer and acquire the
same package ID and version. Client A serves an archive with one Markdown
document; client B serves an archive with two.

Previously, completed storage used only `id@version`, so B could answer from
A's retained archive. The new outcome is:

| Operation | New payload requests | Documents | From cache |
| --- | --- | --- | --- |
| Acquire through A | 1 | 1 | false |
| Acquire through B | 1 | 2 | false |
| Repeat through A | 0 | 1 | true |
| Repeat through B | 0 | 2 | true |

`PackageAcquisition_DistinctSameProducerClientsRetainTheirOwnPayloads`
exercises that scenario through product-owned acquisition. The neighboring
same-client case still makes one request and preserves its content generation.

The workspace case opens `First.dll` and `Second.dll` from two acquired
archives at one coordinate. Each has its own scope; repeating A reuses A's
scope. Retiring A and applying cache pressure preserves B's leased archive
and usable query scope. Concurrent downloads from distinct clients also share
the existing global package and byte budgets.

The existing coordinate-only method-body exports retain their Gallery
association when finding that workspace. The real-Wasm method-body case
preserves different-method, exact-match, and bodyless comparison outcomes.

## Design basis

**Normative owner:** Browser Package Sources,
`docs/design/browser-package-sources.md`, sections
`Browser pending-acquisition association` and
`Browser retained-acquisition association`.

**Claim:** the exact runtime-client association already used for pending work
survives through completed payloads, reservations, leases, and workspace reuse.
Package composition remains responsible for deciding whether transports may
represent one authority; Browser does not infer that from producer equality.

The existing pending-acquisition reference key is the analogous implementation.
Per-client store adapters now receive opaque session namespaces, while cache
entries and capacity accounting remain in the existing session-wide owner.
Acquired packages carry their issued cache key into scope construction rather
than reconstructing it from package ID and version.

**Production consumers:** the existing Gallery-backed Browser package path,
including unbound scope opening, and the shared default-Gallery store used by
platform workspaces. There is no new presentation surface in this slice.
The existing Browser/Wasm platform contract remains applicable.

## Adoption path

The [counted plan in #5637][plan] has three steps:

1. **This PR:** client-associated retained acquisition and workspace ownership.
2. Live configured authorities, exact result adoption, session credentials,
   retirement, multi-source routing, and engine configuration operations.
3. Settings source management and credential entry connected to those
   operations, with the completed Browser/Wasm end-to-end path.

This is the bottom slice and targets `main`; there is no parent PR.
Gallery remains the production source. Registry admission, authority
retirement, configured V3 routing, and PAT support remain follow-up work.
Desktop credential-provider plugins and portable source bundles are outside
these implementation slices.

## Validation

The replacement candidate passed the **complete 365-test Browser engine
Release suite**:

```bash
"$DOTNET_ROOT/dotnet" run \
  --project prototypes/inspect-web/engine.Tests -c Release \
  --no-launch-profile
```

The first integrated run exposed an order-dependent test assumption: draining
package archives does not remove unrelated platform-only scopes. The new
scope case now asserts retention of both owned scopes and the global bound,
rather than assuming the session contains exactly those two scopes.

The first CI attempt then exposed a missed production consumer:
`LeaseRetainedPackageScope` still built the old coordinate-only key.
The replacement shares the scope-coordinate key builder between construction
and lookup. All 14 affected method-body cases pass in the full suite, and
the distinct-client case checks that coordinate-only lookup cannot choose
another client's scope. This is a repair, not a retry of the failing head.

Changed Markdown passed `markdownlint`, and `npm run build` produced the
frontend bundle. These gates also passed at the pushed candidate:

```bash
"$DOTNET_ROOT/dotnet" publish \
  prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
  -c Release --output artifacts/inspect-web-publish --verbosity quiet
node prototypes/inspect-web/scripts/verify-published-engine-facades.ts \
  artifacts/inspect-web-publish/wwwroot production
DOTNET="$DOTNET_ROOT/dotnet" eng/test-inspect-web-package-adoption-gate.sh
```

The production smoke loaded seven facades through one SDK runtime. The real
Firefox/Wasm package gate passed four cases; its opt-in live Gallery browsing
case was skipped. The separate bounded network-backed package-opening case
ran and passed.

The existing production method-body Browser case also passed against the
replacement's published site:

```bash
INSPECT_WEB_METHOD_BODY_URL=http://127.0.0.1:19532/index.html \
  npm run test:browser -- browser/method-body-production.spec.ts \
  --grep 'generated facade preserves real pair'
```

That temporary loopback site was served using the existing
`scripts/serve-package-adoption-gate.ts` and stopped after the run.

[plan]: https://github.com/richlander/dotnet-inspect/issues/5637#issuecomment-5557271566
