### PR TITLE
Add explicit platform policy for frozen compiler references

### DIFF
--- a/docs/design/csharp-member-recompilation.md
+++ b/docs/design/csharp-member-recompilation.md
@@ -554,7 +554,8 @@ produces a `CompileReferenceInventory` containing every candidate considered.
 Selection produces either one immutable `CompileReferenceSet` or a typed
 failure. Discovery order is never a binding policy.
 
-Before descriptor construction or selection, discovery requests the
+Before constructing frozen-reference descriptors or selecting compiler
+references, discovery requests the
 owner-issued retained-content digest from
 [#4916](https://github.com/richlander/dotnet-inspect/issues/4916) for the source
 artifact and every candidate. If any required digest capability or result is
@@ -646,24 +647,119 @@ binding, digest-before-descriptor ordering, source exclusion, stale authority,
 and retained-snapshot consumption by both Metadata and Roslyn. These gates do
 not establish the later closure, admission, or rebuilt-binding receipts.
 
+#### Explicit platform compatibility policy
+
+[#6120](https://github.com/richlander/dotnet-inspect/issues/6120) adds an
+explicit tools policy for the existing RTS platform-compatibility cases. The
+initial exact-only policy remains the default. The user approved this
+prerequisite to preserve supported behavior before the RTS migration in
+[#6103](https://github.com/richlander/dotnet-inspect/issues/6103); it does not
+authorize a general local roll-forward policy or new platform entitlement.
+
+The policy consumes Services-issued platform selections for a finite set of
+explicit binding requests. Services owns candidate acquisition, platform
+eligibility, precedence, and version selection. Tools records those answers;
+it does not reproduce the owner's probing or forwarding algorithms. Metadata
+may prepare forwarding requests under that policy before the context freezes.
+This preparation is not a signature or body closure receipt.
+
+The initial explicit mode accepts `Platform`-scope assembly-reference requests
+with a required version and either a global or registered source-relative
+origin. It preserves Services' seed continuations; contextual or foreign
+continuations and other target kinds produce a typed unsupported outcome.
+Platform-selected compiler references use the global alias without embedded
+interop types. Ordinary exact requests retain their existing role options;
+conflicting roles cannot silently replace the platform roles.
+
+For each platform-reference request:
+
+1. Services must select a platform acquisition for the original identity and
+   origin in `Platform` scope. The selected acquisition must carry the owner's
+   `PlatformAsset` provenance. Platform scope alone is insufficient: a
+   designated acquisition is not thereby a platform acquisition. Caller-supplied
+   provenance labels, names, paths, keys, and content digests do not grant this
+   authority.
+2. The requested name, culture, and public-key token must match the selected
+   full identity under the initial policy's exact-family semantics. Only the
+   owner-authorized one-way version substitution is permitted; omitted token
+   and culture do not become wildcards.
+3. Services must also select an acquisition in `Any` scope for the
+   platform-selected full identity, retaining the requesting origin. Using
+   the selected version here permits an older platform request without
+   weakening the sibling comparison.
+4. After artifact admission and digest-first discovery, both selections must
+   agree in full identity, MVID, and owner-issued retained-content digest.
+   Missing, ambiguous, unavailable, or disagreeing selections remain visible
+   failures, including a version-skewed sibling that owns the name but cannot
+   satisfy the selected identity.
+5. The compiler set explicitly selects the platform acquisition. An identical
+   sibling remains a distinct, unselected inventory candidate with its own
+   provenance. Digest agreement establishes compatibility for this policy;
+   it neither coalesces registrations nor grants the sibling platform authority.
+
+Supporting-owner acquisition precedes artifact admission; tools descriptor
+construction and compiler selection still follow owner digest acquisition.
+Preparation retains the acquired images before returning, so later publication
+and query consumption cannot reacquire changed path content.
+The tools preparation result retains the association between each original
+Services acquisition registration and the contribution actually registered
+with the artifact owner. It cannot accept a separately asserted association
+based on path, display identity, or digest equality.
+
+The frozen result binds the declared requests, their origin and scope,
+owner policy version, selected registrations, and agreement evidence to one
+artifact generation. The set encoding includes the policy mode and accepted
+binding mappings: different accepted requested versions cannot share a set
+key merely because their compiler images match. Opaque issuer-version
+identity also participates in equality alongside the artifact generation and
+digest. It remains typed; object display text or hash codes are not durable
+policy identity.
+
+Scoped Metadata binding preserves request and origin distinctions and uses
+only the frozen mappings and artifact-guarded images. Roslyn receives the same
+selected images. Unprepared platform bindings remain unavailable; `Use` cannot
+invoke Services, reopen paths, acquire another candidate, or substitute a new
+policy answer. Existing source separation and query-lease lifetime rules still
+apply.
+Origin-free lookup remains exact and `Any`-scope only over the selected set;
+platform compatibility uses the origin-aware `IAssemblyBindingPolicy` surface.
+
+`CompileReferencePlatformPolicyTests` gates unchanged exact-only behavior,
+older platform requests and identical siblings, differing-content and
+version-skewed siblings, and policy-sensitive ordering and identity.
+`OlderPlatformRequestPreparesForwardingAndBindsRetainedCoreLib` and
+`SupportingAcquisitionsAreRetainedBeforeArtifactSealAndScopedUse` exercise
+Metadata forwarding and Roslyn binding to retained images.
+`FrozenBindingsRemapArtifactOriginsAndPreserveScopeAndSeedOccurrences`
+gates origin remapping and unavailable unprepared platform bindings.
+These cases run in the ordinary Release harness contract suite.
+This policy does not expose Services' complete discovery inventory or complete
+the later RTS migration.
+
 #### Tools adoption
 
 [#6005](https://github.com/richlander/dotnet-inspect/issues/6005) tracks the
 frozen-reference implementation within the overall decoder-adoption tracker
 [#5890](https://github.com/richlander/dotnet-inspect/issues/5890).
-The frozen-reference adoption path has two steps:
+The compatibility-preserving frozen-reference adoption path has three steps:
 
 1. Implement the inventory, selected set, and scoped context API. The immediate
    production host for this test infrastructure is the decompiler harness
    contract suite, which exercises Metadata and Roslyn with the selected images.
-2. Migrate ReturnToSender's compiler-closure acquisition to the frozen context
-   and retire its simple-name-first-wins reference enumeration on that path.
+   This step landed in [#6006](https://github.com/richlander/dotnet-inspect/pull/6006).
+2. Add the explicit platform policy in
+   [#6120](https://github.com/richlander/dotnet-inspect/issues/6120), with the
+   same harness contract suite as its immediate production consumer.
+3. Migrate ReturnToSender's compiler-closure acquisition to the frozen context
+   in [#6103](https://github.com/richlander/dotnet-inspect/issues/6103) and retire
+   its simple-name-first-wins reference enumeration and competing compiler
+   binding projection on that path.
 
 The user-approved tools-first scope defers CLI/browser production adoption.
 The first step does not relabel the legacy ReturnToSender path as conforming,
 adopt the signature decoder there, or complete closure and admission. These
 steps are prerequisites within #5890's second decoder-adoption step, not a
-claim that the entire compile-back architecture takes two slices.
+claim about the total number of compile-back implementation slices.
 
 ### Compile-context definition identity
 

--- a/src/ILInspector.Decompiler.Tests/CompileReferencePlatformPolicyTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileReferencePlatformPolicyTests.cs
@@ -1,0 +1,486 @@
+using System.Buffers.Binary;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Artifacts;
+using DotnetInspector.Artifacts.Workspaces;
+using DotnetInspector.Fixtures;
+using DotnetInspector.Services;
+using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "RoundTrip")]
+public sealed class CompileReferencePlatformPolicyTests
+{
+    static CancellationToken Cancellation => TestContext.Current.CancellationToken;
+    static string RuntimePath => PlatformPath("System.Runtime.dll");
+    static string JsonPath => typeof(System.Text.Json.JsonSerializer).Assembly.Location;
+    static AssemblyReferenceIdentity RuntimeIdentity => Identity(RuntimePath);
+    static AssemblyReferenceIdentity JsonIdentity => Identity(JsonPath);
+    static AssemblyReferenceIdentity OlderRuntime => RuntimeIdentity with
+    {
+        Version = new Version(RuntimeIdentity.Version!.Major - 1, 0, 0, 0),
+    };
+
+    [Fact]
+    public async Task OlderPlatformRequestPreparesForwardingAndBindsRetainedCoreLib()
+    {
+        await using var fixture = new Fixture();
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(OlderRuntime);
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        CompileReferenceSet set = Ready(policy.Select(inventory, [], Cancellation));
+        Assert.Contains(policy.Bindings, binding =>
+            binding.PlatformSelection.Selection is AssemblyBindingSelection.Selected selected
+            && selected.Assembly.Identity.Name == "System.Private.CoreLib");
+        Assert.Same(fixture.Resolver.Version, policy.OwnerPolicyVersion);
+        Assert.Same(policy.OwnerPolicyVersion, set.Digest.OwnerPolicyVersion);
+        Assert.All(set.References, reference => Assert.True(reference.IsPlatformAuthorized));
+
+        Ready(set.Use(context =>
+        {
+            var request = TypeResolutionRequest.FromReference(
+                OlderRuntime, AssemblyBindingOrigin.FromAssembly(context.Source),
+                AssemblyResolutionScope.Platform, TypeName("System", "IConvertible"));
+            using TypeResolutionContext metadata = TypeResolutionContext.Create(context, [context.Source], [request]);
+            var resolved = Assert.IsType<TypeResolutionOutcome.Resolved>(metadata.Resolve(request));
+            Assert.Equal("System.Private.CoreLib", resolved.Definition.Assembly.Assembly.Identity.Name);
+            CompileReferenceImage image = Assert.Single(set.References,
+                reference => reference.Image.Identity.Name == "System.Private.CoreLib").Image;
+            Assert.Same(image.ArtifactRegistration, resolved.Definition.Assembly.Assembly.Registration.ArtifactRegistration);
+            Assert.Equal(image.ModuleVersionId, resolved.Definition.Address.ModuleVersionId);
+            AssertCompilerType(context, "System.IConvertible", image);
+            return true;
+        }, Cancellation));
+    }
+
+    [Fact]
+    public async Task IdenticalSiblingRemainsDistinctAndOnlyOwnerPlatformIsSelected()
+    {
+        await using var fixture = new Fixture("identical");
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(JsonIdentity, OlderRuntime);
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        CompilePlatformBindingEvidence binding = JsonBinding(policy);
+        Assert.NotSame(binding.PlatformArtifact, binding.AgreementArtifact);
+        CompileReferenceImage platform = Image(inventory, binding.PlatformArtifact);
+        CompileReferenceImage sibling = Image(inventory, binding.AgreementArtifact);
+        Assert.Equal(platform.ContentDigest.HexValue, sibling.ContentDigest.HexValue);
+        Assert.Equal(platform.ModuleVersionId, sibling.ModuleVersionId);
+        Assert.NotSame(platform.MetadataRegistration, sibling.MetadataRegistration);
+        Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(platform.Provenance);
+        Assert.IsType<AssemblyResolutionProvenance.LocalAsset>(sibling.Provenance);
+        Rejected(inventory.Select([new(JsonIdentity)], Cancellation),
+            CompileReferenceFailureKind.ReferenceSelectionAmbiguous);
+
+        CompileReferenceSet set = Ready(policy.Select(inventory, [], Cancellation));
+        Assert.Contains(set.References, reference => ReferenceEquals(reference.InventoryId, binding.PlatformArtifact));
+        Assert.DoesNotContain(set.References, reference => ReferenceEquals(reference.InventoryId, binding.AgreementArtifact));
+        Assert.All(inventory.Candidates, image =>
+            Assert.Same(image.ArtifactRegistration, image.MetadataRegistration.ArtifactRegistration));
+        Ready(set.Use(context =>
+        {
+            AssertCompilerType(context, "System.Text.Json.JsonSerializerOptions", platform);
+            return true;
+        }, Cancellation));
+    }
+
+    [Fact]
+    public async Task ChangedSiblingWithSameIdentityAndMvidRefusesAfterOwnerDigests()
+    {
+        await using var fixture = new Fixture("changed");
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(JsonIdentity);
+        var charges = new List<long>();
+        CompileReferenceInventory inventory = await fixture.Publish(policy, charges.Add);
+        CompilePlatformBindingEvidence binding = JsonBinding(policy);
+        CompileReferenceImage platform = Image(inventory, binding.PlatformArtifact);
+        CompileReferenceImage sibling = Image(inventory, binding.AgreementArtifact);
+        Assert.True(platform.Identity.IsEquivalentTo(sibling.Identity));
+        Assert.Equal(platform.ModuleVersionId, sibling.ModuleVersionId);
+        Assert.NotEqual(platform.ContentDigest.HexValue, sibling.ContentDigest.HexValue);
+        Assert.Equal(inventory.Candidates.Length + 1, charges.Count);
+        foreach (CompileReferenceImage image in inventory.Candidates.Prepend(inventory.Source))
+        {
+            var digest = Assert.IsType<ArtifactContentAccessOutcome<ArtifactContentDigest>.Accessed>(
+                fixture.Owner.GetContentDigest(image.InventoryId, fixture.Lease,
+                    _ => Assert.Fail("Expected an already-issued owner digest."), Cancellation));
+            Assert.Same(digest.Value, image.ContentDigest);
+        }
+        CompileReferenceFailure failure = Rejected(policy.Select(inventory, [], Cancellation),
+            CompileReferenceFailureKind.ReferencePlatformAgreementMismatch);
+        Assert.Equal([binding.PlatformArtifact, binding.AgreementArtifact], failure.Candidates);
+    }
+
+    [Fact]
+    public async Task VersionSkewedSiblingRetainsOwnerNameMismatchRefusal()
+    {
+        await using var fixture = new Fixture("skewed");
+        CompileReferenceFailure failure = Rejected(await fixture.TryPrepare(JsonIdentity),
+            CompileReferenceFailureKind.ReferencePlatformSelectionUnavailable);
+        Assert.Equal(AssemblyResolutionScope.Any, failure.BindingRequest!.Scope);
+        Assert.Equal(JsonIdentity, ((AssemblyBindingTarget.AssemblyReference)failure.BindingRequest.Target).Identity);
+        Assert.Equal(AssemblyBindingMissDisposition.NameOwnedNoMatch,
+            Assert.IsType<AssemblyBindingSelection.Missing>(failure.PolicySelection!.Selection).Disposition);
+    }
+
+    [Fact]
+    public async Task PlatformScopeDoesNotPromoteDesignatedAcquisitions()
+    {
+        await using var fixture = new Fixture("identical", designateSibling: true);
+        CompileReferenceFailure failure = Rejected(await fixture.TryPrepare(JsonIdentity),
+            CompileReferenceFailureKind.ReferencePlatformSelectionUnavailable);
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(failure.PolicySelection!.Selection);
+        Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(selected.Assembly.Provenance);
+        Assert.Equal(AssemblyResolutionScope.Platform, failure.BindingRequest!.Scope);
+    }
+
+    [Fact]
+    public async Task ServicesWildcardAndDescriptiveOptionsDoNotWeakenExactFamilyOrOneWayVersion()
+    {
+        await using var fixture = new Fixture(ignoreVersion: true);
+        Rejected(await fixture.TryPrepare(JsonIdentity with { PublicKeyToken = null }),
+            CompileReferenceFailureKind.ReferencePlatformIdentityMismatch);
+        Rejected(await fixture.TryPrepare(JsonIdentity with { Version = new Version(JsonIdentity.Version!.Major + 1, 0, 0, 0) }),
+            CompileReferenceFailureKind.ReferencePlatformIdentityMismatch);
+        Rejected(await fixture.TryPrepare(JsonIdentity with { Culture = "fr-FR" }),
+            CompileReferenceFailureKind.ReferencePlatformSelectionUnavailable);
+    }
+
+    [Fact]
+    public async Task PlatformLookingLocalInputAndLabelCannotAuthorizeSelection()
+    {
+        await using var fixture = new Fixture(includePlatform: false);
+        AssemblyReferenceIdentity identity = fixture.Source.Identity;
+        var labelled = ResolvedAssemblyReference.CreateFromPath(fixture.SourcePath,
+            AssemblyResolutionProvenance.Platform("claimed framework", "1", "caller label"));
+        var request = new AssemblyBindingRequest(AssemblyBindingTarget.Reference(identity),
+            AssemblyBindingOrigin.FromAssembly(labelled), AssemblyResolutionScope.Platform);
+        Rejected(await CompileReferencePlatformPolicy.PrepareAsync(
+            fixture.Owner, fixture.Resolver, labelled, [request], Cancellation),
+            CompileReferenceFailureKind.ReferencePlatformSelectionUnavailable);
+    }
+
+    [Fact]
+    public async Task ExactDefaultNeverUsesCapturedPlatformPermission()
+    {
+        await using var fixture = new Fixture();
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(OlderRuntime);
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        Rejected(inventory.Select([new(OlderRuntime)], Cancellation), CompileReferenceFailureKind.ReferenceNotFound);
+        CompileReferenceSet exact = Ready(inventory.Select([new(RuntimeIdentity)], Cancellation));
+        Assert.Null(exact.Digest.OwnerPolicyVersion);
+        Assert.False(Assert.Single(exact.References).IsPlatformAuthorized);
+        Ready(exact.Use(context =>
+        {
+            Assert.Null(context.Resolve(OlderRuntime, AssemblyResolutionScope.Platform));
+            Assert.IsType<AssemblyBindingSelection.Unavailable>(context.Select(
+                Request(OlderRuntime, context.Source)).Selection);
+            return true;
+        }, Cancellation));
+    }
+
+    [Fact]
+    public async Task FrozenBindingsRemapArtifactOriginsAndPreserveScopeAndSeedOccurrences()
+    {
+        await using var fixture = new Fixture();
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(OlderRuntime, JsonIdentity);
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        CompileReferenceSet set = Ready(policy.Select(inventory, [], Cancellation));
+        Ready(set.Use(context =>
+        {
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                context.Select(Request(OlderRuntime, context.Source)).Selection);
+            Assert.Same(AssemblyBindingLineage.Seed, selected.Occurrence.Lineage);
+            Assert.NotSame(fixture.Source.Registration, context.Source.Registration);
+            Assert.IsType<AssemblyBindingSelection.Rejected>(
+                context.Select(Request(OlderRuntime, fixture.Source)).Selection);
+            Assert.IsType<AssemblyBindingSelection.Unavailable>(context.Select(new(
+                AssemblyBindingTarget.Reference(OlderRuntime), AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Platform)).Selection);
+            Assert.IsType<AssemblyBindingSelection.Unavailable>(context.Select(new(
+                AssemblyBindingTarget.Reference(OlderRuntime), AssemblyBindingOrigin.FromAssembly(context.Source),
+                AssemblyResolutionScope.Any)).Selection);
+            ResolvedAssemblyReference other = context.Resolve(JsonIdentity, AssemblyResolutionScope.Any)!;
+            Assert.IsType<AssemblyBindingSelection.Unavailable>(
+                context.Select(Request(OlderRuntime, other)).Selection);
+            var lineage = new ForeignLineage(new AssemblyBindingPolicyVersion());
+            Assert.IsType<AssemblyBindingSelection.Rejected>(context.Select(new(
+                AssemblyBindingTarget.Reference(OlderRuntime),
+                AssemblyBindingOrigin.FromOccurrence(lineage.Bind(context.Source)),
+                AssemblyResolutionScope.Platform)).Selection);
+            // Services could resolve this identity, but it was never prepared for this origin.
+            Assert.IsType<AssemblyBindingSelection.Unavailable>(
+                context.Select(Request(RuntimeIdentity, context.Source)).Selection);
+            return true;
+        }, Cancellation));
+    }
+
+    [Fact]
+    public async Task PolicyRequestsOriginsAndIssuerVersionArePartOfSetIdentity()
+    {
+        await using var fixture = new Fixture();
+        AssemblyReferenceIdentity earlier = OlderRuntime with { Version = new Version(OlderRuntime.Version!.Major - 1, 0, 0, 0) };
+        var first = await Build(OlderRuntime, global: false);
+        var anotherVersion = await Build(earlier, global: false);
+        var anotherOrigin = await Build(OlderRuntime, global: true);
+        Assert.Equal(first.Images, anotherVersion.Images);
+        Assert.Equal(first.Images, anotherOrigin.Images);
+        Assert.NotEqual(first.Digest.HexValue, anotherVersion.Digest.HexValue);
+        Assert.NotEqual(first.Digest.HexValue, anotherOrigin.Digest.HexValue);
+        Assert.Same(fixture.Resolver.Version, first.Digest.OwnerPolicyVersion);
+
+        async Task<(CompileReferenceSetDigest Digest, string[] Images)> Build(AssemblyReferenceIdentity identity, bool global)
+        {
+            await using var owner = new ArtifactSetSession();
+            AssemblyBindingRequest request = global
+                ? new(AssemblyBindingTarget.Reference(identity), AssemblyBindingOrigin.Global(), AssemblyResolutionScope.Platform)
+                : Request(identity, fixture.Source);
+            CompileReferencePlatformPolicy policy = Ready(await CompileReferencePlatformPolicy.PrepareAsync(
+                owner, fixture.Resolver, fixture.Source, [request], Cancellation));
+            Assert.IsType<ArtifactSetPublicationOutcome.Published>(await owner.SealAsync(Cancellation));
+            using ArtifactQueryLease lease = owner.IssueLease(owner.CreateQueryAuthorization());
+            CompileReferenceInventory inventory = Ready(policy.Discover(lease, _ => { }, Cancellation));
+            CompileReferenceSet set = Ready(policy.Select(inventory, [], Cancellation));
+            return (set.Digest, [.. set.References.Select(reference => reference.Image.ContentDigest.HexValue)]);
+        }
+    }
+
+    [Fact]
+    public async Task RepeatedDiscoveryAndReorderedSelectionsPreservePolicySetIdentity()
+    {
+        await using var fixture = new Fixture("identical");
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(OlderRuntime, JsonIdentity);
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        CompileReferenceRequest[] requests = [.. policy.Bindings.Select(binding => binding.PlatformArtifact).Distinct()
+            .Select(id => new CompileReferenceRequest(Image(inventory, id).Identity, id))];
+        CompileReferenceSet first = Ready(policy.Select(inventory, requests, Cancellation));
+        CompileReferenceInventory rediscovered = Ready(policy.Discover(fixture.Lease, _ => Assert.Fail("Warm digest charge."), Cancellation));
+        CompileReferenceSet second = Ready(policy.Select(rediscovered, requests.Reverse(), Cancellation));
+        Assert.Equal(first.Digest, second.Digest);
+        Assert.Equal(first.References.Select(reference => reference.InventoryId), second.References.Select(reference => reference.InventoryId));
+    }
+
+    [Fact]
+    public async Task EquivalentRepeatedRequestsDoNotCreateCompetingBindings()
+    {
+        await using var fixture = new Fixture();
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(OlderRuntime,
+            OlderRuntime with { Name = OlderRuntime.Name.ToLowerInvariant(), Culture = "neutral" });
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        CompileReferenceSet set = Ready(policy.Select(inventory, [], Cancellation));
+        Ready(set.Use(context =>
+        {
+            var first = Assert.IsType<AssemblyBindingSelection.Selected>(
+                context.Select(Request(OlderRuntime, context.Source)).Selection);
+            var second = Assert.IsType<AssemblyBindingSelection.Selected>(
+                context.Select(Request(OlderRuntime with { Culture = "neutral" }, context.Source)).Selection);
+            Assert.Same(first.Assembly, second.Assembly);
+            return true;
+        }, Cancellation));
+    }
+
+    [Fact]
+    public async Task PlatformSelectionCannotReintroduceTheSourceRegistration()
+    {
+        await using var fixture = new Fixture();
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            fixture.Resolver.Select(Request(JsonIdentity, fixture.Source)).Selection);
+        CompileReferencePlatformPolicy policy = Ready(await CompileReferencePlatformPolicy.PrepareAsync(
+            fixture.Owner, fixture.Resolver, selected.Assembly, [Request(JsonIdentity, selected.Assembly)], Cancellation));
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        Rejected(policy.Select(inventory, [], Cancellation), CompileReferenceFailureKind.SourceReferenceExcluded);
+    }
+
+    [Fact]
+    public async Task FailedSupportingImageRetainsTheMetadataFailure()
+    {
+        await using var fixture = new Fixture();
+        var source = ResolvedAssemblyReference.Create(fixture.Source.Identity, null,
+            () => new MemoryStream([1, 2, 3]), AssemblyResolutionProvenance.Local("malformed source"));
+        CompileReferenceFailure failure = Rejected(await CompileReferencePlatformPolicy.PrepareAsync(
+            fixture.Owner, fixture.Resolver, source, [Request(OlderRuntime, source)], Cancellation),
+            CompileReferenceFailureKind.ReferenceContentUnavailable);
+        Assert.Equal(CandidateOpenFailureKind.InvalidImage, failure.ContentFailure!.Kind);
+    }
+
+    [Fact]
+    public async Task SupportingAcquisitionsAreRetainedBeforeArtifactSealAndScopedUse()
+    {
+        await using var fixture = new Fixture("identical");
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(OlderRuntime, JsonIdentity);
+        File.Delete(fixture.SourcePath);
+        File.WriteAllBytes(fixture.SiblingPath, [1, 2, 3]);
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        CompileReferenceSet set = Ready(policy.Select(inventory, [], Cancellation));
+        File.Delete(fixture.SiblingPath);
+        Ready(set.Use(context =>
+        {
+            using var pe = new PEReader(context.Source.OpenRead());
+            Assert.Equal(inventory.Source.ModuleVersionId, pe.GetMetadataReader().GetGuid(pe.GetMetadataReader().GetModuleDefinition().Mvid));
+            CompileReferenceImage json = Image(inventory, JsonBinding(policy).PlatformArtifact);
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                context.Select(Request(JsonIdentity, context.Source)).Selection);
+            using var selectedPe = new PEReader(selected.Assembly.OpenRead());
+            Assert.Equal(json.ModuleVersionId, selectedPe.GetMetadataReader().GetGuid(selectedPe.GetMetadataReader().GetModuleDefinition().Mvid));
+            AssertCompilerType(context, "System.Text.Json.JsonSerializerOptions", json);
+            return true;
+        }, Cancellation));
+    }
+
+    [Theory]
+    [InlineData("lease")]
+    [InlineData("revoked")]
+    [InlineData("session")]
+    public async Task StaleAuthorityRejectsPolicySelectionAndConsumption(string mode)
+    {
+        await using var fixture = new Fixture();
+        CompileReferencePlatformPolicy policy = await fixture.Prepare(OlderRuntime);
+        CompileReferenceInventory inventory = await fixture.Publish(policy);
+        CompileReferenceSet set = Ready(policy.Select(inventory, [], Cancellation));
+        switch (mode)
+        {
+            case "lease": fixture.Lease.Dispose(); break;
+            case "revoked": fixture.Owner.Revoke(fixture.Authorization); break;
+            case "session": await fixture.Owner.DisposeAsync(); break;
+        }
+        Rejected(policy.Select(inventory, [], Cancellation), CompileReferenceFailureKind.ReferenceAuthorityUnavailable);
+        Rejected(set.Use<int>(_ => throw new InvalidOperationException("Must not consume."), Cancellation),
+            CompileReferenceFailureKind.ReferenceAuthorityUnavailable);
+    }
+
+    [Fact]
+    public async Task PreparationCannotBindAnUnrelatedArtifactGeneration()
+    {
+        await using var first = new Fixture();
+        await using var second = new Fixture();
+        CompileReferencePlatformPolicy firstPolicy = await first.Prepare(OlderRuntime);
+        CompileReferencePlatformPolicy secondPolicy = await second.Prepare(OlderRuntime);
+        CompileReferenceInventory secondInventory = await second.Publish(secondPolicy);
+        Rejected(firstPolicy.Select(secondInventory, [], Cancellation), CompileReferenceFailureKind.ReferencePlatformPolicyMismatch);
+    }
+
+    static void AssertCompilerType(CompileReferenceContext context, string typeName, CompileReferenceImage image)
+    {
+        var syntax = CSharpSyntaxTree.ParseText($"public sealed class Consumer {{ public {typeName} Value; }}",
+            cancellationToken: Cancellation);
+        var compilation = CSharpCompilation.Create("PlatformConsumer", [syntax], context.CompilerReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Assert.Empty(compilation.GetDiagnostics(Cancellation).Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        VariableDeclaratorSyntax declaration = syntax.GetRoot(Cancellation).DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        IFieldSymbol field = Assert.IsAssignableFrom<IFieldSymbol>(compilation.GetSemanticModel(syntax).GetDeclaredSymbol(declaration, Cancellation));
+        Assert.Equal(typeName, field.Type.ToDisplayString());
+        Assert.Equal(image.Identity.Name, field.Type.ContainingAssembly.Name);
+        Assert.Equal(image.Identity.Version, field.Type.ContainingAssembly.Identity.Version);
+        PortableExecutableReference reference = Assert.Single(context.CompilerReferences, candidate =>
+            compilation.GetAssemblyOrModuleSymbol(candidate) is IAssemblySymbol symbol
+            && SymbolEqualityComparer.Default.Equals(symbol, field.Type.ContainingAssembly));
+        Assert.Equal(image.ModuleVersionId,
+            Assert.Single(Assert.IsType<AssemblyMetadata>(reference.GetMetadata()).GetModules()).GetModuleVersionId());
+    }
+
+    static AssemblyBindingRequest Request(AssemblyReferenceIdentity identity, ResolvedAssemblyReference source) =>
+        new(AssemblyBindingTarget.Reference(identity), AssemblyBindingOrigin.FromAssembly(source), AssemblyResolutionScope.Platform);
+
+    static CompilePlatformBindingEvidence JsonBinding(CompileReferencePlatformPolicy policy) =>
+        Assert.Single(policy.Bindings, binding => ((AssemblyBindingTarget.AssemblyReference)binding.Request.Target).Identity.IsEquivalentTo(JsonIdentity));
+
+    static CompileReferenceImage Image(CompileReferenceInventory inventory, ArtifactIdentity id) =>
+        inventory.Candidates.Prepend(inventory.Source).Single(image => ReferenceEquals(image.InventoryId, id));
+
+    static MetadataTypeDefinitionName TypeName(string ns, string name) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(MetadataTypeDefinitionName.Create(ns, [name])).Name;
+
+    static string PlatformPath(string name) => (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+        .Single(path => Path.GetFileName(path) == name);
+
+    static AssemblyReferenceIdentity Identity(string path)
+    {
+        using var pe = new PEReader(File.OpenRead(path));
+        return AssemblyReferenceIdentity.FromAssemblyDefinition(pe.GetMetadataReader());
+    }
+
+    static T Ready<T>(CompileReferenceResult<T> result) =>
+        Assert.IsType<CompileReferenceResult<T>.Ready>(result).Value;
+
+    static CompileReferenceFailure Rejected<T>(CompileReferenceResult<T> result, CompileReferenceFailureKind kind)
+    {
+        CompileReferenceFailure failure = Assert.IsType<CompileReferenceResult<T>.Rejected>(result).Failure;
+        Assert.Equal(kind, failure.Kind);
+        return failure;
+    }
+
+    sealed record ForeignLineage(AssemblyBindingPolicyVersion PolicyVersion) : AssemblyBindingLineage(PolicyVersion)
+    {
+        internal AssemblyBindingOccurrence Bind(ResolvedAssemblyReference assembly) => CreateOccurrence(assembly);
+    }
+
+    sealed class Fixture : IAsyncDisposable
+    {
+        readonly string _directory = Path.Combine("artifacts", "platform-policy-tests", Guid.NewGuid().ToString("N"));
+        public ArtifactSetSession Owner { get; } = new();
+        public ArtifactQueryAuthorization Authorization { get; private set; } = null!;
+        public ArtifactQueryLease Lease { get; private set; } = null!;
+        public AssemblyDependencyResolver Resolver { get; }
+        public ResolvedAssemblyReference Source { get; }
+        public string SourcePath { get; }
+        public string SiblingPath { get; }
+
+        public Fixture(string? sibling = null, bool designateSibling = false, bool ignoreVersion = false, bool includePlatform = true)
+        {
+            Directory.CreateDirectory(_directory);
+            SourcePath = Path.Combine(_directory, "Fixture.dll");
+            File.Copy(FixtureCatalog.AssemblyPath(FixtureIds.DecompilerTypeIdentity), SourcePath);
+            SiblingPath = Path.Combine(_directory, "System.Text.Json.dll");
+            if (sibling is not null)
+            {
+                byte[] bytes = File.ReadAllBytes(JsonPath);
+                using var pe = new PEReader(new MemoryStream(bytes, writable: false));
+                if (sibling == "changed")
+                    bytes[pe.PEHeaders.CoffHeaderStartOffset + 4] ^= 1;
+                else if (sibling == "skewed")
+                    BinaryPrimitives.WriteUInt16LittleEndian(
+                        bytes.AsSpan(pe.PEHeaders.MetadataStartOffset + pe.GetMetadataReader().GetTableMetadataOffset(TableIndex.Assembly) + 4),
+                        checked((ushort)(JsonIdentity.Version!.Major - 1)));
+                File.WriteAllBytes(SiblingPath, bytes);
+            }
+            Resolver = new(new AssemblyDependencyResolutionOptions(SourcePath)
+            {
+                PackageRoots = [],
+                ExcludeTargetAssembly = true,
+                IncludeAspNetCoreSharedFramework = false,
+                IncludeDepsJsonAssets = false,
+                IncludeTrustedPlatformAssemblies = includePlatform,
+                AllowPlatformAssemblyVersionRollForward = true,
+                IgnoreAssemblyVersion = ignoreVersion,
+                CorpusAssemblyPaths = designateSibling ? [SiblingPath] : null,
+            });
+            Source = Resolver.AcquireTargetAssembly()!;
+        }
+
+        public ValueTask<CompileReferenceResult<CompileReferencePlatformPolicy>> TryPrepare(params AssemblyReferenceIdentity[] identities) =>
+            CompileReferencePlatformPolicy.PrepareAsync(Owner, Resolver, Source,
+                identities.Select(identity => Request(identity, Source)), Cancellation);
+
+        public async Task<CompileReferencePlatformPolicy> Prepare(params AssemblyReferenceIdentity[] identities) =>
+            Ready(await TryPrepare(identities));
+
+        public async Task<CompileReferenceInventory> Publish(CompileReferencePlatformPolicy policy, Action<long>? charge = null)
+        {
+            Assert.IsType<ArtifactSetPublicationOutcome.Published>(await Owner.SealAsync(Cancellation));
+            Authorization = Owner.CreateQueryAuthorization();
+            Lease = Owner.IssueLease(Authorization);
+            return Ready(policy.Discover(Lease, charge ?? (_ => { }), Cancellation));
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Lease?.Dispose();
+            await Owner.DisposeAsync();
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -65,6 +65,7 @@ public sealed class DynamicCompilationSiteInventoryTests
 
             // Cross-assembly reference seam.
             ["CompileReferenceSetTests.cs"] = (3, "Compiler-reference semantic-model seam: binds consumer syntax against selected cataloged images to verify aliases, source exclusion, and retained snapshot identity; emits no inspected fixture."),
+            ["CompileReferencePlatformPolicyTests.cs"] = (1, "Platform-reference semantic-model seam: binds consumer syntax to owner-authorized retained platform images; emits no inspected fixture."),
             ["CrossAssemblyMethodFactsTests.cs"] = (1, "Cross-assembly seam: constructs referencing compilations to test cross-assembly facts."),
             ["AuthoredRebuildFidelityTests.cs"] = (2, "Cross-assembly snapshot + portable-PDB seams: replaces a same-identity dependency after RTS acquisition, and emits checksum-bearing PDB fixtures for live source-acquisition outcomes."),
             ["ReferenceEqualityMetadataFactsTests.cs"] = (1, "Cross-assembly version-pair seam: builds same-name hierarchy assemblies with distinct versions to gate exact visited identity."),
@@ -142,9 +143,11 @@ public sealed class DynamicCompilationSiteInventoryTests
     //   #6005 adds CompileReferenceSetTests.cs (3 sites): binds consumer syntax
     //     against frozen cataloged images for alias, source-exclusion, and
     //     retained-snapshot reference contracts.
-    //   Combined: 45 files, 59 sites.
-    const int ExpectedDynamicFiles = 45;
-    const int ExpectedDynamicSites = 59;
+    //   #6120 adds CompileReferencePlatformPolicyTests.cs (1 site): binds against
+    //     the same retained platform images that Metadata resolves.
+    //   Combined: 46 files, 60 sites.
+    const int ExpectedDynamicFiles = 46;
+    const int ExpectedDynamicSites = 60;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="..\..\tools\DecompilerHarness\CompileReferenceInventory.cs" Link="CompileReferenceInventory.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CompileReferenceSet.cs" Link="CompileReferenceSet.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CompileReferenceContext.cs" Link="CompileReferenceContext.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\CompileReferencePlatformPolicy.cs" Link="CompileReferencePlatformPolicy.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\InverseLedger.cs" Link="InverseArchitecture\InverseLedger.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\HarnessLog.cs"
              Link="HarnessLog.cs" />

--- a/tools/DecompilerHarness/CompileReferenceContext.cs
+++ b/tools/DecompilerHarness/CompileReferenceContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using DotnetInspector.Artifacts;
 using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
 
@@ -8,7 +9,7 @@ namespace ILInspector.DecompilerHarness;
 /// Scoped Metadata and Roslyn views of a frozen set. Use only within the
 /// CompileReferenceSet.Use callback; the source is never a compiler reference.
 /// </summary>
-public sealed class CompileReferenceContext : IAssemblyReferenceResolver
+public sealed class CompileReferenceContext : IAssemblyReferenceResolver, IAssemblyBindingPolicy
 {
     readonly CompileReferenceSet _set;
 
@@ -22,8 +23,9 @@ public sealed class CompileReferenceContext : IAssemblyReferenceResolver
 
     public ResolvedAssemblyReference Source { get; }
     public ImmutableArray<PortableExecutableReference> CompilerReferences { get; }
+    public AssemblyBindingPolicyVersion Version => _set.BindingVersion;
 
-    /// <summary>Exact identity resolution only; this slice authorizes no platform candidates.</summary>
+    /// <summary>Origin-free compatibility lookup remains exact and Any-scope only.</summary>
     public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
     {
         ArgumentNullException.ThrowIfNull(identity);
@@ -31,5 +33,26 @@ public sealed class CompileReferenceContext : IAssemblyReferenceResolver
             return null;
         return _set.References
             .SingleOrDefault(reference => identity.IsEquivalentTo(reference.Image.Identity))?.Image.Assembly;
+    }
+
+    public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Origin is AssemblyBindingOrigin.RequestingAssembly origin)
+        {
+            ArtifactAcquisitionRegistration? registration = origin.Registration.ArtifactRegistration;
+            bool ownsOrigin = registration is not null
+                && (_set.PlatformBindings?.OwnsOrigin(registration)
+                    ?? (ReferenceEquals(Source.Registration.ArtifactRegistration, registration)
+                        || _set.References.Any(reference => ReferenceEquals(reference.Image.ArtifactRegistration, registration))));
+            if (!FrozenPlatformBindings.IsSeed(origin.Lineage) || !ownsOrigin)
+                return new(Version, AssemblyBindingSelection.Invalid(new(AssemblyBindingFailureKind.InvalidBindingOrigin)));
+        }
+        if (request.Scope == AssemblyResolutionScope.Platform && _set.PlatformBindings is { } platform)
+            return new(Version, platform.Select(request));
+        return new(Version, request.Target is AssemblyBindingTarget.AssemblyReference reference
+            && Resolve(reference.Identity, request.Scope) is { } selected
+                ? AssemblyBindingSelection.Found(selected)
+                : AssemblyBindingSelection.CannotSelect(new(AssemblyBindingFailureKind.IdentityPolicyRequired)));
     }
 }

--- a/tools/DecompilerHarness/CompileReferenceInventory.cs
+++ b/tools/DecompilerHarness/CompileReferenceInventory.cs
@@ -17,13 +17,21 @@ public enum CompileReferenceFailureKind
     ReferenceSelectionAmbiguous,
     SourceReferenceExcluded,
     ReferenceRoleConflict,
+    ReferencePlatformRequestUnsupported,
+    ReferencePlatformSelectionUnavailable,
+    ReferencePlatformIdentityMismatch,
+    ReferencePlatformAgreementMismatch,
+    ReferencePlatformPolicyMismatch,
 }
 
 public sealed record CompileReferenceFailure(
     CompileReferenceFailureKind Kind,
     ArtifactIdentity? Artifact = null,
     AssemblyReferenceIdentity? RequestedIdentity = null,
-    ImmutableArray<ArtifactIdentity> Candidates = default);
+    ImmutableArray<ArtifactIdentity> Candidates = default,
+    AssemblyBindingRequest? BindingRequest = null,
+    AssemblyBindingSelectionSnapshot? PolicySelection = null,
+    CandidateOpenFailure? ContentFailure = null);
 
 public abstract class CompileReferenceResult<T>
 {

--- a/tools/DecompilerHarness/CompileReferencePlatformPolicy.cs
+++ b/tools/DecompilerHarness/CompileReferencePlatformPolicy.cs
@@ -1,0 +1,393 @@
+using System.Collections.Immutable;
+using DotnetInspector.Artifacts;
+using DotnetInspector.Artifacts.Workspaces;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+using InertText;
+
+namespace ILInspector.DecompilerHarness;
+
+public sealed class CompilePlatformBindingEvidence
+{
+    internal CompilePlatformBindingEvidence(
+        AssemblyBindingRequest request,
+        AssemblyBindingSelectionSnapshot platform,
+        AssemblyBindingSelectionSnapshot agreement,
+        ArtifactIdentity? origin,
+        ArtifactIdentity platformArtifact,
+        ArtifactIdentity agreementArtifact)
+    {
+        Request = request;
+        PlatformSelection = platform;
+        AgreementSelection = agreement;
+        Origin = origin;
+        PlatformArtifact = platformArtifact;
+        AgreementArtifact = agreementArtifact;
+    }
+
+    public AssemblyBindingRequest Request { get; }
+    public AssemblyBindingSelectionSnapshot PlatformSelection { get; }
+    public AssemblyBindingSelectionSnapshot AgreementSelection { get; }
+    public ArtifactIdentity? Origin { get; }
+    public ArtifactIdentity PlatformArtifact { get; }
+    public ArtifactIdentity AgreementArtifact { get; }
+}
+
+/// <summary>
+/// Explicit, finite platform preparation. Supporting acquisitions are retained
+/// before this helper returns; the caller seals and owns the artifact session.
+/// No Services resolver is retained by the frozen binding view.
+/// </summary>
+public sealed class CompileReferencePlatformPolicy
+{
+    readonly ArtifactSetSession _owner;
+    readonly CompileReferenceInput _source;
+    readonly ImmutableArray<CompileReferenceInput> _candidates;
+
+    CompileReferencePlatformPolicy(
+        ArtifactSetSession owner,
+        AssemblyBindingPolicyVersion ownerPolicyVersion,
+        CompileReferenceInput source,
+        ImmutableArray<CompileReferenceInput> candidates,
+        ImmutableArray<CompilePlatformBindingEvidence> bindings)
+    {
+        _owner = owner;
+        OwnerPolicyVersion = ownerPolicyVersion;
+        _source = source;
+        _candidates = candidates;
+        Bindings = bindings;
+    }
+
+    public AssemblyBindingPolicyVersion OwnerPolicyVersion { get; }
+    public ImmutableArray<CompilePlatformBindingEvidence> Bindings { get; }
+
+    public static async ValueTask<CompileReferenceResult<CompileReferencePlatformPolicy>> PrepareAsync(
+        ArtifactSetSession owner,
+        AssemblyDependencyResolver resolver,
+        ResolvedAssemblyReference source,
+        IEnumerable<AssemblyBindingRequest> requests,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(requests);
+        cancellationToken.ThrowIfCancellationRequested();
+        AssemblyBindingRequest[] declared = requests.ToArray();
+        var capture = new CapturePolicy(resolver, cancellationToken);
+        try
+        {
+            ResolvedAssemblyReference retainedSource = capture.Retain(source);
+            var roots = new List<ResolvedAssemblyReference> { retainedSource };
+            foreach (AssemblyBindingRequest request in declared)
+            {
+                ArgumentNullException.ThrowIfNull(request);
+                CapturePolicy.RequireSupported(request);
+                if (request.Origin is AssemblyBindingOrigin.RequestingAssembly origin)
+                    roots.Add(capture.Retain(origin.Assembly));
+            }
+            using (var catalog = new TypeResolutionCatalog())
+            using (catalog.CreateContextWithCancellation(
+                capture, roots.DistinctBy(root => root.Registration), declared, [], cancellationToken))
+            {
+                // Metadata owns forwarding discovery and its scope/occurrence transitions.
+            }
+            if (!ReferenceEquals(capture.Version, resolver.Version))
+                return Reject(new(CompileReferenceFailureKind.ReferencePlatformPolicyMismatch));
+
+            var inputs = new Dictionary<AssemblyAcquisitionRegistration, CompileReferenceInput>();
+            await owner.AddRequiredAcquisitionAsync((scope, _) =>
+            {
+                var contributions = new List<ArtifactContribution>();
+                foreach (ResolvedAssemblyReference assembly in capture.Retained.Values)
+                {
+                    ArtifactContribution contribution = scope.Register(
+                        new ServicesAcquisitionProvenance(assembly.Registration, assembly.Provenance),
+                        _ => assembly.OpenRead());
+                    contributions.Add(contribution);
+                    inputs.Add(assembly.Registration, new CompileReferenceInput(
+                        contribution.Descriptor.Identity, assembly.Provenance,
+                        assembly.Path is { } path ? new InertString(TextPolicy.Field, path) : null));
+                }
+                return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                    new ArtifactAcquisitionOutcome.Acquired(contributions, ArtifactAcquisitionLeases.None));
+            }, cancellationToken: cancellationToken);
+
+            return new CompileReferenceResult<CompileReferencePlatformPolicy>.Ready(new(
+                owner, capture.Version, inputs[source.Registration],
+                [.. inputs.Where(entry => !ReferenceEquals(entry.Key, source.Registration)).Select(entry => entry.Value)],
+                [.. capture.Bindings.Select(binding => new CompilePlatformBindingEvidence(
+                    binding.Request, binding.Platform, binding.Agreement,
+                    binding.Request.Origin is AssemblyBindingOrigin.RequestingAssembly origin
+                        ? inputs[origin.Registration].Artifact : null,
+                    inputs[((AssemblyBindingSelection.Selected)binding.Platform.Selection).Assembly.Registration].Artifact,
+                    inputs[((AssemblyBindingSelection.Selected)binding.Agreement.Selection).Assembly.Registration].Artifact))]));
+        }
+        catch (PreparationFailure failure)
+        {
+            return Reject(failure.Failure);
+        }
+    }
+
+    public CompileReferenceResult<CompileReferenceInventory> Discover(
+        ArtifactQueryLease lease,
+        Action<long> chargeWork,
+        CancellationToken cancellationToken = default) =>
+        CompileReferenceInventory.Discover(_owner, lease, _source, _candidates, chargeWork, cancellationToken);
+
+    public CompileReferenceResult<CompileReferenceSet> Select(
+        CompileReferenceInventory inventory,
+        IEnumerable<CompileReferenceRequest> exactRequests,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+        ArgumentNullException.ThrowIfNull(exactRequests);
+        if (!ReferenceEquals(_owner, inventory.Owner)
+            || !ReferenceEquals(_source.Artifact, inventory.Source.InventoryId))
+            return RejectSet(new(CompileReferenceFailureKind.ReferencePlatformPolicyMismatch));
+
+        var images = inventory.Candidates.Prepend(inventory.Source).Distinct()
+            .ToDictionary(image => image.InventoryId);
+        foreach (CompileReferenceInput input in _candidates.Prepend(_source))
+        {
+            if (!images.TryGetValue(input.Artifact, out CompileReferenceImage? image)
+                || image.ArtifactRegistration.Provenance is not ServicesAcquisitionProvenance provenance
+                || provenance.Provenance != input.Provenance
+                || image.Provenance != input.Provenance)
+                return RejectSet(new(CompileReferenceFailureKind.ReferencePlatformPolicyMismatch, input.Artifact));
+            if (_owner.WithQueryContent(input.Artifact, inventory.Lease, static (_, _) => true, cancellationToken)
+                is not ArtifactContentAccessOutcome<bool>.Accessed)
+                return RejectSet(new(CompileReferenceFailureKind.ReferenceAuthorityUnavailable, input.Artifact));
+        }
+        foreach (CompilePlatformBindingEvidence binding in Bindings)
+        {
+            CompileReferenceImage platform = images[binding.PlatformArtifact];
+            CompileReferenceImage agreement = images[binding.AgreementArtifact];
+            if (!ReferenceEquals(
+                    ((ServicesAcquisitionProvenance)platform.ArtifactRegistration.Provenance).Registration,
+                    ((AssemblyBindingSelection.Selected)binding.PlatformSelection.Selection).Assembly.Registration)
+                || !ReferenceEquals(
+                    ((ServicesAcquisitionProvenance)agreement.ArtifactRegistration.Provenance).Registration,
+                    ((AssemblyBindingSelection.Selected)binding.AgreementSelection.Selection).Assembly.Registration)
+                || binding.Origin is { } origin
+                    && !ReferenceEquals(
+                        ((ServicesAcquisitionProvenance)images[origin].ArtifactRegistration.Provenance).Registration,
+                        ((AssemblyBindingOrigin.RequestingAssembly)binding.Request.Origin).Registration))
+                return RejectSet(new(CompileReferenceFailureKind.ReferencePlatformPolicyMismatch));
+            if (!platform.Identity.IsEquivalentTo(agreement.Identity)
+                || platform.ModuleVersionId != agreement.ModuleVersionId
+                || platform.ContentDigest.Algorithm != agreement.ContentDigest.Algorithm
+                || platform.ContentDigest.HexValue != agreement.ContentDigest.HexValue)
+            {
+                return RejectSet(new(CompileReferenceFailureKind.ReferencePlatformAgreementMismatch,
+                    binding.AgreementArtifact,
+                    ((AssemblyBindingTarget.AssemblyReference)binding.Request.Target).Identity,
+                    [binding.PlatformArtifact, binding.AgreementArtifact]));
+            }
+        }
+        var frozen = new FrozenPlatformBindings(OwnerPolicyVersion, Bindings, images);
+        return CompileReferenceSet.Select(inventory, exactRequests, cancellationToken, frozen);
+    }
+
+    static CompileReferenceResult<CompileReferencePlatformPolicy> Reject(CompileReferenceFailure failure) =>
+        new CompileReferenceResult<CompileReferencePlatformPolicy>.Rejected(failure);
+
+    static CompileReferenceResult<CompileReferenceSet> RejectSet(CompileReferenceFailure failure) =>
+        new CompileReferenceResult<CompileReferenceSet>.Rejected(failure);
+
+    sealed record ServicesAcquisitionProvenance(
+        AssemblyAcquisitionRegistration Registration,
+        AssemblyResolutionProvenance Provenance) : IArtifactProvenance;
+
+    sealed class PreparationFailure(CompileReferenceFailure failure) : Exception
+    {
+        public CompileReferenceFailure Failure { get; } = failure;
+    }
+
+    sealed record CapturedBinding(
+        AssemblyBindingRequest Request,
+        AssemblyBindingSelectionSnapshot Platform,
+        AssemblyBindingSelectionSnapshot Agreement);
+
+    sealed class CapturePolicy(
+        AssemblyDependencyResolver resolver,
+        CancellationToken cancellationToken) : IAssemblyBindingPolicy
+    {
+        long _retainedBytes;
+        public AssemblyBindingPolicyVersion Version { get; } = resolver.Version;
+        public Dictionary<AssemblyAcquisitionRegistration, ResolvedAssemblyReference> Retained { get; } = [];
+        public List<CapturedBinding> Bindings { get; } = [];
+
+        public static void RequireSupported(AssemblyBindingRequest request)
+        {
+            if (request.Scope != AssemblyResolutionScope.Platform
+                || request.Target is not AssemblyBindingTarget.AssemblyReference { Identity.Version: not null }
+                || request.Origin is AssemblyBindingOrigin.RequestingAssembly origin
+                    && !FrozenPlatformBindings.IsSeed(origin.Lineage))
+                throw new PreparationFailure(new(CompileReferenceFailureKind.ReferencePlatformRequestUnsupported,
+                    BindingRequest: request));
+        }
+
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RequireSupported(request);
+            if (request.Origin is AssemblyBindingOrigin.RequestingAssembly origin)
+                Retain(origin.Assembly);
+            AssemblyBindingSelectionSnapshot platform = resolver.Select(request);
+            var requested = ((AssemblyBindingTarget.AssemblyReference)request.Target).Identity;
+            if (!ReferenceEquals(Version, platform.Version))
+                throw new PreparationFailure(new(CompileReferenceFailureKind.ReferencePlatformPolicyMismatch));
+            if (platform.Selection is not AssemblyBindingSelection.Selected selected
+                || selected.Assembly.Provenance is not AssemblyResolutionProvenance.PlatformAsset)
+                throw new PreparationFailure(new(CompileReferenceFailureKind.ReferencePlatformSelectionUnavailable,
+                    RequestedIdentity: requested, BindingRequest: request, PolicySelection: platform));
+            if (!FrozenPlatformBindings.IsSeed(selected.Occurrence.Lineage)
+                || selected.Assembly.Identity.Version is not { } version
+                || version < requested.Version
+                || !(requested with { Version = version }).IsEquivalentTo(selected.Assembly.Identity))
+                throw new PreparationFailure(new(CompileReferenceFailureKind.ReferencePlatformIdentityMismatch,
+                    RequestedIdentity: requested, BindingRequest: request, PolicySelection: platform));
+
+            var agreementRequest = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(selected.Assembly.Identity), request.Origin, AssemblyResolutionScope.Any);
+            AssemblyBindingSelectionSnapshot agreement = resolver.Select(agreementRequest);
+            if (!ReferenceEquals(Version, agreement.Version))
+                throw new PreparationFailure(new(CompileReferenceFailureKind.ReferencePlatformPolicyMismatch));
+            if (agreement.Selection is not AssemblyBindingSelection.Selected compiler
+                || !FrozenPlatformBindings.IsSeed(compiler.Occurrence.Lineage))
+                throw new PreparationFailure(new(CompileReferenceFailureKind.ReferencePlatformSelectionUnavailable,
+                    RequestedIdentity: requested, BindingRequest: agreementRequest, PolicySelection: agreement));
+
+            Bindings.Add(new(request, platform, agreement));
+            Retain(compiler.Assembly);
+            foreach (ResolvedAssemblyReference shadow in selected.ShadowedAssemblies.Concat(compiler.ShadowedAssemblies))
+                Retain(shadow);
+            // Services currently issues Seed occurrences. Retention preserves both
+            // that continuation and the original acquisition registration.
+            return new(Version, AssemblyBindingSelection.Found(Retain(selected.Assembly),
+                [.. selected.ShadowedAssemblies.Select(Retain)]));
+        }
+
+        public ResolvedAssemblyReference Retain(ResolvedAssemblyReference assembly)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Retained.TryGetValue(assembly.Registration, out ResolvedAssemblyReference? retained))
+                return retained;
+            AssemblyImageSnapshotResult snapshot = AssemblyImageSnapshot.Open(
+                assembly,
+                bytes =>
+                {
+                    if (bytes > AssemblyImageSnapshot.DefaultMaxRetainedImageBytes - _retainedBytes)
+                        return false;
+                    _retainedBytes += bytes;
+                    return true;
+                },
+                bytes => _retainedBytes -= bytes);
+            if (snapshot is not AssemblyImageSnapshotResult.Ready ready)
+                throw new PreparationFailure(new(CompileReferenceFailureKind.ReferenceContentUnavailable,
+                    ContentFailure: ((AssemblyImageSnapshotResult.Rejected)snapshot).Failure));
+            retained = ready.Snapshot.RetainAssemblyReference(assembly);
+            Retained.Add(assembly.Registration, retained);
+            return retained;
+        }
+    }
+}
+
+internal sealed class FrozenPlatformBindings
+{
+    readonly Dictionary<BindingKey, CompileReferenceImage> _bindings = new(new BindingKeyComparer());
+    readonly IReadOnlyDictionary<ArtifactIdentity, CompileReferenceImage> _images;
+
+    internal FrozenPlatformBindings(
+        AssemblyBindingPolicyVersion ownerVersion,
+        ImmutableArray<CompilePlatformBindingEvidence> evidence,
+        IReadOnlyDictionary<ArtifactIdentity, CompileReferenceImage> images)
+    {
+        OwnerVersion = ownerVersion;
+        _images = images;
+        var unique = ImmutableArray.CreateBuilder<CompilePlatformBindingEvidence>();
+        foreach (CompilePlatformBindingEvidence binding in evidence)
+        {
+            var identity = ((AssemblyBindingTarget.AssemblyReference)binding.Request.Target).Identity;
+            var key = new BindingKey(identity, binding.Origin, binding.Request.Scope);
+            if (_bindings.TryAdd(key, images[binding.PlatformArtifact]))
+                unique.Add(binding);
+            else if (!ReferenceEquals(_bindings[key].InventoryId, binding.PlatformArtifact))
+                throw new InvalidOperationException("Services returned conflicting equivalent platform bindings.");
+        }
+        Evidence = unique.ToImmutable();
+        PlatformImages = [.. evidence.Select(binding => images[binding.PlatformArtifact]).Distinct()];
+    }
+
+    internal AssemblyBindingPolicyVersion OwnerVersion { get; }
+    internal ImmutableArray<CompilePlatformBindingEvidence> Evidence { get; }
+    internal ImmutableArray<CompileReferenceImage> PlatformImages { get; }
+
+    internal static bool IsSeed(AssemblyBindingLineage? lineage) =>
+        lineage is null || lineage == AssemblyBindingLineage.Seed;
+
+    internal bool OwnsOrigin(ArtifactAcquisitionRegistration registration) =>
+        _images.TryGetValue(registration.Artifact, out CompileReferenceImage? image)
+        && ReferenceEquals(image.ArtifactRegistration, registration);
+
+    internal AssemblyBindingSelection Select(AssemblyBindingRequest request)
+    {
+        ArtifactIdentity? origin = null;
+        if (request.Origin is AssemblyBindingOrigin.RequestingAssembly requesting)
+        {
+            if (!IsSeed(requesting.Lineage)
+                || requesting.Registration.ArtifactRegistration is not { } registration
+                || !OwnsOrigin(registration))
+                return AssemblyBindingSelection.Invalid(new(AssemblyBindingFailureKind.InvalidBindingOrigin));
+            origin = registration.Artifact;
+        }
+        if (request.Target is AssemblyBindingTarget.AssemblyReference reference
+            && _bindings.TryGetValue(new(reference.Identity, origin, request.Scope), out CompileReferenceImage? selected))
+            return AssemblyBindingSelection.Found(selected.Assembly);
+        return AssemblyBindingSelection.CannotSelect(new(AssemblyBindingFailureKind.IdentityPolicyRequired));
+    }
+
+    internal void WriteEncoding(BinaryWriter writer)
+    {
+        CompileReferenceSet.WriteText(writer, "platform-compatibility/v1");
+        var ordered = Evidence.Select(binding => (
+                Binding: binding,
+                // Strict family validation permits the retained spelling to canonicalize
+                // equivalent request spellings without changing the requested version.
+                Identity: _images[binding.PlatformArtifact].Identity with
+                {
+                    Version = ((AssemblyBindingTarget.AssemblyReference)binding.Request.Target).Identity.Version,
+                }))
+            .OrderBy(item => item.Binding.Origin?.Ordinal ?? -1)
+            .ThenBy(item => item.Binding.Request.Scope)
+            .ThenBy(item => item.Identity.Name, StringComparer.Ordinal)
+            .ThenBy(item => item.Identity.Version)
+            .ThenBy(item => item.Identity.Culture, StringComparer.Ordinal)
+            .ThenBy(item => item.Identity.PublicKeyToken, StringComparer.Ordinal)
+            .ToArray();
+        writer.Write(ordered.Length);
+        foreach (var (binding, identity) in ordered)
+        {
+            writer.Write(binding.Origin?.Ordinal ?? -1);
+            writer.Write((int)binding.Request.Scope);
+            CompileReferenceSet.WriteIdentity(writer, identity);
+            writer.Write(binding.PlatformArtifact.Ordinal);
+            CompileReferenceSet.WriteImage(writer, _images[binding.AgreementArtifact]);
+        }
+    }
+
+    readonly record struct BindingKey(
+        AssemblyReferenceIdentity Identity,
+        ArtifactIdentity? Origin,
+        AssemblyResolutionScope Scope);
+
+    sealed class BindingKeyComparer : IEqualityComparer<BindingKey>
+    {
+        public bool Equals(BindingKey x, BindingKey y) =>
+            x.Identity.IsEquivalentTo(y.Identity) && ReferenceEquals(x.Origin, y.Origin) && x.Scope == y.Scope;
+
+        public int GetHashCode(BindingKey value) => HashCode.Combine(
+            AssemblyReferenceIdentity.EquivalentComparer.GetHashCode(value.Identity), value.Origin, value.Scope);
+    }
+}

--- a/tools/DecompilerHarness/CompileReferenceSet.cs
+++ b/tools/DecompilerHarness/CompileReferenceSet.cs
@@ -41,40 +41,47 @@ public sealed class CompileReferenceRequest
 public sealed class CompileReferenceDescriptor
 {
     internal CompileReferenceDescriptor(
-        CompileReferenceImage image, int selectedOrdinal, MetadataReferenceProperties properties)
+        CompileReferenceImage image, int selectedOrdinal, MetadataReferenceProperties properties,
+        bool isPlatformAuthorized = false)
     {
         Image = image;
         SelectedOrdinal = selectedOrdinal;
         Properties = properties;
+        IsPlatformAuthorized = isPlatformAuthorized;
     }
 
     public CompileReferenceImage Image { get; }
     public ArtifactIdentity InventoryId => Image.InventoryId;
     public int SelectedOrdinal { get; }
     public MetadataReferenceProperties Properties { get; }
-    // This slice has no platform-authorizing policy, even for platform-looking names.
-    public bool IsPlatformAuthorized => false;
+    public bool IsPlatformAuthorized { get; }
 }
 
 /// <summary>
 /// A generation-scoped set key. HexValue alone is not a cross-generation identity:
 /// the encoding uses owner ordinals only as deterministic generation-local order.
+/// Platform keys also retain the typed Services policy-version association.
 /// </summary>
 public sealed class CompileReferenceSetDigest : IEquatable<CompileReferenceSetDigest>
 {
-    internal CompileReferenceSetDigest(ArtifactGenerationIdentity generation, string hexValue)
+    internal CompileReferenceSetDigest(
+        ArtifactGenerationIdentity generation, string hexValue,
+        AssemblyBindingPolicyVersion? ownerPolicyVersion = null)
     {
         Generation = generation;
         HexValue = hexValue;
+        OwnerPolicyVersion = ownerPolicyVersion;
     }
 
     public ArtifactGenerationIdentity Generation { get; }
     public string Algorithm => "SHA-256";
     public string HexValue { get; }
+    public AssemblyBindingPolicyVersion? OwnerPolicyVersion { get; }
     public bool Equals(CompileReferenceSetDigest? other) =>
-        other is not null && ReferenceEquals(Generation, other.Generation) && HexValue == other.HexValue;
+        other is not null && ReferenceEquals(Generation, other.Generation)
+        && ReferenceEquals(OwnerPolicyVersion, other.OwnerPolicyVersion) && HexValue == other.HexValue;
     public override bool Equals(object? obj) => obj is CompileReferenceSetDigest other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Generation, HexValue);
+    public override int GetHashCode() => HashCode.Combine(Generation, HexValue, OwnerPolicyVersion);
 }
 
 /// <summary>
@@ -84,14 +91,18 @@ public sealed class CompileReferenceSetDigest : IEquatable<CompileReferenceSetDi
 public sealed class CompileReferenceSet
 {
     readonly CompileReferenceInventory _inventory;
+    internal FrozenPlatformBindings? PlatformBindings { get; }
+    internal AssemblyBindingPolicyVersion BindingVersion { get; } = new();
 
     CompileReferenceSet(
         CompileReferenceInventory inventory,
-        ImmutableArray<CompileReferenceDescriptor> references)
+        ImmutableArray<CompileReferenceDescriptor> references,
+        FrozenPlatformBindings? platformBindings)
     {
         _inventory = inventory;
         Source = inventory.Source;
         References = references;
+        PlatformBindings = platformBindings;
         Digest = ComputeDigest();
     }
 
@@ -102,14 +113,18 @@ public sealed class CompileReferenceSet
     internal static CompileReferenceResult<CompileReferenceSet> Select(
         CompileReferenceInventory inventory,
         IEnumerable<CompileReferenceRequest> requests,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        FrozenPlatformBindings? platformBindings = null)
     {
         ArgumentNullException.ThrowIfNull(requests);
         if (Validate(inventory, inventory.Source, cancellationToken) is { } unavailable)
             return new CompileReferenceResult<CompileReferenceSet>.Rejected(unavailable);
 
         var selected = new Dictionary<ArtifactIdentity, (CompileReferenceImage Image, MetadataReferenceProperties Properties)>();
-        foreach (CompileReferenceRequest request in requests)
+        IEnumerable<CompileReferenceRequest> allRequests = platformBindings is null ? requests
+            : requests.Concat(platformBindings.PlatformImages.Select(image =>
+                new CompileReferenceRequest(image.Identity, image.InventoryId)));
+        foreach (CompileReferenceRequest request in allRequests)
         {
             ArgumentNullException.ThrowIfNull(request);
             cancellationToken.ThrowIfCancellationRequested();
@@ -142,13 +157,14 @@ public sealed class CompileReferenceSet
 
         ImmutableArray<CompileReferenceDescriptor> descriptors = [.. selected.Values
             .OrderBy(value => value.Image.InventoryId.Ordinal)
-            .Select((value, index) => new CompileReferenceDescriptor(value.Image, index, value.Properties))];
+            .Select((value, index) => new CompileReferenceDescriptor(value.Image, index, value.Properties,
+                platformBindings?.PlatformImages.Contains(value.Image) == true))];
         foreach (CompileReferenceDescriptor descriptor in descriptors)
         {
             if (Validate(inventory, descriptor.Image, cancellationToken) is { } failure)
                 return new CompileReferenceResult<CompileReferenceSet>.Rejected(failure);
         }
-        return new CompileReferenceResult<CompileReferenceSet>.Ready(new(inventory, descriptors));
+        return new CompileReferenceResult<CompileReferenceSet>.Ready(new(inventory, descriptors, platformBindings));
     }
 
     /// <summary>
@@ -211,7 +227,9 @@ public sealed class CompileReferenceSet
         using var encoding = new MemoryStream();
         using (var writer = new BinaryWriter(encoding, Encoding.UTF8, leaveOpen: true))
         {
-            WriteText(writer, "DecompilerHarness.CompileReferenceSet/v1/exact-identity");
+            WriteText(writer, PlatformBindings is null
+                ? "DecompilerHarness.CompileReferenceSet/v1/exact-identity"
+                : "DecompilerHarness.CompileReferenceSet/v2/platform-compatibility");
             WriteImage(writer, Source);
             writer.Write(References.Length);
             foreach (CompileReferenceDescriptor descriptor in References)
@@ -225,24 +243,31 @@ public sealed class CompileReferenceSet
                 writer.Write(descriptor.Properties.EmbedInteropTypes);
                 writer.Write(descriptor.IsPlatformAuthorized);
             }
+            PlatformBindings?.WriteEncoding(writer);
         }
         return new(Source.InventoryId.Generation,
-            Convert.ToHexStringLower(SHA256.HashData(encoding.GetBuffer().AsSpan(0, checked((int)encoding.Length)))));
+            Convert.ToHexStringLower(SHA256.HashData(encoding.GetBuffer().AsSpan(0, checked((int)encoding.Length)))),
+            PlatformBindings?.OwnerVersion);
     }
 
-    static void WriteImage(BinaryWriter writer, CompileReferenceImage image)
+    internal static void WriteImage(BinaryWriter writer, CompileReferenceImage image)
     {
         writer.Write(image.InventoryId.Ordinal);
         WriteText(writer, image.ContentDigest.Algorithm);
         WriteText(writer, image.ContentDigest.HexValue);
         writer.Write(image.ModuleVersionId.ToByteArray());
-        WriteText(writer, image.Identity.Name);
-        WriteText(writer, image.Identity.Version!.ToString());
-        WriteText(writer, image.Identity.Culture ?? "");
-        WriteText(writer, image.Identity.PublicKeyToken ?? "");
+        WriteIdentity(writer, image.Identity);
     }
 
-    static void WriteText(BinaryWriter writer, string value)
+    internal static void WriteIdentity(BinaryWriter writer, AssemblyReferenceIdentity identity)
+    {
+        WriteText(writer, identity.Name);
+        WriteText(writer, identity.Version!.ToString());
+        WriteText(writer, identity.Culture ?? "");
+        WriteText(writer, identity.PublicKeyToken ?? "");
+    }
+
+    internal static void WriteText(BinaryWriter writer, string value)
     {
         // Length-prefixed UTF-16 code units also distinguish unpaired surrogates.
         writer.Write(value.Length);


### PR DESCRIPTION
# Explicit frozen platform compatibility

Make compiler-reference evidence reliable without dropping supported platform
compatibility. This supplies the explicit frozen policy needed for the next
ReturnToSender migration; it does not narrow existing RTS behavior or change
the exact-only default.

Closes #6120. Advances #6103 and #5890.

## Demo

The public-API probe uses the cataloged type-identity fixture, an older
`System.Runtime` request, and a copy of the running platform's
`System.Text.Json.dll` beside the source. Full probe source is posted in a
comment on this PR; replace its project directive with your checkout path.
Run from the checkout after building the Release fixtures:

```bash
dotnet run /tmp/frozen-platform-policy-demo.cs -c Release
```

Observed with SDK `11.0.100-preview.7.26381.103`:

```text
Sibling: identical bytes, distinct acquisition
Exact-only older request: ReferenceNotFound
Explicit platform policy: Ready
Sibling remains distinct: True
Selected platform, not sibling: True
Older System.Runtime 10.0.0.0 resolves IConvertible in: System.Private.CoreLib
Roslyn binds after original paths are deleted: True
Sibling: changed bytes, same identity
Exact-only older request: ReferenceNotFound
Explicit platform policy: ReferencePlatformAgreementMismatch
```

Notice that compatibility selects the owner-issued platform acquisition; it
does not turn byte equality into acquisition identity. The neighboring case
changes the sibling's bytes while preserving its assembly identity and MVID:
selection visibly refuses it. Exact-only selection refuses the older request
in both cases, just as before.

## Design basis

One normative owner: `tools/DecompilerHarness`, under
[`Explicit platform compatibility policy`](https://github.com/richlander/dotnet-inspect/blob/c5b6bd78c57a15074a423f6e2ee1250456937136/docs/design/csharp-member-recompilation.md#explicit-platform-compatibility-policy).
The owned claim is that a finite, explicit platform policy freezes
Services-authorized compatibility selections into the same retained images
consumed by Metadata and Roslyn, without weakening exact-only selection.

Supporting contracts retain their existing roles: Services owns acquisition,
platform provenance and version policy; Metadata owns identity, registrations,
occurrences and forwarding preparation; Artifacts owns contribution identity,
retained bytes, digests and query authority; Roslyn consumes compiler references.

For each request, preparation captures the Services `Platform` answer P and
the `Any` answer A for P's selected full identity at the same origin. P must
be an owner-issued `PlatformAsset`, not merely an answer in Platform scope.
Strict name/culture/token matching permits only owner-authorized one-way
version substitution. After artifact admission and owner digests, A and P
must agree in full identity, MVID and retained-content digest. Selection
explicitly pins P and retains an identical sibling as distinct and unselected.

The API accepts finite Platform-scope assembly-reference requests with a
required version and seed origins. Platform compiler roles are global and
non-embedded; ordinary exact requests keep their role options. Prepared
bindings preserve origin and scope through artifact-registration remapping.
Unprepared platform bindings remain unavailable.

Exact mode keeps its `v1/exact-identity` encoding. Explicit compatibility uses
`v2/platform-compatibility`, including the materialized request mappings and
agreement evidence. Set equality also retains the typed Services policy-version
association; an opaque owner identity is not serialized as display text.
These are reference-set encodings, not a change to the signature census's
measurement contract.

The baseline is the existing Services platform policy and the unchanged RTS
positive/negative compatibility cases. The deliberate stricter boundary is
digest agreement plus explicit registration selection, rather than
simple-name-first-wins enumeration. The capture/retention bridge is necessary
to preserve owner-issued provenance while using artifact-guarded images.

## Adoption and scope

The user explicitly chose preserve-with-policy rather than exact-only
refusals; the approval and revised sequence are recorded on #6103:
<https://github.com/richlander/dotnet-inspect/issues/6103#issuecomment-5557217174>.
The immediate production consumer of this test infrastructure is the harness
contract suite, which actually exercises both Metadata and Roslyn.

The frozen-reference adoption path has three steps:

1. Exact inventory, selected set and scoped API: landed in #6006.
2. Explicit platform compatibility: this PR, tracked by #6120.
3. RTS acquisition and authored-rebuild lifetime migration, retiring its
   simple-name-first-wins enumeration and competing binding projection: #6103.

This is a prerequisite inside #5890's second decoder-adoption step, not a new
count of every compile-back slice. CLI/browser production adoption remains
deferred under the approved tools-first scope. Rendering is not applicable:
the changed surface is a typed harness API, not a product output section.

RTS migration, Services' nondeduplicated discovery surface, signature/body
closure, admission, correspondence and census expansion remain deferred.
The legacy RTS path is unchanged, not relabeled as conforming.

## Validation

Release focused gate: **49 passed**, zero failures or skips. This includes
19 new policy cases, 21 existing exact-reference cases, four dynamic-site
inventory cases and five unchanged RTS compatibility cases:

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- \
  -method 'ILInspector.Decompiler.Tests.CompileReferencePlatformPolicyTests.*' \
  -method 'ILInspector.Decompiler.Tests.CompileReferenceSetTests.*' \
  -method 'ILInspector.Decompiler.Tests.DynamicCompilationSiteInventoryTests.*' \
  -method ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests.ResolveExternalTypeDefinition_RollsOlderPlatformFacadeIntoCompilationClosure \
  -method ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests.ResolveExternalTypeDefinition_AcceptsByteIdenticalPlatformSibling \
  -method ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests.ResolveExternalTypeDefinition_DeclinesWhenSiblingSpoofsDurableAddress \
  -method ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests.ResolveExternalTypeDefinition_DeclinesWhenPlatformSelectionDiffersFromCompilationClosure \
  -method ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests.ResolveExternalTypeDefinition_DeclinesWhenVersionSkewedSiblingShadowsPlatform
```

The new cases exercise provenance eligibility, unchanged exact defaults,
forwarding and Roslyn image agreement, differing-content and version-skewed
siblings, generation/origin/scope/version association, retained images and
stale query authority. The Roslyn semantic-model site is registered in the
retained-site inventory: 46 files / 60 sites.

The public-API demo also builds and runs the harness project. Changed
Markdown passes `markdownlint`; the diff passes `git diff --check`.
PR CI and locked-head adversarial review follow publication.

## Frozen candidate

Head: `c5b6bd78c57a15074a423f6e2ee1250456937136`.
Effective base: `51b9cbf8663c7c2f3d9ccefc82679f97d473b2d4` on `main`.
