### PR TITLE
Preserve Queries binding facade snapshots and continuations

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1168,9 +1168,11 @@ internal interface IAssemblyBindingResolver
 > `AssemblyBindingSelectionSnapshot`, and Metadata validates the returned token
 > before interpreting a cold answer and validates the current token again at
 > the generation commit point. Focused Release tests enforce foreign-snapshot
-> rejection and policy-publication exclusion. Non-reused transforming-policy
-> tokens, delegated-version refresh, supersession retry, and full
-> model-to-implementation correspondence remain unverified.
+> rejection and policy-publication exclusion. Queries facade adoption in
+> #5669 adds distinct transforming-policy tokens, delegated-version refresh,
+> and continuation-preserving descriptor adaptation, with the focused gates
+> listed below. Broader policy adoption, supersession retry, and full
+> model-to-implementation correspondence remain separate work.
 
 `AssemblyBindingSelectionSnapshot` is the policy owner's immutable answer for
 one request. It atomically carries the exact
@@ -1310,6 +1312,35 @@ mutations, commit-point validation, pre-commit policy-publication exclusion,
 and eventual publication. Its companion composite model checks matching success,
 foreign-snapshot propagation, state refresh, route replacement, and retry
 progress.
+
+**Queries facade adoption (#5669).** Two existing facades transform policy
+answers; neither is transparent. `CancellationObservingBindingPolicy` adapts
+selected descriptors to observe cancellation during later reads.
+`AssemblyContextAnalysisSource.BindingPolicyResolver` retains descriptors and
+maps seed requests to its configured participant. Their outer occurrences
+retain the delegate's original occurrence, so continued requests preserve that
+context rather than repeat seed routing. The immutable `RoleBindingPolicy`
+leaf has no delegate and keeps its existing fixed token.
+
+This is one production-adoption step, shared by existing callers: CLI
+`MemberCommand` reaches the source facade through
+`AssemblyContextSourceComparisonQuery` for Source Diff; Browser `SourceExports`
+uses member/type source queries, and `AnalysisExports` uses method analysis
+and optimization queries. The step replaces delegate tokens used as outer
+tokens and descriptor reconstruction that erased the selected continuation.
+It introduces no host presentation change or workspace retry.
+
+`AssemblyContextAnalysisSourceTests` gates stable distinct versions,
+uninterpreted foreign snapshots, descriptor effects, state refresh, delegated
+continuations, retired-origin rejection, Metadata's null-snapshot failure,
+and the retained-analysis publication guard. `AssemblyContextSourceQueryTests`
+gates cancellation and failure observation, foreign-snapshot failure in source
+comparison, and the source query's captured participant-version boundary.
+The affected analysis queries also validate the group's captured version
+before publishing, including a foreign snapshot that lower-level analysis
+may have handled as incomplete evidence. The existing composite model supports
+the version transitions; these Release cases establish the Queries
+correspondence rather than claiming that the model proves the implementation.
 
 #### Resolver-lineage continuations
 

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextAnalysisSourceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextAnalysisSourceTests.cs
@@ -53,7 +53,7 @@ public sealed class AssemblyContextAnalysisSourceTests
                 AssemblyBindingOrigin.FromAssembly(retainedRoot),
                 AssemblyResolutionScope.Any);
 
-            Assert.Same(policy.Version, bindingPolicy.Version);
+            Assert.NotSame(policy.Version, bindingPolicy.Version);
             Assert.Same(terminal, bindingPolicy.Select(request).Selection);
             Assert.Same(
                 assembly.Registration,
@@ -132,6 +132,257 @@ public sealed class AssemblyContextAnalysisSourceTests
         Assert.DoesNotContain(second, retained.Assemblies);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Facade_OwnsStableVersionAndSelectedContinuation(bool observing)
+    {
+        using var fixture = new FacadeFixture();
+        fixture.Inner.Selection = AssemblyBindingSelection.Found(
+            fixture.Selected);
+        IAssemblyBindingPolicy policy = fixture.CreatePolicy(observing);
+        AssemblyBindingPolicyVersion version = policy.Version;
+
+        AssemblyBindingSelectionSnapshot first = policy.Select(
+            Request(fixture.Root));
+        AssemblyBindingSelectionSnapshot second = policy.Select(
+            Request(fixture.Root));
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            first.Selection);
+
+        Assert.NotSame(fixture.Inner.Version, version);
+        Assert.NotSame(version, fixture.CreatePolicy(observing).Version);
+        Assert.Same(version, first.Version);
+        Assert.Same(version, second.Version);
+        Assert.Same(version, policy.Version);
+        Assert.Same(version, selected.Occurrence.Lineage.Version);
+        Assert.Equal(
+            selected.Occurrence.Lineage,
+            Assert.IsType<AssemblyBindingSelection.Selected>(
+                second.Selection).Occurrence.Lineage);
+        Assert.Same(fixture.Selected.Registration, selected.Assembly.Registration);
+        Assert.NotSame(fixture.Selected, selected.Assembly);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Facade_ForwardsForeignSnapshotBeforeDescriptorEffects(bool observing)
+    {
+        using var fixture = new FacadeFixture();
+        fixture.Inner.Selection = AssemblyBindingSelection.Found(
+            fixture.Selected,
+            [fixture.Root]);
+        fixture.Inner.SnapshotVersion = new();
+        IAssemblyBindingPolicy policy = fixture.CreatePolicy(observing);
+        AssemblyBindingPolicyVersion version = policy.Version;
+
+        AssemblyBindingSelectionSnapshot snapshot = policy.Select(
+            Request(fixture.Root));
+
+        Assert.Same(fixture.Inner.LastSnapshot, snapshot);
+        Assert.Same(fixture.Inner.Selection, snapshot.Selection);
+        Assert.Equal(0, fixture.SelectedOpenCount);
+        Assert.NotSame(version, policy.Version);
+        Assert.NotSame(fixture.Inner.Version, policy.Version);
+
+        fixture.Inner.SnapshotVersion = null;
+        AssemblyBindingPolicyVersion refreshed = policy.Version;
+        Assert.Same(refreshed, policy.Select(Request(fixture.Root)).Version);
+        Assert.Same(refreshed, policy.Version);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Facade_RefreshesAfterActualDelegateChange(bool observing)
+    {
+        using var fixture = new FacadeFixture();
+        IAssemblyBindingPolicy policy = fixture.CreatePolicy(observing);
+        AssemblyBindingPolicyVersion first = policy.Version;
+        fixture.Inner.BeforeSelection = () => fixture.Inner.Version = new();
+
+        AssemblyBindingSelectionSnapshot foreign = policy.Select(
+            Request(fixture.Root));
+        AssemblyBindingPolicyVersion second = policy.Version;
+        Assert.Same(fixture.Inner.LastSnapshot, foreign);
+        Assert.NotSame(first, second);
+        Assert.NotSame(fixture.Inner.Version, second);
+
+        fixture.Inner.BeforeSelection = null;
+        Assert.Same(second, policy.Select(Request(fixture.Root)).Version);
+        fixture.Inner.Version = new();
+        AssemblyBindingPolicyVersion third = policy.Version;
+        Assert.NotSame(first, third);
+        Assert.NotSame(second, third);
+        Assert.Same(third, policy.Select(Request(fixture.Root)).Version);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Facade_ContinuesWithOriginalDelegatedOccurrence(bool observing)
+    {
+        using var fixture = new FacadeFixture();
+        AssemblyBindingOccurrence delegated =
+            new TestLineage(fixture.Inner.Version).Issue(fixture.Selected);
+        fixture.Inner.Selection = AssemblyBindingSelection.FoundOccurrence(
+            delegated);
+        IAssemblyBindingPolicy policy = fixture.CreatePolicy(observing);
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            policy.Select(Request(fixture.Root)).Selection);
+        fixture.Inner.BeforeSelection = () =>
+        {
+            fixture.Inner.Selection =
+                fixture.Inner.LastRequest!.Origin
+                    is AssemblyBindingOrigin.RequestingAssembly origin
+                    && ReferenceEquals(origin.Occurrence, delegated)
+                        ? AssemblyBindingSelection.Found(fixture.Root)
+                        : AssemblyBindingSelection.NameNotOwned();
+        };
+
+        var continued = Assert.IsType<AssemblyBindingSelection.Selected>(
+            policy.Select(
+                new AssemblyBindingRequest(
+                    AssemblyBindingTarget.Reference(fixture.Root.Identity),
+                    AssemblyBindingOrigin.FromOccurrence(selected.Occurrence),
+                    AssemblyResolutionScope.Any)).Selection);
+
+        Assert.Same(fixture.Root.Registration, continued.Assembly.Registration);
+        Assert.Same(
+            delegated,
+            Assert.IsType<AssemblyBindingOrigin.RequestingAssembly>(
+                fixture.Inner.LastRequest!.Origin).Occurrence);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Facade_RejectsContinuationFromRetiredState(bool observing)
+    {
+        using var fixture = new FacadeFixture();
+        fixture.Inner.Selection = AssemblyBindingSelection.Found(
+            fixture.Selected);
+        IAssemblyBindingPolicy policy = fixture.CreatePolicy(observing);
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            policy.Select(Request(fixture.Root)).Selection);
+        fixture.Inner.Version = new();
+
+        var rejected = Assert.IsType<AssemblyBindingSelection.Rejected>(
+            policy.Select(
+                new AssemblyBindingRequest(
+                    AssemblyBindingTarget.Reference(fixture.Root.Identity),
+                    AssemblyBindingOrigin.FromOccurrence(selected.Occurrence),
+                    AssemblyResolutionScope.Any)).Selection);
+
+        Assert.Equal(
+            AssemblyBindingFailureKind.InvalidBindingOrigin,
+            rejected.Failure.Kind);
+        Assert.Equal(1, fixture.Inner.SelectionCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Facade_NullSnapshotRemainsInvalidAtMetadata(bool observing)
+    {
+        using var fixture = new FacadeFixture();
+        fixture.Inner.ReturnNull = true;
+        IAssemblyBindingPolicy policy = fixture.CreatePolicy(observing);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(fixture.Selected.Identity),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Any);
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext context = catalog.CreateContext(
+            policy,
+            roots: [],
+            bindingRequests: [request],
+            requests: []);
+
+        var rejected = Assert.IsType<AssemblyBindingOutcome.Rejected>(
+            context.Bind(request));
+        Assert.Equal(
+            AssemblyBindingFailureKind.InvalidPolicyResult,
+            rejected.Failure.Kind);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Facade_ForeignSnapshotPublishesNoMetadataContext(bool observing)
+    {
+        using var fixture = new FacadeFixture();
+        fixture.Inner.Selection = AssemblyBindingSelection.Found(
+            fixture.Selected);
+        fixture.Inner.BeforeSelection = () => fixture.Inner.Version = new();
+        IAssemblyBindingPolicy policy = fixture.CreatePolicy(observing);
+        using var catalog = new TypeResolutionCatalog();
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(fixture.Selected.Identity),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Any);
+
+        Assert.Throws<InvalidOperationException>(
+            () => catalog.CreateContext(
+                policy,
+                roots: [],
+                bindingRequests: [request],
+                requests: []));
+        Assert.Equal(0, fixture.SelectedOpenCount);
+        Assert.Equal(1, fixture.Inner.SelectionCount);
+
+        fixture.Inner.BeforeSelection = null;
+        fixture.Inner.Selection = AssemblyBindingSelection.NameNotOwned();
+        using TypeResolutionContext next = catalog.CreateContext(
+            policy,
+            roots: [],
+            bindingRequests: [request],
+            requests: []);
+        Assert.IsType<AssemblyBindingOutcome.Missing>(next.Bind(request));
+        Assert.Equal(2, fixture.Inner.SelectionCount);
+    }
+
+    [Fact]
+    public void BindingPolicyResolver_LegacyResolveRejectsForeignSnapshot()
+    {
+        using var fixture = new FacadeFixture();
+        fixture.Inner.Selection = AssemblyBindingSelection.Found(
+            fixture.Selected);
+        fixture.Inner.BeforeSelection = () => fixture.Inner.Version = new();
+        IAssemblyReferenceResolver resolver =
+            AssemblyContextAnalysisSource.Resolver(
+                fixture.Group,
+                new AssemblyContextSubject(fixture.Root));
+
+        Assert.Throws<InvalidOperationException>(
+            () => resolver.Resolve(
+                fixture.Selected.Identity,
+                AssemblyResolutionScope.Any));
+        Assert.Equal(0, fixture.SelectedOpenCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BindingPolicyResolver_ValidatesCapturedGroupBeforePublication(
+        bool foreignSnapshot)
+    {
+        using var fixture = new FacadeFixture();
+        var resolver = AssemblyContextAnalysisSource.Resolver(
+            fixture.Group,
+            new AssemblyContextSubject(fixture.Root));
+        if (foreignSnapshot)
+            fixture.Inner.SnapshotVersion = new();
+
+        resolver.Select(Request(fixture.Root));
+        if (!foreignSnapshot)
+            fixture.Inner.Version = new();
+
+        Assert.Throws<InvalidOperationException>(
+            resolver.ValidateForPublication);
+    }
+
     static ResolvedAssemblyReference Descriptor() =>
         ResolvedAssemblyReference.CreateFromPath(
             typeof(AssemblyContextAnalysisSourceTests).Assembly.Location,
@@ -152,22 +403,81 @@ public sealed class AssemblyContextAnalysisSourceTests
     sealed class FixedPolicy(AssemblyBindingSelection selection)
         : IAssemblyBindingPolicy
     {
-        public AssemblyBindingPolicyVersion Version { get; } = new();
+        public AssemblyBindingPolicyVersion Version { get; set; } = new();
+        internal AssemblyBindingPolicyVersion? SnapshotVersion { get; set; }
+        internal AssemblyBindingSelection Selection { get; set; } = selection;
+        internal AssemblyBindingSelectionSnapshot? LastSnapshot { get; private set; }
         internal AssemblyBindingRequest? LastRequest { get; private set; }
+        internal Action? BeforeSelection { get; set; }
+        internal bool ReturnNull { get; set; }
+        internal int SelectionCount { get; private set; }
 
         public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            return new AssemblyBindingSelectionSnapshot(
-                Version,
-                SelectCore());
+            LastRequest = request;
+            SelectionCount++;
+            BeforeSelection?.Invoke();
+            LastSnapshot = ReturnNull
+                ? null
+                : new AssemblyBindingSelectionSnapshot(
+                    SnapshotVersion ?? Version,
+                    Selection);
+            return LastSnapshot!;
+        }
+    }
 
-            AssemblyBindingSelection SelectCore()
-            {
-                LastRequest = request;
-                return selection;
+    sealed record TestLineage(AssemblyBindingPolicyVersion PolicyVersion)
+        : AssemblyBindingLineage(PolicyVersion)
+    {
+        internal AssemblyBindingOccurrence Issue(
+            ResolvedAssemblyReference assembly) => CreateOccurrence(assembly);
+    }
 
-            }
+    sealed class FacadeFixture : IDisposable
+    {
+        readonly InspectionWorkspace _workspace = new();
+
+        internal FacadeFixture()
+        {
+            Selected = ResolvedAssemblyReference.Create(
+                Root.Identity,
+                path: null,
+                openRead: () =>
+                {
+                    SelectedOpenCount++;
+                    return File.OpenRead(
+                        typeof(AssemblyContextAnalysisSourceTests)
+                            .Assembly.Location);
+                },
+                AssemblyResolutionProvenance.Local("test"));
+            Group = _workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(Root, Inner),
+                    new AssemblyContextParticipant(Selected, Inner),
+                ]);
+        }
+
+        internal FixedPolicy Inner { get; } = new(
+            AssemblyBindingSelection.NameNotOwned());
+        internal ResolvedAssemblyReference Root { get; } = Descriptor();
+        internal ResolvedAssemblyReference Selected { get; }
+        internal AssemblyContextGroup Group { get; }
+        internal int SelectedOpenCount { get; private set; }
+
+        internal IAssemblyBindingPolicy CreatePolicy(bool observing) =>
+            observing
+                ? new AssemblyContextSourceQuery
+                    .CancellationObservingBindingPolicy(Inner)
+                : Assert.IsAssignableFrom<IAssemblyBindingPolicy>(
+                    AssemblyContextAnalysisSource.Resolver(
+                        Group,
+                        new AssemblyContextSubject(Root)));
+
+        public void Dispose()
+        {
+            Group.Dispose();
+            _workspace.Dispose();
         }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextSourceQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextSourceQueryTests.cs
@@ -1662,22 +1662,23 @@ public sealed partial class AssemblyContextSourceQueryTests
     }
 
     [Fact]
-    public void CancellationObservingBindingPolicy_RejectsForeignSnapshot()
+    public void CancellationObservingBindingPolicy_ForwardsAndObservesForeignSnapshot()
     {
         var inner = new FrameworkBindingPolicy();
-        AssemblyBindingPolicyVersion expectedVersion = inner.Version;
         inner.SnapshotVersion = new AssemblyBindingPolicyVersion();
         var policy =
             new AssemblyContextSourceQuery.CancellationObservingBindingPolicy(
-                inner,
-                expectedVersion);
+                inner);
         var request = new AssemblyBindingRequest(
             AssemblyBindingTarget.CoreLibrary(),
             AssemblyBindingOrigin.Global(),
             AssemblyResolutionScope.Platform);
 
-        Assert.Throws<InvalidOperationException>(
-            () => policy.Select(request));
+        AssemblyBindingPolicyVersion version = policy.Version;
+        AssemblyBindingSelectionSnapshot snapshot = policy.Select(request);
+        Assert.Same(inner.SnapshotVersion, snapshot.Version);
+        Assert.NotSame(version, policy.Version);
+        Assert.Throws<InvalidOperationException>(policy.ThrowIfObserved);
         Assert.Equal(1, inner.SelectionCount);
     }
 
@@ -1687,8 +1688,7 @@ public sealed partial class AssemblyContextSourceQueryTests
         var inner = new NullSnapshotPolicy();
         var policy =
             new AssemblyContextSourceQuery.CancellationObservingBindingPolicy(
-                inner,
-                inner.Version);
+                inner);
         var request = new AssemblyBindingRequest(
             AssemblyBindingTarget.CoreLibrary(),
             AssemblyBindingOrigin.Global(),

--- a/src/DotnetInspector.Queries/AssemblyBindingPolicyFacade.cs
+++ b/src/DotnetInspector.Queries/AssemblyBindingPolicyFacade.cs
@@ -1,0 +1,144 @@
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+internal abstract class AssemblyBindingPolicyFacade(
+    IAssemblyBindingPolicy inner) : IAssemblyBindingPolicy
+{
+    BindingState _state = new(inner.Version);
+
+    public AssemblyBindingPolicyVersion Version => CurrentState().Version;
+
+    public virtual AssemblyBindingSelectionSnapshot Select(
+        AssemblyBindingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        BindingState state = CurrentState();
+        AssemblyBindingRequest? delegatedRequest = DelegateRequest(
+            state,
+            request);
+        if (delegatedRequest is null)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                state.Version,
+                AssemblyBindingSelection.Invalid(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind.InvalidBindingOrigin)));
+        }
+
+        AssemblyBindingSelectionSnapshot? snapshot =
+            inner.Select(delegatedRequest);
+        if (snapshot is null)
+            return null!;
+        if (!ReferenceEquals(snapshot.Version, state.DelegateVersion))
+        {
+            Interlocked.CompareExchange(
+                ref _state,
+                new BindingState(inner.Version),
+                state);
+            ObserveForeignSnapshot();
+            return snapshot;
+        }
+
+        AssemblyBindingSelection selection =
+            AssemblyBindingSelection.ValidateForRequest(
+                delegatedRequest,
+                snapshot.Selection);
+        AssemblyBindingSelection transformed = TransformSelection(selection);
+        if (selection is AssemblyBindingSelection.Selected selected
+            && transformed is AssemblyBindingSelection.Selected adapted)
+        {
+            // Adapt the descriptor without replacing delegated context with seed routing.
+            var lineage = new FacadeLineage(
+                this,
+                state,
+                selected.Occurrence);
+            transformed = AssemblyBindingSelection.FoundOccurrence(
+                lineage.Issue(adapted.Assembly),
+                adapted.ShadowedAssemblies);
+        }
+
+        return new AssemblyBindingSelectionSnapshot(
+            state.Version,
+            transformed);
+    }
+
+    protected virtual AssemblyBindingRequest SeedRequest(
+        AssemblyBindingRequest request) => request;
+
+    protected abstract AssemblyBindingSelection TransformSelection(
+        AssemblyBindingSelection selection);
+
+    protected virtual void ObserveForeignSnapshot()
+    {
+    }
+
+    AssemblyBindingRequest? DelegateRequest(
+        BindingState state,
+        AssemblyBindingRequest request)
+    {
+        if (request.Origin
+                is not AssemblyBindingOrigin.RequestingAssembly requesting
+            || requesting.Lineage is null
+            || requesting.Lineage == AssemblyBindingLineage.Seed)
+        {
+            return SeedRequest(request);
+        }
+
+        if (requesting.Lineage is not FacadeLineage lineage
+            || !ReferenceEquals(lineage.Issuer, this)
+            || !ReferenceEquals(lineage.State, state))
+        {
+            return null;
+        }
+
+        return new AssemblyBindingRequest(
+            request.Target,
+            AssemblyBindingOrigin.FromOccurrence(lineage.DelegatedOccurrence),
+            request.Scope);
+    }
+
+    BindingState CurrentState()
+    {
+        while (true)
+        {
+            BindingState state = Volatile.Read(ref _state);
+            AssemblyBindingPolicyVersion version = inner.Version;
+            if (ReferenceEquals(state.DelegateVersion, version))
+                return state;
+
+            Interlocked.CompareExchange(
+                ref _state,
+                new BindingState(version),
+                state);
+        }
+    }
+
+    sealed class BindingState(AssemblyBindingPolicyVersion delegateVersion)
+    {
+        internal AssemblyBindingPolicyVersion Version { get; } = new();
+        internal AssemblyBindingPolicyVersion DelegateVersion { get; } =
+            delegateVersion;
+    }
+
+    sealed record FacadeLineage : AssemblyBindingLineage
+    {
+        internal FacadeLineage(
+            AssemblyBindingPolicyFacade issuer,
+            BindingState state,
+            AssemblyBindingOccurrence delegatedOccurrence)
+            : base(state.Version)
+        {
+            Issuer = issuer;
+            State = state;
+            DelegatedOccurrence = delegatedOccurrence;
+        }
+
+        internal AssemblyBindingPolicyFacade Issuer { get; }
+        internal BindingState State { get; }
+        internal AssemblyBindingOccurrence DelegatedOccurrence { get; }
+
+        internal AssemblyBindingOccurrence Issue(
+            ResolvedAssemblyReference assembly) => CreateOccurrence(assembly);
+    }
+}

--- a/src/DotnetInspector.Queries/AssemblyContextAnalysisSource.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextAnalysisSource.cs
@@ -9,10 +9,16 @@ internal static class AssemblyContextAnalysisSource
     internal static string Name(AssemblyContextSubject subject) =>
         subject.Identity.Name;
 
-    internal static IAssemblyReferenceResolver Resolver(
+    internal static BindingPolicyResolver Resolver(
         AssemblyContextGroup group,
-        AssemblyContextSubject subject) =>
-        new BindingPolicyResolver(group, Participant(group, subject));
+        AssemblyContextSubject subject)
+    {
+        var resolver = new BindingPolicyResolver(
+            group,
+            Participant(group, subject));
+        resolver.ValidateForPublication();
+        return resolver;
+    }
 
     static AssemblyContextParticipant Participant(
         AssemblyContextGroup group,
@@ -22,51 +28,64 @@ internal static class AssemblyContextAnalysisSource
                 candidate.Assembly.Registration,
                 subject.Registration));
 
-    sealed class BindingPolicyResolver(
+    internal sealed class BindingPolicyResolver(
         AssemblyContextGroup group,
         AssemblyContextParticipant participant)
-        : IAssemblyReferenceResolver,
-          IAssemblyBindingPolicy
+        : AssemblyBindingPolicyFacade(participant.BindingPolicy),
+          IAssemblyReferenceResolver
     {
-        public AssemblyBindingPolicyVersion Version =>
-            participant.BindingPolicy.Version;
+        int _foreignSnapshotObserved;
+
+        internal void ValidateForPublication()
+        {
+            if (Volatile.Read(ref _foreignSnapshotObserved) != 0
+                || !ReferenceEquals(
+                    participant.BindingPolicy.Version,
+                    group.BindingPolicyVersion))
+            {
+                throw new InvalidOperationException(
+                    "The binding-policy snapshot changed during analysis.");
+            }
+        }
+
+        protected override void ObserveForeignSnapshot() =>
+            Interlocked.Exchange(ref _foreignSnapshotObserved, 1);
 
         public ResolvedAssemblyReference? Resolve(
             AssemblyReferenceIdentity identity,
             AssemblyResolutionScope scope)
         {
             ArgumentNullException.ThrowIfNull(identity);
-            return Select(
-                    new AssemblyBindingRequest(
-                        AssemblyBindingTarget.Reference(identity),
-                        AssemblyBindingOrigin.FromAssembly(
-                            participant.Assembly),
-                        scope))
-                ?.Selection
+            AssemblyBindingPolicyVersion version = Version;
+            AssemblyBindingSelectionSnapshot? snapshot = Select(
+                new AssemblyBindingRequest(
+                    AssemblyBindingTarget.Reference(identity),
+                    AssemblyBindingOrigin.FromAssembly(participant.Assembly),
+                    scope));
+            if (snapshot is not null
+                && (!ReferenceEquals(snapshot.Version, version)
+                    || !ReferenceEquals(Version, version)))
+            {
+                throw new InvalidOperationException(
+                    "The binding-policy snapshot changed during analysis.");
+            }
+
+            return snapshot?.Selection
                 is AssemblyBindingSelection.Selected selected
-                    ? selected.Assembly
-                    : null;
+                ? selected.Assembly
+                : null;
         }
 
-        public AssemblyBindingSelectionSnapshot Select(
+        protected override AssemblyBindingRequest SeedRequest(
             AssemblyBindingRequest request)
-        {
-            ArgumentNullException.ThrowIfNull(request);
-            var participantRequest = new AssemblyBindingRequest(
+            => new(
                 request.Target,
-                AssemblyBindingOrigin.FromAssembly(
-                    participant.Assembly),
+                AssemblyBindingOrigin.FromAssembly(participant.Assembly),
                 request.Scope);
-            AssemblyBindingSelectionSnapshot? snapshot =
-                participant.BindingPolicy.Select(
-                    participantRequest);
-            if (snapshot is null)
-                return null!;
-            AssemblyBindingSelection selection =
-                AssemblyBindingSelection.ValidateForRequest(
-                    participantRequest,
-                    snapshot.Selection);
-            selection = selection switch
+
+        protected override AssemblyBindingSelection TransformSelection(
+            AssemblyBindingSelection selection)
+            => selection switch
             {
                 AssemblyBindingSelection.Selected selected =>
                     RetainSelected(selected),
@@ -74,10 +93,6 @@ internal static class AssemblyContextAnalysisSource
                     RetainAmbiguous(ambiguous),
                 _ => selection,
             };
-            return new AssemblyBindingSelectionSnapshot(
-                snapshot.Version,
-                selection);
-        }
 
         AssemblyBindingSelection RetainSelected(
             AssemblyBindingSelection.Selected selected)

--- a/src/DotnetInspector.Queries/AssemblyContextMethodAnalysisQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextMethodAnalysisQuery.cs
@@ -62,11 +62,14 @@ public static class AssemblyContextMethodAnalysisQuery
         LibraryBodyIndex? index = null;
         try
         {
+            var resolver = AssemblyContextAnalysisSource.Resolver(
+                group,
+                subject);
             index = LibraryBodyIndex.OpenFromPrefetchedImage(
                 AssemblyContextAnalysisSource.Name(subject),
                 snapshot.Content,
                 LibraryBodyAnalysisFeatures.OptimizationOpportunities,
-                AssemblyContextAnalysisSource.Resolver(group, subject),
+                resolver,
                 bodyScope: new HashSet<int> { methodToken });
 
             MethodIdentity? declaration = index.DeclaredMethods.FirstOrDefault(
@@ -117,7 +120,7 @@ public static class AssemblyContextMethodAnalysisQuery
                 methodToken,
                 out ImmutableArray<UnsafeEvidence> unsafeEvidence);
 
-            return new AssemblyMethodAnalysis(
+            var result = new AssemblyMethodAnalysis(
                 methodToken,
                 method,
                 signals ?? MethodSignals.None,
@@ -138,6 +141,8 @@ public static class AssemblyContextMethodAnalysisQuery
                         diagnostic =>
                             diagnostic.MethodToken == methodToken),
                 ]);
+            resolver.ValidateForPublication();
+            return result;
         }
         finally
         {

--- a/src/DotnetInspector.Queries/AssemblyContextOptimizationOpportunitiesQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextOptimizationOpportunitiesQuery.cs
@@ -198,14 +198,15 @@ public static class AssemblyContextOptimizationOpportunitiesQuery
         LibraryBodyIndex? index = null;
         try
         {
+            var resolver = AssemblyContextAnalysisSource.Resolver(
+                group,
+                subject);
             index = LibraryBodyIndex.OpenFromPrefetchedImage(
                 AssemblyContextAnalysisSource.Name(subject),
                 snapshot.Content,
                 LibraryBodyAnalysisFeatures
                     .OptimizationOpportunities,
-                AssemblyContextAnalysisSource.Resolver(
-                    group,
-                    subject));
+                resolver);
 
             ImmutableArray<
                 OptimizationOpportunityMemberRanking> rankings =
@@ -216,13 +217,15 @@ public static class AssemblyContextOptimizationOpportunitiesQuery
                                 .IncludePerformanceOpportunity(
                                     opportunity,
                                     index.GeneratedFrameworkTypes)));
-            return new AssemblyOptimizationOpportunityRanking(
+            var result = new AssemblyOptimizationOpportunityRanking(
                 AggregatePublicMembers(
                     rankings,
                     publicMembers.Members),
                 index.GeneratedFrameworkTypes.ToImmutableHashSet(),
                 index.Diagnostics,
                 publicMembers.InspectionFailures);
+            resolver.ValidateForPublication();
+            return result;
         }
         finally
         {

--- a/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
@@ -888,8 +888,7 @@ public static class AssemblyContextSourceQuery
             bindingPolicyVersion);
         var bindingPolicy =
             new CancellationObservingBindingPolicy(
-                participant.BindingPolicy,
-                bindingPolicyVersion);
+                participant.BindingPolicy);
         MemberRenderResult decompiled =
             MemberBodyProducer.ProduceMember(
                 target.Type,
@@ -994,8 +993,7 @@ public static class AssemblyContextSourceQuery
             bindingPolicyVersion);
         var bindingPolicy =
             new CancellationObservingBindingPolicy(
-                participant.BindingPolicy,
-                bindingPolicyVersion);
+                participant.BindingPolicy);
         ResolvedAssemblyReference decompilerAssembly =
             retained.WithoutLocalPath();
         DecompilerResult decompiled =
@@ -1329,9 +1327,8 @@ public static class AssemblyContextSourceQuery
     }
 
     internal sealed class CancellationObservingBindingPolicy(
-        IAssemblyBindingPolicy inner,
-        AssemblyBindingPolicyVersion expectedVersion)
-        : IAssemblyBindingPolicy
+        IAssemblyBindingPolicy inner)
+        : AssemblyBindingPolicyFacade(inner)
     {
         ExceptionDispatchInfo? _cancellation;
         ExceptionDispatchInfo? _inspectionFailure;
@@ -1340,41 +1337,12 @@ public static class AssemblyContextSourceQuery
             ResolvedAssemblyReference> _observedAssemblies =
                 new(ReferenceEqualityComparer.Instance);
 
-        public AssemblyBindingPolicyVersion Version
-        {
-            get
-            {
-                EnsureVersion();
-                return expectedVersion;
-            }
-        }
-
-        public AssemblyBindingSelectionSnapshot Select(
+        public override AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            EnsureVersion();
             try
             {
-                AssemblyBindingSelectionSnapshot? snapshot =
-                    inner.Select(request);
-                if (snapshot is null)
-                    return null!;
-                if (!ReferenceEquals(
-                        snapshot.Version,
-                        expectedVersion))
-                {
-                    throw new InvalidOperationException(
-                        "The participant binding-policy snapshot changed during source inspection.");
-                }
-
-                AssemblyBindingSelection selection =
-                    AssemblyBindingSelection.ValidateForRequest(
-                        request,
-                        snapshot.Selection);
-                EnsureVersion();
-                return new AssemblyBindingSelectionSnapshot(
-                    expectedVersion,
-                    ObserveSelectedAssemblies(selection));
+                return base.Select(request);
             }
             catch (OperationCanceledException ex)
             {
@@ -1394,18 +1362,12 @@ public static class AssemblyContextSourceQuery
             Volatile.Read(ref _inspectionFailure)?.Throw();
         }
 
-        void EnsureVersion()
-        {
-            if (!ReferenceEquals(
-                    inner.Version,
-                    expectedVersion))
-            {
-                throw new InvalidOperationException(
-                    "The participant binding-policy snapshot changed during source inspection.");
-            }
-        }
+        protected override void ObserveForeignSnapshot() =>
+            ObserveInspectionFailure(
+                new InvalidOperationException(
+                    "The participant binding-policy snapshot changed during source inspection."));
 
-        AssemblyBindingSelection ObserveSelectedAssemblies(
+        protected override AssemblyBindingSelection TransformSelection(
             AssemblyBindingSelection selection)
             => selection switch
             {


### PR DESCRIPTION
Keep a continued dependency lookup on the resolver context that selected its
assembly, even when Queries wraps the assembly descriptor for retention or
cancellation observation. Reject answers from a different binding-policy state
before using their descriptors.

Closes #5669. Overall implementation tracker: #5274. This is existing-consumer
adoption, not a claim that the broader Workspace routes in #5865 are complete.

## Demo

**What changes:** adapting a selected assembly no longer erases the context
needed for its next dependency lookup. A stale binding answer also cannot
cause descriptor retention before its version is rejected.

**Evidence boundary:** the changed behavior is demonstrated at the Queries and
Metadata boundary. We have not yet demonstrated a real CLI or Browser inspection
with an incorrect result before this PR and a corrected result afterward.
The host examples below demonstrate compatibility, not a new user experience.

### Continue from the context that selected the assembly

The regression scenario selects an assembly with an opaque delegated occurrence,
adapts its descriptor through each Queries facade, and makes a follow-on request
from that adapted selection. The delegate returns the expected next assembly
only when it receives the original occurrence.

Semantic trace of the exercised scenario, not literal CLI output:

```text
Select assembly with delegated context C
  -> Queries retains or observes its descriptor
  -> follow-on request uses the adapted selection
  -> delegate receives the original context C
  -> expected next assembly is selected
```

Previously, descriptor reconstruction replaced the continuation with `Seed`,
and the analysis facade rerooted subsequent requests to its configured
participant. The candidate preserves the delegated occurrence inside an outer
continuation and unwraps it for the next request. Its own distinct version
governs the adapted answer.

`Facade_ContinuesWithOriginalDelegatedOccurrence` exercises this distinction
through both facades. The description of previous behavior comes from the
replaced code; a separate baseline execution is not claimed.

### Reject a foreign answer before retaining its assembly

When the delegate returns a snapshot whose version differs from the captured
delegate version, the candidate forwards that exact snapshot unchanged and
retires the outer state. The retention scenario records **zero selected
descriptor opens**, and `TypeResolutionCatalog` refuses to produce a context.
Previously, the retention facade interpreted and retained the descriptor before
Metadata could reject the snapshot.

`Facade_ForwardsForeignSnapshotBeforeDescriptorEffects` and
`Facade_ForeignSnapshotPublishesNoMetadataContext` enforce these outcomes.
The open counter measures retention; the observing variant establishes exact
snapshot forwarding rather than an independent observation-cache measurement.
A separately started generation can use the refreshed token; automatic retry
is not added.

Neighboring cases remain explicit: ordinary repeated selection keeps the same
facade version and equal continuation, and a null snapshot still becomes
`Rejected(InvalidPolicyResult)`, not an ordinary missing dependency.

## Design basis and scope

The sole normative owner is
[`type-forwarding-resolution.md#atomic-selectionversion-snapshots`](https://github.com/richlander/dotnet-inspect/blob/44d89dfb3d39de280d9a48b3c8c1445396318156/docs/design/type-forwarding-resolution.md#atomic-selectionversion-snapshots):
transforming facades own immutable outer versions, validate delegated tokens
before payload effects, refresh retired state, and preserve the selection's
resolver continuation.

The existing composite-version model supports the version transitions. The
resolver-lineage model supports explicit continuation transport. Metadata's
existing currency and generation boundary are consumed contracts, not newly
specified owners. Source cancellation/lifetime behavior and the captured
context-group token remain consuming-query constraints.

**One production-adoption step total, implemented here.** Both transformers
adopt one Queries-local adapter and their existing CLI/Browser callers consume
it without another host layer. The immutable `RoleBindingPolicy` leaf remains
unchanged. Retirement occurs in the same step: delegate-token relabeling,
context-erasing selected reconstruction, and unconditional rerooting of
continued analysis requests are replaced, not left as parallel paths.

Existing production paths are CLI `MemberCommand` Source Diff through
`AssemblyContextSourceComparisonQuery`, Browser `SourceExports` through
member/type source queries, and Browser `AnalysisExports` through method-analysis
and optimization queries. This establishes production wiring, not the missing
production-level before/after demonstration described above.

The added state and continuation are required to associate descriptor adaptation
with its governing policy. The already-landed
`SourceRelativeAssemblyGroupBindingPolicy` is the analogous implementation;
its mechanism is supporting evidence rather than a second normative owner.
The analysis queries also validate the captured group token before publication
and remember foreign snapshots even when lower-level analysis handles them as
incomplete evidence.

This slice does not change workspace retry ownership, Services route learning,
Analysis's caller-scope composition, or host presentation. Existing typed
source/analysis results and their CLI/Browser rendering boundaries stay in
place; it adds no rendering domain or format lowering.

## Compatibility evidence

The existing CLI Source Diff path still works on the fixed candidate:

```text
dotnet run --project src/dotnet-inspect -c Release -- \
  member SourceDiffFixture.Counter Value \
  --library artifacts/bin/DotnetInspector.SourceDiff.V1/release/SourceDiffFixture.dll \
  -S "Source Diff" -v:d --tips q
```

```diff
--- PDB comparison
+++ Decompiled comparison
@@ -1 +1 @@
-public int Value() => 1 + 2;
+public int Value() => 3;
```

The neighboring `Unchanged` method reports identical PDB/decompiled comparisons
and zero added, removed, changed, or moved lines. Both commands exited
successfully. The excerpt omits provenance and diff end-of-file markers.

This is ordinary Source Diff behavior that predates the PR. Likewise, the
Browser endpoint cases retain existing type decompilation, expected missing-type
failure, package-performance results, and physical member-body evidence.
These examples establish that existing callers continue to work; they do not
demonstrate the new resolver-context distinction.

## Validation

Candidate: `44d89dfb3d39de280d9a48b3c8c1445396318156`.
Effective base: `641c758ca6d06ba0ec5a042bdd59aa31fc8792ed`.

- Release Queries run: **162 passed**, zero failures, on the integrated
  candidate. Classes: `AssemblyContextAnalysisSourceTests`,
  `AssemblyContextSourceQueryTests`, `AssemblyContextMethodAnalysisQueryTests`,
  and `AssemblyContextOptimizationOpportunitiesQueryTests`.
- Existing binding selection/version model gate: 3 modules, 15 configurations,
  4 registry-exact outcomes, zero configurations unverified within budget.
- Existing resolver-lineage model gate: 1 module, 7 configurations, all 7
  registry-exact outcomes, zero configurations unverified within budget.
- The model sources were unchanged by the base integration.
- Fixed-head CLI Source Diff: `Counter.Value` produced the comparison above;
  `Counter.Unchanged` reported identical source and zero changes.
- Release Browser endpoints: **4 passed**, zero failures:
  `ExportSuccess_PreservesSourceAndProvenanceAndReleasesScope`,
  `MissingType_IsExpectedFailureAndReleasesScope`,
  `PackagePerformance_UsesProductRankedWorkspaceAnalysis`, and
  `MemberFacts_DistinguishesSurfaceAndBodyTokenResolution`.
- Browser execution used process-local Node 24. The initial engine build under
  Node 22 stopped before tests because Node rejected the `.ts` artifact verifier;
  rerunning the unchanged head with Node 24 passed.
- Changed Markdown passed `markdownlint`; the patch passed `git diff --check`.
- Current-head `ci-required` passed in
  [run 34016085918](https://github.com/richlander/dotnet-inspect/actions/runs/34016085918).
- Round 1: GPT-6 Astra and Claude Opus 5 both returned **CLEAN** at the unchanged
  candidate. The reconciliation records two non-blocking evidence/scope
  observations and the no-interaction classification for subsequent main
  movement. Merge remains separately authorized.
