### PR TITLE
Generate TypeScript JSON union aliases and facades

### DIFF
--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -167,7 +167,7 @@ adds application-facing policy:
 - authenticated JSON parsing and exact wire-result types;
 - readonly producer-owned JSON snapshots;
 - initialization and explicit one-runtime composition; and
-- consumer-facing DTO and enum declarations.
+- consumer-facing DTO, enum, and JSON union declarations.
 
 Generating JavaScript plus JSDoc would express those TypeScript decisions
 indirectly and require the generator to own comment containment, JSDoc import
@@ -234,6 +234,47 @@ Wire DTOs are producer-owned snapshots. Their properties are readonly, arrays
 use `ReadonlyArray<T>`, and string-keyed dictionaries use
 `Readonly<Record<string, T>>`. Direct JS-interop arrays remain mutable because
 they are runtime values, not serialized snapshots.
+
+### JSON union lowering
+
+Slice 3 of [#5892](https://github.com/richlander/dotnet-inspect/issues/5892),
+tracked by [#6106](https://github.com/richlander/dotnet-inspect/issues/6106),
+consumes the union evidence owned by
+[`JsExportSurface`](../../src/ILInspector.JsExportSurface/README.md#json-union-alternatives).
+It does not infer another serializer contract from the union's `Value` member.
+
+A serialize-reached supported union becomes a TypeScript type alias containing
+its mapped case alternatives and the producer's default-null alternative.
+Case types retain their existing JSON mappings, including readonly snapshots,
+byte-array Base64 strings, and local enum/DTO declarations. Aliases and every
+reference participate in the same identity-based module-name allocation as
+other wire declarations. The raw export remains string-valued; the public
+facade parses that JSON and returns the generated alias.
+Case signature trees supply identities rather than nested nullable-reference
+annotations. Reference-valued entries in case arrays and dictionaries therefore
+remain nullable conservatively; null must not disappear from supported JSON.
+
+Generic unions with direct type-parameter cases use generic aliases whose
+arguments are JSON wire types. Closed uses retain their structured argument
+identities. A parameter embedded inside a case signature remains unsupported:
+substituting a wire type into a CLR container is not generally faithful
+(`T[]` writes an array for `T = int`, but a Base64 string for `T = byte`).
+This boundary does not add general generic DTO support.
+
+Deserialize-reached unions, unavailable case/null evidence, unsupported
+converters, unmapped alternatives, and recursive union-case alias components
+fail visibly before publication. Recursive DTO interfaces are not union-case
+alias components and retain their existing behavior.
+Unused union registrations remain inert. No discriminator, replacement
+transport, or runtime schema validator is introduced.
+
+`JsonUnionWireTests` and the compiler/runtime consumer harness
+`eng/test-ts-jsexport-typescript.sh` gate the generated contract against actual
+source-generated serializer results and compiled TypeScript consumers.
+The four-step adoption path remains Metadata evidence, JsExportSurface
+evidence, this CLI generation/harness slice, and inspect-web browser/Wasm
+adoption. The existing TypeScript emitter owns this format lowering; no new
+human-readable rendering path or architecture retirement is needed.
 
 ### Public facade view
 

--- a/eng/test-ts-jsexport-typescript.sh
+++ b/eng/test-ts-jsexport-typescript.sh
@@ -6,6 +6,12 @@ scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
 
 dotnet_root=${DOTNET_ROOT:-$(dirname "$(command -v dotnet)")}
+dotnet_exe="$dotnet_root/dotnet"
+if [[ ! -x "$dotnet_exe" ]]; then
+  echo "The selected .NET executable was not found at $dotnet_exe." >&2
+  exit 1
+fi
+
 dotnet_dts=$(
   find "$dotnet_root/packs/Microsoft.NETCore.App.Runtime.Mono.browser-wasm" \
     -path '*/runtimes/browser-wasm/native/dotnet.d.ts' \
@@ -27,8 +33,8 @@ fi
 fixture_project="$repo_root/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/ILInspector.JsExportSurface.TypeScriptFixtures.csproj"
 fixture_dll="$repo_root/artifacts/bin/ILInspector.JsExportSurface.TypeScriptFixtures/release/ILInspector.JsExportSurface.TypeScriptFixtures.dll"
 
-dotnet build "$fixture_project" -c Release --nologo >/dev/null
-dotnet run \
+"$dotnet_exe" build "$fixture_project" -c Release --nologo >/dev/null
+"$dotnet_exe" run \
   --project "$repo_root/src/ts-jsexport" \
   -c Release \
   -- \
@@ -52,6 +58,191 @@ const transformed: boolean = transformValue(
 void transformed;
 TS
 
+cat > "$scratch/union-usage.ts" <<'TS'
+import {
+  getBoxedCount,
+  getBoxedWidget,
+  getCollectionSelection,
+  getDefaultSelection,
+  getFlagSelection,
+  getKindSelection,
+  getOutcomeSelection,
+  getSelectionEnvelopeAsync,
+  getWidgetSelection,
+  getWrappedBlob,
+} from "./facade.js";
+import type {
+  Boxed,
+  CollectionSelection,
+  FlagSelection,
+  KindSelection,
+  OutcomeSelection,
+  SelectionEnvelope,
+  WidgetDto,
+  WidgetKind,
+  WidgetSelection,
+  Wrapped,
+} from "./facade.js";
+
+// Reference entries in union-case collections stay nullable, so the consumer
+// narrows them instead of asserting presence.
+type SelectionEntries = Extract<CollectionSelection, ReadonlyArray<unknown>>;
+type SelectionMap = Extract<
+  CollectionSelection,
+  Readonly<Record<string, unknown>>
+>;
+type GroupEntries = Extract<SelectionEnvelope["group"], ReadonlyArray<unknown>>;
+
+export const missingSelectionEntry: SelectionEntries[number] = null;
+export const missingMapEntry: SelectionMap[string] = null;
+export const missingGroupEntry: GroupEntries[number] = null;
+
+function isEntryArray(
+  selection: CollectionSelection,
+): selection is SelectionEntries {
+  return Array.isArray(selection);
+}
+
+export function describeCollection(selection: CollectionSelection): string {
+  if (selection === null) {
+    return "none";
+  }
+  if (typeof selection === "number") {
+    return `count-${selection}`;
+  }
+  if (isEntryArray(selection)) {
+    const entries: SelectionEntries = selection;
+    return entries
+      .map((entry) => (entry === null ? "null" : entry.name))
+      .join(",");
+  }
+  const named: SelectionMap = selection;
+  return Object.keys(named)
+    .map((key) => {
+      const entry: WidgetDto | null = named[key] ?? null;
+      return `${key}=${entry === null ? "null" : entry.name}`;
+    })
+    .join(",");
+}
+
+export function describeGroup(group: SelectionEnvelope["group"]): string {
+  if (group === null) {
+    return "none";
+  }
+  if (typeof group === "string") {
+    return group;
+  }
+  return `group:${group
+    .map((entry) => (entry === null ? "null" : entry.name))
+    .join(",")}`;
+}
+
+export function describeSelection(selection: WidgetSelection): string {
+  if (selection === null) {
+    return "none";
+  }
+  if (typeof selection === "string") {
+    return selection;
+  }
+  const widget: WidgetDto = selection;
+  return `${widget.name}:${widget.count}`;
+}
+
+export function describeFlag(flag: FlagSelection): string {
+  if (flag === null) {
+    return "none";
+  }
+  if (typeof flag === "boolean") {
+    return flag ? "true" : "false";
+  }
+  return flag.name;
+}
+
+export function describeOutcome(outcome: OutcomeSelection): string {
+  if (typeof outcome === "boolean") {
+    return outcome ? "yes" : "no";
+  }
+  return describeSelection(outcome);
+}
+
+export function describeKind(kind: KindSelection): string {
+  if (kind === null) {
+    return "none";
+  }
+  if (typeof kind === "string") {
+    return kind;
+  }
+  const declared: WidgetKind = kind;
+  return `kind-${declared}`;
+}
+
+export function describeBoxed(
+  count: Boxed<number>,
+  widget: Boxed<WidgetDto>,
+): string {
+  const left = count === null
+    ? "none"
+    : typeof count === "string" ? count : count.toFixed(0);
+  const right = widget === null
+    ? "none"
+    : typeof widget === "string" ? widget : widget.name;
+  return `${left}/${right}`;
+}
+
+export function selectWidget(widget: WidgetDto): WidgetSelection {
+  return widget;
+}
+
+// A closed byte[] union argument lowers to the Base64 wire string, so the
+// alias's own number alternative stays distinguishable from it.
+export function describeBlob(blob: Wrapped<string>): string {
+  if (blob === null) {
+    return "none";
+  }
+  if (typeof blob === "number") {
+    return `count-${blob}`;
+  }
+  return `blob:${blob}`;
+}
+
+export function probeSelections(): string {
+  const selection: WidgetSelection = getWidgetSelection(true);
+  const missing: WidgetSelection = getDefaultSelection();
+  return [
+    describeSelection(selection),
+    describeSelection(missing),
+    describeSelection(null),
+    describeFlag(getFlagSelection(true)),
+    describeOutcome(getOutcomeSelection(false)),
+    describeKind(getKindSelection(true)),
+    describeBoxed(getBoxedCount(11), getBoxedWidget("boxed")),
+    describeSelection(selectWidget({ name: "literal", count: 9 })),
+    describeBlob(getWrappedBlob()),
+    describeCollection(getCollectionSelection(0)),
+    describeCollection(getCollectionSelection(1)),
+    describeCollection(getCollectionSelection(3)),
+  ].join("|");
+}
+
+export async function summarizeEnvelope(): Promise<string> {
+  const envelope: SelectionEnvelope =
+    await getSelectionEnvelopeAsync("envelope");
+  const items: ReadonlyArray<WidgetSelection> = envelope.items;
+  const first: WidgetSelection | undefined = items[0];
+  const named: WidgetSelection | undefined = envelope.byName["named"];
+  return [
+    describeSelection(envelope.result),
+    describeSelection(first ?? null),
+    describeSelection(named ?? null),
+    describeOutcome(envelope.outcome),
+    describeKind(envelope.kind),
+    describeBoxed(envelope.count, envelope.widget),
+    describeBlob(envelope.blob),
+    describeGroup(envelope.group),
+  ].join("|");
+}
+TS
+
 cat > "$scratch/tsconfig.json" <<'JSON'
 {
   "compilerOptions": {
@@ -68,7 +259,7 @@ cat > "$scratch/tsconfig.json" <<'JSON'
     "types": [],
     "verbatimModuleSyntax": true
   },
-  "include": ["facade.ts", "callback-usage.ts"]
+  "include": ["facade.ts", "callback-usage.ts", "union-usage.ts"]
 }
 JSON
 cp "$dotnet_dts" "$scratch/dotnet.d.ts"
@@ -84,9 +275,17 @@ cp \
   "$repo_root/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/dotnet.js" \
   "$scratch/out/dotnet.js"
 printf '{ "type": "module" }\n' > "$scratch/out/package.json"
+"$dotnet_exe" run \
+  "$repo_root/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs" \
+  -c Release \
+  -- \
+  "$scratch/union-payloads.json" \
+  >/dev/null
 node \
   "$repo_root/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs" \
-  "$scratch/out/facade.js"
+  "$scratch/out/facade.js" \
+  "$scratch/union-payloads.json" \
+  "$scratch/out/union-usage.js"
 
 expect_compile_failure() {
   local name=$1
@@ -167,5 +366,110 @@ expect_callback_compile_failure \
   void-action-callback \
   'const observe = \(value: number\): undefined =>' \
   'const observe = (value: number): void =>'
+
+expect_union_facade_compile_failure() {
+  local name=$1
+  local expression=$2
+  local replacement=$3
+  local scope=$4
+  local mutation="$scratch/$name"
+  mkdir "$mutation"
+  cp \
+    "$scratch/dotnet.d.ts" \
+    "$scratch/tsconfig.json" \
+    "$scratch/union-usage.ts" \
+    "$mutation/"
+  sed -E "/$scope/ s/$expression/$replacement/" \
+    "$scratch/facade.ts" > "$mutation/facade.ts"
+  if cmp -s "$scratch/facade.ts" "$mutation/facade.ts"; then
+    echo "$name mutation did not change the generated source." >&2
+    exit 1
+  fi
+  if "$tsc" -p "$mutation/tsconfig.json" >/dev/null 2>&1; then
+    echo "$name mutation unexpectedly compiled." >&2
+    exit 1
+  fi
+}
+
+expect_union_usage_compile_failure() {
+  local name=$1
+  local expression=$2
+  local replacement=$3
+  local mutation="$scratch/$name"
+  mkdir "$mutation"
+  cp \
+    "$scratch/dotnet.d.ts" \
+    "$scratch/tsconfig.json" \
+    "$scratch/facade.ts" \
+    "$mutation/"
+  sed -E "s/$expression/$replacement/" \
+    "$scratch/union-usage.ts" > "$mutation/union-usage.ts"
+  if cmp -s "$scratch/union-usage.ts" "$mutation/union-usage.ts"; then
+    echo "$name mutation did not change union usage." >&2
+    exit 1
+  fi
+  if "$tsc" -p "$mutation/tsconfig.json" >/dev/null 2>&1; then
+    echo "$name mutation unexpectedly compiled." >&2
+    exit 1
+  fi
+}
+
+expect_union_facade_compile_failure \
+  union-null-alternative \
+  ' \| null' \
+  '' \
+  '^export type WidgetSelection'
+expect_union_facade_compile_failure \
+  union-dto-case \
+  'WidgetDto \| string' \
+  'string' \
+  '^export type WidgetSelection'
+expect_union_facade_compile_failure \
+  union-closed-generic-argument \
+  'Boxed<number>' \
+  'Boxed<string>' \
+  '^export function getBoxedCount'
+expect_union_facade_compile_failure \
+  union-closed-byte-array-argument \
+  'Wrapped<string>' \
+  'Wrapped<number>' \
+  '^export function getWrappedBlob'
+
+expect_union_facade_compile_failure \
+  union-collection-entry-null \
+  'ReadonlyArray<WidgetDto \| null>' \
+  'ReadonlyArray<WidgetDto>' \
+  '^export type CollectionSelection'
+expect_union_facade_compile_failure \
+  union-collection-map-entry-null \
+  'Record<string, WidgetDto \| null>' \
+  'Record<string, WidgetDto>' \
+  '^export type CollectionSelection'
+expect_union_facade_compile_failure \
+  union-closed-generic-container-entry-null \
+  'WidgetDto \| null' \
+  'WidgetDto' \
+  '^  readonly group:'
+
+expect_union_usage_compile_failure \
+  union-case-narrowing \
+  'typeof selection === "string"' \
+  'typeof selection === "number"'
+expect_union_usage_compile_failure \
+  union-readonly-array-snapshot \
+  'const first: WidgetSelection \| undefined = items\[0\];' \
+  'const first: WidgetSelection | undefined = (items[0] = null);'
+expect_union_usage_compile_failure \
+  union-readonly-member-snapshot \
+  'const items: ReadonlyArray<WidgetSelection> = envelope.items;' \
+  'const items: ReadonlyArray<WidgetSelection> = (envelope.items = []);'
+expect_union_usage_compile_failure \
+  union-alternative-mismatch \
+  'describeKind\(getKindSelection\(true\)\)' \
+  'describeFlag(getKindSelection(true))'
+expect_union_usage_compile_failure \
+  union-closed-generic-mismatch \
+  'describeBoxed\(getBoxedCount\(11\), getBoxedWidget\("boxed"\)\)' \
+  'describeBoxed(getBoxedWidget("boxed"), getBoxedCount(11))'
 
 echo "ts-jsexport TypeScript compiler gates passed."

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/README.md
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/README.md
@@ -1,0 +1,42 @@
+# TypeScript facade fixture
+
+This assembly is the canonical *supported* producer inspected by
+`eng/test-ts-jsexport-typescript.sh`. Every export here must lower to a
+publishable facade, because the harness generates and compiles the whole
+assembly's TypeScript. Unsupported evidence — read classifiers, custom
+converters, recursive aliases, unmapped case shapes — belongs in
+`ILInspector.JsExportSurface.UnionFixtures`, whose assembly boundary keeps it
+out of this facade.
+
+`UnionSelections.cs` owns the native C# union inputs for the JSON union
+lowering contract in
+[`docs/design/ts-jsexport.md`](../../../docs/design/ts-jsexport.md):
+
+- `WidgetSelection` — a DTO-or-string union whose default state is the null
+  alternative.
+- `FlagSelection` — a `bool?` value case beside a DTO case.
+- `OutcomeSelection` — a nested union case beside a primitive case.
+- `KindSelection` — a local enum case beside a string case.
+- `CollectionSelection` — array and dictionary cases of a reference type. The
+  array declares non-nullable entries and still writes a null entry, matching
+  the conservative `T | null` entry lowering that signature-only case facts
+  require. `SelectionEnvelope.Group` repeats that for a closed generic
+  argument container.
+- `Boxed<TValue>` — a generic union definition used only through closed
+  instantiations (`Boxed<int>`, `Boxed<WidgetDto>`); the C# type parameter name
+  is deliberately unlike the emitted TypeScript parameter name.
+- `Wrapped<TValue>` — a direct type-parameter case closed over `byte[]`, whose
+  JSON wire form is a Base64 string rather than an array. A parameter embedded
+  in a case signature, such as `T[]`, stays unsupported and lives in
+  `ILInspector.JsExportSurface.UnionFixtures`.
+- `SelectionEnvelope` — union-valued members, arrays, and dictionaries.
+
+Every union export writes with the source-generated
+`UnionFixtureJsonContext`, so the fixture reaches serialization only. Reading a
+union stays outside this fixture's contract.
+
+`tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs`
+runs the compiled exports and captures their real System.Text.Json output. The
+harness feeds that output through the managed-runtime seam so the generated
+facade, its compiled consumer, and the derived JavaScript are exercised against
+producer-authored payloads rather than hand-written JSON shadows.

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
@@ -181,4 +181,103 @@ public static partial class TypeScriptFixtureExports
             new WidgetDto(name, 1),
             FixtureJsonContext.Default.WidgetDto);
     }
+
+    [JSExport]
+    public static string GetWidgetSelection(bool widget) =>
+        JsonSerializer.Serialize(
+            widget
+                ? new WidgetSelection(new WidgetDto("selected", 2))
+                : new WidgetSelection("fallback"),
+            UnionFixtureJsonContext.Default.WidgetSelection);
+
+    [JSExport]
+    public static string GetDefaultSelection() =>
+        JsonSerializer.Serialize(
+            default(WidgetSelection),
+            UnionFixtureJsonContext.Default.WidgetSelection);
+
+    [JSExport]
+    public static string GetFlagSelection(bool flag) =>
+        JsonSerializer.Serialize(
+            flag
+                ? new FlagSelection((bool?)true)
+                : new FlagSelection(new WidgetDto("flagged", 3)),
+            UnionFixtureJsonContext.Default.FlagSelection);
+
+    [JSExport]
+    public static string GetOutcomeSelection(bool nested) =>
+        JsonSerializer.Serialize(
+            nested
+                ? new OutcomeSelection(new WidgetSelection("nested"))
+                : new OutcomeSelection(true),
+            UnionFixtureJsonContext.Default.OutcomeSelection);
+
+    [JSExport]
+    public static string GetKindSelection(bool declared) =>
+        JsonSerializer.Serialize(
+            declared
+                ? new KindSelection(WidgetKind.Deluxe)
+                : new KindSelection("unknown"),
+            UnionFixtureJsonContext.Default.KindSelection);
+
+    [JSExport]
+    public static string GetBoxedCount(int count) =>
+        JsonSerializer.Serialize(
+            new Boxed<int>(count),
+            UnionFixtureJsonContext.Default.BoxedInt32);
+
+    [JSExport]
+    public static string GetBoxedWidget(string name) =>
+        JsonSerializer.Serialize(
+            new Boxed<WidgetDto>(new WidgetDto(name, 4)),
+            UnionFixtureJsonContext.Default.BoxedWidgetDto);
+
+    [JSExport]
+    public static string GetCollectionSelection(int choice) =>
+        JsonSerializer.Serialize(
+            choice switch
+            {
+                // The array case declares non-nullable entries, yet a producer
+                // can still write a null entry into that JSON array.
+                0 => new CollectionSelection(
+                    [new WidgetDto("listed", 10), null!]),
+                1 => new CollectionSelection(
+                    new Dictionary<string, WidgetDto?>
+                    {
+                        ["present"] = new WidgetDto("mapped", 11),
+                        ["absent"] = null,
+                    }),
+                2 => new CollectionSelection(12),
+                _ => default,
+            },
+            UnionFixtureJsonContext.Default.CollectionSelection);
+
+    [JSExport]
+    public static string GetWrappedBlob() =>
+        JsonSerializer.Serialize(
+            new Wrapped<byte[]>([1, 2, 3]),
+            UnionFixtureJsonContext.Default.WrappedByteArray);
+
+    [JSExport]
+    public static async Task<string> GetSelectionEnvelopeAsync(string name)
+    {
+        await Task.Yield();
+        return JsonSerializer.Serialize(
+            new SelectionEnvelope(
+                new WidgetSelection(new WidgetDto(name, 5)),
+                [new WidgetSelection("first"), default],
+                new Dictionary<string, WidgetSelection>
+                {
+                    ["named"] = new WidgetSelection(new WidgetDto(name, 6)),
+                    ["missing"] = default,
+                },
+                new OutcomeSelection(new WidgetSelection("outcome")),
+                new KindSelection(WidgetKind.Basic),
+                WidgetKind.Deluxe,
+                new Boxed<int>(7),
+                new Boxed<WidgetDto>(new WidgetDto(name, 8)),
+                new Boxed<WidgetDto[]>([new WidgetDto(name, 9), null!]),
+                new Wrapped<byte[]>([4, 5])),
+            UnionFixtureJsonContext.Default.SelectionEnvelope);
+    }
 }

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/UnionSelections.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/UnionSelections.cs
@@ -1,0 +1,55 @@
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.TypeScriptFixtures;
+
+public union WidgetSelection(WidgetDto, string);
+
+public union FlagSelection(bool?, WidgetDto);
+
+public union OutcomeSelection(WidgetSelection, bool);
+
+public union KindSelection(WidgetKind, string);
+
+// Reference entries inside union-case collections stay conservatively
+// nullable: signature-only case facts cannot retain nested NRT annotations,
+// and a producer can write null into either shape.
+public union CollectionSelection(
+    WidgetDto[],
+    IReadOnlyDictionary<string, WidgetDto?>,
+    int);
+
+public union Boxed<TValue>(TValue, string);
+
+// The int alternative keeps the closed byte[] use unambiguous for the read
+// classifier while its wire form stays a Base64 JSON string.
+public union Wrapped<TValue>(TValue, int);
+
+public enum WidgetKind
+{
+    Basic,
+    Deluxe,
+}
+
+public sealed record SelectionEnvelope(
+    WidgetSelection Result,
+    WidgetSelection[] Items,
+    IReadOnlyDictionary<string, WidgetSelection> ByName,
+    OutcomeSelection Outcome,
+    KindSelection Kind,
+    WidgetKind DeclaredKind,
+    Boxed<int> Count,
+    Boxed<WidgetDto> Widget,
+    Boxed<WidgetDto[]> Group,
+    Wrapped<byte[]> Blob);
+
+[JsonSerializable(typeof(WidgetSelection))]
+[JsonSerializable(typeof(FlagSelection))]
+[JsonSerializable(typeof(OutcomeSelection))]
+[JsonSerializable(typeof(KindSelection))]
+[JsonSerializable(typeof(CollectionSelection))]
+[JsonSerializable(typeof(Boxed<int>))]
+[JsonSerializable(typeof(Boxed<WidgetDto>))]
+[JsonSerializable(typeof(Wrapped<byte[]>))]
+[JsonSerializable(typeof(SelectionEnvelope))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class UnionFixtureJsonContext : JsonSerializerContext;

--- a/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/README.md
+++ b/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/README.md
@@ -1,16 +1,17 @@
 # JSON union wire fixture
 
 This assembly owns the native-union export inventory used by
-`JsonUnionWireTests`. Its assembly boundary keeps reached unions, which the
-TypeScript generator must currently reject, out of the canonical supported
-facade fixture. Resolve it through `FixtureIds.JsExportUnions`.
+`JsonUnionWireTests`. Its assembly boundary keeps unsupported read, converter,
+case-mapping, and recursive-alias exports out of the canonical supported facade
+fixture. Resolve it through `FixtureIds.JsExportUnions`.
 
 The source-generated context covers scalar, DTO, generic, nested, collection,
 and custom-converted unions, alongside an ordinary object and a raw string
 export. The tests select an export from the extracted metadata while preserving
 its compiler-generated runtime registration and serializer body evidence.
 
-`ObjectUnion` and `NumberUnion` deliberately produce `SYSLIB1227`: their
+`ObjectUnion`, `NumberUnion`, and `GenericUnion<byte[]>` deliberately produce
+`SYSLIB1227`: their
 alternatives can be serialized, but the default read classifier is ambiguous.
 Only that warning is exempted from warnings-as-errors in this fixture project;
 it remains visible. Other source-generator warnings are not suppressed.
@@ -22,3 +23,10 @@ Generated union metadata selects the actual case and writes its own contract
 inline; its null arm accounts for the default value. A nested scalar union's
 number case and the ambiguous unions are negative read controls, not evidence
 that all successfully written unions can be deserialized.
+
+TypeScript lowering additionally compares closed generic byte-array and
+dictionary arguments with their real JSON representations. The `T[]`
+case-signature pair writes a Base64 string for bytes and an array for integers;
+it cannot be represented by substituting an erased JSON type into a generic
+TypeScript array. Recursive union aliases, unsupported case types, and
+generic-parameter/module-binding name collisions have separate controls.

--- a/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/UnionWireSamples.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.UnionFixtures/UnionWireSamples.cs
@@ -8,6 +8,13 @@ public union ScalarUnion(int, string);
 public union NullableUnion(int?, string);
 public union DtoUnion(PackageSummary, string);
 public union GenericUnion<T>(T, string);
+public union GenericArrayUnion<T>(T[], bool);
+public union ParameterNameUnion<T>(T, T0);
+public union UnsupportedCaseUnion(Guid, int);
+public union initializeRuntime(int, string);
+public union RecursiveUnion(RecursiveOtherUnion);
+public union RecursiveOtherUnion(RecursiveUnion);
+public union ReferenceArrayUnion(string?[], int);
 public union NestedUnion(ScalarUnion, bool);
 public union ObjectUnion(PackageSummary, PackageProblem);
 public union NumberUnion(int, double);
@@ -19,6 +26,7 @@ public sealed record PackageSummary(string Id);
 public sealed record PackageProblem(int Code);
 public sealed record UnionEnvelope(DtoUnion Result, ScalarUnion[] Items);
 public sealed record OrdinaryValue(int Value);
+public sealed record T0(int Value);
 
 public static partial class UnionExports
 {
@@ -46,6 +54,70 @@ public static partial class UnionExports
         JsonSerializer.Serialize(
             new GenericUnion<int>(7),
             UnionJsonContext.Default.GenericUnionInt32);
+
+    [JSExport]
+    public static string GetGenericBytes() =>
+        JsonSerializer.Serialize(
+            new GenericUnion<byte[]>([1, 2, 3]),
+            UnionJsonContext.Default.GenericUnionByteArray);
+
+    [JSExport]
+    public static string GetGenericDictionary() =>
+        JsonSerializer.Serialize(
+            new GenericUnion<Dictionary<string, int?>>(new Dictionary<string, int?>
+            {
+                ["value"] = 42,
+                ["empty"] = null,
+            }),
+            UnionJsonContext.Default.GenericUnionDictionaryStringNullableInt32);
+
+    [JSExport]
+    public static string GetGenericArrayBytes() =>
+        JsonSerializer.Serialize(
+            new GenericArrayUnion<byte>([1, 2, 3]),
+            UnionJsonContext.Default.GenericArrayUnionByte);
+
+    [JSExport]
+    public static string GetGenericArrayNumbers() =>
+        JsonSerializer.Serialize(
+            new GenericArrayUnion<int>([1, 2, 3]),
+            UnionJsonContext.Default.GenericArrayUnionInt32);
+
+    [JSExport]
+    public static string GetParameterNameUnion() =>
+        JsonSerializer.Serialize(
+            new ParameterNameUnion<int>(new T0(3)),
+            UnionJsonContext.Default.ParameterNameUnionInt32);
+
+    [JSExport]
+    public static string GetUnsupportedCase() =>
+        JsonSerializer.Serialize(
+            new UnsupportedCaseUnion(Guid.Empty),
+            UnionJsonContext.Default.UnsupportedCaseUnion);
+
+    [JSExport]
+    public static string GetReservedUnionName() =>
+        JsonSerializer.Serialize(
+            new initializeRuntime(42),
+            UnionJsonContext.Default.initializeRuntime);
+
+    [JSExport]
+    public static string GetRecursiveUnion() =>
+        JsonSerializer.Serialize(
+            default(RecursiveUnion),
+            UnionJsonContext.Default.RecursiveUnion);
+
+    [JSExport]
+    public static string GetReferenceArrayUnion() =>
+        JsonSerializer.Serialize(
+            new ReferenceArrayUnion(["value", null]),
+            UnionJsonContext.Default.ReferenceArrayUnion);
+
+    [JSExport]
+    public static string GetGenericReferenceArray() =>
+        JsonSerializer.Serialize(
+            new GenericUnion<string?[]>(["value", null]),
+            UnionJsonContext.Default.GenericUnionStringArray);
 
     [JSExport]
     public static string GetNested() =>
@@ -113,6 +185,17 @@ public sealed class CustomUnionConverter : JsonConverter<CustomUnion>
 [JsonSerializable(typeof(NullableUnion))]
 [JsonSerializable(typeof(DtoUnion))]
 [JsonSerializable(typeof(GenericUnion<int>))]
+[JsonSerializable(typeof(GenericUnion<byte[]>))]
+[JsonSerializable(typeof(GenericUnion<Dictionary<string, int?>>))]
+[JsonSerializable(typeof(GenericArrayUnion<byte>))]
+[JsonSerializable(typeof(GenericArrayUnion<int>))]
+[JsonSerializable(typeof(ParameterNameUnion<int>))]
+[JsonSerializable(typeof(UnsupportedCaseUnion))]
+[JsonSerializable(typeof(initializeRuntime))]
+[JsonSerializable(typeof(RecursiveUnion))]
+[JsonSerializable(typeof(RecursiveOtherUnion))]
+[JsonSerializable(typeof(ReferenceArrayUnion))]
+[JsonSerializable(typeof(GenericUnion<string?[]>))]
 [JsonSerializable(typeof(NestedUnion))]
 [JsonSerializable(typeof(ObjectUnion))]
 [JsonSerializable(typeof(NumberUnion))]

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -361,9 +361,10 @@ boundary can expand.
 real source-generated serialization, ambiguous and nested read boundaries,
 case discovery, direction propagation, closed generic signatures, and
 unsupported converter evidence. Its neighboring ordinary DTO remains an
-object. The same suite checks that TypeScript generation rejects a reached
-union until slice 3 implements lowering, rather than emitting a misleading
-interface.
+object. TypeScript projection and its stricter publication boundaries are
+owned by the consumer's
+[JSON union lowering contract](../../docs/design/ts-jsexport.md#json-union-lowering),
+not by these serializer facts.
 
 The serializer oracle is bounded to SDK `11.0.100-preview.7.26381.103` and
 [its System.Text.Json source](https://github.com/dotnet/dotnet/tree/e2c1e00b3d0f96afb892fb261d5921565b400246/src/runtime/src/libraries/System.Text.Json).

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using CSharpText;
+using ILInspector.Analysis;
 using ILInspector.JsExportSurface;
 using ILInspector.Metadata;
 
@@ -123,19 +124,72 @@ static class DtsEmitter
     static ApiType[] GetDeclarationTypes(
         ILInspector.JsExportSurface.JsExportSurface surface)
     {
-        JsExportUnion? union = surface.Unions.FirstOrDefault(
-            union => ShouldEmit(surface, union.Definition));
-        if (union is not null)
+        foreach (JsExportUnion union in surface.Unions.Where(
+            union => ShouldEmit(surface, union.Definition)))
         {
-            throw new UnsupportedWireContractException(
-                union.Definition.FullName,
-                "native C# union TypeScript lowering is not implemented");
+            JsonWireDirection directions = surface.WireDirections.GetValueOrDefault(
+                union.Definition, JsonWireDirection.Both);
+            string? reason = (directions & JsonWireDirection.Deserialize) != 0
+                ? union.DeserializationUnsupportedReason
+                : union.SerializationUnsupportedReason;
+            if (reason is not null || union.IncludesNull is null || union.CaseTypes.Count == 0)
+            {
+                throw new UnsupportedWireContractException(
+                    union.Definition.FullName,
+                    reason ?? "union case or null evidence is unavailable");
+            }
         }
+        ValidateUnionCycles(surface);
         return [
             .. surface.Records
                 .Concat(surface.Enums)
+                .Concat(surface.Unions.Select(union => union.Definition))
                 .Where(type => ShouldEmit(surface, type)),
         ];
+    }
+
+    static void ValidateUnionCycles(ILInspector.JsExportSurface.JsExportSurface surface)
+    {
+        var unions = surface.Unions
+            .Where(union => ShouldEmit(surface, union.Definition) && union.Definition.DefinitionName is not null)
+            .ToDictionary(union => union.Definition.DefinitionName!, union => union);
+        var completed = new HashSet<JsExportUnion>();
+        var active = new HashSet<JsExportUnion>();
+        var pending = new Stack<(JsExportUnion Union, bool Exit)>();
+        foreach (JsExportUnion root in unions.Values)
+        {
+            pending.Push((root, false));
+            while (pending.TryPop(out var next))
+            {
+                if (next.Exit)
+                {
+                    active.Remove(next.Union);
+                    completed.Add(next.Union);
+                    continue;
+                }
+                if (completed.Contains(next.Union))
+                    continue;
+                if (!active.Add(next.Union))
+                {
+                    throw new UnsupportedWireContractException(
+                        next.Union.Definition.FullName,
+                        "recursive union case aliases are unsupported");
+                }
+                pending.Push((next.Union, true));
+                var types = new Stack<TypeRef>(next.Union.CaseTypes);
+                while (types.TryPop(out var type))
+                {
+                    if (TsTypeMapper.MatchesContainingAssembly(type, surface.AssemblyIdentity)
+                        && type.Resolution?.Type is { } definition
+                        && unions.TryGetValue(definition, out JsExportUnion? referenced))
+                        pending.Push((referenced, false));
+                    if (type.ElementType is { } element)
+                        types.Push(element);
+                    foreach (var argument in type.TypeArguments)
+                        types.Push(argument);
+                }
+            }
+        }
     }
 
     static IReadOnlyDictionary<ApiTypeReferenceIdentity, ApiType>
@@ -211,6 +265,45 @@ static class DtsEmitter
                 AllocatedTypeName(record, allocatedTypeNames),
                 typeEnvironment,
                 diagnostics);
+
+        foreach (JsExportUnion union in surface.Unions
+            .Where(union => ShouldEmit(surface, union.Definition))
+            .OrderBy(
+                union => AllocatedTypeName(union.Definition, allocatedTypeNames),
+                StringComparer.Ordinal))
+        {
+            EmitUnion(sb, union, typeEnvironment,
+                AllocatedTypeName(union.Definition, allocatedTypeNames));
+        }
+    }
+
+    static void EmitUnion(
+        StringBuilder sb,
+        JsExportUnion union,
+        TypeMappingEnvironment environment,
+        string name)
+    {
+        var usedNames = new HashSet<string>(environment.IdentityNames.Values, StringComparer.Ordinal);
+        string[] parameters = new string[union.Definition.TypeParameters.Count];
+        for (int index = 0; index < parameters.Length; index++)
+        {
+            string parameter = $"T{index}";
+            while (!usedNames.Add(parameter))
+                parameter += "_";
+            parameters[index] = parameter;
+        }
+
+        string[] mapped = [.. union.CaseTypes.SelectMany(type =>
+            TsJsonUnionMapper.MapCase(type, parameters, environment.UnionContext, union.Definition.FullName))];
+        IEnumerable<string> alternatives = mapped.Where(type => type != "null");
+        if (union.IncludesNull == true || mapped.Contains("null", StringComparer.Ordinal))
+            alternatives = alternatives.Append("null");
+
+        sb.Append("export type ").Append(name);
+        if (parameters.Length > 0)
+            sb.Append('<').AppendJoin(", ", parameters).Append('>');
+        sb.Append(" = ").AppendJoin(" | ", alternatives.Distinct(StringComparer.Ordinal))
+            .Append(";\n\n");
     }
 
     static TypeScriptFunctionSignature GetFunctionSignature(
@@ -268,7 +361,8 @@ static class DtsEmitter
                 BlockedAliases(
                     function.ReturnTypeReferences,
                     typeEnvironment.KnownTypeNames,
-                    typeEnvironment.KnownTypeIdentities))
+                    typeEnvironment.KnownTypeIdentities),
+                typeEnvironment.UnionContext)
             : TsTypeMapper.MapReturnType(
                 function.ReturnType,
                 typeEnvironment.KnownTypeNames,
@@ -433,7 +527,19 @@ static class DtsEmitter
             knownTypeIdentities,
             aliases,
             identityNames,
-            delegateMappingContext);
+            delegateMappingContext,
+            new TsJsonUnionMappingContext(
+                surface.AssemblyIdentity,
+                identityNames,
+                surface.AssemblyIdentity is { } unionAssembly
+                    ? surface.Unions
+                        .Where(union => union.Definition.TypeParameters.Count > 0)
+                        .ToDictionary(
+                            union => new ApiTypeReferenceIdentity(
+                                unionAssembly, union.Definition.FullName, union.Definition.DefinitionName),
+                            union => union.Definition.TypeParameters.Count)
+                    : new Dictionary<ApiTypeReferenceIdentity, int>(),
+                delegateMappingContext));
     }
 
     static IReadOnlyDictionary<string, string> MappedTypeNames(
@@ -468,7 +574,20 @@ static class DtsEmitter
         allocatedTypeNames is not null
             && allocatedTypeNames.TryGetValue(type, out string? name)
                 ? name
-                : type.Name;
+                : PreferredTypeName(type);
+
+    internal static string PreferredTypeName(ApiType type)
+    {
+        if (type.HasUnionAttribute == true
+            && type.TypeParameters.Count > 0
+            && type.DefinitionName is { } definition)
+        {
+            string segment = definition.Segments[^1];
+            int arity = segment.LastIndexOf('`');
+            return arity >= 0 ? segment[..arity] : segment;
+        }
+        return type.Name;
+    }
 
     static bool ShouldEmit(
         ILInspector.JsExportSurface.JsExportSurface surface,
@@ -641,7 +760,8 @@ static class DtsEmitter
                         member.SignatureModel?.ReturnTypeReferences
                             ?? []),
                     member.SignatureModel?.ReturnTypeShape,
-                    typeEnvironment.IdentityNames);
+                    typeEnvironment.IdentityNames,
+                    typeEnvironment.UnionContext);
             }
             sb.Append("  readonly ").Append(tsName).Append(": ").Append(tsType).Append(";\n");
         }
@@ -657,6 +777,8 @@ static class DtsEmitter
     {
         foreach (ApiType type in types)
         {
+            if (type.HasUnionAttribute == true)
+                continue;
             bool converterControlled =
                 HasUnsupportedJsonConverter(type);
             foreach (ApiMember member in type.Members)
@@ -1049,7 +1171,8 @@ static class DtsEmitter
         HashSet<ApiTypeReferenceIdentity> KnownTypeIdentities,
         Dictionary<string, string> Aliases,
         Dictionary<ApiTypeReferenceIdentity, string> IdentityNames,
-        TsDelegateMappingContext DelegateMappingContext);
+        TsDelegateMappingContext DelegateMappingContext,
+        TsJsonUnionMappingContext UnionContext);
 
     static void EmitFunction(
         StringBuilder sb,
@@ -1122,7 +1245,7 @@ static class DtsEmitter
         return blocked.Count == 0 ? null : blocked;
     }
 
-    static bool IsAuthenticFrameworkMapping(
+    internal static bool IsAuthenticFrameworkMapping(
         ApiTypeReferenceIdentity reference)
     {
         if (!PlatformKeys.IsPlatform(

--- a/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
@@ -1,0 +1,212 @@
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+
+namespace ILInspector.TypeScriptGeneration;
+
+sealed record TsJsonUnionMappingContext(
+    ApiAssemblyIdentity? Assembly,
+    IReadOnlyDictionary<ApiTypeReferenceIdentity, string> Names,
+    IReadOnlyDictionary<ApiTypeReferenceIdentity, int> GenericArities,
+    TsDelegateMappingContext LocalTypes);
+
+static class TsJsonUnionMapper
+{
+    internal static IEnumerable<string> MapCase(
+        TypeRef type,
+        IReadOnlyList<string> parameters,
+        TsJsonUnionMappingContext context,
+        string location)
+    {
+        if (type.Kind == TypeRefKind.GenericParameter)
+        {
+            if (type.GenericParameterIndex >= 0
+                && type.GenericParameterIndex < parameters.Count)
+                return [parameters[type.GenericParameterIndex]];
+            throw Unsupported(location, "union case generic parameter is unavailable");
+        }
+
+        var pending = new Stack<TypeRef>();
+        pending.Push(type);
+        while (pending.TryPop(out TypeRef? component))
+        {
+            if (component.Kind == TypeRefKind.GenericParameter)
+                throw Unsupported(location, "generic parameters embedded in union case signatures are unsupported");
+            if (component.ElementType is { } element)
+                pending.Push(element);
+            foreach (TypeRef argument in component.TypeArguments)
+                pending.Push(argument);
+        }
+        return type is { Kind: TypeRefKind.GenericInstance, ElementType: { } definition, TypeArguments: [var nullable] }
+            && IsCoreType(definition, "Nullable`1")
+                ? [MapClosedCase(nullable, context, location), "null"]
+                : [MapClosedCase(type, context, location)];
+    }
+
+    static string MapClosedCase(
+        TypeRef type,
+        TsJsonUnionMappingContext context,
+        string location)
+    {
+        if (type.Kind == TypeRefKind.SzArray && type.ElementType is { } element)
+            return IsCoreType(element, "Byte")
+                ? "string"
+                : $"ReadonlyArray<{MapCollectionCase(element, context, location)}>";
+
+        TypeRef definition = type.Kind == TypeRefKind.GenericInstance
+            ? type.ElementType!
+            : type;
+        if (definition.Kind != TypeRefKind.Definition)
+            throw Unsupported(location, "unsupported union case signature");
+
+        if (type.Kind == TypeRefKind.GenericInstance)
+        {
+            if (IsCoreType(definition, "Nullable`1")
+                && type.TypeArguments is [var nullable])
+                return WithNull(MapClosedCase(nullable, context, location));
+
+            if (TsTypeMapper.IsAuthenticFrameworkMapping(definition)
+                && definition.Namespace == "System.Collections.Generic"
+                && definition.Name is "Dictionary`2" or "IReadOnlyDictionary`2"
+                && type.TypeArguments is [var key, var value]
+                && IsCoreType(key, "String"))
+            {
+                return $"Readonly<Record<string, {MapCollectionCase(value, context, location)}>>";
+            }
+
+            if (LocalIdentity(definition, context) is { } identity
+                && context.GenericArities.TryGetValue(identity, out int arity)
+                && arity == type.TypeArguments.Length
+                && context.Names.TryGetValue(identity, out string? name))
+            {
+                return $"{name}<{string.Join(", ", type.TypeArguments.Select(
+                    argument => MapClosedCase(argument, context, location)))}>";
+            }
+            throw Unsupported(location, "unsupported generic union case type");
+        }
+
+        if (definition.Namespace == "System"
+            && TsTypeMapper.IsAuthenticFrameworkMapping(definition)
+            && Enum.TryParse(definition.Name, out ApiPrimitiveType primitive)
+            && primitive != ApiPrimitiveType.Void
+            && TsTypeMapper.MapPrimitive(primitive) is { } primitiveName)
+            return primitiveName;
+
+        if (definition.Namespace == "System.Text.Json"
+            && definition.Name == "JsonElement"
+            && TsTypeMapper.IsAuthenticFrameworkMapping(definition))
+            return "unknown";
+
+        if (LocalIdentity(definition, context) is { } local
+            && !context.GenericArities.ContainsKey(local)
+            && context.Names.TryGetValue(local, out string? localName))
+            return localName;
+
+        throw Unsupported(location, $"unsupported union case type '{type.ToDisplayString()}'");
+    }
+
+    internal static string MapClosedShape(
+        ApiTypeShape shape,
+        TsJsonUnionMappingContext context,
+        string location)
+    {
+        if (shape.Kind == ApiTypeShapeKind.Primitive
+            && shape.Primitive is { } primitive
+            && primitive != ApiPrimitiveType.Void
+            && TsTypeMapper.MapPrimitive(primitive) is { } primitiveName)
+            return primitiveName;
+
+        if (shape.Kind == ApiTypeShapeKind.SzArray && shape.ElementType is { } element)
+            return element is { Kind: ApiTypeShapeKind.Primitive, Primitive: ApiPrimitiveType.Byte }
+                ? "string"
+                : $"ReadonlyArray<{MapCollectionShape(element, context, location)}>";
+
+        if (shape.Definition is { } identity)
+        {
+            if (context.Names.TryGetValue(identity, out string? name))
+            {
+                if (shape.Kind == ApiTypeShapeKind.Named
+                    && !context.GenericArities.ContainsKey(identity))
+                    return name;
+                if (shape.Kind == ApiTypeShapeKind.GenericInstance
+                    && context.GenericArities.TryGetValue(identity, out int arity)
+                    && arity == shape.TypeArguments.Length)
+                {
+                    return $"{name}<{string.Join(", ", shape.TypeArguments.Select(
+                        argument => MapClosedShape(argument, context, location)))}>";
+                }
+            }
+
+            if (DtsEmitter.IsAuthenticFrameworkMapping(identity))
+            {
+                if (shape.Kind == ApiTypeShapeKind.Named
+                    && identity.FullName == "System.Text.Json.JsonElement")
+                    return "unknown";
+                if (shape.Kind == ApiTypeShapeKind.Named
+                    && identity.FullName == "System.Decimal")
+                    return "number";
+                if (shape.Kind == ApiTypeShapeKind.GenericInstance
+                    && identity.FullName == "System.Nullable`1"
+                    && shape.TypeArguments is [var nullable])
+                    return WithNull(MapClosedShape(nullable, context, location));
+                if (shape.Kind == ApiTypeShapeKind.GenericInstance
+                    && identity.FullName is "System.Collections.Generic.Dictionary`2"
+                        or "System.Collections.Generic.IReadOnlyDictionary`2"
+                    && shape.TypeArguments is [var key, var value]
+                    && key is { Kind: ApiTypeShapeKind.Primitive, Primitive: ApiPrimitiveType.String })
+                {
+                    return $"Readonly<Record<string, {MapCollectionShape(value, context, location)}>>";
+                }
+            }
+        }
+        throw Unsupported(location, "unsupported closed generic union argument");
+    }
+
+    internal static string WithNull(string type) =>
+        $"{type} | null";
+
+    // Signature-only case trees do not retain nested nullable-reference annotations.
+    static string MapCollectionCase(TypeRef type, TsJsonUnionMappingContext context, string location)
+    {
+        string mapped = MapClosedCase(type, context, location);
+        return TsTypeMapper.ClassifyAuthenticatedType(type, context.LocalTypes) == TsLocalTypeKind.Reference
+            ? WithNull(mapped)
+            : mapped;
+    }
+
+    static string MapCollectionShape(ApiTypeShape shape, TsJsonUnionMappingContext context, string location)
+    {
+        string mapped = MapClosedShape(shape, context, location);
+        bool reference = shape.Kind == ApiTypeShapeKind.SzArray
+            || shape is { Kind: ApiTypeShapeKind.Primitive, Primitive: ApiPrimitiveType.String };
+        if (shape.Definition is { } identity)
+        {
+            reference |= identity.DefinitionName is { } definition
+                && context.LocalTypes.LocalTypeKinds.TryGetValue(definition, out var kind)
+                && kind == TsLocalTypeKind.Reference
+                && context.Names.ContainsKey(identity);
+            reference |= identity.FullName is "System.Collections.Generic.Dictionary`2"
+                    or "System.Collections.Generic.IReadOnlyDictionary`2"
+                && DtsEmitter.IsAuthenticFrameworkMapping(identity);
+        }
+        return reference ? WithNull(mapped) : mapped;
+    }
+
+    static ApiTypeReferenceIdentity? LocalIdentity(
+        TypeRef type,
+        TsJsonUnionMappingContext context) =>
+        context.Assembly is { } assembly
+        && TsTypeMapper.MatchesContainingAssembly(type, assembly)
+        && type.Resolution?.Type is { } definition
+            ? new(assembly, definition.ToMetadataFullName(), definition)
+            : null;
+
+    static bool IsCoreType(TypeRef type, string name) =>
+        type.Kind == TypeRefKind.Definition
+        && type.Namespace == "System"
+        && type.Name == name
+        && type.Assembly == TypeRef.CoreLibrary
+        && type.TrustedFrameworkAssembly;
+
+    static UnsupportedWireContractException Unsupported(string location, string reason) =>
+        new(location, reason);
+}

--- a/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
@@ -169,7 +169,8 @@ static class TsTypeMapper
         ApiTypeShape? wireTypeShape = null,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, string>?
             identityNames = null,
-        IReadOnlySet<string>? envelopeBlockedAliases = null)
+        IReadOnlySet<string>? envelopeBlockedAliases = null,
+        TsJsonUnionMappingContext? unionContext = null)
     {
         string trimmed = csharpType.Trim();
         if (IsBlockedType(trimmed, envelopeBlockedAliases))
@@ -188,7 +189,8 @@ static class TsTypeMapper
             mappedTypeNames,
             TsTypeMappingContext.JsonWire,
             wireTypeShape,
-            identityNames);
+            identityNames,
+            unionContext);
 
         if (IsJsonEnvelopeReturnType(trimmed))
         {
@@ -270,7 +272,8 @@ static class TsTypeMapper
         IReadOnlyDictionary<string, string>? mappedTypeNames = null,
         ApiTypeShape? typeShape = null,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, string>?
-            identityNames = null) =>
+            identityNames = null,
+        TsJsonUnionMappingContext? unionContext = null) =>
         Map(
             csharpType.Trim(),
             recordNames,
@@ -280,7 +283,8 @@ static class TsTypeMapper
             mappedTypeNames,
             TsTypeMappingContext.JsonWire,
             typeShape,
-            identityNames);
+            identityNames,
+            unionContext);
 
     static string Map(
         string csharpType,
@@ -292,7 +296,8 @@ static class TsTypeMapper
         TsTypeMappingContext mappingContext,
         ApiTypeShape? typeShape = null,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, string>?
-            identityNames = null)
+            identityNames = null,
+        TsJsonUnionMappingContext? unionContext = null)
     {
         string trimmed = csharpType.Trim();
         if (typeShape is null
@@ -316,7 +321,8 @@ static class TsTypeMapper
                 mappedTypeNames,
                 mappingContext,
                 typeShape,
-                identityNames)} | null";
+                identityNames,
+                unionContext)} | null";
         }
 
         // System.Text.Json encodes a byte[] value as one Base64 JSON string. Direct JS interop
@@ -345,7 +351,8 @@ static class TsTypeMapper
                 mappedTypeNames,
                 mappingContext,
                 ArrayElementShape(typeShape),
-                identityNames);
+                identityNames,
+                unionContext);
             if (mappingContext == TsTypeMappingContext.JsonWire)
             {
                 return $"ReadonlyArray<{mappedElement}>";
@@ -381,7 +388,8 @@ static class TsTypeMapper
                 mappedTypeNames,
                 mappingContext,
                 GenericArgumentShape(typeShape, 0),
-                identityNames)} | null";
+                identityNames,
+                unionContext)} | null";
         }
 
         if (TryMapDictionary(
@@ -394,9 +402,18 @@ static class TsTypeMapper
                 mappingContext,
                 typeShape,
                 identityNames,
+                unionContext,
                 out string? dictionaryType))
         {
             return dictionaryType!;
+        }
+
+        if (mappingContext == TsTypeMappingContext.JsonWire
+            && typeShape is { Kind: ApiTypeShapeKind.GenericInstance, Definition: { } unionIdentity }
+            && unionContext?.GenericArities.ContainsKey(unionIdentity) == true)
+        {
+            return TsJsonUnionMapper.MapClosedShape(
+                typeShape, unionContext, location ?? trimmed);
         }
 
         if (typeShape is
@@ -529,7 +546,7 @@ static class TsTypeMapper
         return mapped;
     }
 
-    static string? MapPrimitive(ApiPrimitiveType primitive) =>
+    internal static string? MapPrimitive(ApiPrimitiveType primitive) =>
         primitive switch
         {
             ApiPrimitiveType.Char or ApiPrimitiveType.String => "string",
@@ -580,6 +597,7 @@ static class TsTypeMapper
         ApiTypeShape? typeShape,
         IReadOnlyDictionary<ApiTypeReferenceIdentity, string>?
             identityNames,
+        TsJsonUnionMappingContext? unionContext,
         out string? mappedType)
     {
         if (!TryUnwrapGeneric(typeName, "System.Collections.Generic.Dictionary", out string? dictionaryArgs)
@@ -630,7 +648,8 @@ static class TsTypeMapper
             mappedTypeNames,
             mappingContext,
             GenericArgumentShape(typeShape, 0),
-            identityNames);
+            identityNames,
+            unionContext);
         string mappedValue = Map(
             valueType!,
             recordNames,
@@ -640,7 +659,8 @@ static class TsTypeMapper
             mappedTypeNames,
             mappingContext,
             GenericArgumentShape(typeShape, 1),
-            identityNames);
+            identityNames,
+            unionContext);
         if (mappedKey != "string")
         {
             diagnostics?.ReportUnmappedType(location ?? typeName, typeName);
@@ -1267,7 +1287,7 @@ static class TsTypeMapper
         && type.Name == expectedName
         && IsAuthenticFrameworkMapping(type);
 
-    static bool IsAuthenticFrameworkMapping(TypeRef type)
+    internal static bool IsAuthenticFrameworkMapping(TypeRef type)
     {
         if (!type.TrustedFrameworkAssembly)
             return false;
@@ -1303,7 +1323,7 @@ static class TsTypeMapper
         && type.Namespace == expectedNamespace
         && type.Name == expectedName;
 
-    static TsLocalTypeKind? ClassifyAuthenticatedType(
+    internal static TsLocalTypeKind? ClassifyAuthenticatedType(
         TypeRef type,
         TsDelegateMappingContext mappingContext)
     {
@@ -1405,7 +1425,7 @@ static class TsTypeMapper
             out kind);
     }
 
-    static bool MatchesContainingAssembly(
+    internal static bool MatchesContainingAssembly(
         TypeRef type,
         ApiAssemblyIdentity? containingAssembly)
     {

--- a/src/ILInspector.TypeScriptGeneration/TypeScriptFacadeEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/TypeScriptFacadeEmitter.cs
@@ -453,9 +453,14 @@ internal static class TypeScriptFacadeEmitter
             var typeNames = new Dictionary<ApiType, string>();
             foreach (ApiType type in surface.Records
                 .Concat(surface.Enums)
+                .Concat(surface.Unions
+                    .Where(union => !surface.WireDirections.TryGetValue(union.Definition, out var direction)
+                        || direction != JsonWireDirection.None)
+                    .Select(union => union.Definition))
                 .OrderBy(CanonicalTypeIdentity, StringComparer.Ordinal))
             {
-                if (!TypeScriptIdentifier.IsIdentifierName(type.Name))
+                string preferredName = DtsEmitter.PreferredTypeName(type);
+                if (!TypeScriptIdentifier.IsIdentifierName(preferredName))
                 {
                     throw new UnsupportedWireContractException(
                         type.MetadataToken is { } token
@@ -468,7 +473,7 @@ internal static class TypeScriptFacadeEmitter
                     type,
                     Allocate(
                         moduleBindings,
-                        type.Name,
+                        preferredName,
                         "type",
                         CanonicalTypeIdentity(type),
                         TypeScriptIdentifier.IsTypeDeclarationIdentifier));

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
@@ -2,12 +2,46 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-if (process.argv.length !== 3) {
-  throw new Error("Usage: node runtime-probe.mjs <generated-facade.js>");
+if (process.argv.length !== 5) {
+  throw new Error(
+    "Usage: node runtime-probe.mjs <generated-facade.js> "
+      + "<union-payloads.json> <union-usage.js>",
+  );
 }
 
 const facadeUrl = pathToFileURL(process.argv[2]);
 const facadeSource = readFileSync(process.argv[2], "utf8");
+// Real source-generated System.Text.Json output captured from the compiled
+// producer fixture by union-payloads.cs.
+const unionPayloads = JSON.parse(readFileSync(process.argv[3], "utf8"));
+const unionUsageUrl = pathToFileURL(process.argv[4]);
+for (
+  const name of [
+    "widgetSelectionDto",
+    "widgetSelectionString",
+    "defaultSelection",
+    "flagSelectionTrue",
+    "flagSelectionWidget",
+    "outcomeNested",
+    "outcomeBoolean",
+    "kindDeclared",
+    "kindString",
+    "collectionArray",
+    "collectionMap",
+    "collectionNumber",
+    "collectionDefault",
+    "boxedCount",
+    "boxedWidget",
+    "wrappedBlob",
+    "selectionEnvelope",
+  ]
+) {
+  assert.equal(
+    typeof unionPayloads[name],
+    "string",
+    `The producer fixture did not supply the ${name} union payload.`,
+  );
+}
 const configureHostKey =
   facadeSource.match(/"(ConfigureHost\.-?\d+)"/)?.[1];
 const echoKey = facadeSource.match(/"(Echo\.-?\d+)"/)?.[1];
@@ -29,6 +63,26 @@ const getNullableWidgetAsyncKey =
   facadeSource.match(/"(GetNullableWidgetAsync\.-?\d+)"/)?.[1];
 const getJsonElementKey =
   facadeSource.match(/"(GetJsonElement\.-?\d+)"/)?.[1];
+const getWidgetSelectionKey =
+  facadeSource.match(/"(GetWidgetSelection\.-?\d+)"/)?.[1];
+const getDefaultSelectionKey =
+  facadeSource.match(/"(GetDefaultSelection\.-?\d+)"/)?.[1];
+const getFlagSelectionKey =
+  facadeSource.match(/"(GetFlagSelection\.-?\d+)"/)?.[1];
+const getOutcomeSelectionKey =
+  facadeSource.match(/"(GetOutcomeSelection\.-?\d+)"/)?.[1];
+const getKindSelectionKey =
+  facadeSource.match(/"(GetKindSelection\.-?\d+)"/)?.[1];
+const getCollectionSelectionKey =
+  facadeSource.match(/"(GetCollectionSelection\.-?\d+)"/)?.[1];
+const getBoxedCountKey =
+  facadeSource.match(/"(GetBoxedCount\.-?\d+)"/)?.[1];
+const getBoxedWidgetKey =
+  facadeSource.match(/"(GetBoxedWidget\.-?\d+)"/)?.[1];
+const getWrappedBlobKey =
+  facadeSource.match(/"(GetWrappedBlob\.-?\d+)"/)?.[1];
+const getSelectionEnvelopeAsyncKey =
+  facadeSource.match(/"(GetSelectionEnvelopeAsync\.-?\d+)"/)?.[1];
 const observeValueKey =
   facadeSource.match(/"(ObserveValue\.-?\d+)"/)?.[1];
 const transformValueKey =
@@ -84,6 +138,47 @@ assert.ok(
 assert.ok(
   getJsonElementKey,
   "The generated GetJsonElement runtime dispatch key was not found.",
+);
+assert.ok(
+  getWidgetSelectionKey,
+  "The generated GetWidgetSelection runtime dispatch key was not found.",
+);
+assert.ok(
+  getDefaultSelectionKey,
+  "The generated GetDefaultSelection runtime dispatch key was not found.",
+);
+assert.ok(
+  getFlagSelectionKey,
+  "The generated GetFlagSelection runtime dispatch key was not found.",
+);
+assert.ok(
+  getOutcomeSelectionKey,
+  "The generated GetOutcomeSelection runtime dispatch key was not found.",
+);
+assert.ok(
+  getKindSelectionKey,
+  "The generated GetKindSelection runtime dispatch key was not found.",
+);
+assert.ok(
+  getCollectionSelectionKey,
+  "The generated GetCollectionSelection runtime dispatch key was not found.",
+);
+assert.ok(
+  getBoxedCountKey,
+  "The generated GetBoxedCount runtime dispatch key was not found.",
+);
+assert.ok(
+  getBoxedWidgetKey,
+  "The generated GetBoxedWidget runtime dispatch key was not found.",
+);
+assert.ok(
+  getWrappedBlobKey,
+  "The generated GetWrappedBlob runtime dispatch key was not found.",
+);
+assert.ok(
+  getSelectionEnvelopeAsyncKey,
+  "The generated GetSelectionEnvelopeAsync runtime dispatch key "
+    + "was not found.",
 );
 assert.ok(
   observeValueKey,
@@ -162,6 +257,45 @@ function managedExports(methods = {}) {
             [getJsonElementKey]:
               methods.getJsonElement
               ?? (() => JSON.stringify({ value: "json" })),
+            [getWidgetSelectionKey]:
+              methods.getWidgetSelection
+              ?? ((widget) => (widget
+                ? unionPayloads.widgetSelectionDto
+                : unionPayloads.widgetSelectionString)),
+            [getDefaultSelectionKey]:
+              methods.getDefaultSelection
+              ?? (() => unionPayloads.defaultSelection),
+            [getFlagSelectionKey]:
+              methods.getFlagSelection
+              ?? ((flag) => (flag
+                ? unionPayloads.flagSelectionTrue
+                : unionPayloads.flagSelectionWidget)),
+            [getOutcomeSelectionKey]:
+              methods.getOutcomeSelection
+              ?? ((nested) => (nested
+                ? unionPayloads.outcomeNested
+                : unionPayloads.outcomeBoolean)),
+            [getKindSelectionKey]:
+              methods.getKindSelection
+              ?? ((declared) => (declared
+                ? unionPayloads.kindDeclared
+                : unionPayloads.kindString)),
+            [getCollectionSelectionKey]:
+              methods.getCollectionSelection
+              ?? ((choice) => [
+                unionPayloads.collectionArray,
+                unionPayloads.collectionMap,
+                unionPayloads.collectionNumber,
+              ][choice] ?? unionPayloads.collectionDefault),
+            [getBoxedCountKey]:
+              methods.getBoxedCount ?? (() => unionPayloads.boxedCount),
+            [getBoxedWidgetKey]:
+              methods.getBoxedWidget ?? (() => unionPayloads.boxedWidget),
+            [getWrappedBlobKey]:
+              methods.getWrappedBlob ?? (() => unionPayloads.wrappedBlob),
+            [getSelectionEnvelopeAsyncKey]:
+              methods.getSelectionEnvelopeAsync
+              ?? (async () => unionPayloads.selectionEnvelope),
             [observeValueKey]:
               methods.observeValue
               ?? ((callback) => callback(42)),
@@ -302,6 +436,74 @@ async function freshFacade() {
     { public: "public" },
   );
   assert.deepEqual(facade.getJsonElement(), { value: "json" });
+  assert.deepEqual(
+    facade.getWidgetSelection(true),
+    { name: "selected", count: 2 },
+  );
+  assert.equal(facade.getWidgetSelection(false), "fallback");
+  assert.equal(facade.getDefaultSelection(), null);
+  assert.equal(facade.getFlagSelection(true), true);
+  assert.deepEqual(
+    facade.getFlagSelection(false),
+    { name: "flagged", count: 3 },
+  );
+  assert.equal(facade.getOutcomeSelection(true), "nested");
+  assert.equal(facade.getOutcomeSelection(false), true);
+  assert.equal(facade.getKindSelection(true), 1);
+  assert.equal(facade.getKindSelection(false), "unknown");
+  // A producer can write null into a non-nullable-annotated reference array,
+  // so the lowered entry type stays nullable.
+  assert.deepEqual(
+    facade.getCollectionSelection(0),
+    [{ name: "listed", count: 10 }, null],
+  );
+  assert.deepEqual(
+    facade.getCollectionSelection(1),
+    { present: { name: "mapped", count: 11 }, absent: null },
+  );
+  assert.equal(facade.getCollectionSelection(2), 12);
+  assert.equal(facade.getCollectionSelection(3), null);
+  assert.equal(facade.getBoxedCount(11), 11);
+  assert.deepEqual(facade.getBoxedWidget("boxed"), { name: "boxed", count: 4 });
+  // A closed byte[] union argument keeps its Base64 JSON string wire form.
+  assert.equal(facade.getWrappedBlob(), "AQID");
+  assert.deepEqual(
+    await facade.getSelectionEnvelopeAsync("envelope"),
+    {
+      result: { name: "envelope", count: 5 },
+      items: ["first", null],
+      byName: {
+        named: { name: "envelope", count: 6 },
+        missing: null,
+      },
+      outcome: "outcome",
+      kind: 0,
+      declaredKind: 1,
+      count: 7,
+      widget: { name: "envelope", count: 8 },
+      group: [{ name: "envelope", count: 9 }, null],
+      blob: "BAU=",
+    },
+  );
+
+  // The compiled union consumer imports the unsuffixed facade module, so it
+  // needs its own initialization under the same configured scenario.
+  const sharedFacade = await import(facadeUrl.href);
+  await sharedFacade.initializeRuntime();
+  const unionUsage = await import(unionUsageUrl.href);
+  assert.equal(
+    unionUsage.probeSelections(),
+    "selected:2|none|none|true|yes|kind-1|11/boxed|literal:9|blob:AQID"
+      + "|listed,null|present=mapped,absent=null|none",
+  );
+  assert.equal(
+    await unionUsage.summarizeEnvelope(),
+    "envelope:5|first|envelope:6|outcome|kind-0|7/envelope|blob:BAU="
+      + "|group:envelope,null",
+  );
+  assert.equal(unionUsage.missingSelectionEntry, null);
+  assert.equal(unionUsage.missingMapEntry, null);
+  assert.equal(unionUsage.missingGroupEntry, null);
   const observed = [];
   facade.observeValue((value) => {
     observed.push(value);

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
@@ -1,0 +1,57 @@
+#:project ../../../../fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/ILInspector.JsExportSurface.TypeScriptFixtures.csproj
+#:property NoWarn=CA1416
+
+// Executes the compiled TypeScript fixture's exports so the runtime probe
+// asserts against real source-generated System.Text.Json union payloads.
+
+using System.Text.Json;
+using ILInspector.JsExportSurface.TypeScriptFixtures;
+
+if (args is not [string outputPath])
+{
+    throw new ArgumentException(
+        "Usage: dotnet run union-payloads.cs -- <output.json>");
+}
+
+(string Name, string Payload)[] payloads =
+[
+    ("widgetSelectionDto", TypeScriptFixtureExports.GetWidgetSelection(true)),
+    ("widgetSelectionString", TypeScriptFixtureExports.GetWidgetSelection(false)),
+    ("defaultSelection", TypeScriptFixtureExports.GetDefaultSelection()),
+    ("flagSelectionTrue", TypeScriptFixtureExports.GetFlagSelection(true)),
+    ("flagSelectionWidget", TypeScriptFixtureExports.GetFlagSelection(false)),
+    ("outcomeNested", TypeScriptFixtureExports.GetOutcomeSelection(true)),
+    ("outcomeBoolean", TypeScriptFixtureExports.GetOutcomeSelection(false)),
+    ("kindDeclared", TypeScriptFixtureExports.GetKindSelection(true)),
+    ("kindString", TypeScriptFixtureExports.GetKindSelection(false)),
+    ("collectionArray", TypeScriptFixtureExports.GetCollectionSelection(0)),
+    ("collectionMap", TypeScriptFixtureExports.GetCollectionSelection(1)),
+    ("collectionNumber", TypeScriptFixtureExports.GetCollectionSelection(2)),
+    ("collectionDefault", TypeScriptFixtureExports.GetCollectionSelection(3)),
+    ("boxedCount", TypeScriptFixtureExports.GetBoxedCount(11)),
+    ("boxedWidget", TypeScriptFixtureExports.GetBoxedWidget("boxed")),
+    ("wrappedBlob", TypeScriptFixtureExports.GetWrappedBlob()),
+    (
+        "selectionEnvelope",
+        await TypeScriptFixtureExports.GetSelectionEnvelopeAsync("envelope")),
+];
+
+using (var stream = File.Create(outputPath))
+using (var writer = new Utf8JsonWriter(
+    stream,
+    new JsonWriterOptions { Indented = true }))
+{
+    writer.WriteStartObject();
+    foreach ((string name, string payload) in payloads)
+    {
+        writer.WriteString(name, payload);
+    }
+    writer.WriteEndObject();
+}
+
+foreach ((string name, string payload) in payloads)
+{
+    Console.WriteLine($"{name}: {payload}");
+}
+
+return 0;

--- a/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
+++ b/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The payload oracle runs as a file-based app, not as test-host source. -->
+    <Compile Remove="Fixtures/ts-jsexport-runtime/union-payloads.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/tests/ILInspector.JsExportSurface.Tests/JsonUnionWireTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonUnionWireTests.cs
@@ -179,14 +179,125 @@ public sealed class JsonUnionWireTests
     }
 
     [Fact]
-    public void Emit_ReachedUnionFailsUntilTypeScriptLoweringIsImplemented()
+    public void Emit_RetainsScalarUnionAliasAndRawFacadeReturn()
     {
         var surface = Build(nameof(UnionExports.GetScalar));
+        string declaration = DtsEmitter.Emit(surface);
+        Assert.Contains("export type ScalarUnion = number | string | null;", declaration, StringComparison.Ordinal);
+        Assert.Contains("getScalar(choice: number): ScalarUnion", declaration, StringComparison.Ordinal);
+        Assert.DoesNotContain("interface ScalarUnion", declaration, StringComparison.Ordinal);
+        string facade = TypeScriptFacadeEmitter.Emit(surface, "./dotnet.js");
+        Assert.Contains("export type ScalarUnion = number | string | null;", facade, StringComparison.Ordinal);
+        Assert.Contains("getScalar(choice: number): ScalarUnion", facade, StringComparison.Ordinal);
+        Assert.Contains("=> string;", facade, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(nameof(UnionExports.GetDto), "export type DtoUnion = PackageSummary | string | null;")]
+    [InlineData(nameof(UnionExports.GetNullable), "export type NullableUnion = number | string | null;")]
+    [InlineData(nameof(UnionExports.GetGeneric), "export type GenericUnion<T0> = T0 | string | null;")]
+    [InlineData(nameof(UnionExports.GetNested), "export type NestedUnion = ScalarUnion | boolean | null;")]
+    [InlineData(nameof(UnionExports.GetObjects), "export type ObjectUnion = PackageSummary | PackageProblem | null;")]
+    [InlineData(nameof(UnionExports.GetNumbers), "export type NumberUnion = number | null;")]
+    [InlineData(nameof(UnionExports.GetEnvelope), "readonly items: ReadonlyArray<ScalarUnion>;")]
+    public void Emit_PreservesRepresentedCaseKinds(string method, string expected)
+    {
+        var surface = Build(method);
+        var diagnostics = new TypeScriptGenerationDiagnostics();
+        Assert.Contains(expected, DtsEmitter.Emit(surface, diagnostics), StringComparison.Ordinal);
+        Assert.False(diagnostics.HasUnmappedTypes);
+        Assert.Contains(expected, TypeScriptFacadeEmitter.Emit(surface, "./dotnet.js"), StringComparison.Ordinal);
+        if (method == nameof(UnionExports.GetGeneric))
+            Assert.Contains("getGeneric(): GenericUnion<number>", DtsEmitter.Emit(surface), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(nameof(UnionExports.ReadScalar), "deserialization")]
+    [InlineData(nameof(UnionExports.ReadObjects), "deserialization")]
+    [InlineData(nameof(UnionExports.GetCustom), "unsupported wire-shaping attributes")]
+    public void Emit_UnsupportedUnionsStillFailBeforePublication(string method, string reason)
+    {
+        var surface = Build(method);
         var exception = Assert.Throws<UnsupportedWireContractException>(
             () => DtsEmitter.Emit(surface));
-        Assert.Contains("union TypeScript lowering", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(reason, exception.Message, StringComparison.Ordinal);
         Assert.Throws<UnsupportedWireContractException>(
             () => TypeScriptFacadeEmitter.Emit(surface, "./dotnet.js"));
+    }
+
+    [Fact]
+    public void Emit_UsesClosedJsonArgumentsRatherThanRawClrRepresentations()
+    {
+        string bytes = DtsEmitter.Emit(Build(nameof(UnionExports.GetGenericBytes)));
+        Assert.Contains("getGenericBytes(): GenericUnion<string>", bytes, StringComparison.Ordinal);
+        Assert.Equal("\"AQID\"", UnionExports.GetGenericBytes());
+        string dictionary = DtsEmitter.Emit(Build(nameof(UnionExports.GetGenericDictionary)));
+        Assert.Contains("GenericUnion<Readonly<Record<string, number | null>>>", dictionary, StringComparison.Ordinal);
+        Assert.Equal("{\"value\":42,\"empty\":null}", UnionExports.GetGenericDictionary());
+    }
+
+    [Fact]
+    public void Emit_DoesNotSubstituteWireParametersIntoClrArrayCases()
+    {
+        Assert.Equal("\"AQID\"", UnionExports.GetGenericArrayBytes());
+        Assert.Equal("[1,2,3]", UnionExports.GetGenericArrayNumbers());
+        foreach (string method in new[]
+        {
+            nameof(UnionExports.GetGenericArrayBytes),
+            nameof(UnionExports.GetGenericArrayNumbers),
+        })
+        {
+            var surface = Build(method);
+            var exception = Assert.Throws<UnsupportedWireContractException>(() => DtsEmitter.Emit(surface));
+            Assert.Contains("generic parameters embedded", exception.Message, StringComparison.Ordinal);
+            Assert.Throws<UnsupportedWireContractException>(() => TypeScriptFacadeEmitter.Emit(surface, "./dotnet.js"));
+        }
+    }
+
+    [Fact]
+    public void Emit_GenericParametersDoNotShadowCaseDeclarations()
+    {
+        string output = DtsEmitter.Emit(Build(nameof(UnionExports.GetParameterNameUnion)));
+        Assert.Contains("export type ParameterNameUnion<T0_> = T0_ | T0 | null;", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Emit_UnionNamesParticipateInFacadeAllocation()
+    {
+        string output = TypeScriptFacadeEmitter.Emit(Build(nameof(UnionExports.GetReservedUnionName)), "./dotnet.js");
+        string alias = output.Split('\n').Single(line => line.StartsWith("export type type_", StringComparison.Ordinal))
+            .Split(' ')[2];
+        Assert.Contains($"getReservedUnionName(): {alias}", output, StringComparison.Ordinal);
+        Assert.Contains("export function initializeRuntime(", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Emit_UnmappedCaseDoesNotBecomeAnUnknownAlternative()
+    {
+        var surface = Build(nameof(UnionExports.GetUnsupportedCase));
+        Assert.Throws<UnsupportedWireContractException>(() => DtsEmitter.Emit(surface));
+        Assert.Throws<UnsupportedWireContractException>(() => TypeScriptFacadeEmitter.Emit(surface, "./dotnet.js"));
+    }
+
+    [Fact]
+    public void Emit_RecursiveUnionAliasesFailBeforeTypeScriptPublication()
+    {
+        Assert.Equal("null", UnionExports.GetRecursiveUnion());
+        var surface = Build(nameof(UnionExports.GetRecursiveUnion));
+        var exception = Assert.Throws<UnsupportedWireContractException>(() => DtsEmitter.Emit(surface));
+        Assert.Contains("recursive union case aliases", exception.Message, StringComparison.Ordinal);
+        Assert.Throws<UnsupportedWireContractException>(() => TypeScriptFacadeEmitter.Emit(surface, "./dotnet.js"));
+    }
+
+    [Fact]
+    public void Emit_ReferenceCollectionEntriesRetainPossibleNulls()
+    {
+        Assert.Equal("[\"value\",null]", UnionExports.GetReferenceArrayUnion());
+        Assert.Equal("[\"value\",null]", UnionExports.GetGenericReferenceArray());
+        string direct = DtsEmitter.Emit(Build(nameof(UnionExports.GetReferenceArrayUnion)));
+        Assert.Contains("ReadonlyArray<string | null> | number | null", direct, StringComparison.Ordinal);
+        string generic = DtsEmitter.Emit(Build(nameof(UnionExports.GetGenericReferenceArray)));
+        Assert.Contains("GenericUnion<ReadonlyArray<string | null>>", generic, StringComparison.Ordinal);
     }
 
     static JsExportUnion Find(JsExportSurface surface, string name) =>


### PR DESCRIPTION
# Native C# JSON unions for TypeScript consumers

Make C#/TypeScript interoperability more capable without handwritten shadow
types: supported native C# unions now produce TypeScript case aliases and
parsed facade results over the existing JSON-string transport.

Fixes #6106. Advances #5892, slice 3 of 4. The prerequisite evidence slices
merged in #5896 and #6089; inspect-web adoption remains slice 4.

## Demo

The canonical, independently compiled producer declares:

```csharp
public union WidgetSelection(WidgetDto, string);
public union Wrapped<TValue>(TValue, int);
```

Previously, reaching a JSON union stopped TypeScript publication. The same
supported producer now generates these aliases:

```ts
export type WidgetSelection = WidgetDto | string | null;
export type Wrapped<T0> = T0 | number | null;
```

The raw `GetWidgetSelection` export still returns `string`; public facade
signatures now return `WidgetSelection`. `getDefaultSelection()` returns that
same alias, while `getWrappedBlob()` returns `Wrapped<string>`: the closed
`byte[]` case is a Base64 JSON string, not a TypeScript array.

Actual source-generated System.Text.Json payloads captured by the harness:

```text
widgetSelectionDto: {"name":"selected","count":2}
widgetSelectionString: "fallback"
defaultSelection: null
wrappedBlob: "AQID"
collectionArray: [{"name":"listed","count":10},null]
collectionMap: {"present":{"name":"mapped","count":11},"absent":null}
```

The generated facade parses those strings. A compiled TypeScript consumer
narrows the cases, accesses DTO fields, and observes default null, nested
unions, enum cases, readonly collections, and closed generic arguments.
No generated TypeScript is repaired before positive compilation or execution.

Neighboring behavior stays distinct: `echo(value: string): string` remains
raw, and `getWidgetAsync(name, count): Promise<WidgetDto>` retains ordinary
authenticated JSON parsing.

Reproduce with the repository SDK, browser workload, and existing inspect-web
TypeScript dependency installed:

```bash
bash eng/test-ts-jsexport-typescript.sh
```

## Contract and implementation

Normative owner: `docs/design/ts-jsexport.md#json-union-lowering`.
JsExportSurface supplies the already-owned serializer evidence; this change
owns TypeScript representation and publication limits, not serializer
classification or provenance.

- Lower structured constructor-case signatures, preserving the default-null
  alternative, existing JSON wire mappings, and readonly snapshots.
- Share identity-based declaration/facade name allocation, including generic
  formal-name and runtime-infrastructure collisions.
- Support direct type-parameter cases in generic aliases and map their closed
  arguments as JSON wire types.
- Conservatively retain possible null entries in reference-valued case
  collections, whose signature facts lack nested nullable annotations.
- Reject unsupported contracts before publication instead of emitting a
  partial or misleading facade.

## Explicit boundaries

This slice supports serialization, not union deserialization. Unavailable
case/null evidence, unsupported converters, unmapped case types, and recursive
union-case aliases remain explicit failures. Unused registrations stay inert.

Parameters embedded inside a case signature remain unsupported: `T[]` cannot
be faithfully modeled by substituting a JSON wire type, because `byte[]` and
`int[]` have different encodings although both element types map to `number`.
Recursive DTO interfaces retain their existing behavior; this does not add
general generic DTO support.

The four-step adoption tracker covers both the CLI generator and inspect-web
browser/Wasm consumer. This PR completes the generator and compiler/runtime
consumer-harness step, not production browser adoption. It adds no replacement
transport, discriminator protocol, or new rendering path.

## Validation

At effective base `51b9cbf8663c7c2f3d9ccefc82679f97d473b2d4`, using SDK
`11.0.100-preview.7.26381.103`:

- Full Release `ILInspector.JsExportSurface.Tests`: **541 passed**.
- Existing TypeScript compiler/runtime harness: **passed**, including
  **12 union close-negative compiler gates** and actual producer payloads.
- Targeted Release mapper/declaration/facade/union selection: **272 passed**
  before final base integration; the full integrated suite covers those tests.
- Changed Markdown passed `markdownlint`; `git diff --check` passed.

The mixed unsupported union fixture intentionally retains its documented
SYSLIB1227 ambiguous-reading warnings; it is separate from the supported
canonical facade producer. Runtime evidence is pinned to this preview SDK
and does not claim broader union reading support.
