### PR TITLE
Adopt shared comparison queries in round-trip helpers

### DIFF
--- a/docs/design/csharp-member-recompilation.md
+++ b/docs/design/csharp-member-recompilation.md
@@ -416,10 +416,8 @@ diff evidence:
 - `Unavailable` retains the endpoint's `Absent` or `Failed` inspection, identity
   failure, or decompilation/diff failure reason.
 
-This target arbiter is **unverified** until
-`CSharpRoundTripChangedRejectsFailureRows` runs in Release. The shipping
-round-trip envelope currently maps any non-exact diff with complete endpoint
-inspections to `Changed`, including a diff whose only rows are failures.
+`CSharpRoundTripChangedRejectsFailureRows` gates producer failure rows and
+identity failures, both alone and alongside change rows, in Release.
 
 This precondition is deliberate: `CSharpBodyDiffResult.IsExact` alone is not the
 arbiter because an empty native diff can also arise when a body fingerprint is
@@ -428,6 +426,36 @@ and preserves all producer-owned rows and failures.
 
 C# equality is useful for spelling and decompiler stability. It does not prove
 that authored source, reconstructed source, or compiled behavior is equivalent.
+
+### Comparison query consumption
+
+`DotnetInspector.RoundTripCompilation` owns this consumer envelope.
+`RoundTripComparison` and `RoundTripScopeComparison` consume the public
+`DirectMemberComparisonQuery` for each pair admitted by their existing
+correspondence and context checks. The
+[direct-member contract](direct-member-comparison.md) supplies exact input
+association; [local publication](local-comparison-publication.md) supplies
+terminal and native evidence. Neither dependency establishes donor
+correspondence or a harness fidelity verdict.
+
+The tools retain the exact `LocalComparisonQueryResult` in the non-serialized
+`Evidence` property. Their materialized rows and independent C#/IL statuses
+come from its native outcomes. Query-origin non-success, non-completed Research
+execution, and unavailable producer evidence stay unavailable, with the
+owner-issued result retained. They do not become an exact or changed result
+because rows are absent. Endpoint inspections are consumed from that result,
+not repeated by the tool.
+
+Original-to-donor correspondence and hashes, compilation-context eligibility,
+and the separate direct cluster-to-all comparison remain required.
+`RoundTripComparisonTests` gates exact and changed pairs, bodyless and malformed
+body evidence, failed correspondence, query designation rejection, retained
+physical addresses and native rows, and direct donor-pair association in
+Release. This is the focused two-helper adoption slice of
+[#6134](https://github.com/richlander/dotnet-inspect/issues/6134), within
+[#4706](https://github.com/richlander/dotnet-inspect/issues/4706) step 10.
+ReturnToSender's separate comparison path and fidelity oracle, supported Source
+composition, and final Research retirement are not changed by this adoption.
 
 ### IL arbiter
 

--- a/docs/design/direct-member-comparison.md
+++ b/docs/design/direct-member-comparison.md
@@ -186,7 +186,7 @@ this update. These are outcomes, not a promise of eight PRs:
 | 8 | Cut over CLI `match --body`, including presentation and removal of its replaced dispatch/wrapper | Complete: #5967 |
 | 9 | Add the Browser managed facade, explicit pair interaction, and typed result view | Complete: #5990 |
 | 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | #6044 retires the unconsumed body-signal population profile |
-| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Remaining; retained tool/Source callers and #5125 still constrain deletion |
+| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Remaining; retained tool/Source callers still constrain deletion; #5125 identity cleanup landed in #6099 |
 
 Each host path contains **5 milestones, all complete**:
 1, 18, 5, 6, then 8 or 9. The two scoped cleanups close the selected route,
@@ -219,11 +219,17 @@ implementation profile consumed by both hosts. Existing body-signal and
 whole-assembly query input/result shapes still serve `DiffCommand` and
 `DiffSections`, so they remain until their actual callers migrate.
 
-Research `CompareMembers` still serves `ReturnToSender`, both round-trip
-comparison helpers, and the supported PDB-source composition. Native result
+The two `RoundTripCompilation` helpers now consume the public query and its
+retained native outcomes (#6134). Their tools-owned
+[consumer envelope](csharp-member-recompilation.md#comparison-query-consumption)
+preserves correspondence, hashes, context checks, and independent verdicts.
+
+Research `CompareMembers` still serves `ReturnToSender` and the supported
+PDB-source composition. Native result
 translations still serve CLI or harness presentation. These are retained
-caller obligations, not unused placeholders; #5125 remains the focused
-Research body-index association retirement issue.
+caller obligations, not unused placeholders. The focused Research body-index
+association cleanup #5125 landed in #6099; neither that cleanup nor this
+two-helper migration completes broader retirement.
 
 ### Broader migration snapshot
 
@@ -247,12 +253,12 @@ and deletion commits to the tracker.
 | Current consumer or surface | Adoption milestone | Replacement and retirement condition |
 | --- | --- | --- |
 | `MatchCommand.BuildImplementationDiffView` | CLI step 8 after adapter step 6 | Consume the public direct-member query; remove its direct `ImplementationDiff.CompareMembers` call and type-satisfying synthetic `ResearchComparison` wrapper when the presentation consumer moves. Preserve the separate structural-match verdict. |
-| `RoundTripComparison.Compare` and `RoundTripScopeComparison.Compare` | Comparison tools step 10 | Consume the public query and retained native outcomes; remove direct Research dispatch and redundant `CSharpFindings.Inspect` calls. Preserve product-issued original/donor correspondence, hashes, and independent harness verdicts. |
+| `RoundTripComparison.Compare` and `RoundTripScopeComparison.Compare` | Comparison tools step 10, two-helper slice implemented in #6134 | Consume the public query and retained native outcomes; remove direct Research dispatch and redundant `CSharpFindings.Inspect` calls. Preserve product-issued original/donor correspondence, hashes, and independent harness verdicts. |
 | `ReturnToSender.BuildImplementationDiff`, including `AuthoredRebuildFidelity` | Comparison tools step 10 | Migrate every helper caller and its result consumption; remove replaced dispatch and obsolete nullable-result translation. Do not alter compilation, repair generated C#, or replace the harness oracle. |
 | Browser managed facade and explicit two-member workspace comparison | Browser step 9, coordinated with #5083 | Expose the same public query as observable browser behavior. Inventory actual routes then; this plan does not invent a currently existing legacy browser caller. Remove a replaced route if one exists. |
 | `ImplementationComparisonQuery.Execute`, `DiffCommand`, and `DiffSections` assembly-wide paths | Steps 7-9; Source tail 13-15 | Separate from rank 5. Their public execution and result/output adoption precede final shared-shape retirement. |
 | `ImplementationDiff.CompareMembersWithPdbSource` | Source steps 12-15 and Research retirement step 17 | Its call to `CompareMembers` is an explicit deletion blocker even if its present direct callers are tests. Migrate its supported Source composition or record an explicit owner/user decision to remove that behavior; do not keep a hidden legacy C#/IL route. |
-| `ImplementationDiff.CompareMembers`, dependent legacy member-result shapes, and independent old/new query forms | Queries step 16 and Research step 17 | Delete superseded orchestration and shapes after the refreshed caller inventory, including Source and tests, has a disposition. Preserve only APIs justified by a current owner-local contract. Reconcile #5125 separately rather than closing it because a replacement exists. |
+| `ImplementationDiff.CompareMembers`, dependent legacy member-result shapes, and independent old/new query forms | Queries step 16 and Research step 17 | Delete superseded orchestration and shapes after the refreshed caller inventory, including Source and tests, has a disposition. Preserve only APIs justified by a current owner-local contract. #5125 was reconciled independently by the identity cleanup in #6099. |
 
 Native `CSharpBodyDiff`, `IlAssemblyDiff`, Findings payloads, and useful aligned
 hunks are not deletion targets merely because they are below Queries.

--- a/src/ILInspector.Decompiler.Tests/RoundTripComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RoundTripComparisonTests.cs
@@ -1,12 +1,16 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text.Json;
+using DotnetInspector.Queries;
 using DotnetInspector.RoundTripCompilation;
+using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
+using ILInspector.Research;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using DecompilerMetadataSource = ILInspector.Decompiler.Pipeline.MetadataSource;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -27,10 +31,11 @@ public sealed class RoundTripComparisonTests
         Assert.Equal(MethodCorrespondenceStatus.Exact, member.Correspondence.Status);
         Assert.Equal(RoundTripEvidenceStatus.Exact, member.CSharpStatus);
         Assert.Equal(IlBodyDiffOutcome.Exact, member.IlStatus);
-        Assert.NotNull(member.Evidence);
+        AssertRetainedEvidence(member);
         string json = JsonSerializer.Serialize(result);
         Assert.Contains("\"cSharpStatus\":0", json, StringComparison.OrdinalIgnoreCase);
         Assert.Contains($"\"token\":{request.Targets[0].Method.Token}", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"evidence\":", json, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -52,7 +57,7 @@ public sealed class RoundTripComparisonTests
         Assert.Equal(MethodCorrespondenceStatus.Exact, member.Correspondence.Status);
         Assert.Equal(RoundTripEvidenceStatus.Changed, member.CSharpStatus);
         Assert.NotEqual(IlBodyDiffOutcome.Exact, member.IlStatus);
-        Assert.NotNull(member.Evidence);
+        AssertRetainedEvidence(member);
     }
 
     [Fact]
@@ -91,6 +96,135 @@ public sealed class RoundTripComparisonTests
     }
 
     [Fact]
+    public void Compare_PreservesBodylessEndpointAsUnavailable()
+    {
+        var donor = Compile("""
+            namespace ILInspector.Decompiler.Tests;
+            public abstract class RoundTripComparisonFixture
+            {
+                public abstract int Transform(int value);
+            }
+            """);
+
+        var result = RoundTripComparison.Compare(CreateRequest(), donor);
+
+        Assert.Equal(RoundTripComparisonStatus.Completed, result.Status);
+        var member = Assert.Single(result.Members);
+        Assert.Equal(MethodCorrespondenceStatus.Exact, member.Correspondence.Status);
+        Assert.Equal(RoundTripEvidenceStatus.Unavailable, member.CSharpStatus);
+        Assert.Equal(IlBodyDiffOutcome.Unavailable, member.IlStatus);
+        Assert.Null(member.CSharpDiff);
+        Assert.NotEmpty(member.CSharpFailure!);
+        Assert.Contains("new absent:", member.IlFailure);
+        ResearchProducerCompletion completion = Completion(member.Evidence);
+        var native = Assert.IsType<ResearchProducerWorkOutcome.ProducedCSharp>(
+            completion.Results.Single(result => result.Item.Producer == ResearchProducerKind.CSharp).Outcome).Result;
+        Assert.Null(native.BodyDiff);
+        var absent = Assert.IsType<FindingInspection<CSharpCanonicalLine>.Absent>(
+            native.Findings.NewInspection.Value);
+        Assert.Equal(FindingInspectionAbsenceKind.NoApplicableInput, absent.Kind);
+    }
+
+    [Fact]
+    public void Compare_PreservesMalformedBodyAsUnavailable()
+    {
+        byte[] donor = Compile(DonorSource("value + 1"));
+        using (var pe = new PEReader(new MemoryStream(donor, writable: false)))
+        {
+            var reader = pe.GetMetadataReader();
+            int rva = reader.GetMethodDefinition(FindMethod(
+                reader, nameof(RoundTripComparisonFixture), nameof(RoundTripComparisonFixture.Transform)))
+                .RelativeVirtualAddress;
+            var section = pe.PEHeaders.SectionHeaders.Single(section =>
+                rva >= section.VirtualAddress && rva < section.VirtualAddress + section.SizeOfRawData);
+            donor[section.PointerToRawData + rva - section.VirtualAddress] = 0;
+        }
+
+        var result = RoundTripComparison.Compare(CreateRequest(), donor);
+
+        Assert.Equal(RoundTripComparisonStatus.Completed, result.Status);
+        var member = Assert.Single(result.Members);
+        Assert.Equal(MethodCorrespondenceStatus.Exact, member.Correspondence.Status);
+        Assert.Equal(RoundTripEvidenceStatus.Unavailable, member.CSharpStatus);
+        Assert.Equal(IlBodyDiffOutcome.Unavailable, member.IlStatus);
+        Assert.NotNull(member.Evidence);
+        Assert.NotEmpty(member.CSharpFailure!);
+        Assert.NotEmpty(member.IlFailure!);
+    }
+
+    [Fact]
+    public void Compare_PreservesFailedCorrespondenceAsUnavailable()
+    {
+        var valid = CreateRequest();
+        Guid wrongModule = Guid.NewGuid();
+        var request = RoundTripRequest.Create(
+            valid.Artifact,
+            valid.Module with { ModuleVersionId = wrongModule },
+            [valid.Targets[0] with { Method = valid.Targets[0].Method with { ModuleVersionId = wrongModule } }],
+            valid.Scope, valid.BodyPolicy, valid.Replacements);
+
+        var result = RoundTripComparison.Compare(request, File.ReadAllBytes(AssemblyPath));
+
+        Assert.Equal(RoundTripComparisonStatus.Completed, result.Status);
+        var member = Assert.Single(result.Members);
+        Assert.Equal(MethodCorrespondenceStatus.Failed, member.Correspondence.Status);
+        Assert.Equal(RoundTripEvidenceStatus.Unavailable, member.CSharpStatus);
+        Assert.Equal(IlBodyDiffOutcome.Unavailable, member.IlStatus);
+        Assert.Null(member.Evidence);
+        Assert.Equal(member.Correspondence.Failure, member.CSharpFailure);
+    }
+
+    [Fact]
+    public void QueryComparison_RetainsRejectedDesignation()
+    {
+        using var original = DecompilerMetadataSource.OpenWithoutSymbols(AssemblyPath);
+        using var donor = DecompilerMetadataSource.OpenWithoutSymbols(AssemblyPath);
+        using var workspace = new InspectionWorkspace();
+        var query = new RoundTripComparisonQuery(workspace, original, donor);
+        var target = CreateRequest().Targets[0].Method;
+
+        var result = query.Compare(target, target with { ModuleVersionId = Guid.NewGuid() });
+
+        Assert.Equal(RoundTripEvidenceStatus.Unavailable, result.CSharpStatus);
+        Assert.Equal(IlBodyDiffOutcome.Unavailable, result.IlStatus);
+        var failure = Assert.IsType<LocalComparisonQueryResult.NonSuccess>(result.Evidence);
+        Assert.Equal(QueryComparisonSide.After, failure.Side);
+        Assert.IsType<LocalComparisonQueryFailure.DesignationUnavailable>(failure.Failure);
+        Assert.NotEmpty(result.CSharpFailure!);
+        Assert.Null(result.CSharpDiff);
+        Assert.Null(result.IlDiff);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void CSharpRoundTripChangedRejectsFailureRows(bool identityFailure, bool includeChanges)
+    {
+        var request = CreateRequest();
+        var member = Assert.Single(RoundTripComparison.Compare(
+            request, Compile(DonorSource("value + 2"))).Members);
+        var native = Assert.IsType<ResearchProducerWorkOutcome.ProducedCSharp>(
+            Completion(member.Evidence).Results
+                .Single(result => result.Item.Producer == ResearchProducerKind.CSharp).Outcome).Result;
+        var diff = new CSharpBodyDiffResult(
+            includeChanges ? native.BodyDiff!.Rows : [],
+            identityFailure ? [] :
+            [new("", "", request.Targets[0].Anchor, "Transform",
+                CSharpDiffFailureKind.BodyDiffSkipped, "producer diff failed")],
+            identityFailure ?
+            [new("new", "", 0, default, "identity", "identity resolution failed")] : []);
+        var outcome = new CSharpMemberEndpointComparison(
+            native.Old, native.New, native.Findings, diff);
+
+        var result = RoundTripComparisonQuery.ClassifyCSharp(outcome);
+
+        Assert.Equal(RoundTripEvidenceStatus.Unavailable, result.Status);
+        Assert.Contains(identityFailure ? "identity resolution failed" : "producer diff failed", result.Failure);
+    }
+
+    [Fact]
     public void ScopeCompare_ComparesClusterAndAllDonorsDirectly()
     {
         var clusterRequest = CreateRequest();
@@ -112,6 +246,12 @@ public sealed class RoundTripComparisonTests
         Assert.Equal(IlBodyDiffOutcome.Exact, member.IlStatus);
         Assert.NotNull(result.Cluster);
         Assert.NotNull(result.All);
+        var direct = Completion(member.Evidence);
+        var pair = Assert.IsType<ResearchProducerWorkBasis.DesignatedPair>(direct.WorkItems[0].Basis).Pair;
+        Assert.Equal(Assert.Single(result.Cluster.Members).Correspondence.Target,
+            Assert.IsType<ResearchTargetOutcome.Resolved>(pair.Before.Outcome).Address);
+        Assert.Equal(Assert.Single(result.All.Members).Correspondence.Target,
+            Assert.IsType<ResearchTargetOutcome.Resolved>(pair.After.Outcome).Address);
     }
 
     [Fact]
@@ -205,6 +345,32 @@ public sealed class RoundTripComparisonTests
             [new RoundTripTarget(MetadataMethodAddress.Create(image.Reader, methodHandle), anchor)],
             RoundTripScope.Cluster,
             RoundTripBodyPolicy.Selected);
+    }
+
+    static ResearchProducerCompletion Completion(LocalComparisonQueryResult? evidence)
+        => Assert.IsType<ResearchProducerSessionOutcome.Completed>(
+            Assert.IsType<LocalComparisonQueryResult.Published>(evidence).Outcome).Completion;
+
+    static void AssertRetainedEvidence(RoundTripMemberComparison member)
+    {
+        var published = Assert.IsType<LocalComparisonQueryResult.Published>(member.Evidence);
+        Assert.NotSame(published.Identity!.Before, published.Identity.After);
+        var completion = Completion(published);
+        Assert.Equal(2, completion.Results.Length);
+        Assert.All(completion.WorkItems, item =>
+        {
+            var pair = Assert.IsType<ResearchProducerWorkBasis.DesignatedPair>(item.Basis).Pair;
+            Assert.Equal(member.Target.Method,
+                Assert.IsType<ResearchTargetOutcome.Resolved>(pair.Before.Outcome).Address);
+            Assert.Equal(member.Correspondence.Target,
+                Assert.IsType<ResearchTargetOutcome.Resolved>(pair.After.Outcome).Address);
+        });
+        var csharp = Assert.IsType<ResearchProducerWorkOutcome.ProducedCSharp>(
+            completion.Results.Single(result => result.Item.Producer == ResearchProducerKind.CSharp).Outcome).Result;
+        Assert.Equal(csharp.BodyDiff!.Rows, member.CSharpDiff!.Rows);
+        var il = Assert.IsType<ResearchProducerWorkOutcome.ProducedIlBody>(
+            completion.Results.Single(result => result.Item.Producer == ResearchProducerKind.IlBody).Outcome).Result;
+        Assert.Equal(il.MemberDiff!.Diff.Rows, member.IlDiff!.Rows);
     }
 
     static byte[] Compile(string source)

--- a/tools/RoundTripCompilation/RoundTripComparison.cs
+++ b/tools/RoundTripCompilation/RoundTripComparison.cs
@@ -1,12 +1,11 @@
 using System.Collections.Immutable;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
+using DotnetInspector.Queries;
 using ILInspector.Decompiler;
-using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
-using ILInspector.Research;
 using DecompilerMetadataSource = ILInspector.Decompiler.Pipeline.MetadataSource;
 
 namespace DotnetInspector.RoundTripCompilation;
@@ -42,7 +41,7 @@ public sealed record RoundTripMemberComparison(
     IlBodyDiffOutcome IlStatus,
     RoundTripCSharpEvidence? CSharpDiff,
     RoundTripIlEvidence? IlDiff,
-    [property: JsonIgnore] ImplementationMemberDiffResult? Evidence,
+    [property: JsonIgnore] LocalComparisonQueryResult? Evidence,
     string? CSharpFailure,
     string? IlFailure);
 
@@ -81,6 +80,8 @@ public static class RoundTripComparison
             File.WriteAllBytes(temporaryPath, donorPe);
             using var original = DecompilerMetadataSource.OpenWithoutSymbols(request.Artifact.Path);
             using var donor = DecompilerMetadataSource.OpenWithoutSymbols(temporaryPath);
+            using var workspace = new InspectionWorkspace();
+            var query = new RoundTripComparisonQuery(workspace, original, donor);
             var members = ImmutableArray.CreateBuilder<RoundTripMemberComparison>();
             foreach (var target in request.Targets)
             {
@@ -103,34 +104,17 @@ public static class RoundTripComparison
                     continue;
                 }
 
-                var subject = new FindingSubject(
-                    target.Anchor.StableSelector,
-                    $"{target.Anchor.TypeFullName}.{target.Anchor.MemberName}");
-                var oldInspection = CSharpFindings.Inspect(original, target.Method.Handle, subject);
-                var newInspection = CSharpFindings.Inspect(donor, donorTarget.Handle, subject);
-                var evidence = ImplementationDiff.CompareMembers(
-                    original,
-                    target.Method.Handle,
-                    donor,
-                    donorTarget.Handle);
-                var csharpStatus = oldInspection is FindingInspection<CSharpCanonicalLine>.Complete
-                    && newInspection is FindingInspection<CSharpCanonicalLine>.Complete
-                        ? evidence.CSharpDiff is { IsExact: true }
-                            ? RoundTripEvidenceStatus.Exact
-                            : RoundTripEvidenceStatus.Changed
-                        : RoundTripEvidenceStatus.Unavailable;
+                var evidence = query.Compare(target.Method, donorTarget);
                 members.Add(new RoundTripMemberComparison(
                     target,
                     correspondence,
-                    csharpStatus,
-                    evidence.IlDiff?.Diff.Outcome ?? IlBodyDiffOutcome.Unavailable,
-                    ToEvidence(evidence.CSharpDiff),
-                    ToEvidence(evidence.IlDiff?.Diff),
-                    evidence,
-                    CSharpFailure: csharpStatus == RoundTripEvidenceStatus.Unavailable
-                        ? InspectionFailure(oldInspection, newInspection)
-                        : null,
-                    IlFailure: evidence.IlDiff?.Diff.Failure));
+                    evidence.CSharpStatus,
+                    evidence.IlStatus,
+                    evidence.CSharpDiff,
+                    evidence.IlDiff,
+                    evidence.Evidence,
+                    evidence.CSharpFailure,
+                    evidence.IlFailure));
             }
 
             return new RoundTripComparisonResult(
@@ -157,42 +141,6 @@ public static class RoundTripComparison
             }
         }
     }
-
-    static string? InspectionFailure(
-        FindingInspection<CSharpCanonicalLine> oldInspection,
-        FindingInspection<CSharpCanonicalLine> newInspection)
-    {
-        List<string> failures = [];
-        if (oldInspection is FindingInspection<CSharpCanonicalLine>.Absent oldAbsent)
-            failures.Add($"old absent: {oldAbsent.Detail}");
-        else if (oldInspection is FindingInspection<CSharpCanonicalLine>.Failed oldFailed)
-            failures.Add($"old failed: {oldFailed.Error.Reason}");
-        if (newInspection is FindingInspection<CSharpCanonicalLine>.Absent newAbsent)
-            failures.Add($"new absent: {newAbsent.Detail}");
-        else if (newInspection is FindingInspection<CSharpCanonicalLine>.Failed newFailed)
-            failures.Add($"new failed: {newFailed.Error.Reason}");
-        return failures.Count == 0 ? null : string.Join("; ", failures);
-    }
-
-    static RoundTripCSharpEvidence? ToEvidence(CSharpBodyDiffResult? diff)
-        => diff is null
-            ? null
-            : new RoundTripCSharpEvidence(
-                Normalize(diff.Rows),
-                Normalize(diff.FailureRows),
-                Normalize(diff.IdentityFailures));
-
-    static RoundTripIlEvidence? ToEvidence(IlBodyDiffResult? diff)
-        => diff is null
-            ? null
-            : new RoundTripIlEvidence(
-                diff.Outcome,
-                diff.Failure,
-                Normalize(diff.Rows),
-                Normalize(diff.FailureRows));
-
-    static ImmutableArray<T> Normalize<T>(ImmutableArray<T> values)
-        => values.IsDefault ? [] : values;
 
     static string HashFile(string path)
     {

--- a/tools/RoundTripCompilation/RoundTripComparisonQuery.cs
+++ b/tools/RoundTripCompilation/RoundTripComparisonQuery.cs
@@ -1,0 +1,162 @@
+using System.Collections.Immutable;
+using DotnetInspector.Queries;
+using DotnetInspector.Services;
+using ILInspector.Decompiler;
+using ILInspector.Findings;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+using ILInspector.Research;
+using DecompilerMetadataSource = ILInspector.Decompiler.Pipeline.MetadataSource;
+
+namespace DotnetInspector.RoundTripCompilation;
+
+internal sealed record RoundTripBodyEvidence(
+    RoundTripEvidenceStatus CSharpStatus,
+    IlBodyDiffOutcome IlStatus,
+    RoundTripCSharpEvidence? CSharpDiff,
+    RoundTripIlEvidence? IlDiff,
+    LocalComparisonQueryResult Evidence,
+    string? CSharpFailure,
+    string? IlFailure);
+
+internal sealed class RoundTripComparisonQuery
+{
+    readonly AssemblyContextGroup _group;
+    readonly AssemblyContextParticipant _before;
+    readonly AssemblyContextParticipant _after;
+
+    internal RoundTripComparisonQuery(
+        InspectionWorkspace workspace,
+        DecompilerMetadataSource before,
+        DecompilerMetadataSource after)
+    {
+        var beforeAssembly = Assembly(before);
+        var afterAssembly = Assembly(after);
+        var policy = new SourceRelativeAssemblyGroupBindingPolicy(
+        [
+            (beforeAssembly, new AssemblyReferenceBindingPolicy(
+                DecompilerMetadataSource.DefaultAssemblyReferenceResolver(before.Path))),
+            (afterAssembly, new AssemblyReferenceBindingPolicy(
+                DecompilerMetadataSource.DefaultAssemblyReferenceResolver(after.Path))),
+        ]);
+        _before = new(beforeAssembly, policy);
+        _after = new(afterAssembly, policy);
+        _group = workspace.CreateAssemblyContextGroup([_before, _after]);
+    }
+
+    internal RoundTripBodyEvidence Compare(
+        MetadataMethodAddress before,
+        MetadataMethodAddress after)
+    {
+        LocalComparisonQueryResult evidence = DirectMemberComparisonQuery.Execute(
+            _group,
+            new(new(_before, before), new(_after, after), ResearchProducerCatalog.Kinds));
+        if (evidence is not LocalComparisonQueryResult.Published
+            { Outcome: ResearchProducerSessionOutcome.Completed completed })
+        {
+            string failure = QueryFailure(evidence);
+            return new(
+                RoundTripEvidenceStatus.Unavailable, IlBodyDiffOutcome.Unavailable,
+                null, null, evidence, failure, failure);
+        }
+
+        ResearchProducerWorkOutcome csharp = completed.Completion.Results
+            .Single(result => result.Item.Producer == ResearchProducerKind.CSharp).Outcome;
+        ResearchProducerWorkOutcome il = completed.Completion.Results
+            .Single(result => result.Item.Producer == ResearchProducerKind.IlBody).Outcome;
+        CSharpMemberEndpointComparison? csharpResult =
+            (csharp as ResearchProducerWorkOutcome.ProducedCSharp)?.Result;
+        IlBodyDiffResult? ilDiff =
+            (il as ResearchProducerWorkOutcome.ProducedIlBody)?.Result.MemberDiff?.Diff;
+        (RoundTripEvidenceStatus status, string? failureReason) = csharpResult is { }
+            ? ClassifyCSharp(csharpResult)
+            : (RoundTripEvidenceStatus.Unavailable, ProducerFailure(csharp));
+        return new(
+            status,
+            ilDiff?.Outcome ?? IlBodyDiffOutcome.Unavailable,
+            ToEvidence(csharpResult?.BodyDiff),
+            ToEvidence(ilDiff),
+            evidence,
+            failureReason,
+            ilDiff?.Failure ?? (ilDiff is null ? ProducerFailure(il) : null));
+    }
+
+    internal static (RoundTripEvidenceStatus Status, string? Failure) ClassifyCSharp(
+        CSharpMemberEndpointComparison result)
+    {
+        CSharpBodyDiffResult? diff = result.BodyDiff;
+        if (diff is null)
+        {
+            return (RoundTripEvidenceStatus.Unavailable,
+                InspectionFailure(result.Findings.OldInspection, result.Findings.NewInspection));
+        }
+        if (!diff.FailureRows.IsDefaultOrEmpty || !diff.IdentityFailures.IsDefaultOrEmpty)
+        {
+            return (RoundTripEvidenceStatus.Unavailable,
+                string.Join("; ",
+                    Normalize(diff.FailureRows).Select(row => row.Message)
+                        .Concat(Normalize(diff.IdentityFailures).Select(row => row.Detail))));
+        }
+        return (diff.IsExact ? RoundTripEvidenceStatus.Exact : RoundTripEvidenceStatus.Changed, null);
+    }
+
+    static ResolvedAssemblyReference Assembly(DecompilerMetadataSource source)
+        => ResolvedAssemblyReference.CreateFromPath(
+            source.Path,
+            AssemblyResolutionProvenance.Local("round-trip comparison"));
+
+    static string QueryFailure(LocalComparisonQueryResult result)
+        => result switch
+        {
+            LocalComparisonQueryResult.NonSuccess failure =>
+                $"{failure.Side?.ToString() ?? "Comparison"} query: {failure.Failure}",
+            LocalComparisonQueryResult.Published published => published.Outcome switch
+            {
+                ResearchProducerSessionOutcome.Rejected rejected => rejected.Rejection.Summary,
+                ResearchProducerSessionOutcome.Failed failed => failed.Diagnostic.Summary,
+                ResearchProducerSessionOutcome.Cancelled => "comparison query cancelled",
+                _ => throw new InvalidOperationException("Expected a non-completed query outcome."),
+            },
+            _ => throw new InvalidOperationException("Unknown comparison query result."),
+        };
+
+    static string ProducerFailure(ResearchProducerWorkOutcome outcome)
+        => outcome switch
+        {
+            ResearchProducerWorkOutcome.Unavailable unavailable => unavailable.Reason.Summary,
+            ResearchProducerWorkOutcome.Failed failed => failed.Diagnostic.Summary,
+            ResearchProducerWorkOutcome.ProducedIlBody produced =>
+                InspectionFailure(
+                    produced.Result.Findings.OldInspection,
+                    produced.Result.Findings.NewInspection),
+            _ => throw new InvalidOperationException("Expected unavailable producer evidence."),
+        };
+
+    static string InspectionFailure<T>(
+        FindingInspection<T> oldInspection,
+        FindingInspection<T> newInspection) where T : notnull
+    {
+        List<string> failures = [];
+        if (oldInspection.Value is FindingInspection<T>.Absent oldAbsent)
+            failures.Add($"old absent: {oldAbsent.Detail}");
+        else if (oldInspection.Value is FindingInspection<T>.Failed oldFailed)
+            failures.Add($"old failed: {oldFailed.Error.Reason}");
+        if (newInspection.Value is FindingInspection<T>.Absent newAbsent)
+            failures.Add($"new absent: {newAbsent.Detail}");
+        else if (newInspection.Value is FindingInspection<T>.Failed newFailed)
+            failures.Add($"new failed: {newFailed.Error.Reason}");
+        return string.Join("; ", failures);
+    }
+
+    static RoundTripCSharpEvidence? ToEvidence(CSharpBodyDiffResult? diff)
+        => diff is null ? null : new(
+            Normalize(diff.Rows), Normalize(diff.FailureRows), Normalize(diff.IdentityFailures));
+
+    static RoundTripIlEvidence? ToEvidence(IlBodyDiffResult? diff)
+        => diff is null ? null : new(
+            diff.Outcome, diff.Failure, Normalize(diff.Rows), Normalize(diff.FailureRows));
+
+    static ImmutableArray<T> Normalize<T>(ImmutableArray<T> values)
+        => values.IsDefault ? [] : values;
+}

--- a/tools/RoundTripCompilation/RoundTripCompilation.csproj
+++ b/tools/RoundTripCompilation/RoundTripCompilation.csproj
@@ -17,6 +17,9 @@
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
     <ProjectReference Include="../../src/ILInspector.MetadataPrimitives/ILInspector.MetadataPrimitives.csproj" />
     <ProjectReference Include="../../src/ILInspector.Research/ILInspector.Research.csproj" />
+    <ProjectReference Include="../../src/DotnetInspector.ResearchQueries/DotnetInspector.ResearchQueries.csproj" />
+    <ProjectReference Include="../../src/DotnetInspector.Services/DotnetInspector.Services.csproj" />
+    <InternalsVisibleTo Include="ILInspector.Decompiler.Tests" />
   </ItemGroup>
 
 </Project>

--- a/tools/RoundTripCompilation/RoundTripScopeComparison.cs
+++ b/tools/RoundTripCompilation/RoundTripScopeComparison.cs
@@ -1,9 +1,7 @@
 using System.Collections.Immutable;
 using System.Text.Json.Serialization;
-using ILInspector.Decompiler;
-using ILInspector.Findings;
+using DotnetInspector.Queries;
 using ILInspector.Instructions;
-using ILInspector.Research;
 using DecompilerMetadataSource = ILInspector.Decompiler.Pipeline.MetadataSource;
 
 namespace DotnetInspector.RoundTripCompilation;
@@ -20,7 +18,7 @@ public sealed record RoundTripScopeMemberComparison(
     IlBodyDiffOutcome IlStatus,
     RoundTripCSharpEvidence? CSharpDiff,
     RoundTripIlEvidence? IlDiff,
-    [property: JsonIgnore] ImplementationMemberDiffResult? Evidence,
+    [property: JsonIgnore] LocalComparisonQueryResult? Evidence,
     string? CSharpFailure,
     string? IlFailure);
 
@@ -78,12 +76,16 @@ public static class RoundTripScopeComparison
             File.WriteAllBytes(allPath, allPe);
             using var clusterSource = DecompilerMetadataSource.OpenWithoutSymbols(clusterPath);
             using var allSource = DecompilerMetadataSource.OpenWithoutSymbols(allPath);
+            using var workspace = new InspectionWorkspace();
+            var query = new RoundTripComparisonQuery(workspace, clusterSource, allSource);
             var members = ImmutableArray.CreateBuilder<RoundTripScopeMemberComparison>();
             foreach (var target in clusterRequest.Targets)
             {
                 var clusterMember = cluster.Members.Single(member => member.Target.Method == target.Method);
                 var allMember = all.Members.Single(member => member.Target.Method == target.Method);
-                if (clusterMember.Correspondence.Target is not { } clusterTarget
+                if (!clusterMember.Correspondence.IsExact
+                    || clusterMember.Correspondence.Target is not { } clusterTarget
+                    || !allMember.Correspondence.IsExact
                     || allMember.Correspondence.Target is not { } allTarget)
                 {
                     string failure = clusterMember.Correspondence.Failure
@@ -101,33 +103,16 @@ public static class RoundTripScopeComparison
                     continue;
                 }
 
-                var subject = new FindingSubject(
-                    target.Anchor.StableSelector,
-                    $"{target.Anchor.TypeFullName}.{target.Anchor.MemberName}");
-                var clusterInspection = CSharpFindings.Inspect(clusterSource, clusterTarget.Handle, subject);
-                var allInspection = CSharpFindings.Inspect(allSource, allTarget.Handle, subject);
-                var evidence = ImplementationDiff.CompareMembers(
-                    clusterSource,
-                    clusterTarget.Handle,
-                    allSource,
-                    allTarget.Handle);
-                var csharpStatus = clusterInspection is FindingInspection<CSharpCanonicalLine>.Complete
-                    && allInspection is FindingInspection<CSharpCanonicalLine>.Complete
-                        ? evidence.CSharpDiff is { IsExact: true }
-                            ? RoundTripEvidenceStatus.Exact
-                            : RoundTripEvidenceStatus.Changed
-                        : RoundTripEvidenceStatus.Unavailable;
+                var evidence = query.Compare(clusterTarget, allTarget);
                 members.Add(new RoundTripScopeMemberComparison(
                     target,
-                    csharpStatus,
-                    evidence.IlDiff?.Diff.Outcome ?? IlBodyDiffOutcome.Unavailable,
-                    ToEvidence(evidence.CSharpDiff),
-                    ToEvidence(evidence.IlDiff?.Diff),
-                    evidence,
-                    CSharpFailure: csharpStatus == RoundTripEvidenceStatus.Unavailable
-                        ? "cluster or all C# inspection was not complete"
-                        : null,
-                    IlFailure: evidence.IlDiff?.Diff.Failure));
+                    evidence.CSharpStatus,
+                    evidence.IlStatus,
+                    evidence.CSharpDiff,
+                    evidence.IlDiff,
+                    evidence.Evidence,
+                    evidence.CSharpFailure,
+                    evidence.IlFailure));
             }
 
             return new RoundTripScopeComparisonResult(
@@ -185,22 +170,6 @@ public static class RoundTripScopeComparison
                == right with { References = [], ParseFeatures = [] }
            && left.ParseFeatures.SequenceEqual(right.ParseFeatures, StringComparer.Ordinal)
            && left.References.SequenceEqual(right.References);
-
-    static RoundTripCSharpEvidence? ToEvidence(CSharpBodyDiffResult? diff)
-        => diff is null ? null : new(
-            Normalize(diff.Rows),
-            Normalize(diff.FailureRows),
-            Normalize(diff.IdentityFailures));
-
-    static RoundTripIlEvidence? ToEvidence(IlBodyDiffResult? diff)
-        => diff is null ? null : new(
-            diff.Outcome,
-            diff.Failure,
-            Normalize(diff.Rows),
-            Normalize(diff.FailureRows));
-
-    static ImmutableArray<T> Normalize<T>(ImmutableArray<T> values)
-        => values.IsDefault ? [] : values;
 
     static string TemporaryPath(string scope)
         => Path.Combine(Path.GetTempPath(), $"dotnet-inspect-roundtrip-{scope}-{Guid.NewGuid():N}.dll");


### PR DESCRIPTION
## Summary

RoundTripCompilation now consumes the same public comparison query as the CLI
and Browser. Its original/donor and cluster/all helpers retain the exact
`LocalComparisonQueryResult` and classify the native C#/IL evidence instead of
dispatching directly to Research and repeating C# endpoint inspections.

Closes #6134. Advances the two-helper portion of #4706 step 10; does **not**
complete comparison-tool migration or the final Research retirement milestone.

## Design basis

**Normative owner:** `DotnetInspector.RoundTripCompilation`, in
`docs/design/csharp-member-recompilation.md#comparison-query-consumption`.
The claim is consumer receipt: preserve product-issued correspondence, hashes,
context eligibility and independent verdicts while consuming retained native
evidence from the public query.

The direct-member design supplies the existing exact-pair association, local
publication supplies the result boundary, and the adoption ledger supplies the
migration plan. Metadata, Queries, Research, native diff semantics, compilation,
and artifact production are unchanged.

The conventional approach is a thin consumer over owner-issued results, not a
parallel result wrapper. CLI `match --body` and Browser Method Body Diff are
the in-repository analogous consumers. The helper reuses Metadata path
descriptors and the existing source-relative group binding policy with each
source's sibling resolver. One shared tools adapter replaces the duplicated
dispatch, inspection and result projection in the two helpers.

The existing C# arbiter contract additionally requires failure and identity rows
to remain unavailable, even when both inspections completed. This closes its
previously documented, ungated `Changed` classification gap. Producer rows and
the complete published evidence remain retained.

## Improvement and limits

This is caller-backed retirement, not another substrate layer: the two helpers'
direct `ImplementationDiff.CompareMembers` calls and their redundant
`CSharpFindings.Inspect` calls are removed. The `Evidence` property carries the
original query result rather than a synthetic legacy result. Existing
serialized materialized rows and the separate C#/IL verdicts remain the
reporting boundary; `Evidence` remains excluded from JSON.

The gain is reliable association and reuse of already-issued endpoint outcomes,
including failure and absence. This does not claim a smarter diff, semantic
equivalence, better decompilation, or a measured speedup. The broader motivation
and carrying-cost analysis is recorded on
[#5125](https://github.com/richlander/dotnet-inspect/issues/5125#issuecomment-5556965522).

The same-method case still has two query input occurrences. The direct
cluster/all comparison uses donor addresses, not a substitute comparison of
each donor with the original. Non-exact correspondence still prevents dispatch.
The existing group resource and acquisition boundaries remain visible as
unavailable query evidence.

ReturnToSender's separate `BuildImplementationDiff` and fidelity oracle,
supported PDB Source composition, assembly/body-signal query migration, and
final shared API deletion remain separate. The bounded CLI/Browser route stays
at **7/8 milestones**. No shared product substrate or new rendering path is
introduced; this slice immediately adopts existing substrate in the two
production harness helpers.

## Demo

The same public tool API program was run against the baseline
`51b9cbf8663c7c2f3d9ccefc82679f97d473b2d4` and this implementation, using the
existing V2/V1 `DiffFixtureSample` images. No inspected assembly is executed.

Before:

```text
same artifact: correspondence=Exact; C#=Exact; IL=Exact; evidence=ImplementationMemberDiffResult
changed donor: correspondence=Exact; C#=Changed; IL=OperandDiff; evidence=ImplementationMemberDiffResult
bodyless donor: correspondence=Exact; C#=Unavailable; IL=Unavailable; evidence=ImplementationMemberDiffResult
```

After:

```text
same artifact: correspondence=Exact; C#=Exact; IL=Exact; evidence=Published
changed donor: correspondence=Exact; C#=Changed; IL=OperandDiff; evidence=Published
bodyless donor: correspondence=Exact; C#=Unavailable; IL=Unavailable; evidence=Published
```

Notice that the verdicts remain independent and the bodyless neighbor does not
become exact. `Published` is the shared query result retaining its exact
identity, Research completion, and native endpoint outcomes after the
inspection workspace has been disposed.

<details>
<summary>Reproduce the public API demo</summary>

Save as `artifacts/roundtrip-query-demo.cs` in either checkout:

```csharp
#:project ../tools/RoundTripCompilation/RoundTripCompilation.csproj
#:property EnablePreviewFeatures=true
#:property PublishAot=false
#:property PublishSingleFile=false

using System.Reflection.Metadata;
using System.Reflection.PortableExecutable;
using DotnetInspector.RoundTripCompilation;
using ILInspector.Metadata;
using ILInspector.MetadataPrimitives;

string original = Path.GetFullPath(args[0]);
string donor = Path.GetFullPath(args[1]);
Show("same artifact", "Stable", original);
Show("changed donor", "ConstantValue", donor);
Show("bodyless donor", "BodyState", donor);

void Show(string scenario, string methodName, string donorPath)
{
    using var stream = File.OpenRead(original);
    using var pe = new PEReader(stream);
    MetadataReader reader = pe.GetMetadataReader();
    MethodDefinitionHandle handle = reader.MethodDefinitions.First(handle =>
        reader.GetString(reader.GetMethodDefinition(handle).Name) == methodName);
    MethodDefinition method = reader.GetMethodDefinition(handle);
    ModuleDefinition module = reader.GetModuleDefinition();
    var request = RoundTripRequest.Create(
        RoundTripArtifactIdentity.FromFile(original, "query adoption demo"),
        new(reader.GetString(module.Name), reader.GetGuid(module.Mvid)),
        [new(MetadataMethodAddress.Create(reader, handle),
            ApiMemberIdentity.CreateMethodAnchor(reader, method.GetDeclaringType(), method))],
        RoundTripScope.Cluster,
        RoundTripBodyPolicy.Selected);
    var result = RoundTripComparison.Compare(request, File.ReadAllBytes(donorPath));
    if (result.Status != RoundTripComparisonStatus.Completed)
        throw new InvalidOperationException(result.Failure);
    var comparison = result.Members.Single();
    Console.WriteLine($"{scenario}: correspondence={comparison.Correspondence.Status}; "
        + $"C#={comparison.CSharpStatus}; IL={comparison.IlStatus}; "
        + $"evidence={comparison.Evidence?.GetType().Name ?? "none"}");
}
```

The focused test build below supplies the fixture binaries. Then:

```bash
dotnet build artifacts/roundtrip-query-demo.cs -c Release \
  -o artifacts/6134-demo --nologo -v:q
dotnet exec \
  --additional-deps artifacts/6134-demo/RoundTripCompilation.deps.json \
  artifacts/6134-demo/roundtrip-query-demo.dll \
  "$PWD/artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll" \
  "$PWD/artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll"
```

The additional dependency manifest is needed by this preview SDK's file-app
launch; it does not alter product behavior.

</details>

## Validation

- Focused consumer cases: 16 passed.
- Existing consumer integration run: 235 total, 228 passed and 7 skipped
  because `ilasm` was not activated; no failures.
- The failure-only and failure-plus-change cases gate the tools-owned arbiter
  using explicit native-result arm fixtures. These do not manufacture C# for
  compilation or replace the independent compilation/fidelity oracle.
- Changed Markdown and whitespace gates passed.

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class '*RoundTripComparisonTests'
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class '*RoundTripComparisonTests' -class '*ReturnToSenderPrototypeTests'
npx markdownlint-cli docs/design/csharp-member-recompilation.md \
  docs/design/direct-member-comparison.md
git diff --check
```

## Review

Round 1 is complete at `9e745863747da0f7274ae939af06cf29fe298679`.
Two independent GPT-6 Astra seats returned **CLEAN**, following the
no-prior-round roster. No findings or review-driven changes; the head stayed
unchanged. Exact-head `ci-required` succeeded before dispatch.

The PR is review-clean and awaits user-directed merge. This is not a live
merge-readiness claim or authorization to merge.
