### PR TITLE
Show inspection counts and previews on Package Query cards

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [NuGet API Selection](design/nuget.md) | Scenario-to-API decisions, endpoint roles, first/last-result performance evidence, and current versus proposed adoption. |
 | [NuGet Gallery Discovery](design/nuget-gallery-discovery.md) | Proposed NuGetFetch termless/type-filtered Gallery search, source orders, search-facet discovery, and bounded row-source delegation, with CLI/browser adoption tracked separately. |
 | [Package Query Input Selection](design/package-query-input-selection.md) | Exact-ID, explicit-prefix, and explicit Gallery input selection for shared Query and its hosts. |
+| [Package Query Inspection Evidence](design/package-query-inspection-evidence.md) | Inspection-produced item counts and bounded previews, distinct from query-wide context. |
 | [NuGet Feed Authentication](design/nuget-authentication.md) | How feeds are authenticated: `nuget.config` credentials, credential provider discovery and the 401-driven plugin protocol, source-scoped plugin credential isolation, supported credential forms, and hermetic/live test tiers. See [Private NuGet Feeds](private-feeds.md) for setup instructions. |
 | [Local Package Source Identity](design/local-package-source-identity.md) | Canonical config- and command-relative path identity shared by local source consumers. |
 | [Local Folder Package Source](design/local-folder-package-source.md) | General V2/V3 folder-feed recognition, independent capabilities, bounded filesystem and archive observation, typed failures, and payload lifetime. |

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -44,6 +44,10 @@ problem this document surfaced.
 
 Related docs:
 
+- [Package Query inspection evidence](package-query-inspection-evidence.md)
+  owns typed inspection counts and bounded previews, separate from query-wide
+  context. The future CLI facet projection consumes the same compact evidence
+  through Sections/Markout; CLI facet wiring remains pending.
 - [Package Query input selection](package-query-input-selection.md) owns the
   shared choice between exact-ID, explicit-prefix, and explicit Gallery
   candidate inputs. Its host adoption is tracked separately in #6070; the

--- a/docs/design/package-query-experience.md
+++ b/docs/design/package-query-experience.md
@@ -102,7 +102,9 @@ for basic discovery, `nuspec` for explicit manifest evaluation, or
 package archive. Package-content requests are accepted only with at most 20
 candidates. The Browser supplies that capability through its existing
 admitted package store and shared operation deadline; acquisition or
-evaluation failures remain visible per-package failures.
+evaluation failures remain visible per-package failures. Each evidence entry
+retains its product-issued package-or-query scope and optional count-plus-preview
+summary from [Package Query inspection evidence](package-query-inspection-evidence.md).
 
 ## Layout
 
@@ -166,8 +168,12 @@ and
   the whole application DOM for every event. Product-issued progress
   checkpoints distinguish source search, manifest evaluation, and explicit
   package-content evaluation, so filtered candidates remain perceptible
-  without becoming result rows. Each row is a compact package summary plus the
-  product-authored evidence for *why* it matched — never a bare name.
+  without becoming result rows. Query-scoped source-selection context from the
+  first row appears once above the current result list. Each card is a compact
+  package summary plus only its package-scoped, product-authored evidence for
+  *why* it matched, including shared count-and-preview explanations for
+  dependencies and embedded skill documents. Metadata-only rows retain their
+  nonempty query context without inventing package inspection facts.
 - **Handoff, not duplication**: `Open in workspace` submits the row's
   product-issued package ID and exact version once through the standard typed
   Workspace transition, without inferring a framework, source, or fallback
@@ -439,9 +445,12 @@ and browser-history and focus-return outcomes are proved by
    configuration stays idle without engine acquisition. Run an exact ID or
    terminal-star prefix and confirm later facet changes preserve package mode,
    cancel the prior request, and suppress its late rows and failures.
-3. Confirm that product rows, evidence, partial failures, and finite-response,
-   bounded, failed, cancelled, and zero-row completion states remain distinct
-   per the [States](#states) table.
+3. Confirm that query-scoped selection context renders once above the result
+   list, package-scoped dependency and skill counts/previews remain on their
+   cards, and neighboring metadata-only rows do not invent inspection facts.
+   Confirm that partial failures and finite-response, bounded, failed,
+   cancelled, and zero-row completion states remain distinct per the
+   [States](#states) table.
 4. Cancel after rows arrive and confirm that the rows remain visible, the state
    reads as cancelled, and the Browser source operation stops.
 5. Change the search text, leave the route, and start another run; confirm each
@@ -515,6 +524,10 @@ and browser-history and focus-return outcomes are proved by
    explicit package-ID and prefix selection on the website and makes Gallery
    discovery an explicit source gesture. DOM virtualization and Worker
    placement remain separate follow-ups.
+9. [Package Query inspection evidence](package-query-inspection-evidence.md),
+   tracked by #6071, transports typed package/query scope and count-plus-preview
+   summaries to the website. Query context renders once per result set while
+   package inspection evidence remains on its owning card.
 
 The TypeScript state and renderer (`src/package-query.ts` and
 `src/package-query-view.ts`) retain their source-independent controller seam.

--- a/docs/design/package-query-inspection-evidence.md
+++ b/docs/design/package-query-inspection-evidence.md
@@ -1,0 +1,94 @@
+# Package Query inspection evidence
+
+## Claim and ownership
+
+Package Query emits package-specific inspection evidence as a total and a
+bounded preview of the items actually observed. Query-wide source selection
+and provenance remain distinguishable from inspection facts about a package.
+This document is the sole owner of that evidence contract.
+
+[Input selection](package-query-input-selection.md) supplies the candidate
+scope. [Package Query](package-query-cli.md) owns facet meaning, acquisition
+tiers, matching, and failure accounting. The
+[Browser experience](package-query-experience.md) owns presentation and
+demand-window interaction. This contract consumes their outcomes without
+changing them.
+
+The consumer is the Package Query result card. The shared evidence also
+supports the planned CLI Package Query projection through the existing
+Sections/Markout path. [#6071](https://github.com/richlander/dotnet-inspect/issues/6071)
+tracks this adoption within
+[#5816](https://github.com/richlander/dotnet-inspect/issues/5816).
+
+## Item meaning and bounds
+
+An item summary has a total count and at most three previews. Counts describe
+the complete observed item set, not the preview length. Each preview uses
+`InertString` field encoding with a 160-character display budget. A shortened
+preview is display text, never a package coordinate or archive-entry handle.
+
+| Facet | Counted item | Preview |
+| --- | --- | --- |
+| Has dependencies / no dependencies | Distinct declared dependency IDs across manifest groups, using ordinal case-insensitive identity | Up to three IDs, ordered ordinal case-insensitively, preserving the first declared spelling of each ID |
+| Embedded SKILL.md | Distinct matching archive-entry paths, using ordinal path identity and the existing case-insensitive skill-document predicate | Up to three actual paths, ordered ordinally |
+
+Dependency summaries describe declarations, not a resolved dependency closure
+or an applicable framework selection. Repeated declarations for different
+target frameworks count once. Zero dependencies is a known empty item set.
+
+A root `skills/SKILL.md` preview remains that path. The inventory does not
+establish a skill's declared name, valid frontmatter, or valid document body.
+Content that cannot be acquired or evaluated retains the existing visible
+failure outcome; unavailable evidence is not an empty item set.
+
+Only already-requested inspection tiers contribute summaries. A dependency
+summary consumes the admitted manifest; a skills summary consumes the entry
+inventory already used by its selected content facet. Summaries do not request
+additional manifests, archives, or skill-document bodies.
+
+## Evidence and rendering
+
+Each evidence entry retains its product-issued ID and inert explanation, and
+identifies whether it is query-wide context or package-specific evidence. Item
+summaries remain typed alongside their compact text explanation; consumers do
+not parse counts or identities out of prose.
+
+The Browser transports these fields through its generated facade. Its existing
+HTML card renderer uses the shared explanation, while query-scoped evidence
+appears once for the displayed result set rather than inside each card. This
+continues the Browser's existing deliberate host-specific rendering instead of
+introducing Markout into interactive cards. Operation feedback, item failures,
+completion accounting, and window credit retain their existing owners.
+
+The planned CLI projection consumes the same evidence and lowers its compact
+explanation through Sections/Markout. CLI facet execution remains unimplemented;
+this evidence change does not advertise a new CLI command.
+
+## Boundary and evidence
+
+The external actor is a package publisher; input arrives as manifest dependency
+IDs and admitted archive paths. At the transition to display evidence, preview
+construction applies the existing `InertString` field contract. Browser HTML
+encoding remains the final sink boundary. Typed item counts are calculated
+before preview encoding or shortening.
+
+`PackageQueryTests` is the Release outcome gate for distinct IDs, multiple
+frameworks, root and nested skill paths, preview bounds, text containment,
+unchanged acquisition counts, and visible unavailable content. Browser engine
+tests gate the typed projection; frontend source and view tests gate transport,
+package-specific cards, and once-per-result-set context.
+
+The design follows ordinary count-plus-preview disclosure: NuGet manifest
+dependency groups supply the existing structured facts, while the current
+Package Query inventory supplies skill-document presence. These are input
+evidence, not authority for a new dependency resolver or skill parser.
+
+## Three-step production adoption
+
+1. Produce shared typed summaries and scope classification with their outcome
+   gates.
+2. Adopt them in the Browser facade and cards, retiring repeated query context
+   from cards in the same change.
+3. Adopt the shared evidence when CLI Package Query execution lands under
+   [#5919](https://github.com/richlander/dotnet-inspect/issues/5919) and the
+   [CLI owner](package-query-cli.md); keep this step visibly pending in #6071.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -464,6 +464,10 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
   Gallery candidate inputs, consuming existing source intent and acquisition
   contracts without implicit input substitution. Browser adoption is implemented;
   general CLI query execution remains tracked separately.
+- [Package Query inspection evidence](design/package-query-inspection-evidence.md):
+  shared inspection-produced item counts and bounded previews, separated from
+  query-wide source context; acquisition, matching, and host presentation retain
+  their existing owners.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
 - [Cache concurrency and publication](design/cache-concurrency.md): process-local single-flight, atomic publication, dependency overlap, and filesystem guarantees.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.

--- a/prototypes/inspect-web/engine.PackageExports/BrowserPackageContracts.cs
+++ b/prototypes/inspect-web/engine.PackageExports/BrowserPackageContracts.cs
@@ -267,9 +267,22 @@ public sealed record BrowserGalleryDiscoveryCatalog(
     BrowserGalleryPackageTypeFacet PackageType,
     BrowserGalleryDiscoveryOrder[] Orders);
 
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserPackageQueryEvidenceScope>))]
+public enum BrowserPackageQueryEvidenceScope
+{
+    Package,
+    Query,
+}
+
+public sealed record BrowserPackageQueryEvidenceSummary(
+    int Count,
+    string[] Preview);
+
 public sealed record BrowserPackageQueryEvidence(
     string Id,
-    string Text);
+    string Text,
+    BrowserPackageQueryEvidenceScope Scope,
+    BrowserPackageQueryEvidenceSummary? Summary);
 
 public sealed record BrowserPackageQueryRow(
     string PackageId,

--- a/prototypes/inspect-web/engine.PackageExports/PackageQueryExports.cs
+++ b/prototypes/inspect-web/engine.PackageExports/PackageQueryExports.cs
@@ -266,7 +266,24 @@ namespace InspectWeb.Engine.PackageFacade
                             .. match.Value.Evidence.Select(evidence =>
                                 new BrowserPackageQueryEvidence(
                                     evidence.Id,
-                                    evidence.Value)),
+                                    evidence.Value,
+                                    evidence.Scope switch
+                                    {
+                                        PackageQueryEvidenceScope.Package =>
+                                            BrowserPackageQueryEvidenceScope.Package,
+                                        PackageQueryEvidenceScope.Query =>
+                                            BrowserPackageQueryEvidenceScope.Query,
+                                        _ => throw new InvalidOperationException(
+                                            "Unknown package-query evidence scope."),
+                                    },
+                                    evidence.Summary is { } summary
+                                        ? new BrowserPackageQueryEvidenceSummary(
+                                            summary.Count,
+                                            [
+                                                .. summary.Preview.Select(
+                                                    value => value.ToString()),
+                                            ])
+                                        : null)),
                         ],
                         match.Value.Package.TotalDownloads,
                         match.Value.Package.Verified,

--- a/prototypes/inspect-web/engine.Tests/BrowserPackageQueryOperationsTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserPackageQueryOperationsTests.cs
@@ -358,10 +358,29 @@ public sealed class BrowserPackageQueryOperationsTests
             PackageQueryFacetTier.PackageContent,
             [
                 new PackageQueryEvidence(
-                    PackageQuery.ToolV2FacetId,
+                    PackageQuery.EmbeddedSkillFacetId,
                     new InertString(
                         TextPolicy.Prose,
-                        "DotnetToolSettings.xml declares v2.")),
+                        "2 skill documents: skills/SKILL.md, skills/build/SKILL.md."))
+                {
+                    Scope = PackageQueryEvidenceScope.Package,
+                    Summary = new PackageQueryEvidenceSummary(
+                        2,
+                        [
+                            new InertString(TextPolicy.Field, "skills/SKILL.md"),
+                            new InertString(
+                                TextPolicy.Field,
+                                "skills/build/SKILL.md"),
+                        ]),
+                },
+                new PackageQueryEvidence(
+                    "package.query.source-selection",
+                    new InertString(
+                        TextPolicy.Prose,
+                        "Selected by producer ranking."))
+                {
+                    Scope = PackageQueryEvidenceScope.Query,
+                },
             ]);
         var failure = new PackageQueryFailure(
             "Contoso.Bad",
@@ -380,6 +399,25 @@ public sealed class BrowserPackageQueryOperationsTests
         Assert.Equal(
             BrowserPackageQueryFacetTier.PackageContent,
             projectedMatch.Row!.Tier);
+        Assert.Collection(
+            projectedMatch.Row.Evidence,
+            evidence =>
+            {
+                Assert.Equal(
+                    BrowserPackageQueryEvidenceScope.Package,
+                    evidence.Scope);
+                Assert.Equal(2, evidence.Summary!.Count);
+                Assert.Equal(
+                    ["skills/SKILL.md", "skills/build/SKILL.md"],
+                    evidence.Summary.Preview);
+            },
+            evidence =>
+            {
+                Assert.Equal(
+                    BrowserPackageQueryEvidenceScope.Query,
+                    evidence.Scope);
+                Assert.Null(evidence.Summary);
+            });
         Assert.Equal(
             BrowserPackageQueryFailureKind.PackageContentAcquisition,
             projectedFailure.Failure!.Kind);

--- a/prototypes/inspect-web/engine/facades/inspect-web-package.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-package.ts
@@ -10,6 +10,8 @@ export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached
 
 export type BrowserPackageQueryEventKind = "Progress" | "Match" | "Failure" | "Completed" | number;
 
+export type BrowserPackageQueryEvidenceScope = "Package" | "Query" | number;
+
 export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | "SearchMetadata" | number;
 
 export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | "PackageContentAcquisition" | "PackageContentEvaluation" | number;
@@ -204,6 +206,13 @@ export interface BrowserPackageQueryEvent {
 export interface BrowserPackageQueryEvidence {
   readonly id: string;
   readonly text: string;
+  readonly scope: BrowserPackageQueryEvidenceScope;
+  readonly summary: BrowserPackageQueryEvidenceSummary | null;
+}
+
+export interface BrowserPackageQueryEvidenceSummary {
+  readonly count: number;
+  readonly preview: ReadonlyArray<string>;
 }
 
 export interface BrowserPackageQueryFacetCatalog {

--- a/prototypes/inspect-web/src/facades/inspect-web-package.d.ts
+++ b/prototypes/inspect-web/src/facades/inspect-web-package.d.ts
@@ -3,6 +3,7 @@ export type BrowserDependencyCoordinateMatchOutcome = "NoMatch" | "Unique" | "Am
 export type BrowserDependencyCoordinateProvenance = "NuGetPackage" | "PlatformRuntime" | number;
 export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached" | "CandidateLimitReached" | "SourcePageLimitReached" | "ClientPageLimitReached" | "Failed" | "GalleryResponseComplete" | "ExactPackageComplete" | number;
 export type BrowserPackageQueryEventKind = "Progress" | "Match" | "Failure" | "Completed" | number;
+export type BrowserPackageQueryEvidenceScope = "Package" | "Query" | number;
 export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | "SearchMetadata" | number;
 export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | "PackageContentAcquisition" | "PackageContentEvaluation" | number;
 export type BrowserPackageQueryProgressPhase = "Search" | "Manifest" | "PackageContent" | number;
@@ -171,6 +172,12 @@ export interface BrowserPackageQueryEvent {
 export interface BrowserPackageQueryEvidence {
     readonly id: string;
     readonly text: string;
+    readonly scope: BrowserPackageQueryEvidenceScope;
+    readonly summary: BrowserPackageQueryEvidenceSummary | null;
+}
+export interface BrowserPackageQueryEvidenceSummary {
+    readonly count: number;
+    readonly preview: ReadonlyArray<string>;
 }
 export interface BrowserPackageQueryFacetCatalog {
     readonly facets: ReadonlyArray<BrowserPackageQueryFacetDescriptor>;

--- a/prototypes/inspect-web/src/package-query-source.ts
+++ b/prototypes/inspect-web/src/package-query-source.ts
@@ -251,6 +251,15 @@ function numberValue(value: unknown, description: string): number {
   return value;
 }
 
+function countValue(value: unknown, description: string): number {
+  const count = numberValue(value, description);
+  if (!Number.isInteger(count) || count < 0) {
+    throw new TypeError(
+      `The Browser ${description} was not a non-negative integer.`);
+  }
+  return count;
+}
+
 function nullableNumberValue(
   value: unknown,
   description: string,
@@ -280,9 +289,12 @@ function parseRow(value: unknown): BrowserPackageQueryRow {
     tier: rowTierValue(row.tier),
     evidence: row.evidence.map(item => {
       const evidence = objectValue(item, "package-query evidence");
+      const scope = evidenceScopeValue(evidence.scope);
       return {
         id: stringValue(evidence.id, "package-query evidence ID"),
         text: stringValue(evidence.text, "package-query evidence text"),
+        scope,
+        summary: parseEvidenceSummary(evidence.summary),
       };
     }),
     totalDownloads: nullableNumberValue(
@@ -292,6 +304,35 @@ function parseRow(value: unknown): BrowserPackageQueryRow {
       ? null
       : booleanValue(row.verified, "package-query verification flag"),
     producer: stringValue(row.producer, "package-query producer"),
+  };
+}
+
+function evidenceScopeValue(
+  value: unknown,
+): BrowserPackageQueryRow["evidence"][number]["scope"] {
+  switch (value) {
+    case "Package":
+    case "Query":
+      return value;
+    default:
+      throw new TypeError(
+        `Unknown package-query evidence scope '${String(value)}'.`);
+  }
+}
+
+function parseEvidenceSummary(
+  value: unknown,
+): BrowserPackageQueryRow["evidence"][number]["summary"] {
+  if (value === null) return null;
+  const summary = objectValue(value, "package-query evidence summary");
+  if (!Array.isArray(summary.preview)) {
+    throw new TypeError(
+      "The Browser package-query evidence preview was not an array.");
+  }
+  return {
+    count: countValue(summary.count, "package-query evidence count"),
+    preview: summary.preview.map(item =>
+      stringValue(item, "package-query evidence preview")),
   };
 }
 
@@ -479,8 +520,18 @@ function toQueryProgress(
 function toQueryRow(
   row: NonNullable<BrowserPackageQueryEvent["row"]>,
 ): QueryResultRow {
-  const evidence = row.evidence.map(item => item.text);
-  if (!evidence.length || evidence.some(item => item.trim().length === 0)) {
+  const evidence = row.evidence.map(item => ({
+    id: item.id,
+    text: item.text,
+    scope: item.scope === "Package" ? "package" as const : "query" as const,
+    summary: item.summary === null
+      ? null
+      : {
+          count: item.summary.count,
+          preview: [...item.summary.preview],
+        },
+  }));
+  if (!evidence.length || evidence.some(item => item.text.trim().length === 0)) {
     throw new TypeError("A package-query row contained no evidence.");
   }
   return {

--- a/prototypes/inspect-web/src/package-query-view.ts
+++ b/prototypes/inspect-web/src/package-query-view.ts
@@ -266,7 +266,8 @@ function renderRow(
   escapeHtml: (value: unknown) => string,
 ): string {
   const evidence = row.evidence
-    .map(item => `<li>${escapeHtml(item)}</li>`)
+    .filter(item => item.scope === "package")
+    .map(item => `<li>${escapeHtml(item.text)}</li>`)
     .join("");
   return `
     <article class="query-row">
@@ -280,7 +281,7 @@ function renderRow(
       ${row.description?.trim()
         ? `<p class="query-row-description">${escapeHtml(row.description)}</p>`
         : ""}
-      <ul class="query-evidence">${evidence}</ul>
+      ${evidence ? `<ul class="query-evidence">${evidence}</ul>` : ""}
       <div class="query-row-meta">
         <span>${row.totalDownloads === null
           ? "Lifetime downloads unavailable"
@@ -291,6 +292,19 @@ function renderRow(
         <button type="button" data-query-row-open="${escapeHtml(row.packageId)}" data-query-row-version="${escapeHtml(row.version)}">Open in workspace</button>
       </div>
     </article>`;
+}
+
+function renderQueryContext(
+  rows: readonly QueryResultRow[],
+  escapeHtml: (value: unknown) => string,
+): string {
+  const evidence = rows[0]?.evidence
+    .filter(item => item.scope === "query")
+    .map(item => `<li>${escapeHtml(item.text)}</li>`)
+    .join("") ?? "";
+  return evidence
+    ? `<section class="query-context" aria-label="Query context"><h2>Query context</h2><ul class="query-evidence">${evidence}</ul></section>`
+    : "";
 }
 
 function renderFacet(
@@ -562,7 +576,7 @@ function renderResults(
     .map(row => renderRow(row, escapeHtml))
     .join("");
   return rows
-    ? `${renderProgress(state.outcome, escapeHtml)}<div class="query-list">${rows}</div>${renderCompletionFooter(state.outcome, escapeHtml)}`
+    ? `${renderProgress(state.outcome, escapeHtml)}${renderQueryContext(state.outcome.rows, escapeHtml)}<div class="query-list">${rows}</div>${renderCompletionFooter(state.outcome, escapeHtml)}`
     : state.outcome.completion.kind === "streaming" && state.request
       ? `<section class="query-empty query-running"><span class="loader" aria-hidden="true"></span><h2>Acquiring package input</h2><p>Matches will appear as package candidates are evaluated.</p></section>${renderProgress(state.outcome, escapeHtml)}${renderCompletionFooter(state.outcome, escapeHtml)}`
       : renderEmptyState(state, escapeHtml);

--- a/prototypes/inspect-web/src/package-query.ts
+++ b/prototypes/inspect-web/src/package-query.ts
@@ -166,17 +166,29 @@ export function toggleFacet(
   return withFacet(withFacets(request, compatible), facet);
 }
 
-/** One package's projection plus which predicate terms matched and why. Never
- * a bare pass/fail — the evidence is the point (see package-opportunities.ts
- * for the existing "evidence over checkmark" convention this follows). The
- * non-empty tuple type on `evidence` is what actually enforces that: an
- * empty-array row would silently render a blank evidence section (see
- * package-query-view.ts's renderRow). */
+type QueryEvidenceScope = "package" | "query";
+
+interface QueryEvidenceSummary {
+  count: number;
+  preview: readonly string[];
+}
+
+interface QueryEvidence {
+  id: string;
+  text: string;
+  scope: QueryEvidenceScope;
+  summary: QueryEvidenceSummary | null;
+}
+
+/** One package's projection plus product-authored evidence. Query-scoped
+ * evidence supplies shared selection context; package-scoped evidence
+ * describes inspected facts for this row. The non-empty tuple preserves
+ * meaningful context even for metadata-only rows. */
 export interface QueryResultRow {
   packageId: string;
   version: string;
   tier: "search-metadata" | "nuspec" | "package-content";
-  evidence: readonly [string, ...string[]];
+  evidence: readonly [QueryEvidence, ...QueryEvidence[]];
   totalDownloads: number | null;
   description?: string | null;
   producer?: string;

--- a/prototypes/inspect-web/test/package-query-source.test.ts
+++ b/prototypes/inspect-web/test/package-query-source.test.ts
@@ -36,6 +36,18 @@ const completionEvent: BrowserPackageQueryEvent = {
   },
 };
 
+function packageEvidence(
+  id: string,
+  text: string,
+  summary: { count: number; preview: string[] } | null = null,
+) {
+  return { id, text, scope: "Package" as const, summary };
+}
+
+function queryEvidence(id: string, text: string) {
+  return { id, text, scope: "Query" as const, summary: null };
+}
+
 async function runCompletion(
   completion: BrowserPackageQueryCompletion,
   inputKind: "package" | "gallery" = "gallery",
@@ -125,10 +137,9 @@ test("Gallery metadata rows preserve unknown downloads and source-authored evide
           tier: "SearchMetadata",
           totalDownloads,
           verified,
-          evidence: [{
-            id: "producer.source-selection",
-            text: "Source order: producer ranking; package type: Producer.Type",
-          }],
+          evidence: [queryEvidence(
+            "producer.source-selection",
+            "Source order: producer ranking; package type: Producer.Type")],
         },
       };
       const rows: QueryResultRow[] = [];
@@ -152,7 +163,12 @@ test("Gallery metadata rows preserve unknown downloads and source-authored evide
         totalDownloads,
         description: null,
         producer: "nuget.org",
-        evidence: ["Source order: producer ranking; package type: Producer.Type"],
+        evidence: [{
+          id: "producer.source-selection",
+          text: "Source order: producer ranking; package type: Producer.Type",
+          scope: "query",
+          summary: null,
+        }],
       }]);
     }
   }
@@ -290,7 +306,28 @@ test("streamed metadata admission rejects unknown tiers, malformed metadata, and
     {
       ...toolMatchEvent.row!,
       tier: "SearchMetadata",
-      evidence: [{ id: "producer.source", text: " " }],
+      evidence: [queryEvidence("producer.source", " ")],
+    },
+    {
+      ...toolMatchEvent.row!,
+      evidence: [{
+        ...packageEvidence("package.summary", "Matched."),
+        scope: "Unknown",
+      }],
+    },
+    {
+      ...toolMatchEvent.row!,
+      evidence: [{
+        ...packageEvidence("package.summary", "Matched."),
+        summary: { count: -1, preview: [] },
+      }],
+    },
+    {
+      ...toolMatchEvent.row!,
+      evidence: [{
+        ...packageEvidence("package.summary", "Matched."),
+        summary: { count: 1, preview: "not an array" },
+      }],
     },
   ];
   for (const row of invalidRows) {
@@ -307,7 +344,7 @@ test("streamed metadata admission rejects unknown tiers, malformed metadata, and
       createBrowserPackageQueryDataSource(engine).run(
         createQueryRequest("", "gallery"),
         () => {}, () => {}, () => {}, new AbortController().signal),
-      /Unsupported package-query row tier|not a finite number|not a boolean|not text|no evidence/);
+      /Unsupported package-query row tier|not a finite number|not a non-negative integer|not a boolean|not text|no evidence|Unknown package-query evidence scope|evidence preview was not an array/);
   }
 });
 
@@ -320,10 +357,13 @@ const toolMatchEvent: BrowserPackageQueryEvent = {
     packageId: "Contoso.Tool",
     version: "2.0.0",
     tier: "PackageContent",
-    evidence: [{
-      id: "package.query.dotnet-tool-v2",
-      text: "DotnetToolSettings.xml declares v2.",
-    }],
+    evidence: [packageEvidence(
+      "package.query.dotnet-tool-v2",
+      "2 skill documents: skills/SKILL.md, skills/build/SKILL.md.",
+      {
+        count: 2,
+        preview: ["skills/SKILL.md", "skills/build/SKILL.md"],
+      })],
     totalDownloads: 12,
     description: null,
     verified: false,
@@ -441,7 +481,7 @@ test("Browser data source maps package-content rows and visible failures", async
       return completionEvent;
     },
   };
-  const rows: { packageId: string; tier: string }[] = [];
+  const rows: QueryResultRow[] = [];
   const failures: string[] = [];
   const request = withFacet(createQueryRequest("Contoso."), {
     key: "package.query.dotnet-tool-v2",
@@ -451,18 +491,23 @@ test("Browser data source maps package-content rows and visible failures", async
 
   await createBrowserPackageQueryDataSource(engine).run(
     request,
-    page => rows.push(...page.map(row => ({
-      packageId: row.packageId,
-      tier: row.tier,
-    }))),
+    page => rows.push(...page),
     failure => failures.push(failure),
     () => {},
     new AbortController().signal);
 
   assert.equal(candidateLimit, 20);
-  assert.deepEqual(rows, [{
-    packageId: "Contoso.Tool",
-    tier: "package-content",
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.packageId, "Contoso.Tool");
+  assert.equal(rows[0]?.tier, "package-content");
+  assert.deepEqual(rows[0]?.evidence, [{
+    id: "package.query.dotnet-tool-v2",
+    text: "2 skill documents: skills/SKILL.md, skills/build/SKILL.md.",
+    scope: "package",
+    summary: {
+      count: 2,
+      preview: ["skills/SKILL.md", "skills/build/SKILL.md"],
+    },
   }]);
   assert.deepEqual(
     failures,
@@ -491,7 +536,9 @@ test("Browser data source streams matches and failures before terminal completio
       packageId: "Microsoft.Extensions.Hosting",
       version: "10.0.0",
       tier: "Nuspec",
-      evidence: [{ id: "package.query.source-verified", text: "Verified source" }],
+      evidence: [packageEvidence(
+        "package.query.source-verified",
+        "Verified source")],
       totalDownloads: 1234,
       description: null,
       verified: true,

--- a/prototypes/inspect-web/test/package-query-view.test.ts
+++ b/prototypes/inspect-web/test/package-query-view.test.ts
@@ -104,7 +104,20 @@ function row(packageId: string): QueryResultRow {
     packageId,
     version: "1.0.0",
     tier: "nuspec",
-    evidence: ["net45", "net461"],
+    evidence: [
+      {
+        id: "test.framework.net45",
+        text: "net45",
+        scope: "package",
+        summary: null,
+      },
+      {
+        id: "test.framework.net461",
+        text: "net461",
+        scope: "package",
+        summary: null,
+      },
+    ],
     totalDownloads: 4200,
   };
 }
@@ -247,18 +260,40 @@ test("basic metadata rows show producer evidence and unavailable lifetime downlo
     const html = renderPackageQueryView({
       state: {
         request: createQueryRequest(""),
-        outcome: appendRows(emptyOutcome(), [{
-          ...row("Producer.Result"),
-          tier: "search-metadata",
-          totalDownloads,
-          evidence: ["Source selection and order from the producer"],
-        }]),
+        outcome: appendRows(emptyOutcome(), [
+          {
+            ...row("Producer.Result"),
+            tier: "search-metadata",
+            totalDownloads,
+            evidence: [{
+              id: "producer.source-selection",
+              text: "Source selection and order from the producer",
+              scope: "query",
+              summary: null,
+            }],
+          },
+          {
+            ...row("Producer.Neighbor"),
+            tier: "search-metadata",
+            totalDownloads,
+            evidence: [{
+              id: "producer.source-selection",
+              text: "Source selection and order from the producer",
+              scope: "query",
+              summary: null,
+            }],
+          },
+        ]),
       },
       availableFacets: [],
       escapeHtml,
     });
     assert.match(html, /query-tier-search-metadata">search-metadata</);
     assert.match(html, /Source selection and order from the producer/);
+    assert.equal((html.match(/Source selection and order from the producer/g)
+      ?? []).length, 1);
+    assert.equal((html.match(/<article class="query-row">/g) ?? []).length, 2);
+    assert.equal((html.match(/<ul class="query-evidence">/g) ?? []).length, 1);
     if (totalDownloads === null) {
       assert.match(html, /Lifetime downloads unavailable/);
       assert.doesNotMatch(html, /0 lifetime downloads/);
@@ -267,6 +302,65 @@ test("basic metadata rows show producer evidence and unavailable lifetime downlo
       assert.doesNotMatch(html, /Lifetime downloads unavailable/);
     }
   }
+});
+
+test("query context renders once while package summaries remain on their cards", () => {
+  const queryEvidence = {
+    id: "producer.source-selection",
+    text: "Selected by producer ranking.",
+    scope: "query" as const,
+    summary: null,
+  };
+  const first = {
+    ...row("Contoso.First"),
+    evidence: [
+      queryEvidence,
+      {
+        id: "package.query.has-dependencies",
+        text: "4 dependencies: A, B, C (+1 more).",
+        scope: "package" as const,
+        summary: {
+          count: 4,
+          preview: ["A", "B", "C"],
+        },
+      },
+    ] as const,
+  };
+  const second = {
+    ...row("Contoso.Second"),
+    evidence: [
+      queryEvidence,
+      {
+        id: "package.query.embedded-skill",
+        text: "2 skill documents: skills/SKILL.md, skills/build/SKILL.md.",
+        scope: "package" as const,
+        summary: {
+          count: 2,
+          preview: ["skills/SKILL.md", "skills/build/SKILL.md"],
+        },
+      },
+    ] as const,
+  };
+
+  const html = renderPackageQueryView({
+    state: {
+      request: createQueryRequest("", "gallery"),
+      outcome: appendRows(emptyOutcome(), [first, second]),
+    },
+    availableFacets: [],
+    escapeHtml,
+  });
+
+  assert.equal((html.match(/Selected by producer ranking\./g) ?? []).length, 1);
+  assert.match(
+    html,
+    /<section class="query-context"[\s\S]*Selected by producer ranking\.[\s\S]*<div class="query-list">/);
+  assert.equal((html.match(/4 dependencies: A, B, C \(\+1 more\)\./g)
+    ?? []).length, 1);
+  assert.equal((html.match(/2 skill documents:/g) ?? []).length, 1);
+  assert.doesNotMatch(
+    html,
+    /<article class="query-row">[\s\S]*Selected by producer ranking\./);
 });
 
 test("Gallery completion text retains the finite bound and estimate with or without rows", () => {

--- a/prototypes/inspect-web/test/package-query.test.ts
+++ b/prototypes/inspect-web/test/package-query.test.ts
@@ -79,7 +79,12 @@ function row(packageId: string): QueryResultRow {
     packageId,
     version: "1.0.0",
     tier: "nuspec",
-    evidence: ["net45"],
+    evidence: [{
+      id: "test.package",
+      text: "net45",
+      scope: "package",
+      summary: null,
+    }],
     totalDownloads: 100,
   };
 }
@@ -182,7 +187,12 @@ test("controller runs explicit blank Gallery discovery with source selection and
       onPage([{
         ...row("Browse.Result"),
         tier: "search-metadata",
-        evidence: ["Producer source selection and order"],
+        evidence: [{
+          id: "producer.source-selection",
+          text: "Producer source selection and order",
+          scope: "query",
+          summary: null,
+        }],
         totalDownloads: null,
       }]);
       return { kind: "bounded", reason: "one finite Gallery response" };

--- a/src/DotnetInspector.Queries.Tests/PackageQueryGalleryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryGalleryTests.cs
@@ -110,6 +110,11 @@ public sealed class PackageQueryGalleryTests
             Assert.Contains(match.Evidence, item => item.Id == PackageQuery.GalleryPackageTypeEvidenceId);
             Assert.Contains(match.Evidence, item => item.Id == PackageQuery.GalleryOrderEvidenceId);
             Assert.DoesNotContain(match.Evidence, item => item.Id == PackageQuery.ToolFacetId);
+            Assert.All(match.Evidence, item =>
+            {
+                Assert.Equal(PackageQueryEvidenceScope.Query, item.Scope);
+                Assert.Null(item.Summary);
+            });
         });
         var summary = Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
         Assert.Equal(count, summary.SourceCandidates);

--- a/src/DotnetInspector.Queries.Tests/PackageQueryInputTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryInputTests.cs
@@ -88,6 +88,7 @@ public sealed class PackageQueryInputTests
         Assert.Null(match.Package.Verified);
         Assert.Equal(PackageQueryFacetTier.SearchMetadata, match.Tier);
         Assert.Equal(PackageQuery.ExactPackageEvidenceId, Assert.Single(match.Evidence).Id);
+        Assert.Equal(PackageQueryEvidenceScope.Query, Assert.Single(match.Evidence).Scope);
         Assert.Equal(PackageQueryCompletionKind.ExactPackageComplete, Summary(events).Completion);
         Assert.Equal(1, Summary(events).Candidates);
         Assert.Equal(1, Summary(events).SourceCandidates);

--- a/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
@@ -430,10 +430,12 @@ public sealed class PackageQueryTests
         Assert.Equal(
             "Package ID matches prefix \"Contoso.\".",
             match.Evidence[0].Value);
-        Assert.Contains(
-            "1 dependency across 1 target-framework group.",
-            match.Evidence[3].Value,
-            StringComparison.Ordinal);
+        Assert.Equal("1 dependency: Example.Dependency.", match.Evidence[3].Value);
+        Assert.Equal(PackageQueryEvidenceScope.Query, match.Evidence[0].Scope);
+        Assert.All(match.Evidence.Skip(1), evidence =>
+            Assert.Equal(PackageQueryEvidenceScope.Package, evidence.Scope));
+        Assert.Equal(1, Assert.IsType<PackageQueryEvidenceSummary>(
+            match.Evidence[3].Summary).Count);
         Assert.Contains(
             "1,500,000 total downloads",
             match.Evidence[4].Value,
@@ -448,6 +450,95 @@ public sealed class PackageQueryTests
                         TextPolicy.Prose,
                         evidence.Value));
             });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DependencyEvidenceCountsDistinctIdsAcrossGroups()
+    {
+        var source = SourceFor(Manifest(
+            "Contoso.Package",
+            dependencies:
+            """
+            <group targetFramework="net8.0">
+              <dependency id="Gamma" version="[1.0.0]" />
+              <dependency id="beta" version="[1.0.0]" />
+              <dependency id="Alpha" version="[1.0.0]" />
+            </group>
+            <group targetFramework="net9.0">
+              <dependency id="BETA" version="[2.0.0]" />
+              <dependency id="Alpha" version="[2.0.0]" />
+              <dependency id="Zeta" version="[1.0.0]" />
+            </group>
+            """));
+        PackageQueryPlan plan = Accepted(PackageQuery.Plan(
+            new PackageQueryRequest(
+                "Contoso.", [PackageQuery.HasDependenciesFacetId],
+                MaximumCandidates: 1, MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(PackageQuery.ExecuteAsync(
+            source, plan, TestContext.Current.CancellationToken));
+
+        PackageQueryMatch match = Assert.Single(events.OfType<PackageQueryEvent.Match>()).Value;
+        PackageQueryEvidence evidence = Assert.Single(match.Evidence,
+            item => item.Id == PackageQuery.HasDependenciesFacetId);
+        PackageQueryEvidenceSummary summary =
+            Assert.IsType<PackageQueryEvidenceSummary>(evidence.Summary);
+        Assert.Equal(4, summary.Count);
+        Assert.Equal(["Alpha", "beta", "Gamma"],
+            summary.Preview.Select(item => item.ToString()));
+        Assert.Equal("4 dependencies: Alpha, beta, Gamma (+1 more).", evidence.Value);
+        Assert.Equal(PackageQueryEvidenceScope.Package, evidence.Scope);
+        Assert.Single(source.ManifestRequests);
+        Assert.Equal(0, source.PackageRequests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkillEvidenceUsesBoundedActualInventoryPaths()
+    {
+        string longPath = $"skills/{new string('a', 200)}/SKILL.md";
+        var archive = new FakePackageContent(
+            ("skills/z/skill.MD", "Not parsed as skill frontmatter."),
+            ("docs/SKILL.md", ""),
+            ("skills/SKILL.md", ""),
+            ("skills/x/SKILL.md", ""),
+            ("skills/b\nname/SKILL.md", ""),
+            (longPath, ""),
+            ("skills/not-skill.md", ""),
+            ("SKILL.md", ""));
+        var content = new FakePackageQueryContentProvider(
+            new Dictionary<string, IPackageContent> { ["Contoso.Package"] = archive });
+        var source = SourceFor(Manifest("Contoso.Package"));
+        PackageQueryPlan plan = Accepted(PackageQuery.Plan(
+            new PackageQueryRequest(
+                "Contoso.", [PackageQuery.EmbeddedSkillFacetId],
+                MaximumCandidates: 1, MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(PackageQuery.ExecuteAsync(
+            source, plan, content, TestContext.Current.CancellationToken));
+
+        PackageQueryMatch match = Assert.Single(events.OfType<PackageQueryEvent.Match>()).Value;
+        PackageQueryEvidence evidence = Assert.Single(match.Evidence,
+            item => item.Id == PackageQuery.EmbeddedSkillFacetId);
+        PackageQueryEvidenceSummary summary =
+            Assert.IsType<PackageQueryEvidenceSummary>(evidence.Summary);
+        Assert.Equal(5, summary.Count);
+        Assert.Equal(PackageQuery.MaximumEvidencePreviewItems, summary.Preview.Length);
+        Assert.Equal("skills/SKILL.md", summary.Preview[0].ToString());
+        Assert.True(summary.Preview[1].IsTruncated);
+        Assert.True(summary.Preview[2].WasEncoded);
+        Assert.All(summary.Preview, preview =>
+        {
+            Assert.True(preview.ToString().Length <= PackageQuery.MaximumEvidencePreviewCharacters);
+            Assert.True(InertString.IsPermitted(TextPolicy.Field, preview.ToString()));
+        });
+        Assert.StartsWith("5 skill documents: skills/SKILL.md, ", evidence.Value);
+        Assert.EndsWith("(+2 more).", evidence.Value);
+        Assert.DoesNotContain("\n", evidence.Value);
+        Assert.DoesNotContain(longPath, evidence.Value);
+        Assert.Equal(PackageQueryEvidenceScope.Package, evidence.Scope);
+        Assert.Single(source.ManifestRequests);
+        Assert.Single(content.Requests);
+        Assert.Empty(archive.EntryRequests);
     }
 
     [Fact]
@@ -696,6 +787,13 @@ public sealed class PackageQueryTests
             skillEvents.OfType<PackageQueryEvent.Match>()
                 .Select(item => item.Value.Package.PackageId));
         Assert.Equal(
+            [
+                "1 skill document: SKILLS/demo/skill.MD.",
+                "1 skill document: skills/SKILL.md.",
+            ],
+            skillEvents.OfType<PackageQueryEvent.Match>()
+                .Select(item => item.Value.Evidence[^1].Value));
+        Assert.Equal(
             ["Contoso.V1", "Contoso.V2", "Contoso.Library"],
             content.Requests);
     }
@@ -901,6 +999,8 @@ public sealed class PackageQueryTests
             Assert.Single(events.OfType<PackageQueryEvent.Match>()).Value;
         PackageQueryEvidence evidence = Assert.Single(match.Evidence);
         Assert.Equal(PackageQuery.PrefixEvidenceId, evidence.Id);
+        Assert.Equal(PackageQueryEvidenceScope.Query, evidence.Scope);
+        Assert.Null(evidence.Summary);
     }
 
     [Fact]
@@ -957,7 +1057,15 @@ public sealed class PackageQueryTests
                 noDependenciesSource,
                 noDependencies,
                 TestContext.Current.CancellationToken));
-        Assert.Single(noDependencyEvents.OfType<PackageQueryEvent.Match>());
+        PackageQueryMatch emptyMatch =
+            Assert.Single(noDependencyEvents.OfType<PackageQueryEvent.Match>()).Value;
+        PackageQueryEvidence emptyEvidence = Assert.Single(emptyMatch.Evidence,
+            evidence => evidence.Id == PackageQuery.NoDependenciesFacetId);
+        PackageQueryEvidenceSummary emptySummary =
+            Assert.IsType<PackageQueryEvidenceSummary>(emptyEvidence.Summary);
+        Assert.Equal(0, emptySummary.Count);
+        Assert.Empty(emptySummary.Preview);
+        Assert.Equal("0 dependencies.", emptyEvidence.Value);
 
         var hasDependenciesSource = SourceFor(
             manifest,
@@ -1652,6 +1760,7 @@ public sealed class PackageQueryTests
         public bool FromCache => false;
         public string ProducerKey => "nuget.org";
         public bool RequiresArchiveTreeMatch => false;
+        public List<string> EntryRequests { get; } = [];
 
         public bool TryOpenArchive([NotNullWhen(true)] out Stream? stream)
         {
@@ -1663,6 +1772,7 @@ public sealed class PackageQueryTests
             string relativePath,
             [NotNullWhen(true)] out Stream? stream)
         {
+            EntryRequests.Add(relativePath);
             if (_entries.TryGetValue(relativePath, out byte[]? content))
             {
                 stream = new MemoryStream(content, writable: false);
@@ -1678,6 +1788,7 @@ public sealed class PackageQueryTests
             long maxExpandedBytes,
             [NotNullWhen(true)] out Stream? stream)
         {
+            EntryRequests.Add(relativePath);
             if (!_entries.TryGetValue(relativePath, out byte[]? content)
                 || content.LongLength > maxExpandedBytes)
             {

--- a/src/DotnetInspector.Queries/PackageQuery.Gallery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.Gallery.cs
@@ -59,7 +59,7 @@ public static partial class PackageQuery
     {
         if (plan.GalleryRequest is not { } request)
         {
-            evidence.Add(new PackageQueryEvidence(
+            evidence.Add(ScopeEvidence(
                 plan.PackageInput is SourceSelector.Package
                     ? ExactPackageEvidenceId
                     : PrefixEvidenceId,
@@ -67,24 +67,27 @@ public static partial class PackageQuery
             return;
         }
 
-        evidence.Add(new PackageQueryEvidence(GalleryScopeEvidenceId, plan.PrefixEvidence));
-        evidence.Add(new PackageQueryEvidence(
+        evidence.Add(ScopeEvidence(GalleryScopeEvidenceId, plan.PrefixEvidence));
+        evidence.Add(ScopeEvidence(
             GalleryOrderEvidenceId,
             Evidence(request.Order == NuGetGalleryDiscoveryOrder.MostDownloaded
                 ? "Gallery download-ranked response order; not a global top-N."
                 : "Gallery relevance response order.")));
-        evidence.Add(new PackageQueryEvidence(
+        evidence.Add(ScopeEvidence(
             GalleryPrereleaseEvidenceId,
             Evidence(request.IncludePrerelease
                 ? "Gallery source selection permits prerelease versions."
                 : "Gallery source selection permits stable versions only.")));
         if (request.PackageType is { } packageType)
         {
-            evidence.Add(new PackageQueryEvidence(
+            evidence.Add(ScopeEvidence(
                 GalleryPackageTypeEvidenceId,
                 Evidence($"Gallery applied package type \"{packageType.Name}\"; this is index evidence.")));
         }
     }
+
+    static PackageQueryEvidence ScopeEvidence(string id, InertString text) =>
+        new(id, text) { Scope = PackageQueryEvidenceScope.Query };
 
     static async IAsyncEnumerable<PackageQueryInputEvent> AcquireInputAsync(
         IPackageSourceClient source,

--- a/src/DotnetInspector.Queries/PackageQuery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.cs
@@ -172,11 +172,25 @@ public sealed class PackageQueryPlan
     internal ImmutableArray<PackageQueryFacetDefinition> Definitions { get; }
 }
 
+/// <summary>Whether evidence describes the query input or an inspected package.</summary>
+public enum PackageQueryEvidenceScope
+{
+    Package,
+    Query,
+}
+
+/// <summary>A complete observed item count and bounded inert display previews.</summary>
+public sealed record PackageQueryEvidenceSummary(
+    int Count,
+    ImmutableArray<InertString> Preview);
+
 /// <summary>One product-authored explanation for a package-query match.</summary>
 public sealed record PackageQueryEvidence(
     string Id,
     InertString Text)
 {
+    public PackageQueryEvidenceScope Scope { get; init; }
+    public PackageQueryEvidenceSummary? Summary { get; init; }
     public string Value => Text.ToString();
 }
 
@@ -300,11 +314,15 @@ public interface IPackageQueryContentProvider
 internal sealed record PackageQueryFacetDefinition(
     PackageQueryFacetDescriptor Descriptor,
     Func<PackageQueryPackage, bool> MatchesManifest,
-    Func<PackageQueryPackage, InertString> Evidence,
+    Func<PackageQueryPackage, PackageContentFacts?, PackageQueryFacetEvidence> Evidence,
     Func<PackageContentFacts, bool>? MatchesPackageContent = null);
 
+internal sealed record PackageQueryFacetEvidence(
+    InertString Text,
+    PackageQueryEvidenceSummary? Summary = null);
+
 internal sealed record PackageContentFacts(
-    bool HasSkillDocument,
+    PackageQueryEvidenceSummary? SkillDocuments,
     string? ToolSettingsVersion);
 
 /// <summary>
@@ -318,6 +336,8 @@ public static partial class PackageQuery
     public const int MaximumPackageContentCandidates = 20;
     public const int MaximumFacetIdLength = 100;
     public const int MaximumToolSettingsBytes = 64 * 1024;
+    public const int MaximumEvidencePreviewItems = 3;
+    public const int MaximumEvidencePreviewCharacters = 160;
 
     public const string PrefixEvidenceId = "package.query.scope.prefix";
     public const string ExactPackageEvidenceId = "package.query.scope.exact-package";
@@ -344,7 +364,7 @@ public static partial class PackageQuery
                 100,
                 PackageQueryFacetTier.Nuspec),
             static match => match.Verified == true,
-            static _ => Evidence(
+            static (_, _) => Describe(
                 "The package source reports this package as verified.")),
         new(
             new PackageQueryFacetDescriptor(
@@ -357,7 +377,7 @@ public static partial class PackageQuery
                 ToolDisplayGroupId,
                 ".NET tool format"),
             static match => match.RequiredManifest.IsToolPackage,
-            static _ => Evidence(
+            static (_, _) => Describe(
                 "The package manifest declares a .NET tool package.")),
         new(
             new PackageQueryFacetDescriptor(
@@ -373,7 +393,7 @@ public static partial class PackageQuery
                 CombinesWithinSelectionGroup = true,
             },
             static match => match.RequiredManifest.IsToolPackage,
-            static _ => Evidence(
+            static (_, _) => Describe(
                 "DotnetToolSettings.xml declares the portable .NET tool v1 format."),
             static content => content.ToolSettingsVersion == "1"),
         new(
@@ -390,7 +410,7 @@ public static partial class PackageQuery
                 CombinesWithinSelectionGroup = true,
             },
             static match => match.RequiredManifest.IsToolPackage,
-            static _ => Evidence(
+            static (_, _) => Describe(
                 "DotnetToolSettings.xml declares the RID-specific .NET tool v2 format."),
             static content => content.ToolSettingsVersion == "2"),
         new(
@@ -401,17 +421,8 @@ public static partial class PackageQuery
                 300,
                 PackageQueryFacetTier.Nuspec,
                 DependencySelectionGroupId),
-            static match => DependencyCount(match) > 0,
-            static match =>
-            {
-                int dependencies = DependencyCount(match);
-                int groups = NonEmptyDependencyGroupCount(match);
-                return Evidence(
-                    $"The package manifest declares {dependencies.ToString(CultureInfo.InvariantCulture)} "
-                    + $"{Pluralize(dependencies, "dependency", "dependencies")} across "
-                    + $"{groups.ToString(CultureInfo.InvariantCulture)} target-framework "
-                    + $"{Pluralize(groups, "group", "groups")}.");
-            }),
+            static match => HasDependencies(match),
+            static (match, _) => DescribeDependencies(match)),
         new(
             new PackageQueryFacetDescriptor(
                 NoDependenciesFacetId,
@@ -420,9 +431,8 @@ public static partial class PackageQuery
                 400,
                 PackageQueryFacetTier.Nuspec,
                 DependencySelectionGroupId),
-            static match => DependencyCount(match) == 0,
-            static _ => Evidence(
-                "The package manifest declares no dependencies.")),
+            static match => !HasDependencies(match),
+            static (match, _) => DescribeDependencies(match)),
         new(
             new PackageQueryFacetDescriptor(
                 MillionDownloadsFacetId,
@@ -431,7 +441,7 @@ public static partial class PackageQuery
                 500,
                 PackageQueryFacetTier.Nuspec),
             static match => match.TotalDownloads >= 1_000_000,
-            static match => Evidence(
+            static (match, _) => Describe(
                 $"The package source reports {match.TotalDownloads?.ToString("N0", CultureInfo.InvariantCulture)} total downloads.")),
         new(
             new PackageQueryFacetDescriptor(
@@ -442,7 +452,7 @@ public static partial class PackageQuery
                 PackageQueryFacetTier.Nuspec),
             static match => !string.IsNullOrWhiteSpace(
                 match.RequiredManifest.ReadmeFile),
-            static _ => Evidence(
+            static (_, _) => Describe(
                 "The package manifest declares an embedded README file.")),
         new(
             new PackageQueryFacetDescriptor(
@@ -452,9 +462,13 @@ public static partial class PackageQuery
                 700,
                 PackageQueryFacetTier.PackageContent),
             static _ => true,
-            static _ => Evidence(
-                "The package contains a skills/SKILL.md document."),
-            static content => content.HasSkillDocument),
+            static (_, content) => DescribeItems(
+                content?.SkillDocuments
+                    ?? throw new InvalidOperationException(
+                        "Skill-document evidence requires its package-content inventory."),
+                "skill document",
+                "skill documents"),
+            static content => content.SkillDocuments is { Count: > 0 }),
     ];
 
     static readonly IReadOnlyDictionary<string, PackageQueryFacetDefinition>
@@ -944,10 +958,7 @@ public static partial class PackageQuery
                 {
                     continue;
                 }
-                evidence.Add(
-                    new PackageQueryEvidence(
-                        candidate.Descriptor.Id,
-                        candidate.Evidence(match)));
+                evidence.Add(CreateFacetEvidence(candidate, match, null));
             }
         }
 
@@ -995,10 +1006,7 @@ public static partial class PackageQuery
 
             foreach (PackageQueryFacetDefinition candidate in matched)
             {
-                evidence.Add(
-                    new PackageQueryEvidence(
-                        candidate.Descriptor.Id,
-                        candidate.Evidence(match)));
+                evidence.Add(CreateFacetEvidence(candidate, match, content));
             }
         }
 
@@ -1016,14 +1024,16 @@ public static partial class PackageQuery
             definition.Descriptor.Id == EmbeddedSkillFacetId);
         bool needsToolSettings = definitions.Any(definition =>
             definition.Descriptor.Id is ToolV1FacetId or ToolV2FacetId);
-        bool hasSkill = needsSkills && entries.Any(IsSkillDocument);
+        PackageQueryEvidenceSummary? skills = needsSkills
+            ? SummarizeItems(entries.Where(IsSkillDocument), StringComparer.Ordinal)
+            : null;
         string? toolVersion = needsToolSettings
             ? await ReadToolSettingsVersionAsync(
                 content,
                 entries,
                 cancellationToken).ConfigureAwait(false)
             : null;
-        return new PackageContentFacts(hasSkill, toolVersion);
+        return new PackageContentFacts(skills, toolVersion);
     }
 
     static async ValueTask<string?> ReadToolSettingsVersionAsync(
@@ -1129,13 +1139,66 @@ public static partial class PackageQuery
             failure.Message,
             failure.ManifestFailureReason);
 
-    static int DependencyCount(PackageQueryPackage match) =>
-        match.RequiredManifest.DependencyGroups.Sum(group =>
-            group.Dependencies.Length);
-
-    static int NonEmptyDependencyGroupCount(PackageQueryPackage match) =>
-        match.RequiredManifest.DependencyGroups.Count(group =>
+    static bool HasDependencies(PackageQueryPackage match) =>
+        match.RequiredManifest.DependencyGroups.Any(group =>
             !group.Dependencies.IsEmpty);
+
+    static PackageQueryFacetEvidence DescribeDependencies(PackageQueryPackage match) =>
+        DescribeItems(
+            SummarizeItems(
+                match.RequiredManifest.DependencyGroups
+                    .SelectMany(group => group.Dependencies)
+                    .Select(dependency => dependency.Id),
+                StringComparer.OrdinalIgnoreCase),
+            "dependency",
+            "dependencies");
+
+    static PackageQueryEvidenceSummary SummarizeItems(
+        IEnumerable<string> items,
+        StringComparer comparer)
+    {
+        string[] distinct = [.. items.Distinct(comparer).Order(comparer)];
+        return new PackageQueryEvidenceSummary(
+            distinct.Length,
+            [
+                .. distinct.Take(MaximumEvidencePreviewItems)
+                    .Select(item => new InertString(
+                        TextPolicy.Field, item, MaximumEvidencePreviewCharacters)),
+            ]);
+    }
+
+    static PackageQueryFacetEvidence DescribeItems(
+        PackageQueryEvidenceSummary summary,
+        string singular,
+        string plural)
+    {
+        string heading = $"{summary.Count.ToString(CultureInfo.InvariantCulture)} "
+            + Pluralize(summary.Count, singular, plural);
+        if (summary.Preview.IsEmpty)
+            return new PackageQueryFacetEvidence(Evidence(heading + "."), summary);
+
+        InertString preview = InertString.Join(", ", TextPolicy.Prose, [.. summary.Preview]);
+        int remaining = summary.Count - summary.Preview.Length;
+        InertString text = remaining > 0
+            ? InertString.Format(TextPolicy.Prose,
+                $"{heading}: {preview} (+{remaining.ToString(CultureInfo.InvariantCulture)} more).")
+            : InertString.Format(TextPolicy.Prose, $"{heading}: {preview}.");
+        return new PackageQueryFacetEvidence(text, summary);
+    }
+
+    static PackageQueryFacetEvidence Describe(string text) => new(Evidence(text));
+
+    static PackageQueryEvidence CreateFacetEvidence(
+        PackageQueryFacetDefinition definition,
+        PackageQueryPackage package,
+        PackageContentFacts? content)
+    {
+        PackageQueryFacetEvidence description = definition.Evidence(package, content);
+        return new PackageQueryEvidence(definition.Descriptor.Id, description.Text)
+        {
+            Summary = description.Summary,
+        };
+    }
 
     static string Pluralize(int count, string singular, string plural) =>
         count == 1 ? singular : plural;


### PR DESCRIPTION
# Inspection-produced Package Query cards

Make Package Query results useful at a glance: show what an inspection found,
not the same source-selection explanation on every package.

Addresses #6071 within #5816. Stacked on #6138; this is the third corrective
slice after incremental prefix production (#5954) and explicit package input
(#6138).

## Demo

Before, a skills result repeated query-wide context on every card:

```text
Package belongs to the Gallery response for "markout".
Gallery relevance response order.
Gallery source selection permits stable versions only.
The package contains a skills/SKILL.md document.
```

Now query-wide context appears once above the result list. Package cards retain
their identity, metadata, and workspace action, and selected inspections supply
compact package-specific evidence.

The production query exercised with deterministic manifest/archive fixtures
produces:

```text
Has dependencies, six declarations across two framework groups:
  4 dependencies: Alpha, beta, Gamma (+1 more).

Embedded SKILL.md, root document:
  1 skill document: skills/SKILL.md.

Embedded SKILL.md, nested document:
  1 skill document: SKILLS/demo/skill.MD.

No dependencies, neighboring empty framework groups:
  0 dependencies.
```

The dependency fixture counts `beta` and `BETA` once, preserves the first
declared spelling, and does not mistake framework-group repetition for more
packages. The pathological skills fixture has five matching paths, including
a long path and a line-break-bearing path: its total stays five, its preview
stays at three field-encoded/bounded paths, and it reports `(+2 more)`.
No skill-document bodies are opened.

A neighboring metadata-only query retains source context once but receives no
invented package inspection evidence. Existing progress, visible failures,
completion accounting, cancellation, and demand-driven delivery remain.

## Design basis and boundaries

Sole normative owner:
`docs/design/package-query-inspection-evidence.md`.
Its claim is inspection-produced totals and bounded actual-item previews,
distinguished from query-wide context.

The baseline is ordinary count-plus-preview disclosure over the existing
manifest dependency groups and archive inventory. The added structure serves
the user's request for useful result cards; it is not a dependency resolver,
skill parser, or new event protocol.

Each summary retains a full count and up to three `InertString` previews, each
with a 160-character display budget. Dependency IDs are distinct ordinal
case-insensitively across groups. Skill paths retain ordinal identity and use
the existing case-insensitive matcher. Previews are display text, not package
coordinates or archive handles.

The package publisher supplies manifest IDs and admitted archive paths.
Shared construction applies the existing inert field contract; Browser HTML
encoding remains the sink boundary. Acquisition, facet predicates, source
authority, and stream lifetime retain their existing owners.

Production adoption has three steps: shared evidence here, Browser
facade/cards here, and the planned CLI facet projection under #5919.
The latter remains pending in #6071. Browser cards deliberately retain their
existing host-specific HTML renderer over typed evidence; the planned CLI
projection uses the same compact explanation through Sections/Markout.
Per-card repetition of query context is retired in this slice.

Deployment, CLI facet command wiring, DOM virtualization, Worker placement,
and production latency comparisons are not claimed.

## Validation

- Release shared Query build and 107 focused query/input/Gallery/profile cases.
- Release Browser engine build and 30 package-query operation/projection cases.
- Full frontend `npm run analyze`, including Knip.
- Full frontend `npm run build`, including application, test, and tooling
  type-checks plus site artifact verification.
- 287 affected frontend package-query/Spotlight cases.
- Facade generation and final `--check`, including runtime canaries and
  versioned declarations; generated drift is limited to the package TypeScript
  facade and its declaration file.
- Changed Markdown and `git diff --check`.

Current-head CI and fixed-head review are recorded after publication.
