### PR TITLE
Add sparse package assembly projection and exact Root reacquisition

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -2263,10 +2263,13 @@ limit, an aggregate retained-image bound of `2N` admits projection while
 After caller input validation, the package-owned projection outcome is closed:
 
 - **Available** carries one operation-scoped sparse realization containing the
-  canonical selected asset, exact one-participant group and participant, and
-  the Metadata bridge's `IdentityDecoded` signal. The group is required query
-  authority; the signal prevents a consumer from treating a rejection-carrier
-  identity as decoded assembly evidence.
+  canonical selected asset, exact one-participant group and participant, the
+  Metadata bridge's `IdentityDecoded` signal, and the exact exhaustive
+  `ArtifactAssemblyProjectionOutcome` retained from admission. The group is
+  required query authority; the signal prevents a consumer from treating a
+  rejection-carrier identity as decoded assembly evidence. `Projected`,
+  `NotAssembly`, and `Rejected` are read only from the retained admission
+  outcome and are never inferred from `IdentityDecoded`.
 - **InvalidBinding** means the Root no longer corresponds to the binding's
   content-generation identity.
 - **InvalidSelectedAsset** means the supplied object is not an exact canonical
@@ -2304,24 +2307,103 @@ secondary diagnostics and do not replace the primary failure or cancellation.
 Unexpected implementation exceptions remain exceptional rather than becoming
 success-shaped or generic typed outcomes.
 
-The current artifact materializer's `using`-declaration path can let a throwing
-stream disposal replace a cancellation raised by `ReadAsync`. #5798 must first
-close that owner-local gap by capturing the materialization failure, disposing
-separately, attaching disposal failure as cleanup evidence, and rethrowing the
-original condition. The cancellation-preservation claim remains unverified
-until the named sparse cleanup gate exercises a stream whose read is cancelled
-and whose disposal throws.
+The artifact materializer's former `using`-declaration path could let a
+throwing stream disposal replace a cancellation raised by `ReadAsync`. That
+owner-local gap is now closed: the materializer captures the primary
+materialization failure, disposes the source stream separately, attaches a
+throwing disposal as secondary cleanup evidence on that exact exception, and
+rethrows the original condition with its original token. A disposal failure on
+an otherwise successful read still propagates rather than being swallowed.
+`ArtifactSetSession.GetCleanupFailures` is the typed accessor for that
+secondary evidence, which the session keeps under a private data key rather
+than a caller-guessable string. `AttachCleanupFailures` is the matching entry
+for every producer of that evidence, including callers in other assemblies; it
+merges, so a second attachment to the same failure adds to the first instead of
+discarding it, and no caller reproduces the key. Gated by
+`ArtifactSetSessionCleanupEvidenceTests.DisposalFailureDoesNotReplaceCancelledRead`,
+`DisposalFailureDoesNotReplaceReadFailure`,
+`DisposalFailureOnSuccessfulReadStillPropagates`, and
+`AttachedCleanupEvidenceMergesRatherThanReplaces`.
 
-An available projection is operation-scoped and resource-bearing. It supplies
-the canonical selected asset, group, participant, and `IdentityDecoded` signal
-only. Query roles, selection rationale, sibling accounting, and durable
-evidence remain consumer-owned.
+Before ownership transfers to the candidate workspace, the sparse adapter owns
+its own cleanup and reports it as a bounded, product-authored receipt. The
+receipt is present only when that owner-local cleanup did not complete, is
+always secondary to the typed primary outcome, cancellation, or unexpected
+exception, and is absent on `Available` and on successful cleanup. It carries
+only closed stage and count data — which of the participant, query-lease, and
+artifact-session stages did not complete, and how many failures each observed —
+and never an exception, message, path, package-authored string, stream,
+session, lease, participant, workspace, callback, or opener. A typed accessor
+reads the receipt from the exact primary exception through the same private
+data-key convention. After transfer, the candidate workspace's `CloseAsync`
+remains the release owner and continues to report its own group and artifact
+cleanup failures.
+
+An available projection is operation-scoped and intentionally
+resource-bearing. It supplies the canonical selected asset, group,
+participant, `IdentityDecoded` signal, retained admission outcome, and one
+operation-scoped query entry point only. Query roles, selection rationale,
+sibling accounting, and durable evidence remain consumer-owned.
 
 Artifact registration and participant remain execution authority, not durable
 query evidence. A consumer may copy the package coordinate, content-generation
-identity, selection identity, and selected asset into a resource-free receipt,
-but it cannot retain the workspace, artifact identity or registration,
-group, participant, content opener, stream, session, lease, or callback.
+identity, selection identity, selected asset, and typed admission facts into a
+resource-free receipt, but it cannot retain the workspace, artifact identity or
+registration, group, participant, content opener, stream, session, lease, or
+callback.
+
+Being live is the contract here, not a defect. #5843's public resource-free
+data gate governs the closed facts a consumer copies out — coordinate,
+identities, asset, admission classification, and cleanup receipt — and must not
+be read as a claim that the `Available` execution context is itself
+resource-free. The two are separately gated:
+`Projection_IncompleteCleanupProducesBoundedResourceFreeReceipt` and
+`ReacquisitionRequest_IsExactResourceFreeAndSeparatesTargets` close the
+resource-free facts, while `Projection_CloseWaitsForActiveQueryThenDeniesAccess`
+closes the deliberately live one.
+
+Without an entry point, an available projection would hand a consumer a
+participant it could not lawfully query. The realization therefore exposes one
+operation-scoped query call that runs a bounded producer against the retained
+artifact through the assembly-inspection owner's existing revalidation: the
+one-participant group supplies active-operation quiescence, the artifact owner
+supplies the authorized content view, and the owner's
+`ArtifactAssemblyQueryOutcome` is returned unchanged. No raw bytes, stream,
+opener, content view, or query lease crosses that boundary, and none is
+reachable from durable data. When the retained admission is not `Projected`,
+the call refuses with the same owner-typed reason and never runs the producer.
+After workspace close, the call is denied by the group's ordinary disposed
+semantics.
+
+The producer's own shape stays the assembly-inspection owner's. This contract
+fixes only whether a producer may run and under what lifetime, never what a
+producer is handed or what it may charge; the producer type is forwarded
+verbatim at a single call site, so an owner change to that seam adapts here
+without a semantic decision to unwind. Note also what this projection's bounds
+do and do not charge: the selected entry's declared and observed bytes are
+charged before and during its one open, and the retained image is charged at
+group admission, but a transient allocation a producer makes inside a query
+callback is charged by neither. Charge-before-allocation inside a producer is
+the assembly-inspection and analysis owners' property, not something an
+aggregate retained-image budget can supply.
+
+This projection is not a Root publication and does not become one. It mints no
+correspondence, reserves no Root admission, advances no composition generation,
+enters nothing into the Workspace Root registry, and never reaches the Scope
+publication participant; a consumer that needs a published Root uses the
+package Root producer instead. It also deliberately does not reuse that
+producer's extracted construction, because that construction realizes the
+Root's whole role universe — exactly the cost this contract exists to avoid.
+The two are owner-internal siblings over the same package Root binding, not a
+host reconstruction of Root construction, and the sparse path adds no second
+Root lifetime concept.
+
+Where the two do share a concern, they share the implementation rather than
+duplicating it. Cleanup evidence is the concrete case: both attach secondary
+failures to the primary exception through the artifact owner's merging
+`ArtifactSetSession.AttachCleanupFailures` and read them through
+`GetCleanupFailures`, so neither a release sweep nor a materialization
+disposal can silently replace the other's evidence on the same failure.
 
 Workspace close is the candidate release boundary. Disposing a realization
 alone does not release its transferred artifact session, so a streaming caller
@@ -2356,24 +2438,37 @@ metadata as the limit.
 
 The target Release gates are:
 
-- `SparsePackageAssemblyProjection_RejectsReconstructedOrForeignAsset`
-- `SparsePackageAssemblyProjection_UsesOnlyCanonicalAssetFields`
-- `SparsePackageAssemblyProjection_OpensSelectedPackageEntryExactlyOnce`
-- `SparsePackageAssemblyProjection_DoesNotEnumerateOrOpenSiblingEntriesAfterBinding`
-- `SparsePackageAssemblyProjection_ExactAggregatePartitionBoundary`
-- `SparsePackageAssemblyProjection_FileSystemLengthUsesManifestPreflight`
-- `SparsePackageAssemblyProjection_DeclaredOrObservedBytesMapToEntryLimit`
-- `SparsePackageAssemblyProjection_CompatibilityCasesUseMetadataOutcome`
-- `SparsePackageAssemblyProjection_RejectionCarrierIsDeterministicAndNotDecoded`
-- `SparsePackageAssemblyProjection_EmptyCompileGroupImplementationCanProject`
-- `SparsePackageAssemblyProjection_PublishesOneExactParticipantOrNone`
-- `SparsePackageAssemblyProjection_PreservesBindingCorrespondence`
-- `SparsePackageAssemblyProjection_CancellationDuringMaterializationPublishesNone`
-- `SparsePackageAssemblyProjection_CloseWaitsForActiveQueryCallback`
-- `SparsePackageAssemblyProjection_RealizationDisposeRetainsArtifactUntilWorkspaceClose`
-- `SparsePackageAssemblyProjection_TerminalPathsReleaseLeaseAndSession`
-- `SparsePackageAssemblyProjection_CleanupFailurePreservesPrimaryCondition`
-- `SparsePackageAssemblyProjection_BrowserConsumerExecutesQueryThroughGroup`
+The Release gates in `SparsePackageAssemblyProjectionTests` are:
+
+- `Projection_PublishesOneExactParticipantForCanonicalAsset`, which also closes
+  exactly one entry open and no sibling enumeration or reselection after
+  binding
+- `Projection_RetainsProducerPinnedPackageProvenance`
+- `Projection_RejectsReconstructedOrForeignSelectedAsset`
+- `Projection_RejectsGenerationMismatchBeforeContentAccess`
+- `Projection_AggregatePartitionAdmitsAtTwiceTheImage`, the exact `2N` accept
+  and `2N - 1` reject boundary
+- `Projection_DeclaredEntryLimitRejectsBeforeOpen`, paired with
+  `FileSystemPackageContentManifestTests.FileSystemLengthUsesManifestPreflight`
+  for the product filesystem manifest
+- `Projection_ObservedBytesBeyondDeclaredLengthExceedLimit`
+- `Projection_ReportsSelectedEntryUnavailableWithoutContent`
+- `Projection_ReportsArtifactPublicationFailureWithOwnerCodes`
+- `Projection_IncompleteCleanupProducesBoundedResourceFreeReceipt`
+- `Projection_CancellationKeepsCancellationAndAttachesReceipt`
+- `Projection_RunsProducerThroughOwnerAuthorizedQueryView`
+- `Projection_RejectedCarrierRefusesQueryWithOwnerFailure`
+- `Projection_CloseWaitsForActiveQueryThenDeniesAccess`
+- `ProjectionOptions_RequirePositiveExplicitBounds`
+
+Three contract-defining cases have no existing benign fixture and remain
+**unverified** in this slice: a malformed managed image that reaches
+`MalformedMetadata` rather than `NotAssembly`, an empty-MVID assembly, and a
+canonical implementation asset under an explicit empty compile group. The first
+two require crafted malformed binaries, which this repository's fixture policy
+does not admit; the third needs a Root fixture the package owner does not yet
+publish. The `IdentityDecoded`-versus-admission separation is still gated
+through the `NotAssembly` carrier case.
 
 The Package Query evaluator tracked by
 [#5785](https://github.com/richlander/dotnet-inspect/issues/5785) is the first
@@ -2750,6 +2845,167 @@ Both values are erasing projections. They strongly own no
 artifact, assembly context, artifact session, lease, provisional receipt,
 stream opener, delegate, or access authority. Holding either value after
 retirement cannot delay generation quiescence or resource release.
+
+#### Exact package Root acquisition and reacquisition
+
+Correspondence is Workspace-scoped, so it cannot reopen a Root after the
+candidate Workspace that issued it closes. A streaming consumer that closes one
+candidate Workspace per package and later needs the same logical Root — to
+re-run a query, to show provenance, or to hand a result back to a Browser host
+across a transport boundary — needs a second, Workspace-free currency.
+
+Artifact Acquisition therefore also issues an immutable, resource-free
+**reacquisition request** from a `PackageRootBinding`. It reuses the same
+logical package Root request currency as correspondence, including its
+framework and runtime normalization and its structural equality, so two
+requests are equal exactly when this owner classifies them as the same logical
+Root. It is not `PackageArtifactRootCorrespondence` and carries no Workspace
+identity.
+
+The request preserves two facts separately:
+
+- the realized producer-pinned acquisition coordinate, whose acquisition
+  framework may be absent for framework-neutral source acquisition; and
+- the normalized selection target framework and runtime identifier that froze
+  the binding's compile-asset selection.
+
+Keeping them separate is load-bearing. `WorkspaceContextLoader.LoadAsync`
+realizes every assembly in the Root and requires an acquisition target, so it
+cannot by itself express framework-neutral acquisition paired with a real
+selection target; collapsing the two facts would either fail with
+`MissingAcquisitionTarget` or silently select a different asset universe.
+
+The request carries no generation, selection identity, Workspace identity,
+content, session, lease, callback, opener, path authority, or credential. It is
+therefore safe to hold across candidate Workspace disposal and to observe a
+replacement physical generation, while never silently changing the requested
+target.
+
+##### One acquisition entry for both request forms
+
+A streaming consumer does not only reacquire. Its first candidate arrives as a
+caller-authored exact `ID@VERSION` coordinate, and every later visit to the
+same package arrives as the owner-issued reacquisition request. Both need the
+same thing: one package Root, acquired under the destination host's own policy,
+without full-role assembly realization.
+
+Artifact Acquisition therefore exposes **one** acquisition entry with two
+request forms rather than two acquisition paths. Both forms run the same
+authorization, resolution, and payload acquisition the Workspace loader
+already runs, so neither invents a source policy, a producer preference, or a
+second set of payload bounds. The entry creates no Workspace group and
+realizes no assembly universe, which is what separates it from
+`WorkspaceContextLoader`: that loader realizes every assembly in the Root and
+requires an acquisition target, so it cannot serve framework-neutral
+acquisition paired with a real selection target.
+
+The caller-authored form names an exact package id and version, because this
+owner performs no gallery, prefix, or floating-version discovery — a request
+that did not name an exact version would be asking for one. It names no
+producer: which authorized producer serves the bytes is the destination host's
+decision at acquisition time. Its ordinary shape derives the acquisition
+framework from the selection target; a separate framework-neutral shape states
+the separation explicitly, pairing package-level acquisition with an exact
+selection target, and accepts no runtime identifier because a realized
+coordinate's runtime identifier requires an acquisition framework.
+
+A successful acquisition returns the new `PackageRootBinding`, the live
+acquired payload it was formed from, and the producer-pinned reacquisition
+request issued for the Root that actually resulted. A consumer that started
+from an explicit coordinate therefore holds a reacquirable handle immediately
+and never has to rebuild one from display fields.
+
+The acquisition result is intentionally live and resource-bearing. The
+resource-free restriction is a property of the issued request — the value a
+host may retain past the candidate and hand across a transport boundary — and
+it does not extend to the result that produced it. Reading the result as
+resource-free would be the same misreading as treating the sparse projection's
+`Available` context as a durable resource-free fact.
+
+Exposing the payload is load-bearing for a destination that wraps the acquired
+package in its own coordinate type and verifies that the wrapper and the
+binding name the same content. The payload's content is the exact
+`IPackageContent` instance the binding reads through, so the destination adapts
+that instance and verifies it with the package owner's existing
+`PackageRootRealization.ReferencesContent`. Rebuilding a content handle from
+copied archive bytes instead would copy the payload and mint a second
+`PackageContentGenerationIdentity`, leaving the wrapper and the binding naming
+different retained generations while appearing to agree. Reacquisition served
+by a store entry likewise issues another handle over the same retained
+generation rather than a new one, so a destination may re-enter a Root after
+its candidate closes without paying for the bytes again.
+
+Source, authorization, and selection failures stay visible:
+
+- the authorized producer set is intersected with a pinned request's producer,
+  so a host authorizing several producers for that id still reacquires the Root
+  the binding came from, and an unauthorized producer is a typed
+  `ProducerNotAuthorized`;
+- an authorization naming no producer for a caller-authored coordinate is
+  `PackageUnavailable`, never a fallback to a default feed;
+- an unresolvable coordinate is a typed `InvalidCoordinate`;
+- content served by a producer other than the one a pinned request names is
+  `ProducerNotAuthorized`; and
+- a reacquired Root whose exact logical request differs from the one asked for
+  is `SelectionRequestNotReproduced` rather than a silent substitution.
+
+Typed compile-asset selection failure remains where the package owner already
+reports it, on the returned binding's selection status, so a replacement
+generation that no longer satisfies the selection target reports that
+owner-typed outcome instead of a neighboring asset set. Cancellation is not an
+outcome arm and propagates with the caller's token.
+
+##### The transport seam
+
+Hosts pass the issued request opaquely. Reconstructing one from package id,
+target framework, runtime identifier, asset path, or any other display field is
+outside the contract. In-process that is the value itself. Across a transport
+boundary — a Browser result that outlives the worker that produced it, or a
+candidate disposed before the user acts on the result — the owner also issues a
+single opaque token from the request and decodes it back.
+
+The token is this owner's, not a host format: its version tag, field order, and
+encoding are owner-owned, and only the owner's decode reads it. It carries
+exactly the facts the request carries and no content, generation, Workspace
+identity, session, lease, path, source URL, or credential.
+
+Decoding is total, because a token can arrive from an untrusted transport. It
+is bounded in length before parsing, requires the exact field count, and
+revalidates every field through the owner's own canonical coordinate and
+request construction, so a malformed, over-long, or forged token is a
+`false` return rather than an exception or a value this owner would not have
+issued. A token that is not already canonical is refused rather than silently
+normalized, so one request has exactly one token. A decoded request is a
+request, **not** an authorization: acquiring the Root it names still passes the
+destination host's own source authorization, transfer policy, and payload
+limits. Host caches, registries, credential handling, and worker transport stay
+outside this owner entirely.
+
+##### Release gates
+
+In `SparsePackageAssemblyProjectionTests`:
+`ReacquisitionRequest_IsExactResourceFreeAndSeparatesTargets`, which closes
+exactness, normalization, both the pinned-framework and framework-neutral
+shapes, and the resource-free property; and
+`ReacquisitionRequest_SurvivesCandidateWorkspaceDisposal`, which closes
+post-disposal replacement against a new content generation.
+
+In `PackageRootAcquisitionTests`:
+`ExplicitCoordinate_AcquiresRootAndIssuesExactRequest`,
+`Acquired_ExposesTheLiveContentTheBindingReads`,
+`ExactRequest_ReacquiresSameLogicalRootThroughToken`,
+`ExactRequest_SeparatesAcquisitionAndSelectionTargets`,
+`ExactRequest_ReopensAfterCandidateWorkspaceDisposal`,
+`ExplicitCoordinate_UnauthorizedSourcesFailVisibly`,
+`ExactRequest_UnauthorizedProducerFailsVisibly`,
+`Token_RoundTripsExactRequest`, `Token_RejectsMalformedOrNonCanonicalInput`,
+and `ExplicitRequest_StatesItsTargetContract`.
+
+Acquisition against a live feed over the network is **unverified** in this
+slice: the gates serve exact versions from a cached store and fail the test
+host's HTTP client on any request, which exercises authorization, resolution,
+payload acquisition, binding, and the issued request without a network
+dependency.
 
 `ArtifactRootScopeProjection` is an immutable snapshot, not a live view.
 Consumers may retain `ArtifactRootCorrespondence` as logical identity and may

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -2981,6 +2981,13 @@ destination host's own source authorization, transfer policy, and payload
 limits. Host caches, registries, credential handling, and worker transport stay
 outside this owner entirely.
 
+Binding factories use one runtime identifier for acquisition and selection.
+Decoding therefore requires the selection runtime to equal the acquisition
+coordinate's already validated runtime, including agreement on absence.
+This also rejects invalid runtime syntax without duplicating the coordinate
+owner's grammar. Acquisition and selection frameworks may still differ;
+framework-neutral acquisition with a real selection target remains valid.
+
 ##### Release gates
 
 In `SparsePackageAssemblyProjectionTests`:
@@ -2999,7 +3006,8 @@ In `PackageRootAcquisitionTests`:
 `ExplicitCoordinate_UnauthorizedSourcesFailVisibly`,
 `ExactRequest_UnauthorizedProducerFailsVisibly`,
 `Token_RoundTripsExactRequest`, `Token_RejectsMalformedOrNonCanonicalInput`,
-and `ExplicitRequest_StatesItsTargetContract`.
+`Token_RejectsSelectionRuntimeNotIssuedByBinding`, and
+`ExplicitRequest_StatesItsTargetContract`.
 
 Acquisition against a live feed over the network is **unverified** in this
 slice: the gates serve exact versions from a cached store and fail the test

--- a/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
+++ b/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
@@ -122,6 +122,9 @@ public abstract class ArtifactSetPublicationOutcome
 /// </remarks>
 public sealed class ArtifactSetSession : IAsyncDisposable
 {
+    private const string CleanupFailuresKey =
+        "DotnetInspector.Artifacts.Workspaces.CleanupFailures";
+
     private readonly object _gate = new();
     private readonly ArtifactGenerationAuthority _authority = new();
     private readonly ArtifactAdmissionAuthorization _admission;
@@ -220,13 +223,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
             scope.Dispose();
             IReadOnlyList<Exception> cleanupFailures =
                 await AbortAsync().ConfigureAwait(false);
-            if (cleanupFailures.Count > 0)
-            {
-                ex.Data[
-                    "DotnetInspector.Artifacts.Workspaces.CleanupFailures"] =
-                    cleanupFailures;
-            }
-
+            AttachCleanupFailures(ex, cleanupFailures);
             throw;
         }
         finally
@@ -297,9 +294,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                 IReadOnlyList<Exception> cleanupFailures =
                     new ReadOnlyCollection<Exception>([ex]);
                 RecordCleanupFailures(cleanupFailures);
-                disposed.Data[
-                    "DotnetInspector.Artifacts.Workspaces.CleanupFailures"] =
-                    cleanupFailures;
+                AttachCleanupFailures(disposed, cleanupFailures);
             }
         }
 
@@ -861,21 +856,16 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         {
             IReadOnlyList<Exception> cleanupFailures =
                 await AbortAsync().ConfigureAwait(false);
-            if (cleanupFailures.Count > 0)
-            {
-                ex.Data[
-                    "DotnetInspector.Artifacts.Workspaces.CleanupFailures"] =
-                    cleanupFailures;
-            }
-
+            AttachCleanupFailures(ex, cleanupFailures);
             throw;
         }
         catch (ObjectDisposedException) when (IsDisposed())
         {
             throw;
         }
-        catch (ArtifactMaterializationLimitException)
+        catch (ArtifactMaterializationLimitException ex)
         {
+            RecordMaterializationCleanupFailures(ex);
             failures.Add(
                 Failure(
                     ArtifactSetAdmissionFailureKind.Rejected,
@@ -892,6 +882,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                     "The artifact session was disposed during publication.");
             }
 
+            RecordMaterializationCleanupFailures(ex);
             failures.Add(
                 Failure(
                     ArtifactSetAdmissionFailureKind.Failed,
@@ -1269,8 +1260,9 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                 }
             }
         }
-        catch (ArtifactMaterializationLimitException)
+        catch (ArtifactMaterializationLimitException ex)
         {
+            RecordMaterializationCleanupFailures(ex);
             return new RequiredCheckpointResult(
                 [],
                 0,
@@ -1282,6 +1274,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         catch (Exception ex) when (
             !IsDisposed() && IsMaterializationFailure(ex))
         {
+            RecordMaterializationCleanupFailures(ex);
             return new RequiredCheckpointResult(
                 [],
                 0,
@@ -1378,8 +1371,9 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                         snapshot));
             }
         }
-        catch (ArtifactMaterializationLimitException)
+        catch (ArtifactMaterializationLimitException ex)
         {
+            RecordMaterializationCleanupFailures(ex);
             return new SupplementalMaterializationResult(
                 [],
                 0,
@@ -1391,6 +1385,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         catch (Exception ex) when (
             !IsDisposed() && IsMaterializationFailure(ex))
         {
+            RecordMaterializationCleanupFailures(ex);
             return new SupplementalMaterializationResult(
                 [],
                 0,
@@ -1513,17 +1508,61 @@ public sealed class ArtifactSetSession : IAsyncDisposable
             or InvalidOperationException
             or OverflowException;
 
-    private static void AttachCleanupFailures(
+    /// <summary>
+    /// Attaches cleanup evidence to a primary exception, merging with any this
+    /// owner already attached.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Cleanup evidence is always secondary and additive. Callers outside this
+    /// assembly use this entry rather than writing the key directly, because a
+    /// raw assignment would replace evidence an earlier stage attached to the
+    /// same exception — for example a throwing stream disposal recorded during
+    /// materialization, which must survive a later release sweep over the same
+    /// failure.
+    /// </para>
+    /// <para>
+    /// Read it back with <see cref="GetCleanupFailures"/>. Gated by
+    /// <c>ArtifactSetSessionCleanupEvidenceTests.AttachedCleanupEvidenceMergesRatherThanReplaces</c>.
+    /// </para>
+    /// </remarks>
+    public static void AttachCleanupFailures(
         Exception primary,
         IReadOnlyList<Exception> cleanupFailures)
     {
-        if (cleanupFailures.Count > 0)
-        {
-            primary.Data[
-                "DotnetInspector.Artifacts.Workspaces.CleanupFailures"] =
-                cleanupFailures;
-        }
+        ArgumentNullException.ThrowIfNull(primary);
+        ArgumentNullException.ThrowIfNull(cleanupFailures);
+        if (cleanupFailures.Count == 0)
+            return;
+
+        primary.Data[CleanupFailuresKey] =
+            primary.Data[CleanupFailuresKey]
+                is IReadOnlyList<Exception> existing
+                ? new ReadOnlyCollection<Exception>(
+                    [.. existing, .. cleanupFailures])
+                : cleanupFailures;
     }
+
+    /// <summary>
+    /// Reads the cleanup failures this owner attached to a primary exception.
+    /// </summary>
+    /// <remarks>
+    /// Cleanup evidence is always secondary: a cancelled or failed
+    /// materialization keeps its own exception and token, and a throwing
+    /// stream disposal is reported here instead of replacing it. Gated by
+    /// <c>ArtifactSetSessionCleanupEvidenceTests.DisposalFailureDoesNotReplaceCancelledRead</c>.
+    /// </remarks>
+    public static IReadOnlyList<Exception> GetCleanupFailures(
+        Exception failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return failure.Data[CleanupFailuresKey]
+            as IReadOnlyList<Exception>
+            ?? [];
+    }
+
+    private void RecordMaterializationCleanupFailures(Exception failure) =>
+        RecordCleanupFailures(GetCleanupFailures(failure));
 
     private static void AttachAdmissionFailures(
         Exception primary,
@@ -1548,7 +1587,42 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         long maxArtifactBytes,
         CancellationToken cancellationToken)
     {
-        using Stream stream = contribution.OpenRead(_admissionLease);
+        Stream stream = contribution.OpenRead(_admissionLease);
+        Exception? primary = null;
+        try
+        {
+            return await CopyBoundedAsync(
+                    stream,
+                    maxArtifactBytes,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception failure)
+        {
+            primary = failure;
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                stream.Dispose();
+            }
+            // A throwing disposal must not replace the cancellation or read
+            // failure that is already being reported; it stays secondary
+            // evidence on that exact exception.
+            catch (Exception disposalFailure) when (primary is not null)
+            {
+                AttachCleanupFailures(primary, [disposalFailure]);
+            }
+        }
+    }
+
+    private static async ValueTask<byte[]> CopyBoundedAsync(
+        Stream stream,
+        long maxArtifactBytes,
+        CancellationToken cancellationToken)
+    {
         if (stream.CanSeek
             && checked(stream.Length - stream.Position)
                 > maxArtifactBytes)

--- a/src/DotnetInspector.Packages/Storage/FileSystemPackageContent.cs
+++ b/src/DotnetInspector.Packages/Storage/FileSystemPackageContent.cs
@@ -8,7 +8,18 @@ namespace DotnetInspector.Packages;
 /// <see cref="RootPath"/>. This is the desktop content: the extracted directory
 /// itself is what the CLI's existing consumers open by path.
 /// </summary>
-public sealed class FileSystemPackageContent : IPackageContent
+/// <remarks>
+/// The extracted file length is the declared entry length, so this content also
+/// implements <see cref="IPackageContentEntryManifest"/>. Without it, a bounded
+/// caller would only learn that an entry is over budget from the
+/// <see cref="InvalidDataException"/> raised inside
+/// <see cref="TryOpenEntry(string, long, out Stream?)"/>, which is
+/// indistinguishable from an unrelated read failure. Gated by
+/// <c>FileSystemPackageContentManifestTests.FileSystemLengthUsesManifestPreflight</c>.
+/// </remarks>
+public sealed class FileSystemPackageContent :
+    IPackageContent,
+    IPackageContentEntryManifest
 {
     private readonly string _root;
 
@@ -102,6 +113,42 @@ public sealed class FileSystemPackageContent : IPackageContent
         {
             yield return Path.GetRelativePath(_root, file).Replace(Path.DirectorySeparatorChar, '/');
         }
+    }
+
+    /// <inheritdoc />
+    public bool TryGetEntryLength(string relativePath, out long length)
+    {
+        var file = new FileInfo(ResolveEntryPath(relativePath));
+        if (!file.Exists)
+        {
+            length = 0;
+            return false;
+        }
+
+        length = file.Length;
+        return true;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<PackageContentEntry> EnumerateEntriesWithLengths()
+    {
+        if (!Directory.Exists(_root))
+            return [];
+
+        var entries = new List<PackageContentEntry>();
+        foreach (var file in Directory.EnumerateFiles(
+            _root,
+            "*",
+            SearchOption.AllDirectories))
+        {
+            entries.Add(
+                new PackageContentEntry(
+                    Path.GetRelativePath(_root, file)
+                        .Replace(Path.DirectorySeparatorChar, '/'),
+                    new FileInfo(file).Length));
+        }
+
+        return entries;
     }
 
     private string ResolveEntryPath(string relativePath)

--- a/src/DotnetInspector.Queries.Tests/PackageRootAcquisitionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageRootAcquisitionTests.cs
@@ -1,0 +1,604 @@
+using System.IO.Compression;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+
+using DotnetInspector.Packages;
+using ILInspector.Metadata;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries.Tests;
+
+/// <summary>
+/// Acquiring one exact package Root without full-role assembly realization,
+/// from an explicit coordinate and from the owner-issued exact reacquisition
+/// request, including the opaque token a host hands across a transport
+/// boundary.
+/// </summary>
+public sealed class PackageRootAcquisitionTests
+{
+    const string PackageId = "acq.sample";
+    const string Version = "1.0.0";
+    const string Framework = "net11.0";
+    const string AssemblyName = "Acq.Sample";
+
+    static readonly PackageSource NuGetOrg = PackageSource.NuGetOrg;
+    static readonly PackageSource Private =
+        new("private", "https://private.test/v3/index.json");
+
+    [Fact]
+    public async Task ExplicitCoordinate_AcquiresRootAndIssuesExactRequest()
+    {
+        using var http = new HttpClient(new FailingHandler());
+        IPackageStore store = await CachedStoreAsync(LibraryPackage());
+
+        var acquired = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                PackageRootAcquisitionRequest.Create(
+                    PackageId,
+                    Version,
+                    Framework),
+                Options(http, store),
+                TestContext.Current.CancellationToken));
+
+        PackageRootBinding binding = acquired.Binding;
+        Assert.Equal(PackageId, binding.Coordinate.PackageId);
+        Assert.Equal(Version, binding.Coordinate.Version);
+        Assert.Equal(
+            NuGetCache.GetSourceKey(NuGetOrg.Url),
+            binding.Coordinate.Producer);
+        Assert.Equal(Framework, binding.Coordinate.Framework);
+        Assert.Null(binding.Coordinate.RuntimeIdentifier);
+        Assert.Equal(
+            $"lib/{Framework}/{AssemblyName}.dll",
+            binding.Root.AssetSelection.Assets.Single().Path);
+
+        // The issued request is the binding's own, so a consumer that started
+        // from an explicit coordinate holds a reacquirable handle immediately.
+        Assert.Equal(binding.CreateReacquisitionRequest(), acquired.Request);
+        Assert.Equal(Framework, acquired.Request.SelectionTargetFramework);
+    }
+
+    [Fact]
+    public async Task Acquired_ExposesTheLiveContentTheBindingReads()
+    {
+        using var http = new HttpClient(new FailingHandler());
+        IPackageStore store = await CachedStoreAsync(LibraryPackage());
+        WorkspaceContextLoadOptions options = Options(http, store);
+
+        var first = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                PackageRootAcquisitionRequest.Create(
+                    PackageId,
+                    Version,
+                    Framework),
+                options,
+                TestContext.Current.CancellationToken));
+
+        // The destination adapts this instance; it is the one the binding
+        // reads through, so an exact-content check against the binding holds
+        // without the destination re-deriving source or selection authority.
+        IPackageContent content = first.Payload.Content;
+        Assert.True(first.Binding.Root.ReferencesContent(content));
+        Assert.Same(
+            content.GenerationIdentity,
+            first.Binding.ContentGenerationIdentity);
+        Assert.Equal(
+            first.Binding.Coordinate.Producer,
+            first.Payload.ProducerKey);
+        Assert.Equal(content.ProducerKey, first.Payload.ProducerKey);
+
+        var second = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                first.Request,
+                options,
+                TestContext.Current.CancellationToken));
+
+        // Reacquiring the same retained generation issues another handle over
+        // it rather than copying the archive or minting a second generation.
+        Assert.Same(
+            content.GenerationIdentity,
+            second.Payload.Content.GenerationIdentity);
+        Assert.True(
+            second.Binding.Root.ReferencesContent(second.Payload.Content));
+        Assert.Equal(
+            PackagePayloadOrigin.Cache,
+            second.Payload.Origin);
+    }
+
+    [Fact]
+    public async Task ExactRequest_ReacquiresSameLogicalRootThroughToken()
+    {
+        using var http = new HttpClient(new FailingHandler());
+        IPackageStore store = await CachedStoreAsync(LibraryPackage());
+        WorkspaceContextLoadOptions options = Options(http, store);
+
+        var first = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                PackageRootAcquisitionRequest.Create(
+                    PackageId,
+                    Version,
+                    Framework),
+                options,
+                TestContext.Current.CancellationToken));
+
+        Assert.True(
+            PackageRootReacquisitionRequest.TryDecode(
+                first.Request.Encode(),
+                out PackageRootReacquisitionRequest? decoded));
+
+        var second = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                decoded,
+                options,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(first.Request, second.Request);
+        Assert.Equal(
+            first.Binding.Root.AssetSelection.Assets.Single().Path,
+            second.Binding.Root.AssetSelection.Assets.Single().Path);
+        Assert.NotSame(first.Binding, second.Binding);
+        Assert.NotSame(first.Binding.SelectionIdentity, second.Binding.SelectionIdentity);
+    }
+
+    [Fact]
+    public async Task ExactRequest_SeparatesAcquisitionAndSelectionTargets()
+    {
+        using var http = new HttpClient(new FailingHandler());
+        IPackageStore store = await CachedStoreAsync(
+            LibraryPackage("netstandard2.0"));
+        WorkspaceContextLoadOptions options = Options(http, store);
+
+        PackageRootAcquisitionRequest explicitRequest =
+            PackageRootAcquisitionRequest.CreateFrameworkNeutral(
+                PackageId,
+                Version,
+                "netstandard2.0");
+        Assert.Null(explicitRequest.AcquisitionFramework);
+        Assert.Equal(
+            "netstandard2.0",
+            explicitRequest.SelectionTargetFramework);
+
+        var acquired = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                explicitRequest,
+                options,
+                TestContext.Current.CancellationToken));
+
+        Assert.Null(acquired.Binding.Coordinate.Framework);
+        Assert.Equal(
+            "netstandard2.0",
+            acquired.Request.SelectionTargetFramework);
+        Assert.Equal(
+            $"lib/netstandard2.0/{AssemblyName}.dll",
+            acquired.Binding.Root.AssetSelection.Assets.Single().Path);
+
+        // The separation survives the transport seam and reacquisition.
+        Assert.True(
+            PackageRootReacquisitionRequest.TryDecode(
+                acquired.Request.Encode(),
+                out PackageRootReacquisitionRequest? decoded));
+        Assert.Null(decoded.Coordinate.Framework);
+
+        var reacquired = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                decoded,
+                options,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(acquired.Request, reacquired.Request);
+        Assert.Equal(
+            $"lib/netstandard2.0/{AssemblyName}.dll",
+            reacquired.Binding.Root.AssetSelection.Assets.Single().Path);
+    }
+
+    [Fact]
+    public async Task ExactRequest_ReopensAfterCandidateWorkspaceDisposal()
+    {
+        using var http = new HttpClient(new FailingHandler());
+        IPackageStore store = await CachedStoreAsync(LibraryPackage());
+        WorkspaceContextLoadOptions options = Options(http, store);
+
+        var acquired = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                PackageRootAcquisitionRequest.Create(
+                    PackageId,
+                    Version,
+                    Framework),
+                options,
+                TestContext.Current.CancellationToken));
+        string token = acquired.Request.Encode();
+
+        await using (InspectionWorkspace candidate =
+            InspectionWorkspace.CreateAsynchronous())
+        {
+            using SparsePackageAssemblyRealization realization =
+                await ProjectAsync(candidate, acquired.Binding);
+            Assert.Equal(
+                AssemblyName,
+                Named(realization));
+            await candidate.CloseAsync();
+        }
+
+        // Only the token survives the candidate; it reopens the same logical
+        // Root in a fresh Workspace with no retained resource in between.
+        Assert.True(
+            PackageRootReacquisitionRequest.TryDecode(
+                token,
+                out PackageRootReacquisitionRequest? decoded));
+        var replacement =
+            Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+                await PackageRootAcquisition.AcquireAsync(
+                    decoded,
+                    options,
+                    TestContext.Current.CancellationToken));
+
+        await using InspectionWorkspace reopened =
+            InspectionWorkspace.CreateAsynchronous();
+        using SparsePackageAssemblyRealization second =
+            await ProjectAsync(reopened, replacement.Binding);
+        Assert.Equal(AssemblyName, Named(second));
+    }
+
+    [Fact]
+    public async Task ExplicitCoordinate_UnauthorizedSourcesFailVisibly()
+    {
+        using var http = new HttpClient(new FailingHandler());
+
+        var failed = Assert.IsType<PackageRootAcquisitionOutcome.Failed>(
+            await PackageRootAcquisition.AcquireAsync(
+                PackageRootAcquisitionRequest.Create(
+                    PackageId,
+                    Version,
+                    Framework),
+                Options(
+                    http,
+                    new InMemoryPackageStore(),
+                    new DenyingAuthorization()),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            PackageRootAcquisitionFailureKind.PackageUnavailable,
+            failed.Kind);
+        Assert.False(string.IsNullOrWhiteSpace(failed.Message));
+    }
+
+    [Fact]
+    public async Task ExactRequest_UnauthorizedProducerFailsVisibly()
+    {
+        using var http = new HttpClient(new FailingHandler());
+        IPackageStore store = await CachedStoreAsync(LibraryPackage());
+        var acquired = Assert.IsType<PackageRootAcquisitionOutcome.Acquired>(
+            await PackageRootAcquisition.AcquireAsync(
+                PackageRootAcquisitionRequest.Create(
+                    PackageId,
+                    Version,
+                    Framework),
+                Options(http, store),
+                TestContext.Current.CancellationToken));
+
+        var denied = Assert.IsType<PackageRootAcquisitionOutcome.Failed>(
+            await PackageRootAcquisition.AcquireAsync(
+                acquired.Request,
+                Options(http, store, new DenyingAuthorization()),
+                TestContext.Current.CancellationToken));
+        Assert.Equal(
+            PackageRootAcquisitionFailureKind.ProducerNotAuthorized,
+            denied.Kind);
+        Assert.False(string.IsNullOrWhiteSpace(denied.Message));
+
+        // A host that authorizes some other producer for this id does not get
+        // a substitute Root: the pinned producer is the only one that answers.
+        var substituted = Assert.IsType<PackageRootAcquisitionOutcome.Failed>(
+            await PackageRootAcquisition.AcquireAsync(
+                acquired.Request,
+                Options(
+                    http,
+                    store,
+                    new UniformPackageSourceAuthorization([Private])),
+                TestContext.Current.CancellationToken));
+        Assert.Equal(
+            PackageRootAcquisitionFailureKind.ProducerNotAuthorized,
+            substituted.Kind);
+    }
+
+    [Fact]
+    public void Token_RoundTripsExactRequest()
+    {
+        foreach (PackageRootReacquisitionRequest request in
+            new[]
+            {
+                Request(Framework, null, Framework, null),
+                Request(Framework, "win-x64", Framework, "win-x64"),
+                Request(null, null, "netstandard2.0", null),
+                Request(null, null, null, null),
+            })
+        {
+            string token = request.Encode();
+            Assert.StartsWith(
+                PackageRootReacquisitionRequest.TokenPrefix,
+                token,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain('=', token);
+            Assert.True(
+                token.Length
+                    <= PackageRootReacquisitionRequest.MaxEncodedLength);
+
+            Assert.True(
+                PackageRootReacquisitionRequest.TryDecode(
+                    token,
+                    out PackageRootReacquisitionRequest? decoded));
+            Assert.Equal(request, decoded);
+            Assert.Equal(request.GetHashCode(), decoded.GetHashCode());
+            Assert.Equal(token, decoded.Encode());
+        }
+
+        // Distinct requests do not share a token.
+        Assert.NotEqual(
+            Request(Framework, null, Framework, null).Encode(),
+            Request(Framework, "win-x64", Framework, "win-x64").Encode());
+    }
+
+    [Fact]
+    public void Token_RejectsMalformedOrNonCanonicalInput()
+    {
+        string valid = Request(Framework, null, Framework, null).Encode();
+        Assert.True(
+            PackageRootReacquisitionRequest.TryDecode(valid, out _));
+
+        foreach (string? candidate in
+            new string?[]
+            {
+                null,
+                string.Empty,
+                "pkgroot0" + valid[8..],
+                valid[8..],
+                string.Join('.', valid.Split('.')[..^1]),
+                valid + ".",
+                Token("A!", "1.0.0", "nuget.org", null, null, null, null),
+                Token("AAAAA", "1.0.0", "nuget.org", null, null, null, null),
+                Token("__4", "1.0.0", "nuget.org", null, null, null, null),
+                Token(null, Version, "nuget.org", null, null, null, null),
+                Token(PackageId, Version, null, null, null, null, null),
+                Token(
+                    "not a package id",
+                    Version,
+                    "nuget.org",
+                    null,
+                    null,
+                    null,
+                    null),
+                Token(
+                    PackageId,
+                    Version,
+                    "nuget.org",
+                    "net11.0",
+                    "WIN-X64",
+                    "net11.0",
+                    "win-x64"),
+                // Canonical facts spelled non-canonically: refused rather
+                // than normalized, so one request has exactly one token.
+                Token(
+                    PackageId,
+                    Version,
+                    "nuget.org",
+                    null,
+                    null,
+                    ".NETStandard,Version=v2.0",
+                    null),
+                Token(
+                    PackageId,
+                    Version,
+                    "nuget.org",
+                    "net11.0",
+                    "win-x64",
+                    "net11.0",
+                    "WIN-X64"),
+                Token(
+                    new string('a', 600),
+                    new string('1', 600),
+                    "nuget.org",
+                    null,
+                    null,
+                    null,
+                    null),
+            })
+        {
+            Assert.False(
+                PackageRootReacquisitionRequest.TryDecode(
+                    candidate,
+                    out PackageRootReacquisitionRequest? decoded),
+                $"Decoding should have refused: {candidate ?? "<null>"}");
+            Assert.Null(decoded);
+        }
+    }
+
+    [Fact]
+    public void ExplicitRequest_StatesItsTargetContract()
+    {
+        PackageRootAcquisitionRequest neutral =
+            PackageRootAcquisitionRequest.Create(PackageId, Version);
+        Assert.Null(neutral.AcquisitionFramework);
+        Assert.Null(neutral.SelectionTargetFramework);
+
+        PackageRootAcquisitionRequest targeted =
+            PackageRootAcquisitionRequest.Create(
+                PackageId,
+                Version,
+                "NET11.0",
+                "win-x64");
+        Assert.Equal(Framework, targeted.AcquisitionFramework);
+        Assert.Equal("NET11.0", targeted.SelectionTargetFramework);
+        Assert.Equal("win-x64", targeted.SelectionRuntimeIdentifier);
+
+        Assert.Throws<ArgumentException>(
+            () => PackageRootAcquisitionRequest.Create(
+                PackageId,
+                Version,
+                Framework,
+                "WIN-X64"));
+        Assert.Throws<ArgumentException>(
+            () => PackageRootAcquisitionRequest.Create(
+                PackageId,
+                Version,
+                ".NETStandard,Version=v2.0",
+                "win-x64"));
+        Assert.Throws<ArgumentException>(
+            () => PackageRootAcquisitionRequest.Create(PackageId, " "));
+
+        // Framework-neutral acquisition states the separation explicitly
+        // rather than inferring it from an unusable selection spelling.
+        PackageRootAcquisitionRequest agnostic =
+            PackageRootAcquisitionRequest.CreateFrameworkNeutral(
+                PackageId,
+                Version,
+                "netstandard2.0");
+        Assert.Null(agnostic.AcquisitionFramework);
+        Assert.Equal("netstandard2.0", agnostic.SelectionTargetFramework);
+        Assert.Null(agnostic.SelectionRuntimeIdentifier);
+        Assert.Throws<ArgumentException>(
+            () => PackageRootAcquisitionRequest.CreateFrameworkNeutral(
+                PackageId,
+                Version,
+                " "));
+    }
+
+    static string Named(SparsePackageAssemblyRealization realization) =>
+        Assert.IsType<ArtifactAssemblyQueryOutcome<string>.Validated>(
+            realization.ExecuteAssemblyQuery(
+                (session, _) => session.IdentityNames().Name,
+                TestContext.Current.CancellationToken)).Value;
+
+    static async Task<SparsePackageAssemblyRealization> ProjectAsync(
+        InspectionWorkspace workspace,
+        PackageRootBinding binding) =>
+        Assert.IsType<SparsePackageAssemblyProjectionOutcome.Available>(
+            await workspace.ProjectSelectedPackageAssemblyAsync(
+                binding,
+                binding.Root.AssetSelection.Assets.Single(),
+                new SparsePackageAssemblyProjectionOptions
+                {
+                    MaxSelectedEntryBytes = 4 * 1024 * 1024,
+                    MaxAggregateRetainedImageBytes = 8 * 1024 * 1024,
+                },
+                TestContext.Current.CancellationToken)).Realization;
+
+    static PackageRootReacquisitionRequest Request(
+        string? acquisitionFramework,
+        string? acquisitionRuntimeIdentifier,
+        string? selectionTargetFramework,
+        string? selectionRuntimeIdentifier)
+    {
+        Assert.True(
+            RealizedMemberCoordinate.Package.TryCreate(
+                PackageId,
+                Version,
+                NuGetCache.GetSourceKey(NuGetOrg.Url),
+                acquisitionFramework,
+                acquisitionRuntimeIdentifier,
+                out RealizedMemberCoordinate.Package? coordinate,
+                out string? problem),
+            problem);
+        return new PackageRootReacquisitionRequest(
+            PackageArtifactRootRequest.Create(
+                coordinate,
+                selectionTargetFramework,
+                selectionRuntimeIdentifier));
+    }
+
+    static string Token(params string?[] fields)
+    {
+        var builder = new StringBuilder(
+            PackageRootReacquisitionRequest.TokenPrefix);
+        foreach (string? field in fields)
+        {
+            builder.Append('.');
+            if (string.IsNullOrEmpty(field))
+                continue;
+
+            builder.Append(
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(field))
+                    .TrimEnd('=')
+                    .Replace('+', '-')
+                    .Replace('/', '_'));
+        }
+
+        return builder.ToString();
+    }
+
+    static WorkspaceContextLoadOptions Options(
+        HttpClient client,
+        IPackageStore store,
+        IPackageSourceAuthorization? authorization = null) =>
+        new()
+        {
+            HttpClient = client,
+            SourceAuthorization = authorization
+                ?? new UniformPackageSourceAuthorization([NuGetOrg]),
+            PackageStore = store,
+        };
+
+    static async Task<IPackageStore> CachedStoreAsync(byte[] nupkg)
+    {
+        var store = new InMemoryPackageStore();
+        await store.CommitAsync(
+            PackageId,
+            Version,
+            NuGetCache.GetSourceKey(NuGetOrg.Url),
+            new MemoryStream(nupkg),
+            TestContext.Current.CancellationToken);
+        return store;
+    }
+
+    static byte[] LibraryPackage(string framework = Framework)
+    {
+        byte[] image = IntegrationAssembly();
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(
+            buffer,
+            ZipArchiveMode.Create,
+            leaveOpen: true))
+        {
+            using Stream stream = archive
+                .CreateEntry($"lib/{framework}/{AssemblyName}.dll")
+                .Open();
+            stream.Write(image, 0, image.Length);
+        }
+
+        return buffer.ToArray();
+    }
+
+    static byte[] IntegrationAssembly()
+    {
+        var assemblyBuilder = new PersistedAssemblyBuilder(
+            new AssemblyName(AssemblyName),
+            typeof(object).Assembly);
+        ModuleBuilder module =
+            assemblyBuilder.DefineDynamicModule(AssemblyName);
+        TypeBuilder type = module.DefineType(
+            "SampleType",
+            TypeAttributes.Public | TypeAttributes.Class);
+        type.DefineDefaultConstructor(MethodAttributes.Public);
+        type.CreateType();
+
+        using var stream = new MemoryStream();
+        assemblyBuilder.Save(stream);
+        return stream.ToArray();
+    }
+
+    sealed class DenyingAuthorization : IPackageSourceAuthorization
+    {
+        public PackageSourceAuthorization AuthorizeSourcesFor(
+            string packageId) =>
+            PackageSourceAuthorization.Deny(
+                "no producer is authorized in this test host");
+    }
+
+    sealed class FailingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException(
+                $"Unexpected network request: {request.RequestUri}");
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/PackageRootAcquisitionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageRootAcquisitionTests.cs
@@ -309,6 +309,8 @@ public sealed class PackageRootAcquisitionTests
             {
                 Request(Framework, null, Framework, null),
                 Request(Framework, "win-x64", Framework, "win-x64"),
+                Request(Framework, null, "netstandard2.0", null),
+                Request(Framework, "win-x64", "netstandard2.0", "win-x64"),
                 Request(null, null, "netstandard2.0", null),
                 Request(null, null, null, null),
             })
@@ -410,6 +412,30 @@ public sealed class PackageRootAcquisitionTests
                 $"Decoding should have refused: {candidate ?? "<null>"}");
             Assert.Null(decoded);
         }
+    }
+
+    [Theory]
+    [InlineData(null, "win-x64")]
+    [InlineData(null, "not a rid")]
+    [InlineData("win-x64", null)]
+    [InlineData("win-x64", "linux-x64")]
+    [InlineData("win-x64", "not a rid")]
+    public void Token_RejectsSelectionRuntimeNotIssuedByBinding(
+        string? acquisitionRuntimeIdentifier,
+        string? selectionRuntimeIdentifier)
+    {
+        string token = Token(
+            PackageId,
+            Version,
+            NuGetCache.GetSourceKey(NuGetOrg.Url),
+            Framework,
+            acquisitionRuntimeIdentifier,
+            Framework,
+            selectionRuntimeIdentifier);
+
+        Assert.False(
+            PackageRootReacquisitionRequest.TryDecode(token, out var decoded));
+        Assert.Null(decoded);
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries.Tests/SparsePackageAssemblyProjectionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/SparsePackageAssemblyProjectionTests.cs
@@ -1,0 +1,975 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using DotnetInspector.Artifacts.Workspaces;
+using DotnetInspector.Packages;
+using ILInspector.Metadata;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class SparsePackageAssemblyProjectionTests
+{
+    const string Framework = "net11.0";
+    const string AssetPath = "lib/net11.0/Sparse.Sample.dll";
+
+    [Fact]
+    public async Task Projection_PublishesOneExactParticipantForCanonicalAsset()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Sample", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Sample", content);
+        // Compile-asset selection is the binding's own frozen work; the
+        // projection may add none of its own.
+        int enumerationsBeforeProjection = content.EnumerationRequests;
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        SparsePackageAssemblyProjectionOutcome outcome =
+            await workspace.ProjectSelectedPackageAssemblyAsync(
+                binding,
+                SelectedAsset(binding),
+                Bounds(image.LongLength),
+                TestContext.Current.CancellationToken);
+
+        var available =
+            Assert.IsType<SparsePackageAssemblyProjectionOutcome.Available>(
+                outcome);
+        using SparsePackageAssemblyRealization realization =
+            available.Realization;
+        Assert.Same(SelectedAsset(binding), realization.Asset);
+        Assert.Same(
+            realization.Participant,
+            Assert.Single(realization.Group.Participants));
+        Assert.True(realization.IdentityDecoded);
+        var projected =
+            Assert.IsType<ArtifactAssemblyProjectionOutcome.Projected>(
+                realization.Admission);
+        Assert.Equal("Sparse.Sample", projected.Value.Identity.Name);
+        Assert.NotEqual(Guid.Empty, projected.Value.Registration.ModuleVersionId);
+
+        // Exactly one source entry is opened, and no sibling is enumerated or
+        // reselected after binding.
+        Assert.Equal(1, content.EntryOpenRequests);
+        Assert.Equal(
+            enumerationsBeforeProjection,
+            content.EnumerationRequests);
+    }
+
+    [Fact]
+    public async Task Projection_RetainsProducerPinnedPackageProvenance()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Provenance", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("sparse.provenance", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        using SparsePackageAssemblyRealization realization =
+            await ProjectAsync(workspace, binding, image.LongLength);
+
+        var registration =
+            Assert.IsType<DotnetInspector.Artifacts.ArtifactAcquisitionRegistration>(
+                realization.Participant.Assembly.Registration
+                    .ArtifactRegistration);
+        var provenance =
+            Assert.IsType<PackageAssemblyArtifactProvenance>(
+                registration.Provenance);
+        Assert.Equal(binding.Coordinate, provenance.Coordinate);
+        Assert.Same(
+            binding.ContentGenerationIdentity,
+            provenance.ContentGenerationIdentity);
+        Assert.Same(binding.SelectionIdentity, provenance.SelectionIdentity);
+        Assert.Same(realization.Asset, provenance.Asset);
+
+        // The retained admission names this exact artifact and generation, so
+        // a consumer copying it out records closed facts about the image it
+        // actually queried.
+        AssemblyProjectionRegistration admission =
+            Assert.IsType<ArtifactAssemblyProjectionOutcome.Projected>(
+                realization.Admission).Value.Registration;
+        Assert.Same(registration.Artifact, admission.Artifact);
+        Assert.Same(registration.Generation, admission.Generation);
+        Assert.Equal(
+            realization.Participant.Assembly.Registration.ModuleVersionId,
+            admission.ModuleVersionId);
+    }
+
+    [Fact]
+    public async Task Projection_RejectsReconstructedOrForeignSelectedAsset()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Foreign", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Foreign", content);
+        PackageCompileAsset canonical = SelectedAsset(binding);
+        var reconstructed = new PackageCompileAsset(
+            canonical.Id,
+            canonical.Path,
+            canonical.AssemblyName,
+            canonical.TargetFramework,
+            canonical.Kind);
+        Assert.Equal(canonical, reconstructed);
+
+        PackageRootBinding foreign = Binding(
+            "Sparse.Foreign",
+            new TrackingPackageContent((AssetPath, image)));
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        foreach (PackageCompileAsset rejected in
+            new[] { reconstructed, SelectedAsset(foreign) })
+        {
+            Assert.IsType<
+                SparsePackageAssemblyProjectionOutcome.InvalidSelectedAsset>(
+                await workspace.ProjectSelectedPackageAssemblyAsync(
+                    binding,
+                    rejected,
+                    Bounds(image.LongLength),
+                    TestContext.Current.CancellationToken));
+        }
+
+        // Rejection happens before any content access.
+        Assert.Equal(0, content.EntryOpenRequests);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public async Task Projection_RejectsGenerationMismatchBeforeContentAccess()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Generation", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Generation", content);
+        PackageCompileAsset asset = SelectedAsset(binding);
+        content.ReplaceGeneration();
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        Assert.IsType<SparsePackageAssemblyProjectionOutcome.InvalidBinding>(
+            await workspace.ProjectSelectedPackageAssemblyAsync(
+                binding,
+                asset,
+                Bounds(image.LongLength),
+                TestContext.Current.CancellationToken));
+        Assert.Equal(0, content.EntryOpenRequests);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(-1, false)]
+    public async Task Projection_AggregatePartitionAdmitsAtTwiceTheImage(
+        int delta,
+        bool admitted)
+    {
+        byte[] image = IntegrationAssembly("Sparse.Budget", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Budget", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        SparsePackageAssemblyProjectionOutcome outcome =
+            await workspace.ProjectSelectedPackageAssemblyAsync(
+                binding,
+                SelectedAsset(binding),
+                new SparsePackageAssemblyProjectionOptions
+                {
+                    MaxSelectedEntryBytes = image.LongLength,
+                    MaxAggregateRetainedImageBytes =
+                        (2 * image.LongLength) + delta,
+                },
+                TestContext.Current.CancellationToken);
+
+        if (admitted)
+        {
+            var available =
+                Assert.IsType<
+                    SparsePackageAssemblyProjectionOutcome.Available>(
+                    outcome);
+            available.Realization.Dispose();
+            return;
+        }
+
+        var exceeded =
+            Assert.IsType<
+                SparsePackageAssemblyProjectionOutcome.EntryByteLimitExceeded>(
+                outcome);
+        Assert.Null(exceeded.Cleanup);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public async Task Projection_DeclaredEntryLimitRejectsBeforeOpen()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Declared", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Declared", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        var exceeded =
+            Assert.IsType<
+                SparsePackageAssemblyProjectionOutcome.EntryByteLimitExceeded>(
+                await workspace.ProjectSelectedPackageAssemblyAsync(
+                    binding,
+                    SelectedAsset(binding),
+                    new SparsePackageAssemblyProjectionOptions
+                    {
+                        MaxSelectedEntryBytes = image.LongLength - 1,
+                        MaxAggregateRetainedImageBytes = 8 * image.LongLength,
+                    },
+                    TestContext.Current.CancellationToken));
+
+        Assert.Null(exceeded.Cleanup);
+        Assert.Equal(0, content.EntryOpenRequests);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public async Task Projection_ObservedBytesBeyondDeclaredLengthExceedLimit()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Observed", "SampleType");
+        var content = new UnderreportingPackageContent(AssetPath, image);
+        PackageRootBinding binding = Binding("Sparse.Observed", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        var exceeded =
+            Assert.IsType<
+                SparsePackageAssemblyProjectionOutcome.EntryByteLimitExceeded>(
+                await workspace.ProjectSelectedPackageAssemblyAsync(
+                    binding,
+                    SelectedAsset(binding),
+                    new SparsePackageAssemblyProjectionOptions
+                    {
+                        MaxSelectedEntryBytes = image.LongLength - 1,
+                        MaxAggregateRetainedImageBytes =
+                            2 * (image.LongLength - 1),
+                    },
+                    TestContext.Current.CancellationToken));
+
+        Assert.Null(exceeded.Cleanup);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public async Task Projection_ReportsSelectedEntryUnavailableWithoutContent()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Missing", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image))
+        {
+            RefuseOpen = true,
+        };
+        PackageRootBinding binding = Binding("Sparse.Missing", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        var unavailable =
+            Assert.IsType<
+                SparsePackageAssemblyProjectionOutcome.SelectedEntryUnavailable>(
+                await workspace.ProjectSelectedPackageAssemblyAsync(
+                    binding,
+                    SelectedAsset(binding),
+                    Bounds(image.LongLength),
+                    TestContext.Current.CancellationToken));
+
+        Assert.Null(unavailable.Cleanup);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public async Task Projection_ReportsArtifactPublicationFailureWithOwnerCodes()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Publication", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image))
+        {
+            FailOpen = () => new InvalidOperationException(
+                "synthetic materialization failure"),
+        };
+        PackageRootBinding binding = Binding("Sparse.Publication", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        var failed =
+            Assert.IsType<
+                SparsePackageAssemblyProjectionOutcome.ArtifactPublicationFailed>(
+                await workspace.ProjectSelectedPackageAssemblyAsync(
+                    binding,
+                    SelectedAsset(binding),
+                    Bounds(image.LongLength),
+                    TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            "artifact.session.materialization-failed",
+            Assert.Single(failed.Failures).Diagnostic.Code);
+        Assert.Null(failed.Cleanup);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public async Task Projection_IncompleteCleanupProducesBoundedResourceFreeReceipt()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Cleanup", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image))
+        {
+            FailDispose = true,
+            FailOpen = () => new InvalidOperationException(
+                "synthetic materialization failure"),
+        };
+        PackageRootBinding binding = Binding("Sparse.Cleanup", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        var failed =
+            Assert.IsType<
+                SparsePackageAssemblyProjectionOutcome.ArtifactPublicationFailed>(
+                await workspace.ProjectSelectedPackageAssemblyAsync(
+                    binding,
+                    SelectedAsset(binding),
+                    Bounds(image.LongLength),
+                    TestContext.Current.CancellationToken));
+
+        SparsePackageProjectionCleanupReceipt? receipt = failed.Cleanup;
+        Assert.NotNull(receipt);
+        SparsePackageProjectionCleanupEvidence evidence =
+            Assert.Single(receipt.IncompleteStages);
+        Assert.Equal(
+            SparsePackageProjectionCleanupStage.ArtifactSession,
+            evidence.Stage);
+        Assert.Equal(1, evidence.FailureCount);
+        Assert.Equal(1, receipt.FailureCount);
+        AssertResourceFree(receipt);
+    }
+
+    [Fact]
+    public async Task Projection_CancellationKeepsCancellationAndAttachesReceipt()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Cancel", "SampleType");
+        using var cancellation = new CancellationTokenSource();
+        var content = new TrackingPackageContent((AssetPath, image))
+        {
+            FailDispose = true,
+            OnRead = cancellation.Cancel,
+        };
+        PackageRootBinding binding = Binding("Sparse.Cancel", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+
+        OperationCanceledException cancelled =
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () =>
+                    await workspace.ProjectSelectedPackageAssemblyAsync(
+                        binding,
+                        SelectedAsset(binding),
+                        Bounds(image.LongLength),
+                        cancellation.Token));
+
+        // The original cancellation and token survive; disposal evidence is
+        // strictly secondary.
+        Assert.Equal(cancellation.Token, cancelled.CancellationToken);
+        Exception disposal = Assert.Single(
+            ArtifactSetSession.GetCleanupFailures(cancelled));
+        Assert.IsType<IOException>(disposal);
+        SparsePackageProjectionCleanupReceipt? receipt =
+            SparsePackageProjectionCleanupReceipt.FromException(cancelled);
+        Assert.NotNull(receipt);
+        Assert.Equal(
+            SparsePackageProjectionCleanupStage.ArtifactSession,
+            Assert.Single(receipt.IncompleteStages).Stage);
+        AssertResourceFree(receipt);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public async Task Projection_RunsProducerThroughOwnerAuthorizedQueryView()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Query", "QueryType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Query", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        using SparsePackageAssemblyRealization realization =
+            await ProjectAsync(workspace, binding, image.LongLength);
+
+        ArtifactAssemblyQueryOutcome<string> outcome =
+            realization.ExecuteAssemblyQuery(
+                (session, _) => session.IdentityNames().Name,
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            "Sparse.Query",
+            Assert.IsType<ArtifactAssemblyQueryOutcome<string>.Validated>(
+                outcome).Value);
+        // The retained artifact serves the query; no entry is reopened.
+        Assert.Equal(1, content.EntryOpenRequests);
+    }
+
+    [Fact]
+    public async Task Projection_RejectedCarrierRefusesQueryWithOwnerFailure()
+    {
+        byte[] valid = File.ReadAllBytes(
+            typeof(SparsePackageAssemblyProjectionTests).Assembly.Location);
+        byte[] malformed = new byte[valid.Length];
+        var content = new TrackingPackageContent((AssetPath, malformed));
+        PackageRootBinding binding = Binding("Sparse.Rejected", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        using SparsePackageAssemblyRealization realization =
+            await ProjectAsync(workspace, binding, malformed.LongLength);
+
+        // The exact Metadata-owned classification is retained verbatim; the
+        // adapter neither reclassifies it nor infers it from the carrier.
+        var notAssembly =
+            Assert.IsType<ArtifactAssemblyProjectionOutcome.NotAssembly>(
+                realization.Admission);
+        Assert.Equal(ArtifactNonAssemblyKind.NativeImage, notAssembly.Kind);
+        // A carrier is published as one participant, but is never inferred to
+        // be projectable from its decoded-identity flag.
+        Assert.False(realization.IdentityDecoded);
+        Assert.NotNull(realization.Participant);
+
+        int producerRuns = 0;
+        ArtifactAssemblyQueryOutcome<int> outcome =
+            realization.ExecuteAssemblyQuery(
+                (_, _) => ++producerRuns,
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ArtifactNonAssemblyKind.NativeImage,
+            Assert.IsType<ArtifactAssemblyQueryOutcome<int>.NotAssembly>(
+                outcome).Kind);
+        Assert.Equal(0, producerRuns);
+    }
+
+    [Fact]
+    public async Task Projection_CloseWaitsForActiveQueryThenDeniesAccess()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        byte[] image = IntegrationAssembly("Sparse.Lifetime", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Lifetime", content);
+        await using InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        using SparsePackageAssemblyRealization realization =
+            await ProjectAsync(workspace, binding, image.LongLength);
+
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var resume = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<ArtifactAssemblyQueryOutcome<int>> query = Task.Run(
+            () => realization.ExecuteAssemblyQuery(
+                (_, _) =>
+                {
+                    entered.SetResult();
+                    resume.Task.Wait(cancellationToken);
+                    return 7;
+                },
+                cancellationToken),
+            cancellationToken);
+        await entered.Task.WaitAsync(cancellationToken);
+
+        Task<InspectionWorkspaceCloseReport> close = workspace.CloseAsync();
+        Assert.False(close.IsCompleted);
+        realization.Dispose();
+        Assert.False(close.IsCompleted);
+        resume.SetResult();
+
+        Assert.Equal(
+            7,
+            Assert.IsType<ArtifactAssemblyQueryOutcome<int>.Validated>(
+                await query).Value);
+        InspectionWorkspaceCloseReport report = await close;
+        Assert.Empty(report.ArtifactSessionCleanupFailures);
+        Assert.All(
+            report.Groups,
+            group => Assert.Null(
+                Assert.IsType<InspectionWorkspaceDirectGroupCloseResult>(
+                    group).Failure));
+        Assert.Throws<ObjectDisposedException>(
+            () => realization.ExecuteAssemblyQuery(
+                (_, _) => 0,
+                cancellationToken));
+        Assert.Throws<ObjectDisposedException>(
+            () => realization.Participant.Assembly.OpenRead());
+    }
+
+    [Fact]
+    public async Task ReacquisitionRequest_IsExactResourceFreeAndSeparatesTargets()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Request", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding(
+            "Sparse.Request",
+            content,
+            runtimeIdentifier: "linux-x64");
+
+        PackageRootReacquisitionRequest request =
+            binding.CreateReacquisitionRequest();
+
+        Assert.Equal(request, binding.CreateReacquisitionRequest());
+        Assert.Equal(
+            request.GetHashCode(),
+            binding.CreateReacquisitionRequest().GetHashCode());
+        Assert.Equal("sparse.request", request.Coordinate.PackageId);
+        Assert.Equal("tests", request.Coordinate.Producer);
+        Assert.Equal("1.0.0", request.Coordinate.Version);
+        Assert.Equal(Framework, request.Coordinate.Framework);
+        Assert.Equal(Framework, request.SelectionTargetFramework);
+        Assert.Equal("linux-x64", request.SelectionRuntimeIdentifier);
+
+        // A selection target that is not acquisition-target text keeps
+        // acquisition framework-neutral while the selection stays exact, which
+        // is precisely what a realized coordinate alone cannot express.
+        PackageRootReacquisitionRequest neutral = PackageRootBinding
+            .CreateFromSource(
+                new AcquiredPackageSourcePayload(
+                    PackageSourceCoordinate.Create("sparse.request", "1.0.0"),
+                    new TrackingPackageContent((AssetPath, image)),
+                    "tests",
+                    PackagePayloadOrigin.Download),
+                ".NETStandard,Version=v2.0")
+            .CreateReacquisitionRequest();
+        Assert.Null(neutral.Coordinate.Framework);
+        Assert.Null(neutral.Coordinate.RuntimeIdentifier);
+        Assert.Equal("netstandard2.0", neutral.SelectionTargetFramework);
+        Assert.NotEqual(request, neutral);
+        AssertResourceFree(neutral);
+
+        Assert.NotEqual(
+            request,
+            Binding(
+                    "Sparse.Request",
+                    new TrackingPackageContent((AssetPath, image)),
+                    runtimeIdentifier: "win-x64")
+                .CreateReacquisitionRequest());
+        AssertResourceFree(request);
+    }
+
+    [Fact]
+    public async Task ReacquisitionRequest_SurvivesCandidateWorkspaceDisposal()
+    {
+        byte[] image = IntegrationAssembly("Sparse.Replace", "SampleType");
+        var content = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding binding = Binding("Sparse.Replace", content);
+        PackageRootReacquisitionRequest request =
+            binding.CreateReacquisitionRequest();
+        await using (InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous())
+        {
+            using SparsePackageAssemblyRealization realization =
+                await ProjectAsync(workspace, binding, image.LongLength);
+            Assert.NotNull(realization.Participant);
+            await workspace.CloseAsync();
+        }
+
+        // A replacement generation is a new binding, and the request still
+        // matches it exactly because it names no generation.
+        var replacementContent = new TrackingPackageContent((AssetPath, image));
+        PackageRootBinding replacement =
+            Binding("Sparse.Replace", replacementContent);
+        Assert.NotSame(
+            binding.ContentGenerationIdentity,
+            replacement.ContentGenerationIdentity);
+        Assert.Equal(request, replacement.CreateReacquisitionRequest());
+
+        await using InspectionWorkspace reopened =
+            InspectionWorkspace.CreateAsynchronous();
+        using SparsePackageAssemblyRealization second =
+            await ProjectAsync(reopened, replacement, image.LongLength);
+        Assert.Equal(
+            "Sparse.Replace",
+            Assert.IsType<ArtifactAssemblyQueryOutcome<string>.Validated>(
+                second.ExecuteAssemblyQuery(
+                    (session, _) => session.IdentityNames().Name,
+                    TestContext.Current.CancellationToken)).Value);
+    }
+
+    [Fact]
+    public void ProjectionOptions_RequirePositiveExplicitBounds()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new SparsePackageAssemblyProjectionOptions
+            {
+                MaxSelectedEntryBytes = 0,
+                MaxAggregateRetainedImageBytes = 16,
+            }.Validate());
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new SparsePackageAssemblyProjectionOptions
+            {
+                MaxSelectedEntryBytes = 16,
+                MaxAggregateRetainedImageBytes = 1,
+            }.Validate());
+    }
+
+    static async Task<SparsePackageAssemblyRealization> ProjectAsync(
+        InspectionWorkspace workspace,
+        PackageRootBinding binding,
+        long imageLength) =>
+        Assert.IsType<SparsePackageAssemblyProjectionOutcome.Available>(
+            await workspace.ProjectSelectedPackageAssemblyAsync(
+                binding,
+                SelectedAsset(binding),
+                Bounds(imageLength),
+                TestContext.Current.CancellationToken)).Realization;
+
+    static SparsePackageAssemblyProjectionOptions Bounds(long imageLength) =>
+        new()
+        {
+            MaxSelectedEntryBytes = imageLength,
+            MaxAggregateRetainedImageBytes = 2 * imageLength,
+        };
+
+    static PackageCompileAsset SelectedAsset(PackageRootBinding binding) =>
+        binding.Root.AssetSelection.Assets.Single();
+
+    /// <summary>
+    /// Asserts that a closed owner fact carries only value-shaped data: no
+    /// stream, session, lease, group, participant, workspace, package content,
+    /// exception, or delegate is reachable from its public surface.
+    /// </summary>
+    static void AssertResourceFree(object fact)
+    {
+        foreach (PropertyInfo property in fact.GetType().GetProperties(
+            BindingFlags.Public | BindingFlags.Instance))
+        {
+            object? value = property.GetValue(fact);
+            AssertResourceFreeValue(property.Name, value);
+        }
+    }
+
+    static void AssertResourceFreeValue(string name, object? value)
+    {
+        switch (value)
+        {
+            case null or string or bool or int or long or Enum:
+                return;
+            case IDisposable or IAsyncDisposable or Exception or Delegate
+                or IPackageContent or Stream:
+                Assert.Fail(
+                    $"'{name}' exposes a resource of type {value.GetType()}.");
+                return;
+        }
+
+        if (value is System.Collections.IEnumerable sequence)
+        {
+            int index = 0;
+            foreach (object? item in sequence)
+                AssertResourceFreeValue($"{name}[{index++}]", item);
+            return;
+        }
+
+        if (value.GetType().Assembly == typeof(PackageRootBinding).Assembly
+            || value.GetType().Assembly
+                == typeof(PackageCompileAsset).Assembly)
+        {
+            AssertResourceFree(value);
+        }
+    }
+
+    static PackageRootBinding Binding(
+        string packageId,
+        IPackageContent content,
+        string? runtimeIdentifier = null) =>
+        PackageRootBinding.CreateFromSource(
+            new AcquiredPackageSourcePayload(
+                PackageSourceCoordinate.Create(packageId, "1.0.0"),
+                content,
+                "tests",
+                PackagePayloadOrigin.Download),
+            Framework,
+            runtimeIdentifier);
+
+    static byte[] IntegrationAssembly(string assemblyName, string typeName)
+    {
+        var assemblyBuilder = new PersistedAssemblyBuilder(
+            new AssemblyName(assemblyName),
+            typeof(object).Assembly);
+        ModuleBuilder module =
+            assemblyBuilder.DefineDynamicModule(assemblyName);
+        TypeBuilder type = module.DefineType(
+            typeName,
+            TypeAttributes.Public | TypeAttributes.Class);
+        type.DefineDefaultConstructor(MethodAttributes.Public);
+        type.CreateType();
+
+        using var stream = new MemoryStream();
+        assemblyBuilder.Save(stream);
+        return stream.ToArray();
+    }
+
+    static int GroupCount(InspectionWorkspace workspace)
+    {
+        FieldInfo field =
+            typeof(InspectionWorkspace).GetField(
+                "_groups",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "InspectionWorkspace._groups was not found.");
+        return ((System.Collections.ICollection)field.GetValue(workspace)!)
+            .Count;
+    }
+
+    sealed class TrackingPackageContent : IPackageContent, IPackageContentEntryManifest
+    {
+        readonly (string Path, byte[] Content)[] _entries;
+        PackageContentGenerationIdentity _generation = new();
+
+        internal TrackingPackageContent(
+            params (string Path, byte[] Content)[] entries) =>
+            _entries = entries;
+
+        internal int EntryOpenRequests { get; private set; }
+
+        internal int EnumerationRequests { get; private set; }
+
+        internal bool RefuseOpen { get; init; }
+
+        internal bool FailDispose { get; init; }
+
+        internal Func<Exception>? FailOpen { get; init; }
+
+        internal Action? OnRead { get; init; }
+
+        public string? RootPath => null;
+        public string? NupkgPath => null;
+        public bool FromCache => false;
+        public string ProducerKey => "tests";
+        public bool RequiresArchiveTreeMatch => false;
+
+        public PackageContentGenerationIdentity GenerationIdentity =>
+            _generation;
+
+        internal void ReplaceGeneration() => _generation = new();
+
+        public bool TryOpenArchive([NotNullWhen(true)] out Stream? stream)
+        {
+            stream = null;
+            return false;
+        }
+
+        public bool TryOpenEntry(
+            string relativePath,
+            [NotNullWhen(true)] out Stream? stream)
+        {
+            if (RefuseOpen)
+            {
+                stream = null;
+                return false;
+            }
+            foreach ((string path, byte[] content) in _entries)
+            {
+                if (!relativePath.Equals(path, StringComparison.Ordinal))
+                    continue;
+
+                EntryOpenRequests++;
+                stream = new HookedStream(content, FailDispose, FailOpen, OnRead);
+                return true;
+            }
+
+            stream = null;
+            return false;
+        }
+
+        public IEnumerable<string> EnumerateEntries()
+        {
+            EnumerationRequests++;
+            return _entries.Select(entry => entry.Path);
+        }
+
+        public bool TryGetEntryLength(string relativePath, out long length)
+        {
+            foreach ((string path, byte[] content) in _entries)
+            {
+                if (!relativePath.Equals(path, StringComparison.Ordinal))
+                    continue;
+
+                length = content.LongLength;
+                return true;
+            }
+
+            length = 0;
+            return false;
+        }
+
+        public IReadOnlyList<PackageContentEntry> EnumerateEntriesWithLengths()
+        {
+            EnumerationRequests++;
+            return
+            [
+                .. _entries.Select(entry =>
+                    new PackageContentEntry(entry.Path, entry.Content.LongLength)),
+            ];
+        }
+    }
+
+    /// <summary>
+    /// A benign entry stream with existing outcome-level hooks: it can fail
+    /// its read, cancel mid-read, or fail disposal. The bytes are always a
+    /// normal compiler-generated image.
+    /// </summary>
+    sealed class HookedStream(
+        byte[] content,
+        bool failDispose,
+        Func<Exception>? failRead,
+        Action? onRead) : Stream
+    {
+        readonly MemoryStream _source = new(content, writable: false);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _source.Length;
+
+        public override long Position
+        {
+            get => _source.Position;
+            set => _source.Position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            onRead?.Invoke();
+            if (failRead is not null)
+                throw failRead();
+            return _source.Read(buffer);
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            onRead?.Invoke();
+            cancellationToken.ThrowIfCancellationRequested();
+            if (failRead is not null)
+                throw failRead();
+            return ValueTask.FromResult(_source.Read(buffer.Span));
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            _source.Seek(offset, origin);
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _source.Dispose();
+                if (failDispose)
+                {
+                    throw new IOException(
+                        "synthetic entry stream disposal failure");
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    sealed class UnderreportingPackageContent(
+        string path,
+        byte[] content) : IPackageContent, IPackageContentEntryManifest
+    {
+        public string? RootPath => null;
+        public string? NupkgPath => null;
+        public bool FromCache => false;
+        public string ProducerKey => "tests";
+        public bool RequiresArchiveTreeMatch => false;
+
+        public bool TryOpenArchive([NotNullWhen(true)] out Stream? stream)
+        {
+            stream = null;
+            return false;
+        }
+
+        public bool TryOpenEntry(
+            string relativePath,
+            [NotNullWhen(true)] out Stream? stream)
+        {
+            if (!relativePath.Equals(path, StringComparison.Ordinal))
+            {
+                stream = null;
+                return false;
+            }
+
+            stream = new UnderreportingLengthStream(
+                content,
+                content.LongLength - 1);
+            return true;
+        }
+
+        public IEnumerable<string> EnumerateEntries()
+        {
+            yield return path;
+        }
+
+        public bool TryGetEntryLength(string relativePath, out long length)
+        {
+            length = relativePath.Equals(path, StringComparison.Ordinal)
+                ? content.LongLength - 1
+                : 0;
+            return relativePath.Equals(path, StringComparison.Ordinal);
+        }
+
+        public IReadOnlyList<PackageContentEntry> EnumerateEntriesWithLengths() =>
+            [new(path, content.LongLength - 1)];
+    }
+
+    sealed class UnderreportingLengthStream(
+        byte[] content,
+        long reportedLength) : Stream
+    {
+        readonly MemoryStream _source = new(content, writable: false);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => reportedLength;
+
+        public override long Position
+        {
+            get => _source.Position;
+            set => _source.Position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            _source.Read(buffer, offset, count);
+
+        public override int Read(Span<byte> buffer) => _source.Read(buffer);
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            _source.Seek(offset, origin);
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _source.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/DotnetInspector.Queries/ArtifactRootCorrespondence.cs
+++ b/src/DotnetInspector.Queries/ArtifactRootCorrespondence.cs
@@ -69,7 +69,7 @@ internal readonly record struct PackageArtifactRootRequest(
             NormalizeRuntime(selectionRuntimeIdentifier));
     }
 
-    static string? NormalizeFramework(string? framework)
+    internal static string? NormalizeFramework(string? framework)
     {
         if (string.IsNullOrWhiteSpace(framework))
             return null;
@@ -84,7 +84,7 @@ internal readonly record struct PackageArtifactRootRequest(
                     : framework;
     }
 
-    static string? NormalizeRuntime(string? runtimeIdentifier) =>
+    internal static string? NormalizeRuntime(string? runtimeIdentifier) =>
         RealizedMemberCoordinate.IsCanonicalRuntimeIdentifier(
             runtimeIdentifier)
             ? runtimeIdentifier!.ToLowerInvariant()

--- a/src/DotnetInspector.Queries/PackageArtifactAssemblyContextRealization.cs
+++ b/src/DotnetInspector.Queries/PackageArtifactAssemblyContextRealization.cs
@@ -538,8 +538,9 @@ public sealed partial class InspectionWorkspace
         {
             ImmutableArray<Exception> cleanup =
                 await ReleaseAsync().ConfigureAwait(false);
-            if (!cleanup.IsEmpty)
-                failure.Data["DotnetInspector.Artifacts.Workspaces.CleanupFailures"] = cleanup;
+            // Merged through the artifact owner rather than assigned, so a
+            // disposal failure this exception already carries is not replaced.
+            ArtifactSetSession.AttachCleanupFailures(failure, cleanup);
         }
     }
 }

--- a/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
+++ b/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
@@ -76,6 +76,20 @@ public sealed class PackageRootBinding
     public PackageRootSelectionIdentity SelectionIdentity { get; }
 
     /// <summary>
+    /// Issues the exact, resource-free request that repeats this logical Root
+    /// under another host's acquisition capabilities.
+    /// </summary>
+    /// <remarks>
+    /// The issued value preserves the realized producer-pinned coordinate and
+    /// the normalized selection target separately, and carries no content,
+    /// generation identity, selection identity, workspace identity, lease,
+    /// opener, or path authority. Gated by
+    /// <c>SparsePackageAssemblyProjectionTests.ReacquisitionRequest_IsExactResourceFreeAndSeparatesTargets</c>.
+    /// </remarks>
+    public PackageRootReacquisitionRequest CreateReacquisitionRequest() =>
+        new(PackageArtifactRootRequest.From(this));
+
+    /// <summary>
     /// Binds a payload acquired through the typed source-client path.
     /// </summary>
     public static PackageRootBinding CreateFromSource(
@@ -196,7 +210,7 @@ public sealed class PackageRootBinding
             new PackageRootSelectionIdentity());
     }
 
-    static string? SourceAcquisitionFramework(string? targetFramework) =>
+    internal static string? SourceAcquisitionFramework(string? targetFramework) =>
         PackageCoordinateResolver.IsAcquisitionTargetText(targetFramework)
             ? targetFramework!.ToLowerInvariant()
             : null;

--- a/src/DotnetInspector.Queries/PackageRootAcquisition.cs
+++ b/src/DotnetInspector.Queries/PackageRootAcquisition.cs
@@ -300,6 +300,15 @@ public sealed class PackageRootReacquisitionRequest :
             return false;
         }
 
+        // Unlike framework targets, binding-issued runtime targets cannot differ.
+        if (!string.Equals(
+                fields[6],
+                coordinate.RuntimeIdentifier,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
         PackageArtifactRootRequest decoded = PackageArtifactRootRequest.Create(
             coordinate,
             fields[5],

--- a/src/DotnetInspector.Queries/PackageRootAcquisition.cs
+++ b/src/DotnetInspector.Queries/PackageRootAcquisition.cs
@@ -1,0 +1,712 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+using DotnetInspector.Packages;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// One caller-authored request for an exact package Root that has not been
+/// acquired yet.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the entry a streaming consumer uses for its initial explicit
+/// <c>ID@VERSION</c> coordinates. The version is required: this owner performs
+/// no gallery, prefix, or floating-version discovery, and a request that did
+/// not name an exact version would be asking for one.
+/// </para>
+/// <para>
+/// Unlike <see cref="PackageRootReacquisitionRequest"/>, this request names no
+/// producer, because which authorized producer serves the bytes is decided by
+/// the destination host's policy at acquisition time. The acquired outcome
+/// carries the producer-pinned reacquisition request issued for the Root that
+/// actually resulted.
+/// </para>
+/// <para>
+/// Gated by
+/// <c>PackageRootAcquisitionTests.ExplicitCoordinate_AcquiresRootAndIssuesExactRequest</c>.
+/// </para>
+/// </remarks>
+public sealed class PackageRootAcquisitionRequest
+{
+    PackageRootAcquisitionRequest(
+        string packageId,
+        string version,
+        string? acquisitionFramework,
+        string? selectionTargetFramework,
+        string? selectionRuntimeIdentifier)
+    {
+        PackageId = packageId;
+        Version = version;
+        AcquisitionFramework = acquisitionFramework;
+        SelectionTargetFramework = selectionTargetFramework;
+        SelectionRuntimeIdentifier = selectionRuntimeIdentifier;
+    }
+
+    /// <summary>Creates a request for one exact package id and version.</summary>
+    /// <param name="selectionTargetFramework">
+    /// The compile-asset selection target, which is also the acquisition
+    /// framework. This is the ordinary single-target shape.
+    /// </param>
+    public static PackageRootAcquisitionRequest Create(
+        string packageId,
+        string version,
+        string? selectionTargetFramework = null,
+        string? selectionRuntimeIdentifier = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        // The same input contract PackageRootBinding.CreateFromSource states,
+        // so an explicit coordinate and a bound Root cannot disagree about
+        // which target spellings this owner accepts.
+        string? acquisitionFramework =
+            PackageRootBinding.SourceAcquisitionFramework(
+                selectionTargetFramework);
+        if (selectionRuntimeIdentifier is not null)
+        {
+            if (!RealizedMemberCoordinate.IsCanonicalRuntimeIdentifier(
+                    selectionRuntimeIdentifier))
+            {
+                throw new ArgumentException(
+                    "A package Root runtime identifier must be a canonical lowercase moniker.",
+                    nameof(selectionRuntimeIdentifier));
+            }
+            if (acquisitionFramework is null)
+            {
+                throw new ArgumentException(
+                    "A package Root runtime identifier requires a canonical acquisition framework.",
+                    nameof(selectionTargetFramework));
+            }
+        }
+
+        return new(
+            packageId,
+            version,
+            acquisitionFramework,
+            selectionTargetFramework,
+            selectionRuntimeIdentifier);
+    }
+
+    /// <summary>
+    /// Creates a request whose acquisition is framework-neutral while its
+    /// compile-asset selection target stays exact.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the shape a realized coordinate alone cannot express, and the
+    /// reason the reacquisition request keeps the two facts apart: the
+    /// producer is asked for the package itself rather than for a
+    /// framework-targeted acquisition, and the selection target still decides
+    /// which compile assets the Root exposes.
+    /// </para>
+    /// <para>
+    /// A runtime identifier is not accepted here, because a realized
+    /// coordinate's runtime identifier requires an acquisition framework.
+    /// </para>
+    /// </remarks>
+    public static PackageRootAcquisitionRequest CreateFrameworkNeutral(
+        string packageId,
+        string version,
+        string selectionTargetFramework)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        ArgumentException.ThrowIfNullOrWhiteSpace(selectionTargetFramework);
+        return new(
+            packageId,
+            version,
+            acquisitionFramework: null,
+            selectionTargetFramework,
+            selectionRuntimeIdentifier: null);
+    }
+
+    /// <summary>The requested package id.</summary>
+    public string PackageId { get; }
+
+    /// <summary>The requested exact version.</summary>
+    public string Version { get; }
+
+    /// <summary>
+    /// The acquisition framework derived from the selection target, or
+    /// <see langword="null"/> for framework-neutral acquisition.
+    /// </summary>
+    public string? AcquisitionFramework { get; }
+
+    /// <summary>The compile-asset selection target framework.</summary>
+    public string? SelectionTargetFramework { get; }
+
+    /// <summary>The compile-asset selection runtime identifier.</summary>
+    public string? SelectionRuntimeIdentifier { get; }
+}
+
+/// <summary>
+/// One acquisition-issued, immutable, resource-free request that repeats the
+/// exact logical package Root behind a <see cref="PackageRootBinding"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The request preserves two separate owner facts: the realized
+/// producer-pinned acquisition coordinate, whose
+/// <see cref="RealizedMemberCoordinate.Package.Framework"/> may be absent for
+/// framework-neutral source acquisition, and the normalized selection target
+/// framework and runtime identifier that produced the binding's frozen
+/// compile-asset selection. It is therefore usable where the realized
+/// coordinate alone would fail with
+/// <see cref="WorkspaceContextLoadFailureKind.MissingAcquisitionTarget"/> or
+/// select a different asset universe.
+/// </para>
+/// <para>
+/// The request carries no package content, generation identity, selection
+/// identity, workspace identity, session, lease, callback, opener, or path
+/// authority, and no credential. It may observe a replacement physical
+/// generation but never silently changes the requested target. It is distinct
+/// from Workspace-scoped <see cref="PackageArtifactRootCorrespondence"/>,
+/// which cannot open a fresh Workspace after a candidate closes. Hosts pass
+/// the issued value opaquely — as the value itself in-process, or as the
+/// owner-authored token from <see cref="Encode"/> across a transport boundary
+/// — and never reconstruct it from package id, target framework, runtime
+/// identifier, asset path, or other display fields. Gated by
+/// <c>SparsePackageAssemblyProjectionTests.ReacquisitionRequest_IsExactResourceFreeAndSeparatesTargets</c>
+/// and <c>ReacquisitionRequest_SurvivesCandidateWorkspaceDisposal</c>.
+/// </para>
+/// </remarks>
+public sealed class PackageRootReacquisitionRequest :
+    IEquatable<PackageRootReacquisitionRequest>
+{
+    /// <summary>The current opaque token format tag.</summary>
+    public const string TokenPrefix = "pkgroot1";
+
+    /// <summary>The largest token this owner encodes or decodes.</summary>
+    public const int MaxEncodedLength = 1024;
+
+    const int FieldCount = 7;
+
+    static readonly UTF8Encoding StrictUtf8 = new(
+        encoderShouldEmitUTF8Identifier: false,
+        throwOnInvalidBytes: true);
+
+    readonly PackageArtifactRootRequest _request;
+
+    internal PackageRootReacquisitionRequest(
+        PackageArtifactRootRequest request)
+    {
+        _request = request;
+    }
+
+    /// <summary>The realized producer-pinned package acquisition coordinate.</summary>
+    public RealizedMemberCoordinate.Package Coordinate => _request.Coordinate;
+
+    /// <summary>
+    /// The normalized compile-asset selection target framework, or
+    /// <see langword="null"/> when the binding requested none.
+    /// </summary>
+    public string? SelectionTargetFramework =>
+        _request.SelectionTargetFramework;
+
+    /// <summary>The normalized compile-asset selection runtime identifier.</summary>
+    public string? SelectionRuntimeIdentifier =>
+        _request.SelectionRuntimeIdentifier;
+
+    /// <summary>
+    /// Encodes this request as one owner-authored, credential-free token a
+    /// host may hand across a transport boundary and back.
+    /// </summary>
+    /// <remarks>
+    /// The token is opaque to hosts: its format tag, field order, and encoding
+    /// are this owner's, and only <see cref="TryDecode"/> reads it. It carries
+    /// the same facts the request does and no content, generation, workspace
+    /// identity, lease, path, source URL, or credential. Gated by
+    /// <c>PackageRootAcquisitionTests.Token_RoundTripsExactRequest</c>.
+    /// </remarks>
+    public string Encode()
+    {
+        var builder = new StringBuilder(TokenPrefix);
+        AppendField(builder, Coordinate.PackageId);
+        AppendField(builder, Coordinate.Version);
+        AppendField(builder, Coordinate.Producer);
+        AppendField(builder, Coordinate.Framework);
+        AppendField(builder, Coordinate.RuntimeIdentifier);
+        AppendField(builder, SelectionTargetFramework);
+        AppendField(builder, SelectionRuntimeIdentifier);
+        if (builder.Length > MaxEncodedLength)
+        {
+            throw new InvalidOperationException(
+                $"A package Root reacquisition token exceeds the {MaxEncodedLength}-character limit.");
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Decodes a token this owner encoded, or returns <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The token may arrive from an untrusted transport, so decoding is total:
+    /// a malformed, over-long, non-canonical, or forged token returns
+    /// <see langword="false"/> rather than throwing or producing a value this
+    /// owner would not have issued. Every field is revalidated through the
+    /// owner's own canonical coordinate and request construction.
+    /// </para>
+    /// <para>
+    /// A decoded request is a request, not an authorization. It grants no
+    /// access on its own: acquiring the Root it names still passes through the
+    /// destination host's own source authorization, transfer policy, and
+    /// payload limits. Gated by
+    /// <c>PackageRootAcquisitionTests.Token_RejectsMalformedOrNonCanonicalInput</c>.
+    /// </para>
+    /// </remarks>
+    public static bool TryDecode(
+        string? encoded,
+        [NotNullWhen(true)] out PackageRootReacquisitionRequest? request)
+    {
+        request = null;
+        if (encoded is null
+            || encoded.Length is 0 or > MaxEncodedLength)
+        {
+            return false;
+        }
+
+        string[] parts = encoded.Split('.');
+        if (parts.Length != FieldCount + 1
+            || !string.Equals(parts[0], TokenPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var fields = new string?[FieldCount];
+        for (int index = 0; index < FieldCount; index++)
+        {
+            if (!TryReadField(parts[index + 1], out fields[index]))
+                return false;
+        }
+        if (fields[0] is not { } packageId
+            || fields[1] is not { } version
+            || fields[2] is not { } producer)
+        {
+            return false;
+        }
+        if (!RealizedMemberCoordinate.Package.TryCreate(
+                packageId,
+                version,
+                producer,
+                fields[3],
+                fields[4],
+                out RealizedMemberCoordinate.Package? coordinate,
+                out _))
+        {
+            return false;
+        }
+
+        PackageArtifactRootRequest decoded = PackageArtifactRootRequest.Create(
+            coordinate,
+            fields[5],
+            fields[6]);
+
+        // A token that is not already canonical is refused rather than
+        // silently normalized, so one request has exactly one token.
+        if (!string.Equals(
+                decoded.SelectionTargetFramework,
+                fields[5],
+                StringComparison.Ordinal)
+            || !string.Equals(
+                decoded.SelectionRuntimeIdentifier,
+                fields[6],
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        request = new PackageRootReacquisitionRequest(decoded);
+        return true;
+    }
+
+    public bool Equals(PackageRootReacquisitionRequest? other) =>
+        other is not null && _request == other._request;
+
+    public override bool Equals(object? obj) =>
+        Equals(obj as PackageRootReacquisitionRequest);
+
+    public override int GetHashCode() => _request.GetHashCode();
+
+    public override string ToString() =>
+        $"{Coordinate.PackageId}@{Coordinate.Version}";
+
+    internal bool Matches(PackageArtifactRootRequest request) =>
+        _request == request;
+
+    static void AppendField(StringBuilder builder, string? value)
+    {
+        builder.Append('.');
+        if (string.IsNullOrEmpty(value))
+            return;
+
+        builder.Append(
+            Convert.ToBase64String(StrictUtf8.GetBytes(value))
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_'));
+    }
+
+    static bool TryReadField(string encoded, out string? value)
+    {
+        value = null;
+        if (encoded.Length == 0)
+            return true;
+
+        int remainder = encoded.Length % 4;
+        if (remainder == 1)
+            return false;
+
+        int padding = remainder == 0 ? 0 : 4 - remainder;
+        char[] base64 = new char[encoded.Length + padding];
+        for (int index = 0; index < encoded.Length; index++)
+        {
+            char character = encoded[index];
+            switch (character)
+            {
+                case >= 'A' and <= 'Z':
+                case >= 'a' and <= 'z':
+                case >= '0' and <= '9':
+                    base64[index] = character;
+                    break;
+                case '-':
+                    base64[index] = '+';
+                    break;
+                case '_':
+                    base64[index] = '/';
+                    break;
+                default:
+                    return false;
+            }
+        }
+        for (int index = encoded.Length; index < base64.Length; index++)
+            base64[index] = '=';
+
+        byte[] decoded = new byte[base64.Length / 4 * 3];
+        if (!Convert.TryFromBase64Chars(base64, decoded, out int written)
+            || written == 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            value = StrictUtf8.GetString(decoded.AsSpan(0, written));
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+/// <summary>Why a package Root acquisition did not produce a Root.</summary>
+public enum PackageRootAcquisitionFailureKind
+{
+    /// <summary>The requested coordinate is not resolvable as stated.</summary>
+    InvalidCoordinate,
+
+    /// <summary>
+    /// No authorized producer resolved or served the requested coordinate.
+    /// </summary>
+    PackageUnavailable,
+
+    /// <summary>
+    /// The exact producer the request pins is not authorized by this host for
+    /// that package, or did not serve the bytes that arrived.
+    /// </summary>
+    ProducerNotAuthorized,
+
+    /// <summary>
+    /// Reacquired content produced a Root whose exact logical request differs
+    /// from the one asked for.
+    /// </summary>
+    SelectionRequestNotReproduced,
+}
+
+/// <summary>The typed result of one package Root acquisition.</summary>
+/// <remarks>
+/// Cancellation is not an outcome arm; it propagates with the caller's token.
+/// </remarks>
+public abstract class PackageRootAcquisitionOutcome
+{
+    private protected PackageRootAcquisitionOutcome()
+    {
+    }
+
+    /// <summary>One newly bound Root and the exact request that repeats it.</summary>
+    /// <remarks>
+    /// <para>
+    /// The binding's <see cref="PackageRootRealization.AssetSelection"/> keeps
+    /// the package owner's typed selection status, so content that does not
+    /// satisfy the selection target reports that owner-typed selection failure
+    /// rather than a neighboring asset set. <see cref="Request"/> is the
+    /// producer-pinned request issued for this Root, so a consumer acquiring
+    /// from an explicit coordinate holds a reacquirable handle immediately and
+    /// never has to rebuild one from display fields.
+    /// </para>
+    /// <para>
+    /// This outcome is intentionally live and resource-bearing. The
+    /// resource-free restriction is a property of <see cref="Request"/>, which
+    /// is the value a host may retain and transport; it does not apply to the
+    /// acquisition result itself. <see cref="Payload"/> is therefore the real
+    /// acquired payload, and <c>Payload.Content</c> is the exact
+    /// <see cref="IPackageContent"/> instance <see cref="Binding"/> reads
+    /// through — verifiable with
+    /// <see cref="PackageRootRealization.ReferencesContent"/>.
+    /// </para>
+    /// <para>
+    /// A destination that wraps the acquired package adapts that instance
+    /// rather than rebuilding one. Constructing a second content handle over
+    /// copied archive bytes would copy the payload and mint a second
+    /// <see cref="PackageContentGenerationIdentity"/>, which would make the
+    /// wrapper and the binding disagree about which retained generation they
+    /// name. Gated by
+    /// <c>PackageRootAcquisitionTests.Acquired_ExposesTheLiveContentTheBindingReads</c>.
+    /// </para>
+    /// </remarks>
+    public sealed class Acquired : PackageRootAcquisitionOutcome
+    {
+        internal Acquired(
+            PackageRootBinding binding,
+            AcquiredPackagePayload payload,
+            PackageRootReacquisitionRequest request)
+        {
+            Binding = binding;
+            Payload = payload;
+            Request = request;
+        }
+
+        public PackageRootBinding Binding { get; }
+
+        /// <summary>
+        /// The live acquired payload the binding was formed from, including the
+        /// exact retained content instance, its producer identity, and whether
+        /// a store entry or a download answered.
+        /// </summary>
+        public AcquiredPackagePayload Payload { get; }
+
+        public PackageRootReacquisitionRequest Request { get; }
+    }
+
+    /// <summary>A visible source, authorization, or request failure.</summary>
+    public sealed class Failed : PackageRootAcquisitionOutcome
+    {
+        internal Failed(
+            PackageRootAcquisitionFailureKind kind,
+            string message)
+        {
+            Kind = kind;
+            Message = message;
+        }
+
+        public PackageRootAcquisitionFailureKind Kind { get; }
+
+        public string Message { get; }
+    }
+}
+
+/// <summary>
+/// Acquires one package Root under a host's own acquisition capabilities and
+/// policy, either from an explicit coordinate or from an owner-issued exact
+/// reacquisition request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is deliberately narrower than
+/// <see cref="WorkspaceContextLoader.LoadRealizedAsync"/>: it realizes no
+/// assembly role universe, requires no acquisition target, and creates no
+/// workspace group. Both entries share one authorization, resolution, and
+/// payload-acquisition path — the same
+/// <see cref="PackageCoordinateResolver"/> and
+/// <see cref="PackagePayloadAcquisition"/> the loader uses — so neither invents
+/// a source policy. Source authorization, transfer policy, payload limits, and
+/// the package store remain the destination host's own; neither request form
+/// carries them.
+/// </para>
+/// <para>
+/// Gated by
+/// <c>PackageRootAcquisitionTests.ExplicitCoordinate_AcquiresRootAndIssuesExactRequest</c>,
+/// <c>ExactRequest_ReacquiresSameLogicalRoot</c>,
+/// <c>ExplicitCoordinate_UnauthorizedSourcesFailVisibly</c>, and
+/// <c>ExactRequest_UnauthorizedProducerFailsVisibly</c>.
+/// </para>
+/// </remarks>
+public static class PackageRootAcquisition
+{
+    /// <summary>Acquires a Root for one explicit, exact coordinate.</summary>
+    public static Task<PackageRootAcquisitionOutcome> AcquireAsync(
+        PackageRootAcquisitionRequest request,
+        WorkspaceContextLoadOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return AcquireCoreAsync(
+            request.PackageId,
+            request.Version,
+            request.AcquisitionFramework,
+            request.SelectionRuntimeIdentifier,
+            request.SelectionTargetFramework,
+            pinnedProducer: null,
+            expected: null,
+            options,
+            cancellationToken);
+    }
+
+    /// <summary>Reacquires the exact logical Root an owner-issued request names.</summary>
+    public static Task<PackageRootAcquisitionOutcome> AcquireAsync(
+        PackageRootReacquisitionRequest request,
+        WorkspaceContextLoadOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        RealizedMemberCoordinate.Package pinned = request.Coordinate;
+        return AcquireCoreAsync(
+            pinned.PackageId,
+            pinned.Version,
+            pinned.Framework,
+            pinned.RuntimeIdentifier,
+            request.SelectionTargetFramework,
+            pinned.Producer,
+            request,
+            options,
+            cancellationToken);
+    }
+
+    static async Task<PackageRootAcquisitionOutcome> AcquireCoreAsync(
+        string packageId,
+        string version,
+        string? acquisitionFramework,
+        string? runtimeIdentifier,
+        string? selectionTargetFramework,
+        string? pinnedProducer,
+        PackageRootReacquisitionRequest? expected,
+        WorkspaceContextLoadOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.HttpClient);
+        ArgumentNullException.ThrowIfNull(options.SourceAuthorization);
+        ArgumentNullException.ThrowIfNull(options.PackageStore);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        PackageSourceAuthorization authorization =
+            options.SourceAuthorization.AuthorizeSourcesFor(packageId);
+        IReadOnlyList<PackageSource> sources = authorization.Sources;
+        if (pinnedProducer is not null)
+        {
+            // The intersection, not a preference: only the producer the request
+            // names may answer, so a host authorizing several producers for
+            // this id still reacquires the Root the binding was realized from.
+            PackageSource? producer = sources.FirstOrDefault(
+                source => string.Equals(
+                    NuGetCache.GetSourceKey(source.Url),
+                    pinnedProducer,
+                    StringComparison.Ordinal));
+            if (producer is null)
+            {
+                return Failed(
+                    PackageRootAcquisitionFailureKind.ProducerNotAuthorized,
+                    authorization.DenialReason
+                    ?? $"The producer recorded for package '{packageId}' is not authorized by this host.");
+            }
+
+            sources = [producer];
+        }
+        else if (sources.Count == 0)
+        {
+            return Failed(
+                PackageRootAcquisitionFailureKind.PackageUnavailable,
+                authorization.DenialReason
+                ?? $"No producer is authorized to serve package '{packageId}'.");
+        }
+
+        PackageCoordinateResolution resolution =
+            await PackageCoordinateResolver.ResolveAsync(
+                    options.HttpClient,
+                    new PackageCoordinate(
+                        packageId,
+                        version,
+                        acquisitionFramework,
+                        runtimeIdentifier),
+                    sources,
+                    options.Log,
+                    options.IncludePrerelease,
+                    options.UseVersionCache,
+                    requireStableFloating: true,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        switch (resolution)
+        {
+            case PackageCoordinateResolution.Invalid invalid:
+                return Failed(
+                    PackageRootAcquisitionFailureKind.InvalidCoordinate,
+                    invalid.Message);
+            case PackageCoordinateResolution.Unavailable unavailable:
+                return Failed(
+                    PackageRootAcquisitionFailureKind.PackageUnavailable,
+                    unavailable.Message);
+        }
+
+        PackagePayloadResult payload =
+            await PackagePayloadAcquisition.AcquireAsync(
+                    options.HttpClient,
+                    ((PackageCoordinateResolution.Resolved)resolution)
+                        .Coordinate,
+                    options.PackageStore,
+                    options.Log,
+                    options.PayloadLimits,
+                    cancellationToken,
+                    options.PackageTransferPolicy)
+                .ConfigureAwait(false);
+        if (payload is PackagePayloadResult.Unavailable payloadFailure)
+        {
+            return Failed(
+                PackageRootAcquisitionFailureKind.PackageUnavailable,
+                payloadFailure.Message);
+        }
+
+        AcquiredPackagePayload acquired =
+            ((PackagePayloadResult.Acquired)payload).Payload;
+        if (pinnedProducer is not null
+            && !string.Equals(
+                acquired.ProducerKey,
+                pinnedProducer,
+                StringComparison.Ordinal))
+        {
+            return Failed(
+                PackageRootAcquisitionFailureKind.ProducerNotAuthorized,
+                $"Package '{packageId}' was served by a producer other than the one the request names.");
+        }
+
+        PackageRootBinding binding = PackageRootBinding.CreateFromResolved(
+            acquired,
+            selectionTargetFramework);
+        PackageRootReacquisitionRequest issued =
+            binding.CreateReacquisitionRequest();
+        if (expected is not null && !expected.Equals(issued))
+        {
+            // The reacquired Root does not repeat the exact logical request,
+            // so it is reported rather than silently substituted.
+            return Failed(
+                PackageRootAcquisitionFailureKind
+                    .SelectionRequestNotReproduced,
+                $"Reacquiring package '{packageId}' produced a different exact Root request.");
+        }
+
+        return new PackageRootAcquisitionOutcome.Acquired(
+            binding,
+            acquired,
+            issued);
+    }
+
+    static PackageRootAcquisitionOutcome Failed(
+        PackageRootAcquisitionFailureKind kind,
+        string message) =>
+        new PackageRootAcquisitionOutcome.Failed(kind, message);
+}

--- a/src/DotnetInspector.Queries/SparsePackageAssemblyProjection.cs
+++ b/src/DotnetInspector.Queries/SparsePackageAssemblyProjection.cs
@@ -1,0 +1,784 @@
+using System.Collections.Immutable;
+
+using DotnetInspector.Artifacts;
+using DotnetInspector.Artifacts.Workspaces;
+using DotnetInspector.Packages;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Explicit entry and aggregate retained-image bounds for one sparse selected
+/// package assembly projection.
+/// </summary>
+/// <remarks>
+/// Both bounds are required and must be positive; the projection never infers
+/// a default budget. The aggregate bound covers the artifact-owned snapshot
+/// and the independent Metadata group snapshot, so half is reserved for each.
+/// </remarks>
+public sealed record SparsePackageAssemblyProjectionOptions
+{
+    /// <summary>The largest expanded package entry the projection admits.</summary>
+    public required long MaxSelectedEntryBytes { get; init; }
+
+    /// <summary>
+    /// The retained-byte budget covering the artifact snapshot and the
+    /// one-participant group snapshot together.
+    /// </summary>
+    public required long MaxAggregateRetainedImageBytes { get; init; }
+
+    internal void Validate()
+    {
+        if (MaxSelectedEntryBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxSelectedEntryBytes),
+                MaxSelectedEntryBytes,
+                "The sparse package assembly projection requires a positive per-entry byte limit.");
+        }
+        if (MaxAggregateRetainedImageBytes < 2)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxAggregateRetainedImageBytes),
+                MaxAggregateRetainedImageBytes,
+                "The sparse package assembly projection requires an aggregate retained-image bound of at least two bytes.");
+        }
+    }
+}
+
+/// <summary>One owner-local cleanup stage attempted before ownership transfer.</summary>
+public enum SparsePackageProjectionCleanupStage
+{
+    /// <summary>Disposal of the not-yet-transferred participant group.</summary>
+    Participant,
+
+    /// <summary>Disposal of the not-yet-transferred artifact query lease.</summary>
+    QueryLease,
+
+    /// <summary>Disposal of the not-yet-transferred artifact session.</summary>
+    ArtifactSession,
+}
+
+/// <summary>One incomplete cleanup stage and how many failures it observed.</summary>
+public readonly record struct SparsePackageProjectionCleanupEvidence(
+    SparsePackageProjectionCleanupStage Stage,
+    int FailureCount);
+
+/// <summary>
+/// Bounded, resource-free evidence that owner-local cleanup before ownership
+/// transfer did not complete.
+/// </summary>
+/// <remarks>
+/// The receipt is always secondary to the primary projection outcome,
+/// cancellation, or unexpected exception, and is absent when cleanup
+/// succeeded or when the projection transferred ownership. It carries closed
+/// stage and count data only: no exception, message, path, package-authored
+/// string, stream, artifact registration, session, lease, participant,
+/// workspace, callback, or opener. Gated by
+/// <c>SparsePackageAssemblyProjectionTests.Projection_CancellationKeepsCancellationAndAttachesReceipt</c>
+/// and <c>Projection_IncompleteCleanupProducesBoundedResourceFreeReceipt</c>.
+/// </remarks>
+public sealed class SparsePackageProjectionCleanupReceipt
+{
+    static readonly object ReceiptKey = new();
+
+    internal SparsePackageProjectionCleanupReceipt(
+        ImmutableArray<SparsePackageProjectionCleanupEvidence> incompleteStages)
+    {
+        IncompleteStages = incompleteStages;
+        int total = 0;
+        foreach (SparsePackageProjectionCleanupEvidence evidence
+            in incompleteStages)
+        {
+            total = checked(total + evidence.FailureCount);
+        }
+
+        FailureCount = total;
+    }
+
+    /// <summary>The owner-local stages whose cleanup did not complete.</summary>
+    public ImmutableArray<SparsePackageProjectionCleanupEvidence>
+        IncompleteStages
+    { get; }
+
+    /// <summary>The total number of observed cleanup failures.</summary>
+    public int FailureCount { get; }
+
+    /// <summary>
+    /// Reads the receipt this owner attached to a primary exception, or
+    /// <see langword="null"/> when owner-local cleanup completed.
+    /// </summary>
+    public static SparsePackageProjectionCleanupReceipt? FromException(
+        Exception failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return failure.Data[ReceiptKey]
+            as SparsePackageProjectionCleanupReceipt;
+    }
+
+    internal void AttachTo(Exception primary) =>
+        primary.Data[ReceiptKey] = this;
+}
+
+/// <summary>
+/// The closed package-owned outcome of one sparse selected-assembly
+/// projection.
+/// </summary>
+/// <remarks>
+/// Null inputs, an invalid bound, and a workspace that is not asynchronous
+/// remain caller contract violations outside this algebra. Cancellation
+/// propagates with the caller's token, and unexpected implementation
+/// exceptions remain exceptional.
+/// </remarks>
+public abstract class SparsePackageAssemblyProjectionOutcome
+{
+    private protected SparsePackageAssemblyProjectionOutcome()
+    {
+    }
+
+    /// <summary>One operation-scoped, resource-bearing sparse realization.</summary>
+    public sealed class Available : SparsePackageAssemblyProjectionOutcome
+    {
+        internal Available(SparsePackageAssemblyRealization realization) =>
+            Realization = realization;
+
+        public SparsePackageAssemblyRealization Realization { get; }
+    }
+
+    /// <summary>
+    /// The Root no longer corresponds to the binding's content-generation
+    /// identity.
+    /// </summary>
+    public sealed class InvalidBinding : SparsePackageAssemblyProjectionOutcome
+    {
+        internal InvalidBinding()
+        {
+        }
+    }
+
+    /// <summary>
+    /// The supplied asset is not an exact canonical member of the binding's
+    /// frozen selected sequences.
+    /// </summary>
+    public sealed class InvalidSelectedAsset :
+        SparsePackageAssemblyProjectionOutcome
+    {
+        internal InvalidSelectedAsset()
+        {
+        }
+    }
+
+    /// <summary>
+    /// The selected entry is missing, or the package content returned
+    /// <see langword="false"/> from bounded open.
+    /// </summary>
+    public sealed class SelectedEntryUnavailable :
+        SparsePackageAssemblyProjectionOutcome
+    {
+        internal SelectedEntryUnavailable(
+            SparsePackageProjectionCleanupReceipt? cleanup) =>
+            Cleanup = cleanup;
+
+        public SparsePackageProjectionCleanupReceipt? Cleanup { get; }
+    }
+
+    /// <summary>
+    /// A declared-length preflight or observed artifact copy crossed the
+    /// admitted entry or artifact-share byte limit.
+    /// </summary>
+    public sealed class EntryByteLimitExceeded :
+        SparsePackageAssemblyProjectionOutcome
+    {
+        internal EntryByteLimitExceeded(
+            SparsePackageProjectionCleanupReceipt? cleanup) =>
+            Cleanup = cleanup;
+
+        public SparsePackageProjectionCleanupReceipt? Cleanup { get; }
+    }
+
+    /// <summary>The artifact owner's typed publication failures, preserved.</summary>
+    public sealed class ArtifactPublicationFailed :
+        SparsePackageAssemblyProjectionOutcome
+    {
+        internal ArtifactPublicationFailed(
+            ImmutableArray<ArtifactSetAdmissionFailure> failures,
+            SparsePackageProjectionCleanupReceipt? cleanup)
+        {
+            Failures = failures;
+            Cleanup = cleanup;
+        }
+
+        public ImmutableArray<ArtifactSetAdmissionFailure> Failures { get; }
+
+        public SparsePackageProjectionCleanupReceipt? Cleanup { get; }
+    }
+}
+
+/// <summary>
+/// One operation-scoped, resource-bearing projection of a single canonical
+/// package assembly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This value is execution authority, not durable query evidence. It is
+/// deliberately live: the group, participant, and query entry point exist so a
+/// consumer can enter real owner-authorized query validation while the
+/// candidate workspace is open. A consumer may copy the package coordinate,
+/// content-generation identity, selection identity, selected asset, and typed
+/// admission facts into a resource-free receipt, but must not retain this
+/// realization, its group, or its participant.
+/// </para>
+/// <para>
+/// Disposing the realization releases its group but not the transferred
+/// artifact session; the candidate workspace remains the release owner until
+/// <see cref="InspectionWorkspace.CloseAsync"/> completes. Gated by
+/// <c>SparsePackageAssemblyProjectionTests.Projection_CloseWaitsForActiveQueryThenDeniesAccess</c>
+/// and
+/// <c>ReacquisitionRequest_SurvivesCandidateWorkspaceDisposal</c>.
+/// </para>
+/// </remarks>
+public sealed class SparsePackageAssemblyRealization : IDisposable
+{
+    readonly PackageAssemblyContextRoles _roles;
+    readonly ArtifactSetSession _session;
+    readonly ArtifactQueryLease _queryLease;
+    readonly ArtifactIdentity _artifact;
+
+    internal SparsePackageAssemblyRealization(
+        PackageAssemblyContextRoles roles,
+        ArtifactSetSession session,
+        ArtifactQueryLease queryLease,
+        ArtifactIdentity artifact,
+        PackageCompileAsset asset,
+        ArtifactAssemblyProjectionOutcome admission,
+        bool identityDecoded)
+    {
+        _roles = roles;
+        _session = session;
+        _queryLease = queryLease;
+        _artifact = artifact;
+        Asset = asset;
+        Admission = admission;
+        IdentityDecoded = identityDecoded;
+        Participant = roles.SurfaceParticipants.Single();
+    }
+
+    /// <summary>The exact canonical selected asset this projection admitted.</summary>
+    public PackageCompileAsset Asset { get; }
+
+    /// <summary>The exact one-participant group that owns query authority.</summary>
+    public AssemblyContextGroup Group => _roles.SurfaceGroup;
+
+    /// <summary>The exact published participant.</summary>
+    public AssemblyContextParticipant Participant { get; }
+
+    /// <summary>
+    /// Whether the compatibility descriptor decoded an assembly identity
+    /// rather than using the deterministic rejection carrier.
+    /// </summary>
+    /// <remarks>
+    /// This is compatibility evidence only. It is never supported-format or
+    /// query authority; <see cref="Admission"/> owns both. Gated by
+    /// <c>SparsePackageAssemblyProjectionTests.Projection_RejectedCarrierRefusesQueryWithOwnerFailure</c>.
+    /// </remarks>
+    public bool IdentityDecoded { get; }
+
+    /// <summary>
+    /// The exact exhaustive Metadata-owned admission outcome for the retained
+    /// artifact.
+    /// </summary>
+    public ArtifactAssemblyProjectionOutcome Admission { get; }
+
+    /// <summary>
+    /// Runs one bounded producer against the retained artifact through the
+    /// assembly-inspection owner's query revalidation.
+    /// </summary>
+    /// <remarks>
+    /// The group owns active-operation quiescence for the call, and the
+    /// artifact owner supplies the content view; no raw bytes, opener, or
+    /// query lease escapes. An admission that is not
+    /// <see cref="ArtifactAssemblyProjectionOutcome.Projected"/> refuses with
+    /// the same owner-typed reason and runs no producer. Gated by
+    /// <c>SparsePackageAssemblyProjectionTests.Projection_RunsProducerThroughOwnerAuthorizedQueryView</c>
+    /// and
+    /// <c>Projection_RejectedCarrierRefusesQueryWithOwnerFailure</c>.
+    /// </remarks>
+    public ArtifactAssemblyQueryOutcome<TResult> ExecuteAssemblyQuery<TResult>(
+        Func<AssemblyInspectionSession, CancellationToken, TResult> producer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(producer);
+        if (Admission is not ArtifactAssemblyProjectionOutcome.Projected
+            projected)
+        {
+            return Refuse<TResult>(Admission);
+        }
+
+        return Group.UseContext(() =>
+            ArtifactAssemblyQueryOutcome<TResult>.FromAccess(
+                _session.WithQueryContent(
+                    _artifact,
+                    _queryLease,
+                    (view, token) => ArtifactAssemblyInspection.Execute(
+                        view,
+                        projected.Value,
+                        producer,
+                        token),
+                    cancellationToken)));
+    }
+
+    public void Dispose() => _roles.Dispose();
+
+    static ArtifactAssemblyQueryOutcome<TResult> Refuse<TResult>(
+        ArtifactAssemblyProjectionOutcome admission) =>
+        admission switch
+        {
+            ArtifactAssemblyProjectionOutcome.NotAssembly notAssembly =>
+                new ArtifactAssemblyQueryOutcome<TResult>.NotAssembly(
+                    notAssembly.Kind),
+            ArtifactAssemblyProjectionOutcome.Rejected rejected =>
+                new ArtifactAssemblyQueryOutcome<TResult>.Rejected(
+                    new ArtifactAssemblyQueryFailure(
+                        QueryFailure(rejected.Failure.Kind))),
+            _ => throw new InvalidOperationException(
+                "Unknown artifact assembly admission outcome."),
+        };
+
+    static ArtifactAssemblyQueryFailureKind QueryFailure(
+        ArtifactAssemblyProjectionFailureKind kind) =>
+        kind switch
+        {
+            ArtifactAssemblyProjectionFailureKind.AdmissionUnauthorized =>
+                ArtifactAssemblyQueryFailureKind.QueryUnauthorized,
+            ArtifactAssemblyProjectionFailureKind.UnsupportedWindowsMetadata =>
+                ArtifactAssemblyQueryFailureKind.UnsupportedWindowsMetadata,
+            ArtifactAssemblyProjectionFailureKind.MalformedMetadata =>
+                ArtifactAssemblyQueryFailureKind.MalformedMetadata,
+            ArtifactAssemblyProjectionFailureKind.EmptyModuleVersionId =>
+                ArtifactAssemblyQueryFailureKind.EmptyModuleVersionId,
+            _ => throw new InvalidOperationException(
+                "Unknown artifact assembly admission failure."),
+        };
+}
+
+public sealed partial class InspectionWorkspace
+{
+    const string SparseRejectionCarrierName = "SelectedPackageAsset";
+
+    /// <summary>
+    /// Projects one exact canonical selected package asset into one
+    /// artifact-backed, one-participant candidate group.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The caller owns why it selected the asset. This adapter does not choose
+    /// a primary assembly, interpret a query role, count siblings, or map
+    /// package selection states into query outcomes. Only the exact canonical
+    /// <see cref="PackageCompileAsset"/> retained in the binding's frozen
+    /// <c>Assets</c> or <c>ImplementationAssets</c> sequence carries opening
+    /// authority; a reconstructed equal value, a foreign binding's asset, or a
+    /// non-selected candidate is rejected before content access.
+    /// </para>
+    /// <para>
+    /// Exactly one package entry is opened and materialized under both the
+    /// declared and observed byte limits. The aggregate bound is partitioned
+    /// between the artifact snapshot and the one Metadata group snapshot, so an
+    /// image of <c>N</c> bytes is admitted at <c>2N</c> and rejected at
+    /// <c>2N - 1</c>. Gated by
+    /// <c>SparsePackageAssemblyProjectionTests.Projection_RejectsReconstructedOrForeignSelectedAsset</c>,
+    /// <c>Projection_PublishesOneExactParticipantForCanonicalAsset</c>,
+    /// <c>Projection_AggregatePartitionAdmitsAtTwiceTheImage</c>,
+    /// <c>Projection_DeclaredEntryLimitRejectsBeforeOpen</c>,
+    /// and
+    /// <c>Projection_ReportsArtifactPublicationFailureWithOwnerCodes</c>.
+    /// </para>
+    /// </remarks>
+    public async ValueTask<SparsePackageAssemblyProjectionOutcome>
+        ProjectSelectedPackageAssemblyAsync(
+            PackageRootBinding package,
+            PackageCompileAsset selectedAsset,
+            SparsePackageAssemblyProjectionOptions options,
+            CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        ArgumentNullException.ThrowIfNull(selectedAsset);
+        ArgumentNullException.ThrowIfNull(options);
+        options.Validate();
+        if (_lifetimeMode
+            != InspectionWorkspaceLifetimeMode.Asynchronous)
+        {
+            throw new InvalidOperationException(
+                "Sparse package assembly projection requires a workspace created by CreateAsynchronous.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        IPackageContent content = package.Root.Content;
+        if (!ReferenceEquals(
+                content.GenerationIdentity,
+                package.ContentGenerationIdentity))
+        {
+            return new SparsePackageAssemblyProjectionOutcome
+                .InvalidBinding();
+        }
+        if (!IsCanonicalSelectedAsset(
+                package.Root.AssetSelection,
+                selectedAsset))
+        {
+            return new SparsePackageAssemblyProjectionOutcome
+                .InvalidSelectedAsset();
+        }
+
+        long artifactShare = options.MaxAggregateRetainedImageBytes / 2;
+        long groupShare =
+            options.MaxAggregateRetainedImageBytes - artifactShare;
+        long entryLimit = Math.Min(
+            options.MaxSelectedEntryBytes,
+            artifactShare);
+        if (content is IPackageContentEntryManifest manifest)
+        {
+            if (!manifest.TryGetEntryLength(
+                    selectedAsset.Path,
+                    out long declaredLength))
+            {
+                return new SparsePackageAssemblyProjectionOutcome
+                    .SelectedEntryUnavailable(cleanup: null);
+            }
+            if (declaredLength < 0 || declaredLength > entryLimit)
+            {
+                return new SparsePackageAssemblyProjectionOutcome
+                    .EntryByteLimitExceeded(cleanup: null);
+            }
+        }
+
+        var session = new ArtifactSetSession(
+            new ArtifactSetSessionLimits
+            {
+                MaxArtifacts = 1,
+                MaxArtifactBytes = entryLimit,
+                MaxRetainedBytes = artifactShare,
+            });
+        var entryState = new SelectedEntryOpenState();
+        ArtifactQueryLease? queryLease = null;
+        PackageAssemblyContextRoles? roles = null;
+        bool transferred = false;
+        try
+        {
+            ArtifactContribution contribution =
+                await RegisterSelectedEntryAsync(
+                        session,
+                        package,
+                        selectedAsset,
+                        entryLimit,
+                        entryState,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            ArtifactAssemblyProjectionOutcome? admission = null;
+            ArtifactSetPublicationOutcome publication =
+                await session.SealWithProjectionAsync(
+                        (view, token) =>
+                        {
+                            admission = ArtifactAssemblyInspection.Project(
+                                view,
+                                token);
+                            // Non-projectable images still publish as
+                            // compatibility rejection carriers.
+                            return null;
+                        },
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            if (publication
+                is ArtifactSetPublicationOutcome.NotPublished rejected)
+            {
+                SparsePackageProjectionCleanupReceipt? receipt =
+                    await CleanupSparseProjectionAsync(
+                            roles: null,
+                            queryLease: null,
+                            session,
+                            primary: null)
+                        .ConfigureAwait(false);
+                return NotPublished(rejected, entryState, receipt);
+            }
+
+            ArtifactQueryAuthorization authorization =
+                session.CreateQueryAuthorization();
+            queryLease = session.IssueLease(authorization);
+            ArtifactContentReference reference =
+                session.GetContentReference(
+                    contribution.Descriptor.Identity,
+                    queryLease);
+            ResolvedAssemblyReference assembly = SparseAssembly(
+                reference,
+                package,
+                selectedAsset,
+                admission!,
+                out bool identityDecoded);
+            roles = CreatePackageAssemblyContextRoles(
+                [assembly],
+                implementationAssemblies: null,
+                correspondences: [],
+                surfaceOptions: new AssemblyContextGroupOptions
+                {
+                    MaxRetainedImageBytes = groupShare,
+                });
+            RegisterArtifactSession(
+                session,
+                queryLease,
+                [roles.SurfaceGroup]);
+            transferred = true;
+            return new SparsePackageAssemblyProjectionOutcome.Available(
+                new SparsePackageAssemblyRealization(
+                    roles,
+                    session,
+                    queryLease,
+                    contribution.Descriptor.Identity,
+                    selectedAsset,
+                    admission!,
+                    identityDecoded));
+        }
+        catch (Exception failure)
+        {
+            if (!transferred)
+            {
+                await CleanupSparseProjectionAsync(
+                        roles,
+                        queryLease,
+                        session,
+                        failure)
+                    .ConfigureAwait(false);
+            }
+
+            throw;
+        }
+    }
+
+    static bool IsCanonicalSelectedAsset(
+        PackageCompileAssetSelection selection,
+        PackageCompileAsset asset) =>
+        Contains(selection.Assets, asset)
+        || Contains(selection.ImplementationAssets, asset);
+
+    static bool Contains(
+        IReadOnlyList<PackageCompileAsset> assets,
+        PackageCompileAsset asset)
+    {
+        for (int index = 0; index < assets.Count; index++)
+        {
+            if (ReferenceEquals(assets[index], asset))
+                return true;
+        }
+
+        return false;
+    }
+
+    static async ValueTask<ArtifactContribution> RegisterSelectedEntryAsync(
+        ArtifactSetSession session,
+        PackageRootBinding package,
+        PackageCompileAsset selectedAsset,
+        long entryLimit,
+        SelectedEntryOpenState entryState,
+        CancellationToken cancellationToken)
+    {
+        ArtifactContribution? registered = null;
+        await session.AddRequiredAcquisitionAsync(
+                (scope, generationEnd) =>
+                {
+                    generationEnd.ThrowIfCancellationRequested();
+                    registered = scope.Register(
+                        new PackageAssemblyArtifactProvenance(
+                            package.Coordinate,
+                            package.ContentGenerationIdentity,
+                            package.SelectionIdentity,
+                            selectedAsset),
+                        token => OpenSelectedEntry(
+                            package.Root.Content,
+                            selectedAsset.Path,
+                            entryLimit,
+                            entryState,
+                            token),
+                        kind: "package-assembly");
+                    return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                        new ArtifactAcquisitionOutcome.Acquired(
+                            [registered],
+                            ArtifactAcquisitionLeases.None));
+                },
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return registered!;
+    }
+
+    static Stream OpenSelectedEntry(
+        IPackageContent content,
+        string path,
+        long maxExpandedBytes,
+        SelectedEntryOpenState entryState,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!content.TryOpenEntry(
+                path,
+                maxExpandedBytes,
+                out Stream? stream))
+        {
+            // The current IPackageContent boundary cannot distinguish a
+            // missing entry from an implementation that refuses the bound.
+            entryState.EntryUnavailable = true;
+            throw new SelectedPackageEntryUnavailableException();
+        }
+
+        return stream;
+    }
+
+    ResolvedAssemblyReference SparseAssembly(
+        ArtifactContentReference reference,
+        PackageRootBinding package,
+        PackageCompileAsset selectedAsset,
+        ArtifactAssemblyProjectionOutcome admission,
+        out bool identityDecoded)
+    {
+        AssemblyResolutionProvenance provenance =
+            AssemblyResolutionProvenance.Package(
+                package.Root.PackageId,
+                package.Root.PackageVersion,
+                selectedAsset.TargetFramework,
+                rid: null);
+        if (admission is ArtifactAssemblyProjectionOutcome.Projected projected
+            && !string.IsNullOrWhiteSpace(projected.Value.Identity.Name))
+        {
+            identityDecoded = true;
+            return ResolvedAssemblyReference.CreateFromArtifactProjection(
+                reference.Registration,
+                projected.Value,
+                reference.OpenRead,
+                provenance);
+        }
+
+        // A rejection carrier keeps the selected image visible as one
+        // participant; its deterministic name is never artifact-derived
+        // identity.
+        ResolvedAssemblyReference carrier = ResolvedAssemblyReference
+            .CreateFromArtifactWithFallbackIdentity(
+                reference.Registration,
+                reference.OpenRead,
+                new AssemblyReferenceIdentity(
+                    SparseRejectionCarrierName,
+                    Version: null,
+                    Culture: null,
+                    PublicKeyToken: null),
+                provenance,
+                out bool usedFallbackIdentity);
+        identityDecoded = !usedFallbackIdentity;
+        return carrier;
+    }
+
+    static SparsePackageAssemblyProjectionOutcome NotPublished(
+        ArtifactSetPublicationOutcome.NotPublished rejected,
+        SelectedEntryOpenState entryState,
+        SparsePackageProjectionCleanupReceipt? cleanup)
+    {
+        if (entryState.EntryUnavailable)
+        {
+            return new SparsePackageAssemblyProjectionOutcome
+                .SelectedEntryUnavailable(cleanup);
+        }
+        foreach (ArtifactSetAdmissionFailure failure in rejected.Failures)
+        {
+            if (failure.Diagnostic.Code
+                is "artifact.session.artifact-byte-limit")
+            {
+                return new SparsePackageAssemblyProjectionOutcome
+                    .EntryByteLimitExceeded(cleanup);
+            }
+        }
+
+        return new SparsePackageAssemblyProjectionOutcome
+            .ArtifactPublicationFailed(
+                [.. rejected.Failures],
+                cleanup);
+    }
+
+    static async ValueTask<SparsePackageProjectionCleanupReceipt?>
+        CleanupSparseProjectionAsync(
+            PackageAssemblyContextRoles? roles,
+            ArtifactQueryLease? queryLease,
+            ArtifactSetSession session,
+            Exception? primary)
+    {
+        var stages =
+            ImmutableArray.CreateBuilder<
+                SparsePackageProjectionCleanupEvidence>();
+        AddStage(
+            stages,
+            SparsePackageProjectionCleanupStage.Participant,
+            TryDispose(roles));
+        AddStage(
+            stages,
+            SparsePackageProjectionCleanupStage.QueryLease,
+            TryDispose(queryLease));
+
+        int sessionFailures = 0;
+        try
+        {
+            await session.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            sessionFailures++;
+        }
+        sessionFailures += session.CleanupFailures.Count;
+        if (primary is not null)
+        {
+            sessionFailures +=
+                ArtifactSetSession.GetCleanupFailures(primary).Count;
+        }
+        AddStage(
+            stages,
+            SparsePackageProjectionCleanupStage.ArtifactSession,
+            sessionFailures);
+        if (stages.Count == 0)
+            return null;
+
+        var receipt = new SparsePackageProjectionCleanupReceipt(
+            stages.ToImmutable());
+        if (primary is not null)
+            receipt.AttachTo(primary);
+        return receipt;
+    }
+
+    static void AddStage(
+        ImmutableArray<SparsePackageProjectionCleanupEvidence>.Builder stages,
+        SparsePackageProjectionCleanupStage stage,
+        int failureCount)
+    {
+        if (failureCount > 0)
+            stages.Add(new(stage, failureCount));
+    }
+
+    static int TryDispose(IDisposable? resource)
+    {
+        if (resource is null)
+            return 0;
+
+        try
+        {
+            resource.Dispose();
+            return 0;
+        }
+        catch
+        {
+            return 1;
+        }
+    }
+
+    sealed class SelectedEntryOpenState
+    {
+        internal bool EntryUnavailable { get; set; }
+    }
+
+    sealed class SelectedPackageEntryUnavailableException : IOException
+    {
+        internal SelectedPackageEntryUnavailableException()
+            : base("The selected package entry is unavailable.")
+        {
+        }
+    }
+}

--- a/src/DotnetInspector.Services.Tests/FileSystemPackageContentManifestTests.cs
+++ b/src/DotnetInspector.Services.Tests/FileSystemPackageContentManifestTests.cs
@@ -1,0 +1,73 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// Filesystem package content exposes declared entry lengths so a bounded
+/// caller can reject an over-budget entry before opening its body.
+/// </summary>
+public sealed class FileSystemPackageContentManifestTests
+{
+    [Fact]
+    public void FileSystemLengthUsesManifestPreflight()
+    {
+        string root = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-manifest-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "lib", "net11.0"));
+            byte[] payload = new byte[1234];
+            string relativePath = "lib/net11.0/Sample.dll";
+            File.WriteAllBytes(
+                Path.Combine(root, "lib", "net11.0", "Sample.dll"),
+                payload);
+
+            var content = new FileSystemPackageContent(
+                root,
+                nupkgPath: null,
+                fromCache: false,
+                producerKey: "tests",
+                requiresArchiveTreeMatch: false);
+
+            var manifest = Assert.IsAssignableFrom<IPackageContentEntryManifest>(
+                content);
+            Assert.True(
+                manifest.TryGetEntryLength(relativePath, out long length));
+            Assert.Equal(payload.LongLength, length);
+            Assert.False(
+                manifest.TryGetEntryLength(
+                    "lib/net11.0/Missing.dll",
+                    out long missing));
+            Assert.Equal(0, missing);
+            Assert.Equal(
+                payload.LongLength,
+                Assert.Single(
+                    manifest.EnumerateEntriesWithLengths(),
+                    entry => entry.Path == relativePath).Length);
+
+            // Over budget, bounded open throws an InvalidDataException that a
+            // caller cannot distinguish from an unrelated read failure. The
+            // manifest is what lets that caller answer before opening at all.
+            Assert.Throws<InvalidDataException>(
+                () => content.TryOpenEntry(
+                    relativePath,
+                    payload.LongLength - 1,
+                    out _));
+            Assert.True(
+                content.TryOpenEntry(
+                    relativePath,
+                    payload.LongLength,
+                    out Stream? admitted));
+            using (admitted)
+            {
+                Assert.NotNull(admitted);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/DotnetInspector.Artifacts.Tests/ArtifactSetSessionCleanupEvidenceTests.cs
+++ b/tests/DotnetInspector.Artifacts.Tests/ArtifactSetSessionCleanupEvidenceTests.cs
@@ -1,0 +1,203 @@
+using DotnetInspector.Artifacts.Workspaces;
+
+namespace DotnetInspector.Artifacts.Tests;
+
+/// <summary>
+/// Materialization cleanup evidence stays strictly secondary to the condition
+/// the session is already reporting.
+/// </summary>
+public sealed class ArtifactSetSessionCleanupEvidenceTests
+{
+    [Fact]
+    public async Task DisposalFailureDoesNotReplaceCancelledRead()
+    {
+        using var cancellation = new CancellationTokenSource();
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) =>
+            {
+                ArtifactContribution artifact = scope.Register(
+                    new CleanupProvenance("cancelled-read"),
+                    _ => new HookedStream(
+                        new byte[64],
+                        failDispose: true,
+                        onRead: cancellation.Cancel));
+                return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                    new ArtifactAcquisitionOutcome.Acquired(
+                        [artifact],
+                        ArtifactAcquisitionLeases.None));
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        OperationCanceledException cancelled =
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await session.SealAsync(cancellation.Token));
+
+        Assert.Equal(cancellation.Token, cancelled.CancellationToken);
+        Exception disposal = Assert.Single(
+            ArtifactSetSession.GetCleanupFailures(cancelled));
+        Assert.Equal(
+            "synthetic disposal failure",
+            Assert.IsType<IOException>(disposal).Message);
+    }
+
+    [Fact]
+    public async Task DisposalFailureDoesNotReplaceReadFailure()
+    {
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) =>
+            {
+                ArtifactContribution artifact = scope.Register(
+                    new CleanupProvenance("failed-read"),
+                    _ => new HookedStream(
+                        new byte[64],
+                        failDispose: true,
+                        failRead: () => new IOException("synthetic read failure")));
+                return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                    new ArtifactAcquisitionOutcome.Acquired(
+                        [artifact],
+                        ArtifactAcquisitionLeases.None));
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var rejected =
+            Assert.IsType<ArtifactSetPublicationOutcome.NotPublished>(
+                await session.SealAsync(
+                    TestContext.Current.CancellationToken));
+
+        // The original read failure classifies the outcome; disposal evidence
+        // is retained separately rather than replacing it.
+        Assert.Equal(
+            "artifact.session.materialization-failed",
+            Assert.Single(rejected.Failures).Diagnostic.Code);
+        Exception disposal = Assert.Single(session.CleanupFailures);
+        Assert.Equal(
+            "synthetic disposal failure",
+            Assert.IsType<IOException>(disposal).Message);
+    }
+
+    [Fact]
+    public void AttachedCleanupEvidenceMergesRatherThanReplaces()
+    {
+        var primary = new InvalidOperationException("primary");
+        var first = new IOException("first cleanup failure");
+        var second = new IOException("second cleanup failure");
+
+        ArtifactSetSession.AttachCleanupFailures(primary, [first]);
+        // A later release sweep over the same failure must add to the earlier
+        // evidence, not replace it; the Workspace root realizer attaches this
+        // way after transfer fails.
+        ArtifactSetSession.AttachCleanupFailures(primary, [second]);
+
+        Assert.Equal(
+            [first, second],
+            ArtifactSetSession.GetCleanupFailures(primary));
+
+        ArtifactSetSession.AttachCleanupFailures(primary, []);
+        Assert.Equal(
+            [first, second],
+            ArtifactSetSession.GetCleanupFailures(primary));
+
+        Assert.Empty(
+            ArtifactSetSession.GetCleanupFailures(
+                new InvalidOperationException("unrelated")));
+    }
+
+    [Fact]
+    public async Task DisposalFailureOnSuccessfulReadStillPropagates()
+    {
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) =>
+            {
+                ArtifactContribution artifact = scope.Register(
+                    new CleanupProvenance("successful-read"),
+                    _ => new HookedStream(new byte[64], failDispose: true));
+                return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                    new ArtifactAcquisitionOutcome.Acquired(
+                        [artifact],
+                        ArtifactAcquisitionLeases.None));
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var rejected =
+            Assert.IsType<ArtifactSetPublicationOutcome.NotPublished>(
+                await session.SealAsync(
+                    TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            "artifact.session.materialization-failed",
+            Assert.Single(rejected.Failures).Diagnostic.Code);
+    }
+
+    private sealed record CleanupProvenance(string Source) :
+        IArtifactProvenance;
+
+    private sealed class HookedStream(
+        byte[] content,
+        bool failDispose,
+        Func<Exception>? failRead = null,
+        Action? onRead = null) : Stream
+    {
+        readonly MemoryStream _source = new(content, writable: false);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _source.Length;
+
+        public override long Position
+        {
+            get => _source.Position;
+            set => _source.Position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            onRead?.Invoke();
+            if (failRead is not null)
+                throw failRead();
+            return _source.Read(buffer);
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            onRead?.Invoke();
+            cancellationToken.ThrowIfCancellationRequested();
+            if (failRead is not null)
+                throw failRead();
+            return ValueTask.FromResult(_source.Read(buffer.Span));
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            _source.Seek(offset, origin);
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _source.Dispose();
+                if (failDispose)
+                    throw new IOException("synthetic disposal failure");
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Build robust, useful Package Query consumption: evaluate one bounded assembly,
release its candidate workspace, and reopen a result through an exact
producer-pinned package Root rather than an ID/version approximation.

This supplies the Artifact Acquisition prerequisite for #6030. It does not
advertise the unfinished host delivery as supported.

## Demo

The Release fixtures exercise these actual owner operations:

```text
ProjectSelectedPackageAssemblyAsync(binding, canonicalAsset, bounds)
  -> Available: one exact participant, with Metadata admission
  -> the admitted query executes through the owner's retained query view

candidate.CloseAsync()
binding.CreateReacquisitionRequest().Encode()
PackageRootAcquisition.AcquireAsync(decodedRequest, destinationOptions)
  -> Acquired: a fresh binding over the returned live payload
  -> producer, acquisition framework, and selection target are preserved
```

Neighboring cases remain distinct: a missing entry returns
`SelectedEntryUnavailable`; an image of N bytes admits with a 2N retained-image
allowance but not 2N-1; a currently unauthorized pinned producer fails instead
of falling back to another source. Incomplete cleanup preserves bounded owner
evidence without replacing cancellation.

Runtime-inconsistent Root tokens previously decoded and then failed during
reacquisition. They now return `false` from `TryDecode`; valid requests with
different acquisition and selection frameworks still round-trip.

Before this slice, consumers had full-role package realization but no
one-selected-asset publication operation or exact resource-free Root reopening
transport. They now have both, without retaining a candidate workspace in a
result.

## Design basis

The sole normative owner is
`docs/design/artifact-acquisition-and-workspaces.md`, specifically
**Sparse selected-assembly projection** and **Exact package Root acquisition
and reacquisition**. Its claim is exact, bounded acquisition correspondence:
one canonical frozen asset is projected through the artifact owner, and an
issued Root request reproduces opening intent under current source policy.

Metadata owns image admission and query authorization. The package selector
owns TFM/RID selection and canonical asset ordering. Package Query owns
semantic evaluation and result composition; neither is redefined here.
The existing full-role realization and payload-acquisition paths are the
implementation precedents. Full-role realization remains appropriate for a
normal Workspace and is not being retired.

The extra cleanup receipt and reacquisition request carry the facts the
consumer must retain after disposal; neither carries an executable capability
or grants source authorization. Local mutation, symlink behavior, and
same-machine actors are not new review scope.

## Production-host adoption

This is delivery slice 3 of 4 for #6030: bounded Metadata access (#6093),
Analysis literal-use production (#6145), this Artifact prerequisite, then the
shared evaluator and both production hosts. The overall #5766 tracker has
12 milestones, with first host consumption at milestone 9, before optional
prefiltering and later optimizations.

The named consumer is `PackageAssemblyEvaluator`, composed by
`PackageAssemblyQuery` for CLI Find and Browser Package Query. Its companion
consumer branch already exercises the real Browser/Wasm query-to-Workspace
flow; that evidence belongs to the consumer change, not this head.
The remaining slice must finish and publish both hosts before #6030 closes.
This prerequisite returns typed data only; CLI Sections/Markout and the
existing Browser-specific renderer remain downstream.

## Validation

- Parent reran 33/33 Release sparse-projection and Root-acquisition cases at
  `412e67a722aa2d279d621ff9df559564e1f3c78e`, including correspondence, image bounds,
  Metadata-authorized execution, pre-transfer cleanup, and reopening after
  candidate disposal. Five new runtime-correspondence cases failed before the
  correction and pass afterward.
- The earlier implementation handoff also reported the normal Release solution build,
  1,482 Query cases and 117 Artifact cases, with six Windows skips.
- Changed owner documentation passes `markdownlint`.
- Current-head CI succeeded and round 2 is 2/2 review-clean: GPT-6 Astra and
  Gemini 3.8 Flash, explicitly substituted for unavailable Gemini Pro.

Related scope: #5798, #5837, #5842, #5843. No merge authorization is implied.
