### PR TITLE
Add and remove exact Roots in a committed Workspace Scope

### DIFF
--- a/docs/design/models/workspace-scope-revisions/README.md
+++ b/docs/design/models/workspace-scope-revisions/README.md
@@ -15,7 +15,9 @@ normative owner. This model addresses
 The immediate implementation consumer is
 [#5821](https://github.com/richlander/dotnet-inspect/issues/5821): initial
 `WorkspaceScopeSnapshot` and exact Replace/Clear with CLI snapshot adoption.
-Browser adoption follows its Add/Remove and complete-restoration prerequisites;
+[#6151](https://github.com/richlander/dotnet-inspect/issues/6151) extends that
+implementation with exact-package Add/Remove and CLI Add-batch adoption.
+Browser adoption follows complete-restoration and host migration prerequisites;
 expansion also follows later. The model deliberately retains the broader #5796 race acceptance rather
 than making that first implementation slice implement every modeled operation.
 [#5697](https://github.com/richlander/dotnet-inspect/issues/5697) owns the

--- a/docs/design/workspace-scope-and-expansion.md
+++ b/docs/design/workspace-scope-and-expansion.md
@@ -47,6 +47,28 @@ preserve display `PackageId`, exact `PackageVersion`, and effective
 `TargetFramework` separately from canonical coordinate and selection facts.
 Root-only and explicit-empty selections remain reportable Roots.
 
+Issue [#6151](https://github.com/richlander/dotnet-inspect/issues/6151) extends
+this exact-package, closed profile with `AddRootsAsync` and
+`RemoveRootOccurrenceAsync`. Add consumes already-acquired bindings and
+appends the complete distinct new batch in first-request order, retaining
+existing order and occurrence identities. An empty or all-present batch is
+`NoEffect` and does not prepare or repair physical Roots. Remove consumes one
+`WorkspaceRootOccurrenceIdentity`; it neither interprets a package name or row
+index nor selects a successor. Both require the expected revision and a finite
+deadline. Ordinary Add/Remove return `Rejected(Busy)` rather than superseding
+preparation; validation precedes that admission decision. Replace/Clear retain
+their existing supersession authority and first-observed stop ordering.
+
+Effective incremental publication requires a current Ready generation for
+every surviving Root, as required by Artifact Acquisition's existing Retain
+arm. If Add or Remove would retain a Pending/Failed Root, this initial profile
+returns `Failed(ArtifactGenerationMismatch)` before preparing new material and
+preserves the complete current Scope. It does not drop that Root, invent a
+generation, or reacquire through a retained snapshot. Removing the non-Ready
+occurrence itself can succeed when every survivor is Ready or the resulting
+set is empty. Supporting publication that retains non-Ready Roots requires
+separate Artifact-owner work; observation of those Roots remains supported.
+
 Membership changes use the sealed Artifact publication participant. Current
 snapshot reads observe every Ready/Pending/Failed projection under the existing
 composition read lease and perform only the clarified Scope-only refresh;
@@ -56,9 +78,12 @@ that observation.
 
 The user-authorized first host adoption is the CLI
 ([#5513](https://github.com/richlander/dotnet-inspect/issues/5513)) in the same
-issue #5821 slice. Browser adoption remains planned under #5697 after its existing
-Add/Remove and complete-restoration contracts are reconciled; this slice
-preserves existing Browser behavior. Add/Remove, expansion scopes and evidence,
+issue #5821 slice. The CLI now populates its fresh Scope with one complete
+`AddRootsAsync` batch, providing a production consumer for the incremental
+path without per-package publication or changed output. Browser Add/remove is
+the named incremental consumer under #5697, but its migration still requires
+owner-backed complete restoration under #5525. Existing Browser behavior and
+its legacy occurrence-view consumer remain unchanged. Expansion scopes and evidence,
 non-package preparation, Navigation, Definitions, and persistence remain later
 work. The broader target gates below remain **unverified** outside the
 implemented subset. CLI inventory rendering uses the committed snapshot rather
@@ -71,7 +96,7 @@ also retains the selected framework.
 [`WorkspaceCommandTests`](../../src/dotnet-inspect.Tests/WorkspaceCommandTests.cs)
 gates duplicate coalescing before row windows/counts, root-only and explicit-empty
 Roots, display/framework preservation, JSON/JSONL shape, and absence of a
-successful prefix after failed replacement. Browser adoption remains unverified.
+successful prefix after a failed Add batch. Browser adoption remains unverified.
 
 The Release implementation gate is
 [`WorkspaceScopeTests`](../../src/DotnetInspector.Queries.Tests/WorkspaceScopeTests.cs).
@@ -84,6 +109,10 @@ Its boundary evidence includes:
 | Validation before supersession, finite deadlines, and exact cancellation | `InvalidSubmissionsDoNotSupersedeAdmittedPreparation`, `DeadlineExpiryAfterAdmissionCancelsRatherThanRejects`, `ExactCancellationActionSettlesTheOriginalOperationAndCannotCancelAnother`, `CancellationBeforeCommitPreservesPriorRevision`, `CancellationAfterCommitCannotRetractPublication` |
 | Clear and Replace supersession without stale publication | `ClearSupersedesBlockedPreparationWithoutWaitingForCurrentQuery`, `ValidReplaceSupersedesPreparationAndOldCompletionCannotOverwriteIt` |
 | Cancellation/deadline versus supersession preserves the first observed outcome | `CancellationBeforeSupersessionRetainsFirstOutcome`, `SupersessionBeforeCancellationRetainsFirstOutcome` |
+| Ordered incremental Add, exact reduction, and no successful prefix | `AddPreservesExistingOrderAndAppendsOneDistinctBatch`, `EmptyOrDuplicateOnlyAddHasNoPhysicalEffect`, `AddReducesExactCorrespondenceBeforeLogicalCapacityAndPreparation`, `LaterAddFailureDoesNotPublishSuccessfulPrefix` |
+| Exact removal, surviving identity, and admitted-query drainage | `RemoveRetainsOtherOccurrencesAndDoesNotWaitForAnAdmittedQuery`, `RemovingTheLastOccurrenceCommitsAnEmptyClosedRevision` |
+| Incremental validation before Busy and inherited stop ordering | `OrdinaryAddAndRemoveAreBusyWithoutSupersedingPreparation`, `IncrementalValidationPrecedesBusy`, `AddSupersessionPreservesFirstObservedStop`, `AddCancellationOrExpiryLeavesThePriorRevisionCurrent`, `RemoveHonorsCancellationBeforeAdmissionAndCannotBeRetractedAfterCommit` |
+| Non-Ready incremental boundary and stale physical refusal | `IncrementalEditsRefuseNonReadySurvivorsBeforePreparingMaterial`, `PhysicalMovementDuringAddRefusesTheStaleCandidateAndRefreshesAllCurrentRoots`, `IncrementalOperationsRespectRuntimeUnavailabilityBeforeInvalidRequests` |
 | Complete physical observation without another Artifact publication | `ObservationRefreshPreservesReadyPendingFailedAndDoesNotPublishArtifactComposition`, `RefreshDuringPreparationPreservesPreparingAndStalePhysicalCandidateCannotRebase` |
 | Runtime unavailability and historical resource drainage | `ClosingWorkspaceReportsUnavailableWhileAnAdmittedQueryDrains`, `CloseDuringPreparationSettlesUnavailableAndReleasesOperationAuthority`, `HistoricalSnapshotsAndResultsDoNotRetainRetiredResources` |
 

--- a/src/DotnetInspector.Queries.Tests/WorkspaceScopeTests.Mutations.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceScopeTests.Mutations.cs
@@ -1,0 +1,454 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed partial class WorkspaceScopeTests
+{
+    [Fact]
+    public async Task AddPreservesExistingOrderAndAppendsOneDistinctBatch()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot initial = await Add(workspace, Binding("First.Package"), Binding("Second.Package"));
+        int duplicateReads = 0;
+        WorkspaceScopeSnapshot? preparing = null;
+        var added = Committed(await workspace.AddRootsAsync(initial.Revision,
+            [Binding("second.package", onOpen: () => duplicateReads++),
+             Binding("Third.Package", onOpen: () => preparing = Current(workspace).GetAwaiter().GetResult()),
+             Binding("third.package", onOpen: () => duplicateReads++),
+             Binding("Fourth.Package"),
+             Binding("first.package", onOpen: () => duplicateReads++)],
+            Deadline, TestContext.Current.CancellationToken));
+
+        Assert.Equal(WorkspaceScopeOperationKind.Add, added.Effect);
+        Assert.Equal(["First.Package", "Second.Package", "Third.Package", "Fourth.Package"], Names(added.Snapshot));
+        Assert.Equal(0, duplicateReads);
+        Assert.NotNull(preparing);
+        Assert.Same(initial.Revision, preparing.Revision);
+        Assert.Same(initial.PhysicalComposition, preparing.PhysicalComposition);
+        Assert.Equal(["First.Package", "Second.Package"], Names(preparing));
+        Assert.NotNull(preparing.Preparing);
+        Assert.Equal(WorkspaceScopeOperationKind.Add, preparing.Preparing.Kind);
+        Assert.Equal(2, preparing.Preparing.RequestedRootCount);
+        for (int index = 0; index < initial.Roots.Length; index++)
+        {
+            Assert.Same(initial.Roots[index].Occurrence, added.Snapshot.Roots[index].Occurrence);
+            Assert.Same(Ready(initial.Roots[index]), Ready(added.Snapshot.Roots[index]));
+        }
+        Assert.NotSame(initial.Revision.Identity, added.Snapshot.Revision.Identity);
+        Assert.NotSame(initial.Closure.Identity, added.Snapshot.Closure.Identity);
+        Assert.Null(added.Snapshot.Preparing);
+        Assert.Same(added.Snapshot, await Current(workspace));
+    }
+
+    [Theory]
+    [InlineData("ready", false)]
+    [InlineData("ready", true)]
+    [InlineData("pending", false)]
+    [InlineData("pending", true)]
+    [InlineData("failed", false)]
+    [InlineData("failed", true)]
+    public async Task EmptyOrDuplicateOnlyAddHasNoPhysicalEffect(string status, bool empty)
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot current = await Add(workspace, Binding("Same.Package"));
+        if (status != "ready")
+            current = await NonReady(workspace, current, 0, status == "failed");
+        int reads = 0;
+        ImmutableArray<PackageRootBinding> roots = empty ? [] :
+            [Binding("same.package", onOpen: () => reads++), Binding("Same.Package", onOpen: () => reads++)];
+        var noEffect = Assert.IsType<WorkspaceScopeOperationResult.NoEffect>(
+            await workspace.AddRootsAsync(current.Revision, roots, Deadline, TestContext.Current.CancellationToken));
+        Assert.Equal(0, reads);
+        Assert.Same(current, noEffect.Snapshot);
+        Assert.Same(current, await Current(workspace));
+        Assert.Same(current.PhysicalComposition, ArtifactAvailable(
+            await workspace.GetCurrentArtifactRootCompositionGenerationAsync(workspace.Identity)));
+    }
+
+    [Fact]
+    public async Task AddReducesExactCorrespondenceBeforeLogicalCapacityAndPreparation()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot initial = await Add(workspace,
+            [.. Enumerable.Range(0, 63).Select(index => Binding($"Root.{index}", entry: "README.md"))]);
+        int duplicateReads = 0;
+        var full = Committed(await workspace.AddRootsAsync(initial.Revision,
+            [Binding("Root.0", onOpen: () => duplicateReads++),
+             Binding("Last.Root", entry: "README.md"),
+             Binding("last.root", onOpen: () => duplicateReads++)],
+            Deadline, TestContext.Current.CancellationToken)).Snapshot;
+        Assert.Equal(64, full.Roots.Length);
+        Assert.Equal(0, duplicateReads);
+        Assert.Equal("Last.Root", Names(full)[^1]);
+
+        int refusedReads = 0;
+        var rejected = Assert.IsType<WorkspaceScopeOperationResult.Rejected>(
+            await workspace.AddRootsAsync(full.Revision,
+                [Binding("Last.Root", onOpen: () => refusedReads++),
+                 Binding("Over.Capacity", onOpen: () => refusedReads++),
+                 Binding("over.capacity", onOpen: () => refusedReads++)],
+                Deadline, TestContext.Current.CancellationToken));
+        Assert.Equal(WorkspaceScopeRejection.RootCapacityExceeded, rejected.Reason);
+        Assert.Equal(0, refusedReads);
+        Assert.Same(full, rejected.Snapshot);
+    }
+
+    [Fact]
+    public async Task LaterAddFailureDoesNotPublishSuccessfulPrefix()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot prior = await Add(workspace, Binding("Prior.Package"));
+        var failure = Assert.IsType<WorkspaceScopeOperationResult.Failed>(
+            await workspace.AddRootsAsync(prior.Revision,
+                [Binding("prior.package"), Binding("Good.Package"), Binding("Bad.Package", malformed: true)],
+                Deadline, TestContext.Current.CancellationToken));
+        Assert.Equal(ArtifactRootFailure.PreparationFailed, failure.Failure);
+        Assert.Same(prior.Revision, failure.Snapshot.Revision);
+        Assert.Same(prior.PhysicalComposition, failure.Snapshot.PhysicalComposition);
+        Assert.Equal(["Prior.Package"], Names(failure.Snapshot));
+        Assert.Null(failure.Snapshot.Preparing);
+        Assert.Same(failure.Snapshot, await Current(workspace));
+        using var lease = ArtifactAvailable(await workspace.ReadArtifactRootCompositionAsync(workspace.Identity));
+        Assert.Single(lease.Roots);
+    }
+
+    [Fact]
+    public async Task RemoveRetainsOtherOccurrencesAndDoesNotWaitForAnAdmittedQuery()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot prior = await Add(workspace,
+            Binding("First.Package"), Binding("Removed.Package"), Binding("Last.Package"));
+        WorkspaceRootOccurrenceDescriptor target = prior.Roots[1];
+        InspectionWorkspace.RootLifetime lifetime = Lifetimes(workspace)
+            .Single(root => root.Projection.Correspondence.Equals(target.Occurrence.Correspondence));
+        using InspectionWorkspace.ArtifactRootQueryLease query = ArtifactAvailable(
+            await workspace.EnterArtifactRootQueryAsync(workspace.Identity, target.Occurrence.Correspondence, Ready(target)));
+
+        var removed = Committed(await workspace.RemoveRootOccurrenceAsync(
+            prior.Revision, target.Occurrence.Identity, Deadline, TestContext.Current.CancellationToken));
+        Assert.Equal(WorkspaceScopeOperationKind.Remove, removed.Effect);
+        Assert.Equal(["First.Package", "Last.Package"], Names(removed.Snapshot));
+        Assert.Same(prior.Roots[0].Occurrence, removed.Snapshot.Roots[0].Occurrence);
+        Assert.Same(prior.Roots[2].Occurrence, removed.Snapshot.Roots[1].Occurrence);
+        Assert.Same(Ready(prior.Roots[0]), Ready(removed.Snapshot.Roots[0]));
+        Assert.Same(Ready(prior.Roots[2]), Ready(removed.Snapshot.Roots[1]));
+        Assert.NotSame(prior.Revision.Identity, removed.Snapshot.Revision.Identity);
+        Assert.NotSame(prior.Closure.Identity, removed.Snapshot.Closure.Identity);
+        Assert.False(lifetime.Released.Task.IsCompleted);
+        using (Stream image = query.Realization.SurfaceParticipants[0].Participant.Assembly.OpenRead())
+            Assert.True(image.Length > 0);
+        query.Dispose();
+        await lifetime.Released.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        WorkspaceScopeSnapshot readded = await Add(workspace, Binding("Removed.Package"));
+        Assert.Equal(target.Occurrence.Correspondence, readded.Roots[^1].Occurrence.Correspondence);
+        Assert.NotSame(target.Occurrence.Identity, readded.Roots[^1].Occurrence.Identity);
+        var retired = Assert.IsType<WorkspaceScopeOperationResult.Rejected>(
+            await workspace.RemoveRootOccurrenceAsync(readded.Revision, target.Occurrence.Identity,
+                Deadline, TestContext.Current.CancellationToken));
+        Assert.Equal(WorkspaceScopeRejection.OccurrenceNotCurrent, retired.Reason);
+        Assert.Same(readded, retired.Snapshot);
+        Assert.Equal(["First.Package", "Removed.Package", "Last.Package"], Names(prior));
+    }
+
+    [Theory]
+    [InlineData("ready")]
+    [InlineData("pending")]
+    [InlineData("failed")]
+    public async Task RemovingTheLastOccurrenceCommitsAnEmptyClosedRevision(string status)
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot prior = await Add(workspace, Binding("Last.Package"));
+        if (status != "ready")
+            prior = await NonReady(workspace, prior, 0, status == "failed");
+        var removed = Committed(await workspace.RemoveRootOccurrenceAsync(
+            prior.Revision, prior.Roots[0].Occurrence.Identity, Deadline, TestContext.Current.CancellationToken));
+        Assert.Empty(removed.Snapshot.Roots);
+        Assert.Empty(removed.Snapshot.Revision.Roots);
+        Assert.Same(workspace.Identity, removed.Snapshot.Revision.Workspace);
+        Assert.Equal(WorkspaceClosureState.ClosedBoundary, removed.Snapshot.Closure.State);
+        Assert.NotSame(prior.Revision.Identity, removed.Snapshot.Revision.Identity);
+        Assert.Same(removed.Snapshot, await Current(workspace));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task IncrementalEditsRefuseNonReadySurvivorsBeforePreparingMaterial(bool failed)
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot ready = await Add(workspace, Binding("NonReady.Package"), Binding("Ready.Package"));
+        WorkspaceScopeSnapshot prior = await NonReady(workspace, ready, 0, failed);
+        int reads = 0;
+        var add = Assert.IsType<WorkspaceScopeOperationResult.Failed>(
+            await workspace.AddRootsAsync(prior.Revision,
+                [Binding("NonReady.Package", onOpen: () => reads++), Binding("New.Package", onOpen: () => reads++)],
+                Deadline, TestContext.Current.CancellationToken));
+        var remove = Assert.IsType<WorkspaceScopeOperationResult.Failed>(
+            await workspace.RemoveRootOccurrenceAsync(prior.Revision, prior.Roots[1].Occurrence.Identity,
+                Deadline, TestContext.Current.CancellationToken));
+        Assert.Equal(0, reads);
+        Assert.Equal(ArtifactRootFailure.ArtifactGenerationMismatch, add.Failure);
+        Assert.Equal(ArtifactRootFailure.ArtifactGenerationMismatch, remove.Failure);
+        Assert.Same(prior, add.Snapshot);
+        Assert.Same(prior, remove.Snapshot);
+        Assert.Same(prior, await Current(workspace));
+
+        var removed = Committed(await workspace.RemoveRootOccurrenceAsync(
+            prior.Revision, prior.Roots[0].Occurrence.Identity, Deadline, TestContext.Current.CancellationToken));
+        Assert.Same(prior.Roots[1].Occurrence, Assert.Single(removed.Snapshot.Roots).Occurrence);
+        Assert.Same(Ready(prior.Roots[1]), Ready(removed.Snapshot.Roots[0]));
+    }
+
+    [Fact]
+    public async Task OrdinaryAddAndRemoveAreBusyWithoutSupersedingPreparation()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot prior = await Add(workspace, Binding("Prior.Package"));
+        int busyReads = 0;
+        PackageRootBinding package = Binding("Added.Package", onOpen: () =>
+        {
+            WorkspaceScopeSnapshot preparing = Current(workspace).GetAwaiter().GetResult();
+            ImmutableArray<WorkspaceScopeOperationResult> results =
+            [
+                workspace.AddRootsAsync(prior.Revision, [Binding("Busy.Package", onOpen: () => busyReads++)],
+                    Deadline, TestContext.Current.CancellationToken).AsTask().GetAwaiter().GetResult(),
+                workspace.AddRootsAsync(prior.Revision, [Binding("Prior.Package")],
+                    Deadline, TestContext.Current.CancellationToken).AsTask().GetAwaiter().GetResult(),
+                workspace.AddRootsAsync(prior.Revision, [],
+                    Deadline, TestContext.Current.CancellationToken).AsTask().GetAwaiter().GetResult(),
+                workspace.RemoveRootOccurrenceAsync(prior.Revision, prior.Roots[0].Occurrence.Identity,
+                    Deadline, TestContext.Current.CancellationToken).AsTask().GetAwaiter().GetResult(),
+            ];
+            Assert.All(results, result =>
+            {
+                var rejected = Assert.IsType<WorkspaceScopeOperationResult.Rejected>(result);
+                Assert.Equal(WorkspaceScopeRejection.Busy, rejected.Reason);
+                Assert.Same(preparing, rejected.Snapshot);
+            });
+        });
+        WorkspaceScopeSnapshot current = await Add(workspace, package);
+        Assert.Equal(0, busyReads);
+        Assert.Equal(["Prior.Package", "Added.Package"], Names(current));
+        Assert.Null(current.Preparing);
+    }
+
+    [Theory]
+    [InlineData(false, "stale", WorkspaceScopeRejection.RevisionMismatch)]
+    [InlineData(false, "foreign", WorkspaceScopeRejection.ForeignWorkspace)]
+    [InlineData(false, "malformed", WorkspaceScopeRejection.Malformed)]
+    [InlineData(false, "null-root", WorkspaceScopeRejection.Malformed)]
+    [InlineData(false, "capacity", WorkspaceScopeRejection.RootCapacityExceeded)]
+    [InlineData(false, "deadline", WorkspaceScopeRejection.DeadlineExpired)]
+    [InlineData(true, "stale", WorkspaceScopeRejection.RevisionMismatch)]
+    [InlineData(true, "foreign", WorkspaceScopeRejection.ForeignWorkspace)]
+    [InlineData(true, "malformed", WorkspaceScopeRejection.Malformed)]
+    [InlineData(true, "foreign-occurrence", WorkspaceScopeRejection.ForeignWorkspace)]
+    [InlineData(true, "retired", WorkspaceScopeRejection.OccurrenceNotCurrent)]
+    [InlineData(true, "deadline", WorkspaceScopeRejection.DeadlineExpired)]
+    public async Task IncrementalValidationPrecedesBusy(
+        bool remove, string invalid, WorkspaceScopeRejection reason)
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        await using InspectionWorkspace foreign = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot old = await Add(workspace, Binding("Prior.Package"), Binding("Retired.Package"));
+        WorkspaceRootOccurrenceIdentity retired = old.Roots[1].Occurrence.Identity;
+        WorkspaceScopeSnapshot prior = Committed(await workspace.RemoveRootOccurrenceAsync(
+            old.Revision, retired, Deadline, TestContext.Current.CancellationToken)).Snapshot;
+        WorkspaceScopeSnapshot other = await Add(foreign, Binding("Foreign.Package"));
+        WorkspaceScopeOperationResult.Rejected? rejection = null;
+        PackageRootBinding package = Binding("Added.Package", onOpen: () =>
+        {
+            WorkspaceScopeSnapshot preparing = Current(workspace).GetAwaiter().GetResult();
+            WorkspaceScopeRevision revision = invalid switch
+            {
+                "stale" => old.Revision,
+                "foreign" => other.Revision,
+                _ => prior.Revision,
+            };
+            WorkspaceRootOccurrenceIdentity target = invalid switch
+            {
+                "malformed" => null!,
+                "foreign-occurrence" => other.Roots[0].Occurrence.Identity,
+                "retired" => retired,
+                _ => prior.Roots[0].Occurrence.Identity,
+            };
+            ImmutableArray<PackageRootBinding> roots = invalid switch
+            {
+                "malformed" => default,
+                "null-root" => [null!],
+                "capacity" => [.. Enumerable.Range(0, 64).Select(index => Binding($"Excess.{index}", entry: "README.md"))],
+                _ => [],
+            };
+            DateTimeOffset deadline = invalid == "deadline" ? DateTimeOffset.UtcNow.AddMinutes(-1) : Deadline;
+            rejection = Assert.IsType<WorkspaceScopeOperationResult.Rejected>((remove
+                ? workspace.RemoveRootOccurrenceAsync(revision, target, deadline, TestContext.Current.CancellationToken)
+                : workspace.AddRootsAsync(revision, roots, deadline, TestContext.Current.CancellationToken))
+                .AsTask().GetAwaiter().GetResult());
+            Assert.Equal(reason, rejection.Reason);
+            Assert.Same(preparing, rejection.Snapshot);
+        });
+        WorkspaceScopeSnapshot current = await Add(workspace, package);
+        Assert.NotNull(rejection);
+        Assert.Equal(["Prior.Package", "Added.Package"], Names(current));
+    }
+
+    [Theory]
+    [InlineData("none", false)]
+    [InlineData("none", true)]
+    [InlineData("caller", false)]
+    [InlineData("caller", true)]
+    [InlineData("deadline", false)]
+    [InlineData("deadline", true)]
+    [InlineData("action", false)]
+    [InlineData("action", true)]
+    [InlineData("late", false)]
+    [InlineData("late", true)]
+    public async Task AddSupersessionPreservesFirstObservedStop(string stop, bool clear)
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        var time = new ScopeTimeProvider();
+        workspace.ConfigureArtifactRootAdmission(new(), time);
+        WorkspaceScopeSnapshot initial = await Add(workspace, Binding("Prior.Package"));
+        using var cancellation = new CancellationTokenSource();
+        WorkspaceScopeOperationResult.Committed? winner = null;
+        WorkspaceScopePreparationDescriptor? preparing = null;
+        Task<WorkspaceScopeOperationResult>? cancellationResult = null;
+        PackageRootBinding package = Binding("Displaced.Package", onOpen: () =>
+        {
+            preparing = Assert.IsType<WorkspaceScopePreparationDescriptor>(
+                Current(workspace).GetAwaiter().GetResult().Preparing);
+            if (stop == "caller") cancellation.Cancel();
+            if (stop == "deadline") time.Advance(TimeSpan.FromMinutes(10));
+            if (stop == "action")
+                cancellationResult = workspace.CancelScopePreparationAsync(preparing.Cancellation).AsTask();
+            DateTimeOffset deadline = time.GetUtcNow().AddMinutes(5);
+            winner = Committed((clear
+                ? workspace.ClearScopeAsync(initial.Revision, deadline, TestContext.Current.CancellationToken)
+                : workspace.ReplaceScopeAsync(initial.Revision,
+                    [Binding("Winning.Package", entry: "README.md")], deadline, TestContext.Current.CancellationToken))
+                .AsTask().GetAwaiter().GetResult());
+            if (stop == "late")
+            {
+                cancellation.Cancel();
+                time.Advance(TimeSpan.FromMinutes(10));
+            }
+        });
+        WorkspaceScopeOperationResult result = await workspace.AddRootsAsync(
+            initial.Revision, [package], time.GetUtcNow().AddMinutes(5), cancellation.Token);
+        Assert.NotNull(winner);
+        Assert.NotNull(preparing);
+        if (stop is "none" or "late")
+        {
+            var superseded = Assert.IsType<WorkspaceScopeOperationResult.Superseded>(result);
+            Assert.Same(winner.Operation, superseded.SupersedingOperation);
+            Assert.Same(winner.Snapshot, superseded.Snapshot);
+        }
+        else
+        {
+            var cancelled = Assert.IsType<WorkspaceScopeOperationResult.Cancelled>(result);
+            Assert.Same(preparing.Operation, cancelled.Operation);
+            Assert.Same(winner.Snapshot, cancelled.Snapshot);
+        }
+        if (cancellationResult is not null)
+            Assert.Same(result, await cancellationResult);
+        Assert.Same(winner.Snapshot, await Current(workspace));
+    }
+
+    [Theory]
+    [InlineData("before")]
+    [InlineData("caller")]
+    [InlineData("deadline")]
+    public async Task AddCancellationOrExpiryLeavesThePriorRevisionCurrent(string cause)
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        var time = new ScopeTimeProvider();
+        workspace.ConfigureArtifactRootAdmission(new(), time);
+        WorkspaceScopeSnapshot prior = await Add(workspace, Binding("Prior.Package"));
+        using var cancellation = new CancellationTokenSource();
+        if (cause == "before") cancellation.Cancel();
+        PackageRootBinding package = Binding("Cancelled.Package", onOpen: () =>
+        {
+            if (cause == "deadline") time.Advance(TimeSpan.FromMinutes(10));
+            else cancellation.Cancel();
+        });
+        var cancelled = Assert.IsType<WorkspaceScopeOperationResult.Cancelled>(
+            await workspace.AddRootsAsync(prior.Revision, [package], time.GetUtcNow().AddMinutes(5), cancellation.Token));
+        Assert.Same(prior.Revision, cancelled.Snapshot.Revision);
+        Assert.Same(prior.PhysicalComposition, cancelled.Snapshot.PhysicalComposition);
+        Assert.Equal(["Prior.Package"], Names(cancelled.Snapshot));
+        Assert.Null(cancelled.Snapshot.Preparing);
+        Assert.Same(cancelled.Snapshot, await Current(workspace));
+    }
+
+    [Fact]
+    public async Task RemoveHonorsCancellationBeforeAdmissionAndCannotBeRetractedAfterCommit()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot prior = await Add(workspace, Binding("Prior.Package"));
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+        var stopped = Assert.IsType<WorkspaceScopeOperationResult.Cancelled>(
+            await workspace.RemoveRootOccurrenceAsync(prior.Revision, prior.Roots[0].Occurrence.Identity,
+                Deadline, cancelled.Token));
+        Assert.Same(prior, stopped.Snapshot);
+        using var after = new CancellationTokenSource();
+        var removed = Committed(await workspace.RemoveRootOccurrenceAsync(
+            prior.Revision, prior.Roots[0].Occurrence.Identity, Deadline, after.Token));
+        after.Cancel();
+        Assert.Empty(removed.Snapshot.Roots);
+        Assert.Same(removed.Snapshot, await Current(workspace));
+    }
+
+    [Fact]
+    public async Task PhysicalMovementDuringAddRefusesTheStaleCandidateAndRefreshesAllCurrentRoots()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot prior = await Add(workspace, Binding("Prior.Package"), Binding("Other.Package"));
+        PackageRootBinding package = Binding("Added.Package", onOpen: () =>
+            ArtifactAvailable(workspace.RetireArtifactRootAsync(
+                prior.Roots[0].Occurrence.Correspondence, Ready(prior.Roots[0])).AsTask().GetAwaiter().GetResult()));
+        var failed = Assert.IsType<WorkspaceScopeOperationResult.Failed>(
+            await workspace.AddRootsAsync(prior.Revision, [package], Deadline, TestContext.Current.CancellationToken));
+        Assert.Equal(ArtifactRootFailure.CompositionMismatch, failed.Failure);
+        Assert.Same(prior.Revision, failed.Snapshot.Revision);
+        Assert.Equal(["Prior.Package", "Other.Package"], Names(failed.Snapshot));
+        Assert.IsType<ArtifactRootRealizationStatus.Pending>(failed.Snapshot.Roots[0].Realization.Status);
+        Assert.Same(prior.Roots[1].Realization, failed.Snapshot.Roots[1].Realization);
+        Assert.Null(failed.Snapshot.Preparing);
+        Assert.Same(failed.Snapshot, await Current(workspace));
+    }
+
+    [Fact]
+    public async Task IncrementalOperationsRespectRuntimeUnavailabilityBeforeInvalidRequests()
+    {
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeSnapshot prior = await Add(workspace, Binding("Prior.Package"));
+        await workspace.DisposeAsync();
+        var add = Assert.IsType<WorkspaceScopeOperationResult.Unavailable>(
+            await workspace.AddRootsAsync(null!, default, DateTimeOffset.MinValue, TestContext.Current.CancellationToken));
+        var remove = Assert.IsType<WorkspaceScopeOperationResult.Unavailable>(
+            await workspace.RemoveRootOccurrenceAsync(null!, null!, DateTimeOffset.MinValue, TestContext.Current.CancellationToken));
+        Assert.Same(prior, add.LastSnapshot);
+        Assert.Same(prior, remove.LastSnapshot);
+        Assert.Equal(ArtifactRootFailure.WorkspaceClosed, add.RuntimeFailure);
+        Assert.Equal(ArtifactRootFailure.WorkspaceClosed, remove.RuntimeFailure);
+    }
+
+    static async Task<WorkspaceScopeSnapshot> Add(
+        InspectionWorkspace workspace, params PackageRootBinding[] bindings) =>
+        Committed(await workspace.AddRootsAsync((await Current(workspace)).Revision,
+            [.. bindings], Deadline, TestContext.Current.CancellationToken)).Snapshot;
+
+    static async Task<WorkspaceScopeSnapshot> NonReady(
+        InspectionWorkspace workspace, WorkspaceScopeSnapshot snapshot, int index, bool failed)
+    {
+        WorkspaceRootOccurrenceDescriptor root = snapshot.Roots[index];
+        ArtifactRootCompositionGenerationIdentity epoch = ArtifactAvailable(
+            await workspace.RetireArtifactRootAsync(root.Occurrence.Correspondence, Ready(root)));
+        if (failed)
+            ArtifactAvailable(await workspace.FailArtifactRootReplacementAsync(
+                root.Occurrence.Correspondence, epoch, ArtifactRootFailure.PreparationFailed));
+        return await Current(workspace);
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/WorkspaceScopeTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceScopeTests.cs
@@ -10,7 +10,7 @@ using NuGetFetch;
 
 namespace DotnetInspector.Queries.Tests;
 
-public sealed class WorkspaceScopeTests
+public sealed partial class WorkspaceScopeTests
 {
     static DateTimeOffset Deadline => DateTimeOffset.UtcNow.AddMinutes(5);
 

--- a/src/DotnetInspector.Queries/InspectionWorkspace.Scope.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.Scope.cs
@@ -51,6 +51,31 @@ public sealed partial class InspectionWorkspace
             WorkspaceScopeOperationKind.Clear, cancellationToken);
 
     /// <summary>
+    /// Appends one all-or-failure batch of distinct already-acquired package
+    /// Roots, preserving current order and exact occurrences. Surviving Roots
+    /// must be Ready unless the batch has no effect.
+    /// </summary>
+    public ValueTask<WorkspaceScopeOperationResult> AddRootsAsync(
+        WorkspaceScopeRevision expectedRevision,
+        ImmutableArray<PackageRootBinding> roots,
+        DateTimeOffset deadline,
+        CancellationToken cancellationToken = default) =>
+        MutateScopeAsync(expectedRevision, roots, deadline,
+            WorkspaceScopeOperationKind.Add, cancellationToken);
+
+    /// <summary>
+    /// Removes one exact current occurrence without choosing a successor or
+    /// waiting for admitted queries to drain. Surviving Roots must be Ready.
+    /// </summary>
+    public ValueTask<WorkspaceScopeOperationResult> RemoveRootOccurrenceAsync(
+        WorkspaceScopeRevision expectedRevision,
+        WorkspaceRootOccurrenceIdentity occurrence,
+        DateTimeOffset deadline,
+        CancellationToken cancellationToken = default) =>
+        MutateScopeAsync(expectedRevision, [], deadline,
+            WorkspaceScopeOperationKind.Remove, cancellationToken, occurrence);
+
+    /// <summary>
     /// Requests cancellation of the exact preparing operation and awaits its
     /// complete settlement. An action for a no-longer-preparing operation has no effect.
     /// </summary>
@@ -93,7 +118,8 @@ public sealed partial class InspectionWorkspace
         ImmutableArray<PackageRootBinding> roots,
         DateTimeOffset deadline,
         WorkspaceScopeOperationKind kind,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        WorkspaceRootOccurrenceIdentity? occurrence = null)
     {
         var read = await ReadArtifactRootCompositionAsync(_identity).ConfigureAwait(false);
         if (read is ArtifactRootResult<ArtifactRootCompositionReadLease>.Rejected rejected)
@@ -117,7 +143,29 @@ public sealed partial class InspectionWorkspace
                     return new WorkspaceScopeOperationResult.Rejected(
                         current, WorkspaceScopeRejection.Malformed);
 
+                if (kind == WorkspaceScopeOperationKind.Remove)
+                {
+                    if (occurrence is null)
+                        return new WorkspaceScopeOperationResult.Rejected(
+                            current, WorkspaceScopeRejection.Malformed);
+                    if (!ReferenceEquals(occurrence.WorkspaceIdentity, _identity))
+                        return new WorkspaceScopeOperationResult.Rejected(
+                            current, WorkspaceScopeRejection.ForeignWorkspace);
+                    if (!current.Roots.Any(row => ReferenceEquals(row.Occurrence.Identity, occurrence)))
+                        return new WorkspaceScopeOperationResult.Rejected(
+                            current, WorkspaceScopeRejection.OccurrenceNotCurrent);
+                }
+
+                ImmutableArray<WorkspaceRootOccurrenceDescriptor> survivors = kind switch
+                {
+                    WorkspaceScopeOperationKind.Add => current.Roots,
+                    WorkspaceScopeOperationKind.Remove =>
+                        [.. current.Roots.Where(row => !ReferenceEquals(row.Occurrence.Identity, occurrence))],
+                    _ => [],
+                };
                 var unique = new HashSet<ArtifactRootCorrespondence>();
+                foreach (WorkspaceRootOccurrenceDescriptor survivor in survivors)
+                    unique.Add(survivor.Occurrence.Correspondence);
                 var candidates = ImmutableArray.CreateBuilder<ScopeRequestedRoot>();
                 foreach (PackageRootBinding binding in roots)
                 {
@@ -127,11 +175,16 @@ public sealed partial class InspectionWorkspace
                         continue;
                     WorkspaceRootOccurrenceDescriptor? retained = current.Roots.FirstOrDefault(
                         row => row.Occurrence.Correspondence.Equals(correspondence));
-                    candidates.Add(new(binding, correspondence, retained));
+                    candidates.Add(retained?.Realization.Status is ArtifactRootRealizationStatus.Ready ready
+                        ? new ScopeRequestedRoot.Retain(retained.Occurrence, ready.Generation)
+                        : new ScopeRequestedRoot.Prepare(binding, correspondence, retained?.Occurrence));
                 }
-                if (candidates.Count > current.Revision.Limits.MaxRoots)
+                if (candidates.Count > current.Revision.Limits.MaxRoots - survivors.Length)
                     return new WorkspaceScopeOperationResult.Rejected(
                         current, WorkspaceScopeRejection.RootCapacityExceeded);
+                if (kind is WorkspaceScopeOperationKind.Add or WorkspaceScopeOperationKind.Remove
+                    && _scopePreparation is not null)
+                    return new WorkspaceScopeOperationResult.Rejected(current, WorkspaceScopeRejection.Busy);
 
                 operation = new(_identity, kind, deadline, cancellationToken, current);
                 if (operation.Stop.IsCancellationRequested)
@@ -139,9 +192,27 @@ public sealed partial class InspectionWorkspace
                     operation.Dispose();
                     return new WorkspaceScopeOperationResult.Cancelled(current, operation.Identity);
                 }
-                requested = candidates.ToImmutable();
+                if (kind == WorkspaceScopeOperationKind.Add && candidates.Count == 0)
+                {
+                    operation.Dispose();
+                    return new WorkspaceScopeOperationResult.NoEffect(current);
+                }
+                var complete = ImmutableArray.CreateBuilder<ScopeRequestedRoot>(survivors.Length + candidates.Count);
+                foreach (WorkspaceRootOccurrenceDescriptor survivor in survivors)
+                {
+                    if (survivor.Realization.Status is not ArtifactRootRealizationStatus.Ready ready)
+                    {
+                        operation.Dispose();
+                        return new WorkspaceScopeOperationResult.Failed(
+                            current, ArtifactRootFailure.ArtifactGenerationMismatch);
+                    }
+                    complete.Add(new ScopeRequestedRoot.Retain(survivor.Occurrence, ready.Generation));
+                }
+                complete.AddRange(candidates);
+                requested = complete.MoveToImmutable();
                 var next = WithScopePreparation(current,
-                    new(_identity, operation.Identity, kind, requested.Length, deadline));
+                    new(_identity, operation.Identity, kind,
+                        kind == WorkspaceScopeOperationKind.Remove ? 1 : candidates.Count, deadline));
                 if (_scopePreparation is { } displaced)
                 {
                     // Preserve a cancellation or deadline that won before displacement.
@@ -171,7 +242,7 @@ public sealed partial class InspectionWorkspace
         try
         {
             ImmutableArray<PackageRootBinding> unmatched =
-                [.. requested.Where(static root => !root.CanRetain).Select(static root => root.Binding)];
+                [.. requested.OfType<ScopeRequestedRoot.Prepare>().Select(static root => root.Binding)];
             if (!unmatched.IsEmpty)
             {
                 var prepared = await PreparePackageArtifactRootsAsync(
@@ -263,18 +334,23 @@ public sealed partial class InspectionWorkspace
         int preparedIndex = 0;
         foreach (ScopeRequestedRoot root in requested)
         {
-            if (root.Retained?.Realization.Status is ArtifactRootRealizationStatus.Ready ready)
-                entries.Add(new ArtifactRootPublicationEntry.Retain(root.Correspondence, ready.Generation));
-            else
+            switch (root)
             {
-                ArtifactRootPreparedEntry prepared = receipt!.Entries[preparedIndex++];
-                if (!prepared.Correspondence.Equals(root.Correspondence))
-                    throw new WorkspaceScopeInvariantException(current, ArtifactRootFailure.CompositionMismatch);
-                entries.Add(new ArtifactRootPublicationEntry.Adopt(receipt.Preparation, prepared.Entry));
+                case ScopeRequestedRoot.Retain retained:
+                    entries.Add(new ArtifactRootPublicationEntry.Retain(
+                        retained.Occurrence.Correspondence, retained.Generation));
+                    occurrences.Add(retained.Occurrence);
+                    break;
+                case ScopeRequestedRoot.Prepare pending:
+                    ArtifactRootPreparedEntry prepared = receipt!.Entries[preparedIndex++];
+                    if (!prepared.Correspondence.Equals(pending.Correspondence))
+                        throw new WorkspaceScopeInvariantException(current, ArtifactRootFailure.CompositionMismatch);
+                    entries.Add(new ArtifactRootPublicationEntry.Adopt(receipt.Preparation, prepared.Entry));
+                    occurrences.Add(pending.ExistingOccurrence
+                        ?? new WorkspaceRootOccurrence(_identity,
+                            new WorkspaceRootDescriptor.Package(pending.Binding), pending.Correspondence));
+                    break;
             }
-            occurrences.Add(root.Retained?.Occurrence
-                ?? new WorkspaceRootOccurrence(_identity,
-                    new WorkspaceRootDescriptor.Package(root.Binding), root.Correspondence));
         }
         var revision = new WorkspaceScopeRevision(_identity, occurrences.MoveToImmutable());
         var candidate = new ScopePublicationCandidate(this, operation, current.PublicationBase, revision);
@@ -365,12 +441,18 @@ public sealed partial class InspectionWorkspace
         WorkspaceScopePreparationDescriptor? preparing) =>
         new(current.Revision, current.PhysicalComposition, current.Roots, current.Closure, preparing);
 
-    sealed record ScopeRequestedRoot(
-        PackageRootBinding Binding,
-        ArtifactRootCorrespondence Correspondence,
-        WorkspaceRootOccurrenceDescriptor? Retained)
+    abstract record ScopeRequestedRoot
     {
-        internal bool CanRetain => Retained?.Realization.Status is ArtifactRootRealizationStatus.Ready;
+        private protected ScopeRequestedRoot() { }
+
+        internal sealed record Retain(
+            WorkspaceRootOccurrence Occurrence,
+            ArtifactRootGenerationReference Generation) : ScopeRequestedRoot;
+
+        internal sealed record Prepare(
+            PackageRootBinding Binding,
+            ArtifactRootCorrespondence Correspondence,
+            WorkspaceRootOccurrence? ExistingOccurrence) : ScopeRequestedRoot;
     }
 
     sealed class ScopePreparation : IDisposable

--- a/src/DotnetInspector.Queries/WorkspaceScopeSnapshot.cs
+++ b/src/DotnetInspector.Queries/WorkspaceScopeSnapshot.cs
@@ -92,7 +92,7 @@ public sealed class WorkspaceRootOccurrenceDescriptor
     public ArtifactRootScopeProjection Realization { get; }
 }
 
-/// <summary>The fixed closed-Scope profile for initial Replace/Clear adoption.</summary>
+/// <summary>The fixed closed-Scope profile for exact package membership operations.</summary>
 public sealed class WorkspaceScopeLimits
 {
     public const int DefaultMaxRoots = 64;
@@ -141,6 +141,8 @@ public enum WorkspaceScopeOperationKind
 {
     Replace,
     Clear,
+    Add,
+    Remove,
 }
 
 /// <summary>An exact resource-free cancellation request, interpreted only by its Workspace.</summary>
@@ -225,6 +227,8 @@ public enum WorkspaceScopeRejection
     RevisionMismatch,
     RootCapacityExceeded,
     AsynchronousWorkspaceRequired,
+    Busy,
+    OccurrenceNotCurrent,
 }
 
 public abstract record WorkspaceScopeOperationResult

--- a/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
+++ b/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
@@ -292,7 +292,7 @@ public sealed class WorkspaceCommandTests
     [Theory]
     [InlineData("net10.0")]
     [InlineData("net11.0")]
-    public async Task FailedReplacement_DoesNotRenderASuccessfulPrefix(string assetFramework)
+    public async Task FailedAddBatch_DoesNotRenderASuccessfulPrefix(string assetFramework)
     {
         var store = new InMemoryPackageStore();
         await AddPackageAsync(store, "Workspace.Good", ("readme.txt", []));

--- a/src/dotnet-inspect/Commands/WorkspaceCommand.cs
+++ b/src/dotnet-inspect/Commands/WorkspaceCommand.cs
@@ -78,19 +78,19 @@ public static class WorkspaceCommand
                     ((WorkspacePackageRootAcquisitionOutcome.Acquired)outcome).Root);
             }
 
-            WorkspaceScopeOperationResult replacement =
-                await workspace.ReplaceScopeAsync(
+            WorkspaceScopeOperationResult addition =
+                await workspace.AddRootsAsync(
                     snapshot.Revision,
                     [.. packageRoots],
                     DateTimeOffset.UtcNow.AddMinutes(5),
                     cancellationToken).ConfigureAwait(false);
-            if (replacement is not WorkspaceScopeOperationResult.Committed committed)
+            if (addition is not WorkspaceScopeOperationResult.Committed committed)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 CommandError.Write(
                     "The Workspace package inventory could not be committed.",
                     [
-                        replacement switch
+                        addition switch
                         {
                             WorkspaceScopeOperationResult.Rejected rejected =>
                                 $"Rejected: {rejected.Reason}",
@@ -99,13 +99,13 @@ public static class WorkspaceCommand
                             WorkspaceScopeOperationResult.Cancelled =>
                                 "Package preparation was cancelled or reached its deadline.",
                             WorkspaceScopeOperationResult.Superseded =>
-                                "The requested replacement was superseded.",
+                                "The requested addition was superseded.",
                             WorkspaceScopeOperationResult.Unavailable missing =>
                                 $"Unavailable: {missing.RuntimeFailure}",
                             WorkspaceScopeOperationResult.NoEffect =>
-                                "The requested replacement did not commit.",
+                                "The requested addition did not commit.",
                             _ => throw new InvalidOperationException(
-                                "Workspace replacement returned an unsupported result."),
+                                "Workspace addition returned an unsupported result."),
                         },
                     ]);
                 return 1;


### PR DESCRIPTION
# Add and remove exact Roots in a committed Workspace Scope

Make the shared Workspace foundation useful for incremental membership:
append one complete package batch or remove one exact occurrence without
reconstructing membership in a host. This advances simple Workspace
Save/edit/Inspect while preserving the existing Browser until its restoration
prerequisite is ready.

Closes #6151. Continues #5697/#6012 and milestone 6 of #5865; does not close
the Browser, Navigation, or restoration trackers. The separately captured
CLI-to-Browser link idea is #6150, not part of this change.

## Demo

The shared API scenario acquires pinned System.Text.Json 10.0.0 and the
root-only NETStandard.Library 2.0.3 for net10.0, adds them incrementally, then
removes the original JSON occurrence by its opaque identity. The mixed Add
retains the original occurrence and appends only the new correspondence.

The duplicate-only neighbor is NoEffect rather than another publication.
The CLI exercises one Add batch from its fresh empty Scope and retains its
existing output shape, order, coalescing, and all-or-failure behavior.

Actual output from the shared API run, using the product acquisition path and
an in-memory package store:

```text
Add JSON: Committed [System.Text.Json]
Add JSON + NETStandard: Committed [System.Text.Json, NETStandard.Library]
Add existing JSON: NoEffect [System.Text.Json, NETStandard.Library]
Remove JSON occurrence: Committed [NETStandard.Library]
```

The first result's JSON occurrence identity remains the removal target after
the second Add. The corresponding ordinary CLI scenario also ran:

```sh
dotnet-inspect workspace \
  --package System.Text.Json@10.0.0 \
  --package System.Text.Json@10.0.0 \
  --package NETStandard.Library@2.0.3 --tfm net10.0 --json
```

```json
[{"package":"System.Text.Json","version":"10.0.0","framework":"net10.0"},{"package":"NETStandard.Library","version":"2.0.3","framework":"net10.0"}]
```

## Design basis

The sole normative owner is
`docs/design/workspace-scope-and-expansion.md`: Add Roots, Remove Root
occurrence, common validation, and mutation authority. The reliability basis
is one complete incremental transition with stable surviving occurrences,
not host reconstruction or a successful prefix of a failed batch.

Artifact Acquisition supplies the existing preparation/publication gate,
exact Ready generation retention, budgets, and lifetime/drainage. The Scope
revision model supplies bounded design evidence for Add/Remove, Busy,
supersession, and complete snapshots; it is not implementation conformance.
Existing Replace/Clear and Browser Add/remove behavior are the comparative
implementation baselines. No generic transaction scheduler or new Artifact
publication arm is introduced.

## Compatibility and initial boundary

The exact-package closed profile remains capped at 64 distinct Roots.
Bindings are transient inputs; snapshots and results retain resource-free
facts. Add validates and coalesces before capacity/preparation, and returns
NoEffect for an empty/all-present batch. Remove uses an exact Workspace-bound
occurrence identity, not a package name or index, and grants no focus authority.

Ordinary Add/Remove report Busy without displacing preparation. Valid
Replace/Clear retain supersession authority. Cancellation/deadline ordering
and final-commit precedence remain unchanged.

The existing Artifact Retain arm requires Ready generations. An effective
incremental operation retaining a Pending/Failed Root fails visibly with
ArtifactGenerationMismatch and preserves complete current state before
preparing new material. It neither silently drops that Root nor reconstructs
its resources. Removing the non-Ready target can succeed when the survivors
are Ready or empty. Duplicate-only Add requires no physical publication.

## Host adoption and remaining work

The CLI `workspace` command is an immediate consumer: it acquires the requested
bindings and submits one complete Add batch to a fresh Scope. It keeps the
existing typed Markout rows and JSON lowering, with no new flags or renderer.
Browser Add/remove is the named incremental consumer after complete-restoration
and host migration prerequisites. Both hosts use the same shared Scope owner.

The nine-milestone ledger remains:

1. Artifact model #5797: landed.
2. Scope model #5796: landed.
3. Artifact producer #6039/#6068: landed.
4. Initial Scope snapshot/Replace/Clear #5821/#6140: landed.
5. CLI committed inventory toward #5513: landed.
6. Scope Add/Remove and CLI Add-batch exercise: this slice.
7. Uncommitted Scope restoration and owner-backed restoration #5525: pending.
8. Browser adoption #5697/#5511: pending.
9. Remaining Browser membership-authority retirement: pending.

Browser source/catalog behavior, Add/remove controls, saved/share/history
restoration, and the legacy occurrence-view consumer remain unchanged.
Expansion, Navigation, Definitions/packets, persistence, editor Save, and
deployment are not included.

## Validation

- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- -class '*WorkspaceScopeTests' -class '*ArtifactRootPublicationTests' -class '*ArtifactRootCorrespondenceTests'`: 121 passed, including 44 incremental cases and the existing Replace/Clear regressions.
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class '*WorkspaceCommandTests' '*SkillCommandTests'`: 40 passed.
- The pinned-package shared API and CLI demos above ran successfully in Release.
- Changed Markdown passes `markdownlint`; `git diff --check` passes.
- Scope/Artifact TLA+ modules and configurations are unchanged. The existing
  50-outcome Scope evidence is historical bounded design evidence, not a
  newly run implementation gate.

Hosted CI and fixed-head two-seat review remain separate prerequisites.
