### PR TITLE
Record function-pointer modifier signature shape flow

### DIFF
--- a/docs/design/member-signature-shape.md
+++ b/docs/design/member-signature-shape.md
@@ -160,6 +160,30 @@ separate from this compiler-backed ledger.
 
 [readonly-parameter-encoding]: https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/ref-readonly-parameters.md#metadata-encoding
 
+`FunctionPointerModifierSignatureShapeFlowTests` extends the ledger to managed
+function-pointer parameters. Its compiled value/reference pairs distinguish the
+outer pointer parameter's `Value` passing from an inner by-reference argument
+(`&` in `mss1`, not outer `r`). Raw nested signatures record `modreq(OutAttribute)`
+for `out`, `modreq(InAttribute)` for `in`, and
+`modopt(RequiresLocationAttribute)` for `ref readonly`, following the
+[function-pointer metadata encoding][readonly-function-pointer-encoding].
+These modifiers erase to the same available Metadata shape as plain `ref`;
+that equality does not establish binary compatibility.
+
+The current source adapter accepts the value/`ref`/`out`/`in` specimens but
+refuses inner `ref readonly` syntax. Its unavailable result is retained:
+Metadata-to-source comparison of the complete `ReadOnly` group is unavailable
+even for its otherwise matching value sibling. In the other direction, that
+value source uniquely matches the Metadata value candidate. Alternative source
+versions demonstrate unique correspondence, ambiguity, or refusal without
+pretending they coexist as legal overloads; the
+[compiler pre-work](https://github.com/richlander/dotnet-inspect/issues/6163#issuecomment-5560340986)
+records rejection of overloads differing only in those nested modifiers.
+This evidence does not expand source syntax support or cover every calling
+convention, return modifier, or modifier placement.
+
+[readonly-function-pointer-encoding]: https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/ref-readonly-parameters.md#function-pointers
+
 ### Demo: distinguish overloads, retain ambiguity
 
 Within the compiled `Ref` group:

--- a/tests/ILInspector.Metadata.Tests/FunctionPointerModifierFlowSamples.cs
+++ b/tests/ILInspector.Metadata.Tests/FunctionPointerModifierFlowSamples.cs
@@ -1,0 +1,16 @@
+namespace ILInspector.Metadata.Tests;
+
+public static unsafe class FunctionPointerModifierFlowSamples
+{
+    public static void Ref(delegate*<int, void> value) { }
+    public static void Ref(delegate*<ref int, void> reference) { }
+
+    public static void Out(delegate*<int, void> value) { }
+    public static void Out(delegate*<out int, void> reference) { }
+
+    public static void In(delegate*<int, void> value) { }
+    public static void In(delegate*<in int, void> reference) { }
+
+    public static void ReadOnly(delegate*<int, void> value) { }
+    public static void ReadOnly(delegate*<ref readonly int, void> reference) { }
+}

--- a/tests/ILInspector.Metadata.Tests/FunctionPointerModifierSignatureShapeFlowTests.cs
+++ b/tests/ILInspector.Metadata.Tests/FunctionPointerModifierSignatureShapeFlowTests.cs
@@ -1,0 +1,286 @@
+using CSharpText;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class FunctionPointerModifierSignatureShapeFlowTests
+{
+    const string ValueTransport = "mss1:0(1:vf7:managedp11:System.Void1:p12:System.Int32)n";
+    const string ReferenceTransport = "mss1:0(1:vf7:managedp11:System.Void1:&p12:System.Int32)n";
+
+    static readonly MemberSignatureShape ValueShape = new(
+        0, new([new MemberParameterSignatureShape(
+            ParameterPassingKind.Value, new FunctionPointerTypeSignatureShape(
+                "managed", new PrimitiveTypeSignatureShape("System.Void"),
+                new([new PrimitiveTypeSignatureShape("System.Int32")])))]));
+    static readonly MemberSignatureShape ReferenceShape = new(
+        0, new([new MemberParameterSignatureShape(
+            ParameterPassingKind.Value, new FunctionPointerTypeSignatureShape(
+                "managed", new PrimitiveTypeSignatureShape("System.Void"),
+                new([new ByReferenceTypeSignatureShape(
+                    new PrimitiveTypeSignatureShape("System.Int32"))])))]));
+
+    static readonly Specimen[] Specimens =
+    [
+        new("RefValue", "Ref", "delegate*<int, void>", false, ValueShape, ValueTransport),
+        new("RefReference", "Ref", "delegate*<ref int, void>", true, ReferenceShape, ReferenceTransport),
+        new("OutValue", "Out", "delegate*<int, void>", false, ValueShape, ValueTransport),
+        new("OutReference", "Out", "delegate*<out int, void>", true, ReferenceShape, ReferenceTransport,
+            SignatureTypeCode.RequiredModifier, "System.Runtime.InteropServices.OutAttribute"),
+        new("InValue", "In", "delegate*<int, void>", false, ValueShape, ValueTransport),
+        new("InReference", "In", "delegate*<in int, void>", true, ReferenceShape, ReferenceTransport,
+            SignatureTypeCode.RequiredModifier, "System.Runtime.InteropServices.InAttribute"),
+        new("ReadOnlyValue", "ReadOnly", "delegate*<int, void>", false, ValueShape, ValueTransport),
+        new("ReadOnlyReference", "ReadOnly", "delegate*<ref readonly int, void>", true,
+            ReferenceShape, ReferenceTransport,
+            SignatureTypeCode.OptionalModifier, "System.Runtime.CompilerServices.RequiresLocationAttribute",
+            SourceAvailable: false),
+    ];
+
+    public static TheoryData<string> FlowCases => new(Specimens.Select(specimen => specimen.Name));
+
+    public static TheoryData<string> ModifiedCases =>
+        new(Specimens.Where(specimen => specimen.ModifierKind is not null).Select(specimen => specimen.Name));
+
+    [Theory]
+    [MemberData(nameof(FlowCases))]
+    public void FunctionPointerFlow_RecordsEncodingShapeTransportAndRefusal(string specimenName)
+    {
+        Specimen specimen = FindSpecimen(specimenName);
+        Specimen[] group = Specimens.Where(candidate => candidate.MethodName == specimen.MethodName).ToArray();
+        using var peReader = OpenFixture();
+        MetadataReader reader = peReader.GetMetadataReader();
+        foreach (Specimen candidate in group)
+            AssertCompilerEncoding(reader, ExpectedHandle(candidate), candidate);
+
+        MethodDefinitionHandle expected = ExpectedHandle(specimen);
+        var metadataCandidates = MetadataCandidates(reader, specimen.MethodName);
+        MemberSignatureShapeResult metadata = Assert.Single(
+            metadataCandidates, candidate => candidate.Candidate == expected).Shape;
+        MemberSignatureShapeResult restoredMetadata = AssertStages(metadata, specimen);
+        var restoredCandidates = metadataCandidates
+            .Select(candidate => (candidate.Candidate, Shape: Transport(candidate.Shape)))
+            .ToArray();
+        AssertUnique(MemberSignatureShapeMatcher.Match(metadata, metadataCandidates), expected);
+        AssertUnique(MemberSignatureShapeMatcher.Match(restoredMetadata, restoredCandidates), expected);
+
+        MemberSignatureShapeResult source = SourceShape(specimen);
+        MemberSignatureShapeResult restoredSource = AssertSourceStages(source, specimen);
+        if (specimen.SourceAvailable)
+        {
+            AssertUnique(MemberSignatureShapeMatcher.Match(source, metadataCandidates), expected);
+            AssertUnique(MemberSignatureShapeMatcher.Match(restoredSource, restoredCandidates), expected);
+        }
+        else
+        {
+            AssertUnavailable(MemberSignatureShapeMatcher.Match(source, metadataCandidates));
+            AssertUnavailable(MemberSignatureShapeMatcher.Match(restoredSource, restoredCandidates));
+        }
+
+        var sourceCandidates = group
+            .Select(candidate => (Candidate: candidate.Name, Shape: SourceShape(candidate)))
+            .ToArray();
+        var restoredSourceCandidates = sourceCandidates
+            .Select(candidate => (
+                candidate.Candidate, Shape: AssertSourceStages(candidate.Shape, FindSpecimen(candidate.Candidate))))
+            .ToArray();
+        if (group.Any(candidate => !candidate.SourceAvailable))
+        {
+            AssertUnavailable(MemberSignatureShapeMatcher.Match(metadata, sourceCandidates));
+            AssertUnavailable(MemberSignatureShapeMatcher.Match(restoredMetadata, restoredSourceCandidates));
+        }
+        else
+        {
+            AssertUnique(MemberSignatureShapeMatcher.Match(metadata, sourceCandidates), specimen.Name);
+            AssertUnique(MemberSignatureShapeMatcher.Match(restoredMetadata, restoredSourceCandidates), specimen.Name);
+        }
+
+        AssertUnavailable(MemberSignatureShapeMatcher.Match(
+            restoredMetadata, restoredCandidates.Where(candidate => candidate.Candidate != expected).ToArray()));
+    }
+
+    [Theory]
+    [MemberData(nameof(ModifiedCases))]
+    public void DistinctFunctionPointerModifierEncoding_DoesNotBecomeSignatureIdentity(string specimenName)
+    {
+        Specimen modified = FindSpecimen(specimenName);
+        Specimen plainReference = FindSpecimen("RefReference");
+        using var peReader = OpenFixture();
+        MetadataReader reader = peReader.GetMetadataReader();
+        MethodDefinitionHandle modifiedHandle = ExpectedHandle(modified);
+        MethodDefinitionHandle plainHandle = ExpectedHandle(plainReference);
+        AssertCompilerEncoding(reader, modifiedHandle, modified);
+        AssertCompilerEncoding(reader, plainHandle, plainReference);
+        Assert.False(reader.GetBlobBytes(reader.GetMethodDefinition(modifiedHandle).Signature).AsSpan()
+            .SequenceEqual(reader.GetBlobBytes(reader.GetMethodDefinition(plainHandle).Signature)));
+
+        MemberSignatureShapeResult metadata = AssertStages(
+            MetadataMemberSignatureShape.Create(reader, modifiedHandle), modified);
+        MemberSignatureShapeResult plainMetadata = AssertStages(
+            MetadataMemberSignatureShape.Create(reader, plainHandle), plainReference);
+        Assert.Equal(plainMetadata.Shape, metadata.Shape);
+
+        MemberSignatureShapeResult original = AssertSourceStages(SourceShape(modified), modified);
+        MemberSignatureShapeResult alternative = AssertStages(
+            SourceMemberSignatureShape.Create(
+                $"void {modified.MethodName}(delegate*<ref int, void> reference);",
+                SourceMemberSignatureKind.Method), modified);
+        Specimen value = Specimens.Single(candidate =>
+            candidate.MethodName == modified.MethodName && !candidate.ByReferenceArgument);
+        MemberSignatureShapeResult valueSource = AssertStages(SourceShape(value), value);
+
+        // Independent source-version scenarios, not one legal overload group.
+        AssertUnique(
+            MemberSignatureShapeMatcher.Match(metadata, [("value", valueSource), ("alternative", alternative)]),
+            "alternative");
+        MemberSignatureCorrespondence<string> result = MemberSignatureShapeMatcher.Match(
+            metadata, [("value", valueSource), ("original", original), ("alternative", alternative)]);
+        if (modified.SourceAvailable)
+        {
+            Assert.Equal(MemberSignatureCorrespondenceKind.Ambiguous, result.Kind);
+            Assert.Equal(["original", "alternative"], result.Candidates);
+            Assert.Null(result.Match);
+            Assert.Null(result.UnavailableReason);
+        }
+        else
+        {
+            AssertUnavailable(result);
+        }
+    }
+
+    static void AssertCompilerEncoding(
+        MetadataReader reader, MethodDefinitionHandle handle, Specimen specimen)
+    {
+        MethodDefinition method = reader.GetMethodDefinition(handle);
+        BlobReader signature = reader.GetBlobReader(method.Signature);
+        Assert.Equal(0x00, signature.ReadByte()); // Static, non-generic default calling convention.
+        Assert.Equal(1, signature.ReadCompressedInteger());
+        Assert.Equal(SignatureTypeCode.Void, signature.ReadSignatureTypeCode());
+        Assert.Equal(SignatureTypeCode.FunctionPointer, signature.ReadSignatureTypeCode());
+        Assert.Equal(0x00, signature.ReadByte()); // Managed function pointer, not the enclosing method.
+        Assert.Equal(1, signature.ReadCompressedInteger());
+        Assert.Equal(SignatureTypeCode.Void, signature.ReadSignatureTypeCode());
+        if (specimen.ModifierKind is { } modifierKind)
+        {
+            Assert.Equal(modifierKind, signature.ReadSignatureTypeCode());
+            EntityHandle modifier = signature.ReadTypeHandle();
+            (StringHandle Namespace, StringHandle Name) modifierName = modifier.Kind switch
+            {
+                HandleKind.TypeDefinition => (
+                    reader.GetTypeDefinition((TypeDefinitionHandle)modifier).Namespace,
+                    reader.GetTypeDefinition((TypeDefinitionHandle)modifier).Name),
+                HandleKind.TypeReference => (
+                    reader.GetTypeReference((TypeReferenceHandle)modifier).Namespace,
+                    reader.GetTypeReference((TypeReferenceHandle)modifier).Name),
+                _ => throw new Xunit.Sdk.XunitException($"Unexpected compiler modifier handle: {modifier.Kind}."),
+            };
+            Assert.Equal(specimen.ModifierName,
+                $"{reader.GetString(modifierName.Namespace)}.{reader.GetString(modifierName.Name)}");
+        }
+        if (specimen.ByReferenceArgument)
+            Assert.Equal(SignatureTypeCode.ByReference, signature.ReadSignatureTypeCode());
+        Assert.Equal(SignatureTypeCode.Int32, signature.ReadSignatureTypeCode());
+        Assert.Equal(0, signature.RemainingBytes);
+
+        Parameter parameter = method.GetParameters().Select(reader.GetParameter)
+            .Single(parameter => parameter.SequenceNumber == 1);
+        Assert.Equal(ParameterAttributes.None, parameter.Attributes);
+    }
+
+    static (MethodDefinitionHandle Candidate, MemberSignatureShapeResult Shape)[] MetadataCandidates(
+        MetadataReader reader, string methodName)
+    {
+        var typeHandle = (TypeDefinitionHandle)MetadataTokens.EntityHandle(
+            typeof(FunctionPointerModifierFlowSamples).MetadataToken);
+        return reader.GetTypeDefinition(typeHandle).GetMethods()
+            .Where(handle => reader.StringComparer.Equals(reader.GetMethodDefinition(handle).Name, methodName))
+            .Select(handle => (Candidate: handle, Shape: MetadataMemberSignatureShape.Create(reader, handle)))
+            .ToArray();
+    }
+
+    static MethodDefinitionHandle ExpectedHandle(Specimen specimen)
+    {
+        // Fixture parameter names locate the overload independently of signature projection.
+        MethodInfo method = typeof(FunctionPointerModifierFlowSamples)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Single(method => method.Name == specimen.MethodName
+                && method.GetParameters().Single().Name == specimen.ParameterName);
+        return (MethodDefinitionHandle)MetadataTokens.EntityHandle(method.MetadataToken);
+    }
+
+    static MemberSignatureShapeResult SourceShape(Specimen specimen) =>
+        SourceMemberSignatureShape.Create(
+            $"void {specimen.MethodName}({specimen.ParameterType} {specimen.ParameterName});",
+            SourceMemberSignatureKind.Method);
+
+    static MemberSignatureShapeResult AssertSourceStages(MemberSignatureShapeResult result, Specimen specimen)
+    {
+        if (specimen.SourceAvailable)
+            return AssertStages(result, specimen);
+        Assert.False(result.IsAvailable);
+        Assert.Null(result.Shape);
+        Assert.False(string.IsNullOrWhiteSpace(result.UnavailableReason));
+        return result;
+    }
+
+    static MemberSignatureShapeResult AssertStages(MemberSignatureShapeResult result, Specimen specimen)
+    {
+        Assert.True(result.IsAvailable, result.UnavailableReason);
+        Assert.Null(result.UnavailableReason);
+        Assert.Equal(specimen.ExpectedShape, result.Shape);
+        string text = MemberSignatureShapeCodec.Encode(result.Shape!);
+        Assert.Equal(specimen.ExpectedTransport, text);
+        MemberSignatureShapeResult restored = MemberSignatureShapeCodec.Decode(text);
+        Assert.True(restored.IsAvailable, restored.UnavailableReason);
+        Assert.Null(restored.UnavailableReason);
+        Assert.Equal(specimen.ExpectedShape, restored.Shape);
+        return restored;
+    }
+
+    static MemberSignatureShapeResult Transport(MemberSignatureShapeResult result)
+    {
+        Assert.True(result.IsAvailable, result.UnavailableReason);
+        MemberSignatureShapeResult restored =
+            MemberSignatureShapeCodec.Decode(MemberSignatureShapeCodec.Encode(result.Shape!));
+        Assert.True(restored.IsAvailable, restored.UnavailableReason);
+        return restored;
+    }
+
+    static void AssertUnique<T>(MemberSignatureCorrespondence<T> result, T expected)
+    {
+        Assert.Equal(MemberSignatureCorrespondenceKind.Unique, result.Kind);
+        Assert.Equal(expected, result.Match);
+        Assert.Empty(result.Candidates);
+        Assert.Null(result.UnavailableReason);
+    }
+
+    static void AssertUnavailable<T>(MemberSignatureCorrespondence<T> result)
+    {
+        Assert.Equal(MemberSignatureCorrespondenceKind.Unavailable, result.Kind);
+        Assert.Equal(default, result.Match);
+        Assert.Empty(result.Candidates);
+        Assert.False(string.IsNullOrWhiteSpace(result.UnavailableReason));
+    }
+
+    static Specimen FindSpecimen(string name) => Specimens.Single(specimen => specimen.Name == name);
+
+    static PEReader OpenFixture() =>
+        new(File.OpenRead(typeof(FunctionPointerModifierFlowSamples).Assembly.Location));
+
+    sealed record Specimen(
+        string Name,
+        string MethodName,
+        string ParameterType,
+        bool ByReferenceArgument,
+        MemberSignatureShape ExpectedShape,
+        string ExpectedTransport,
+        SignatureTypeCode? ModifierKind = null,
+        string? ModifierName = null,
+        bool SourceAvailable = true)
+    {
+        public string ParameterName => ByReferenceArgument ? "reference" : "value";
+    }
+}


### PR DESCRIPTION
Strengthen the foundational signature-evidence path with compiler-backed
function-pointer examples: distinguish preserved structure, erased modifiers,
and visible refusal without presenting correspondence as identity.

Adds eight compiled specimens and eleven flow cases under the existing Metadata
test host. **No product behavior changes.** Closes #6163; follows #6115.

## Demo

The compiled specimens use legal value/reference overload pairs. For example:

```csharp
public static void Ref(delegate*<int, void> value) { }
public static void Ref(delegate*<ref int, void> reference) { }

public static void ReadOnly(delegate*<int, void> value) { }
public static void ReadOnly(delegate*<ref readonly int, void> reference) { }
```

The actual fixture class supplies the `unsafe` context. Separate `Out` and `In`
pairs supply the other required-modifier neighbors.

The ledger reads the nested signature bytes and modifier type handles before
calling the product projection:

| Inner function-pointer parameter | Raw compiler modifier | Metadata projection | Source projection |
| --- | --- | --- | --- |
| `int` | None | Value argument | Available |
| `ref int` | None | By-reference argument | Available |
| `out int` | `modreq(System.Runtime.InteropServices.OutAttribute)` | By-reference argument | Available |
| `in int` | `modreq(System.Runtime.InteropServices.InAttribute)` | By-reference argument | Available |
| `ref readonly int` | `modopt(System.Runtime.CompilerServices.RequiresLocationAttribute)` | By-reference argument | **Unavailable** |

The pointer itself is passed **by value** in every row. Its inner argument
preserves value versus reference through these literal transports:

```text
value argument:        mss1:0(1:vf7:managedp11:System.Void1:p12:System.Int32)n
by-reference argument: mss1:0(1:vf7:managedp11:System.Void1:&p12:System.Int32)n
```

The outer `v` and inner `&` describe different levels. The decoded required and
optional modifiers all erase to the second Metadata shape; serialization does
not make a second semantic erasure.

**Why equal payloads are acceptable here:** this is a deliberately limited,
non-authoritative correspondence projection, not CLR signature equivalence or
binary compatibility. The tests prove the modifier-bearing blobs differ from
plain `ref`, even though the projected shapes coincide. Equality must never
deduplicate candidates or substitute for the consumer's attribution evidence.

The complete-group results make the boundary observable:

| Scenario | Result |
| --- | --- |
| `Ref` value/reference pair, either direction, before/after transport | `Unique`, preserving the exact expected candidate |
| `ReadOnly` value source against both Metadata overloads | `Unique`, identifying the value overload |
| `ReadOnly` inner-ref-readonly source against Metadata | `Unavailable`: target spelling is unsupported |
| Either `ReadOnly` Metadata overload against the complete source pair | `Unavailable`: the refused source sibling remains present |
| Only the opposite inner-passing Metadata candidate | `Unavailable`, not an ordinal substitute |

Separate source-version scenarios show a plain-`ref` alternative can be unique
under the projection without proving semantic compatibility. Keeping both
available alternatives yields `Ambiguous`; keeping the refused original
ref-readonly alternative yields `Unavailable`, not a manufactured unique match.
These alternatives are **not one compiled overload set**: the
[compiler pre-work](https://github.com/richlander/dotnet-inspect/issues/6163#issuecomment-5560340986)
records `CS0111` when the four nested reference modes are declared together.

## Design and scope

Normative owner:
[`member-signature-shape.md#projection-policy-and-rationale`](docs/design/member-signature-shape.md#projection-policy-and-rationale).
The [C# function-pointer metadata encoding](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/ref-readonly-parameters.md#function-pointers)
and the selected compiler supply supporting evidence, not competing ownership.

The existing ReturnToSender lookup remains non-authoritative. This is the
one-step evidence adoption tracked by #6163: compile the samples in the existing
Metadata test assembly, exercise the ledger in its existing CI host, and name
the gate in the focused owner. Fixture parameter names locate MethodDef handles
independently of product projection; they are test labels, not a new identity
scheme.

No new source syntax support, codec, harness architecture, fixture project,
dependency, CLI/browser host path, or provenance claim. This small ledger does
not claim coverage of every calling convention, return modifier, or modifier
placement. Existing unavailable-modifier and unsupported-header gates remain
separate.

## Validation

SDK: `11.0.100-preview.7.26381.103`. Focused Release selection:

```bash
DOTNET_ROOT=/home/rich/.local/share/dotnet \
dotnet run --disable-build-servers \
  --project tests/ILInspector.Metadata.Tests -c Release \
  -p:BuildInParallel=false -- \
  --filter-class '*SignatureShape*' \
  --report-ctrf \
  --report-ctrf-filename function-pointer-shape-flow.ctrf.json \
  --results-directory artifacts/test-results/function-pointer-shape-flow
```

**114 passed, zero failed or skipped, including all 11 new cases**, with actual
discovery recorded in CTRF. Changed design Markdown and this PR body pass
`markdownlint`. No full-solution fixture build is needed for these samples:
their inspected binary is the test assembly built by the command above.
