### PR TITLE
Give Library References a full-area working surface

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -557,9 +557,10 @@ Admitted libraries with no public types retain their named Library Overview.
 connects both production browser Overview consumers to this shared frame and
 retires their generic hero composition and Package's inset coordinate editor.
 The user explicitly approved this browser-only presentation scope and requested
-matching local name/icon treatment for Package and Library. Existing typed data supplies the
-content and counts; browser HTML rendering remains the lowering boundary rather
-than Markout because this slice arranges interactive controls and navigation.
+matching local name/icon treatment for Package and Library. Existing typed data
+supplies the content and counts; browser HTML rendering remains the lowering
+boundary rather than Markout because this slice arranges interactive controls
+and navigation.
 The frame reuses the current package-surface conventions, not a new general
 rendering architecture. Other Package and Library lenses remain separate consumers.
 
@@ -613,6 +614,45 @@ strings. The surface creates no page-level horizontal overflow. This slice
 does not change dependency selection, graph construction or navigation,
 Package Overview, Integrations, Opportunities, Analysis, Package Metadata, or
 the Metadata Explorer.
+
+### Library References
+
+Library References fills the inspector area without the generic Library hero or
+an inset reference-section heading. The subject path retains navigation context.
+
+```text
+References                                  direct reference count or state
+reference names, versions, cultures, and public-key tokens
+Library asset and assembly identity              TFM · package@version
+```
+
+One independently scrolling region begins with the reference rows and uses the
+available width. The quiet header and bottom context remain in place while the
+list scrolls. Full Library assembly identity and asset path remain available in
+the footer rather than being discarded with the old heading.
+
+Loading, query failure, inspection failure, and successful zero-reference results
+retain the same frame and remain visibly distinct. Existing Library selection,
+query freshness, direct AssemblyRef semantics, counts, order, and field values
+are unchanged.
+
+At narrow widths the existing Types return control shares the quiet header.
+Reference names and identity fields wrap within rows; header status and footer
+values may elide as complete strings with their full text retained. Long values
+and many rows create local scrolling, not page-level horizontal overflow.
+
+The browser-only presentation scope was explicitly approved for
+[the one-step adoption tracker](https://github.com/richlander/dotnet-inspect/issues/6165).
+Its one production consumer is Library References; adoption retires only that
+consumer's generic hero and inset reference section. Browser HTML lowering
+continues over the existing typed `BrowserPackageDependencies` reference result.
+This is a placement change, not a new query or rendering architecture. Metadata
+and Package Dependencies are the local composition precedents.
+
+Focused renderer and production-composition browser gates cover wide/narrow
+geometry, long names and identities, many/zero rows, pending and failed results,
+and Library navigation. Subject-strip behavior and other Library lenses are
+separate work.
 
 ### Package Metadata
 

--- a/prototypes/inspect-web/browser/library-hierarchy.spec.ts
+++ b/prototypes/inspect-web/browser/library-hierarchy.spec.ts
@@ -99,6 +99,7 @@ async function installFacades(
   page: Page,
   model = surface,
   additionalSurfaces: readonly BrowserPackageSurface[] = [],
+  references: "ready" | "long" | "empty" | "query-error" | "inspection-error" | "deferred" = "ready",
 ) {
   const common = "export async function initializeRuntime() {}";
   const surfaceLookup = `
@@ -139,10 +140,23 @@ async function installFacades(
         const surface = surfaceFor(id);
         const selected = surface.assemblies.find(item => item.id === asset);
         if (!selected) throw new Error("Unknown library: " + asset);
+        const scenario = ${JSON.stringify(references)};
+        if (scenario === "deferred") {
+          await new Promise(resolve => document.addEventListener(
+            "fixture-references-ready:" + asset, resolve, { once: true }));
+        }
+        if (scenario === "query-error") throw new Error("Reference query unavailable.");
         return {
           package: id, version, activeFramework: framework, assembly: selected.name,
-          dependencyGroups: [], dependencyGroupError: null, assemblyReferenceError: null,
-          assemblyReferences: [{ name: selected.name + ".Dependency", version: "1.0.0.0", culture: null, publicKeyToken: null }],
+          dependencyGroups: [], dependencyGroupError: null,
+          assemblyReferenceError: scenario === "inspection-error" ? "Cannot decode AssemblyRef." : null,
+          assemblyReferences: scenario === "empty" ? [] : scenario === "long"
+            ? Array.from({ length: 80 }, (_, index) => ({
+                name: selected.name + "." + "LongNamespace.".repeat(20) + "Reference" + index,
+                version: "1.2.3.4", culture: "x-" + Array(20).fill("private").join("-"),
+                publicKeyToken: "0123456789abcdef"
+              }))
+            : [{ name: selected.name + ".Dependency", version: "1.0.0.0", culture: null, publicKeyToken: null }],
           compileLibrary: surface.compileLibrary
         };
       }`,
@@ -208,6 +222,116 @@ async function installFacades(
 }
 
 const root = "/?package=Example.Package&version=1.0.0&framework=net10.0#pkg";
+
+async function openReferences(page: Page) {
+  await page.goto(root);
+  await page.locator('.library-list [data-lib-scope="asset:core"]').click();
+  await page.locator('[data-library-lens="overview"]').press("ArrowRight");
+  await page.keyboard.press("Enter");
+  await expect(page.locator('[data-library-lens="references"]')).toHaveAttribute("aria-selected", "true");
+}
+
+for (const width of [1440, 390]) {
+  test(`production References fills the pane and retains context at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    await installFacades(page);
+    await openReferences(page);
+    const frame = page.locator(".library-references-surface");
+    await expect(frame.locator(".dep-list li")).toHaveCount(1);
+    await expect(frame.locator("header")).toContainText("1 direct reference");
+    await expect(frame.locator("footer")).toContainText(core.asset);
+    await expect(frame.locator("footer")).toContainText("Example.Core, Version=1.0.0.0");
+    await expect(frame.locator("footer")).toContainText("Example.Package@1.0.0");
+    await expect(page.locator("#inspector-panel > .type-heading")).toHaveCount(0);
+    await expect(frame.locator("h2")).toHaveCount(0);
+    const panelBox = await page.locator("#inspector-panel").boundingBox();
+    const frameBox = await frame.boundingBox();
+    expect(panelBox).not.toBeNull();
+    expect(frameBox).not.toBeNull();
+    expect(Math.abs(frameBox!.width - panelBox!.width)).toBeLessThanOrEqual(2);
+    expect(Math.abs(frameBox!.height - panelBox!.height)).toBeLessThanOrEqual(2);
+    const listBox = await frame.locator(".dep-list").boundingBox();
+    expect(Math.abs(listBox!.x - frameBox!.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(listBox!.width - frameBox!.width)).toBeLessThanOrEqual(2);
+    await page.screenshot({ path: testInfo.outputPath("references.png") });
+    if (width === 390) {
+      const back = page.getByRole("button", { name: "Types", exact: true });
+      await expect(back).toBeVisible();
+      await back.click();
+      await expect(page.locator("#type-list")).toBeFocused();
+      await page.getByRole("button", { name: "Show details", exact: true }).click();
+      await expect(back).toBeFocused();
+      await expect(frame).toBeVisible();
+    }
+  });
+
+  test(`production References contains long fields and scrolls only its list at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    const longCore = library(core.id, "Example." + "LongLibraryName".repeat(25), 1);
+    await installFacades(page, {
+      ...surface, assemblies: [longCore], types: [type("Example.Widget", longCore)], totalMembers: 1,
+    }, [], "long");
+    await openReferences(page);
+    const frame = page.locator(".library-references-surface");
+    await expect(frame.locator(".dep-list li")).toHaveCount(80);
+    await expect(frame.locator("header")).toContainText("80 direct references");
+    await expect(frame.locator("footer span").first()).toHaveAttribute("title", new RegExp(longCore.name));
+    const headerBox = await frame.locator("header").boundingBox();
+    const footerBox = await frame.locator("footer").boundingBox();
+    const scroller = frame.locator(".library-references-scroll");
+    const geometry = await scroller.evaluate(element => ({
+      width: element.clientWidth, scrollWidth: element.scrollWidth,
+      height: element.clientHeight, scrollHeight: element.scrollHeight,
+      pageWidth: document.documentElement.clientWidth,
+      pageScrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.width + 1);
+    expect(geometry.pageScrollWidth).toBeLessThanOrEqual(geometry.pageWidth + 1);
+    expect(geometry.scrollHeight).toBeGreaterThan(geometry.height);
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight; });
+    await expect(frame.locator(".dep-list li").last()).toBeInViewport();
+    expect(await frame.locator("header").boundingBox()).toEqual(headerBox);
+    expect(await frame.locator("footer").boundingBox()).toEqual(footerBox);
+  });
+
+  for (const scenario of ["empty", "query-error", "inspection-error"] as const) {
+    test(`production References preserves its ${scenario} frame at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 900 });
+      await installFacades(page, surface, [], scenario);
+      await openReferences(page);
+      const frame = page.locator(".library-references-surface");
+      await expect(frame.locator("h2")).toHaveText(scenario === "empty"
+        ? "No direct references" : scenario === "query-error"
+          ? "Reference query failed" : "Reference inspection failed");
+      await expect(frame.locator("footer")).toBeInViewport();
+      await expect(frame.locator("footer")).toContainText(core.asset);
+      await expect(frame.locator(".dep-list")).toHaveCount(0);
+      if (scenario !== "empty") {
+        await expect(frame).not.toContainText("0 direct references");
+        await expect(frame).toContainText(scenario === "query-error"
+          ? "Reference query unavailable." : "Cannot decode AssemblyRef.");
+      }
+    });
+  }
+}
+
+test("production References retains a loading frame and does not show a previous Library's rows", async ({ page }) => {
+  await installFacades(page, surface, [], "deferred");
+  await openReferences(page);
+  await expect(page.locator(".library-references-surface")).toContainText("Reading direct AssemblyRef rows");
+  await expect(page.locator(".library-references-surface footer")).toContainText(core.asset);
+  await page.evaluate(() => document.dispatchEvent(new Event("fixture-references-ready:asset:core")));
+  await expect(page.locator(".library-references-scroll")).toContainText("Example.Core.Dependency");
+  await page.locator('[data-subject-tab]:not([hidden])').first().press("Home");
+  await page.locator('.library-list [data-lib-scope="asset:other"]').click();
+  await page.locator('[data-library-lens="overview"]').press("ArrowRight");
+  await page.keyboard.press("Enter");
+  await expect(page.locator(".library-references-surface")).toContainText("Reading direct AssemblyRef rows");
+  await expect(page.locator(".library-references-surface footer")).toContainText(other.asset);
+  await expect(page.locator(".library-references-surface")).not.toContainText("Example.Core");
+  await page.evaluate(() => document.dispatchEvent(new Event("fixture-references-ready:asset:other")));
+  await expect(page.locator(".library-references-scroll")).toContainText("Example.Other.Dependency");
+});
 
 for (const width of [1440, 390]) {
   test(`production Package Overview fills its frame and opens Library at ${width}px`, async ({ page }) => {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -224,6 +224,7 @@ import {
 } from "./call-graph-inspection.ts";
 import { createDocumentInspectionCoordinator } from "./document-inspection.ts";
 import { renderOverviewSurface } from "./overview-surface.ts";
+import { renderLibraryReferencesSurface } from "./library-references.ts";
 import {
   captureMemberFocus,
   createMemberFocusRestorer,
@@ -3513,6 +3514,8 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     activeScope === "package" && state.packageLens === "dependencies";
   const libraryMetadataWorkingSurface =
     activeScope === "library" && state.libraryLens === "metadata";
+  const libraryReferencesWorkingSurface =
+    activeScope === "library" && state.libraryLens === "references";
   const currentMember = current ? selectedMember(current) : undefined;
   const memberOverloadPicker =
     currentMember !== undefined
@@ -3550,6 +3553,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     || overviewWorkingSurface
     || packageDependenciesWorkingSurface
     || libraryMetadataWorkingSurface
+    || libraryReferencesWorkingSurface
     || memberWorkingSurface;
 
   if (scopeBarOwnsFocus) {
@@ -3635,7 +3639,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
           ${contentFrameEnabled
             ? renderContentNavigationBar(contentNavigationLabel)
             : ""}
-          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}${apiWorkingSurface ? " api-working-surface" : ""}${metadataWorkingSurface ? " metadata-working-surface" : ""}${overviewWorkingSurface ? " overview-working-surface" : ""}${packageDependenciesWorkingSurface ? " package-dependencies-working-surface" : ""}${libraryMetadataWorkingSurface ? " package-metadata-working-surface" : ""}${memberWorkingSurface ? " member-working-surface" : ""}"${inspectorPanelSemantics}>
+          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}${apiWorkingSurface ? " api-working-surface" : ""}${metadataWorkingSurface ? " metadata-working-surface" : ""}${overviewWorkingSurface ? " overview-working-surface" : ""}${packageDependenciesWorkingSurface ? " package-dependencies-working-surface" : ""}${libraryMetadataWorkingSurface ? " package-metadata-working-surface" : ""}${libraryReferencesWorkingSurface ? " library-references-working-surface" : ""}${memberWorkingSurface ? " member-working-surface" : ""}"${inspectorPanelSemantics}>
             ${renderLens(current)}
           </article>
         </section>
@@ -4218,6 +4222,7 @@ function libraryHeading() {
 function renderLibraryView() {
   const body = libraryLensBody();
   if (state.libraryLens === "overview"
+    || state.libraryLens === "references"
     || state.libraryLens === "metadata") return body;
   return `${libraryHeading()}${body}`;
 }
@@ -4361,37 +4366,17 @@ function renderPackageDependencies() {
 function renderLibraryReferences() {
   const current = packageDependenciesSignature();
   const fresh = state.packageDependenciesKey === current;
-  if (state.packageDependenciesLoading && fresh) {
-    return `<section class="document-section source-progress"><span class="loader"></span><h2>Reading references…</h2><p>Reading direct AssemblyRef rows.</p></section>`;
-  }
-  if (fresh && state.packageDependenciesError) {
-    return `<section class="document-section empty-document"><span class="large-glyph">⌘</span><h2>Reference query failed</h2><p>${escapeHtml(state.packageDependenciesError)}</p></section>`;
-  }
-  const data = fresh ? state.packageDependencies : null;
-  return data
-    ? assemblyReferencesSectionHtml(data)
-    : `<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
-}
-
-function assemblyReferencesSectionHtml(data: BrowserPackageDependencies) {
-  const references = data.assemblyReferences || [];
-  const assembly = data.assembly || "selected assembly";
-  if (data.assemblyReferenceError) {
-    return `
-      <section class="document-section">
-        <div class="section-title"><h2>Assembly references</h2><span>${escapeHtml(assembly)}</span></div>
-        <div class="empty-list">Inspection failed: ${escapeHtml(data.assemblyReferenceError)}</div>
-      </section>`;
-  }
-
-  return `
-    <section class="document-section">
-      <div class="section-title"><h2>Assembly references</h2><span>${escapeHtml(assembly)} · ${references.length} direct reference${references.length === 1 ? "" : "s"}</span></div>
-      ${references.length
-        ? `<ul class="dep-list">${references.map(reference =>
-            `<li><span class="dep-name">${escapeHtml(reference.name)}</span><code class="dep-version">${escapeHtml(`${reference.version} · ${reference.culture || "neutral"} · ${reference.publicKeyToken ? `pkt ${reference.publicKeyToken}` : "unsigned"}`)}</code></li>`).join("")}</ul>`
-        : `<div class="empty-list">This assembly declares no direct AssemblyRef rows.</div>`}
-    </section>`;
+  const library = selectedLibrary();
+  const pkg = currentPackage();
+  return renderLibraryReferencesSurface({
+    assemblyIdentity: library ? libraryIdentity(library) : "No library selected",
+    assetPath: library?.asset ?? "",
+    coordinate: `${pkg.activeFramework} · ${pkg.id}@${pkg.version}`,
+    loading: state.packageDependenciesLoading && fresh,
+    error: fresh ? state.packageDependenciesError : "",
+    data: fresh ? state.packageDependencies : null,
+    escapeHtml,
+  });
 }
 
 function uniqueCompatiblePackage(

--- a/prototypes/inspect-web/src/library-references.ts
+++ b/prototypes/inspect-web/src/library-references.ts
@@ -1,0 +1,49 @@
+import type { BrowserPackageDependencies } from "./facades/inspect-web-package.d.ts";
+
+export interface LibraryReferencesOptions {
+  assemblyIdentity: string;
+  assetPath: string;
+  coordinate: string;
+  loading: boolean;
+  error: string;
+  data: BrowserPackageDependencies | null;
+  escapeHtml: (value: unknown) => string;
+}
+
+export function renderLibraryReferencesSurface(options: LibraryReferencesOptions): string {
+  const { assemblyIdentity, assetPath, coordinate, loading, error, data, escapeHtml } = options;
+  let status: string;
+  let content: string;
+  if (loading) {
+    status = "Reading references\u2026";
+    content = `<section class="document-section source-progress"><span class="loader"></span><h2>Reading references&hellip;</h2><p>Reading direct AssemblyRef rows.</p></section>`;
+  } else if (error) {
+    status = "Query failed";
+    content = `<section class="document-section empty-document"><span class="large-glyph">&#x2318;</span><h2>Reference query failed</h2><p>${escapeHtml(error)}</p></section>`;
+  } else if (!data) {
+    status = "Loading\u2026";
+    content = `<section class="document-section empty-document"><span class="loader"></span><h2>Loading&hellip;</h2></section>`;
+  } else if (data.assemblyReferenceError) {
+    status = "Inspection failed";
+    content = `<section class="document-section empty-document"><h2>Reference inspection failed</h2><p>${escapeHtml(data.assemblyReferenceError)}</p></section>`;
+  } else {
+    const references = data.assemblyReferences;
+    status = `${references.length.toLocaleString()} direct reference${references.length === 1 ? "" : "s"}`;
+    content = references.length
+      ? `<ul class="dep-list" aria-label="Assembly references">${references.map(reference =>
+          `<li><span class="dep-name">${escapeHtml(reference.name)}</span><code class="dep-version">${escapeHtml(`${reference.version} \u00b7 ${reference.culture || "neutral"} \u00b7 ${reference.publicKeyToken ? `pkt ${reference.publicKeyToken}` : "unsigned"}`)}</code></li>`).join("")}</ul>`
+      : `<section class="document-section empty-document"><h2>No direct references</h2><p>This assembly declares no direct AssemblyRef rows.</p></section>`;
+  }
+  const identity = assetPath ? `${assetPath} \u00b7 ${assemblyIdentity}` : assemblyIdentity;
+  return `<section class="library-references-surface" aria-labelledby="library-references-title">
+    <header class="api-surface-head">
+      <h1 id="library-references-title">References</h1>
+      <p>${escapeHtml(status)}</p>
+    </header>
+    <div class="library-references-scroll">${content}</div>
+    <footer class="metadata-surface-footer">
+      <span title="${escapeHtml(identity)}">${escapeHtml(identity)}</span>
+      <span title="${escapeHtml(coordinate)}">${escapeHtml(coordinate)}</span>
+    </footer>
+  </section>`;
+}

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1008,6 +1008,7 @@ kbd {
 .detail-scroll.metadata-working-surface,
 .detail-scroll.member-working-surface { min-height: 0; overflow: hidden; padding: 0; }
 .detail-scroll.overview-working-surface,
+.detail-scroll.library-references-working-surface,
 .detail-scroll.package-dependencies-working-surface,
 .detail-scroll.package-metadata-working-surface { min-height: 0; overflow: hidden; padding: 0; }
 
@@ -1090,8 +1091,11 @@ kbd {
 .metadata-surface-head p { min-width: 0; flex: 0 1 auto; overflow: hidden; margin: 0; color: var(--dim); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .api-surface-head p span,
 .metadata-surface-head p span { margin-left: 6px; }
+.library-references-surface,
 .metadata-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: 40px minmax(0, 1fr) 34px; background: var(--bg); }
+.library-references-scroll,
 .metadata-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
+.library-references-scroll > .document-section,
 .metadata-surface-scroll > .document-section,
 .metadata-surface-scroll > [data-type-graph-surface] > .document-section { padding: 24px 16px 0; }
 .metadata-surface-scroll > .metadata-shape-section { padding: 0; }
@@ -1501,6 +1505,11 @@ kbd {
 .dep-name.as-link { border: 0; background: transparent; padding: 0; text-align: left; cursor: pointer; color: var(--blue); }
 .dep-name.as-link:hover { text-decoration: underline; }
 .dep-version { flex: 0 0 auto; font: 13px var(--mono); color: var(--dim); white-space: nowrap; }
+.library-references-scroll { overflow-wrap: anywhere; }
+.library-references-scroll > .dep-list { border-top: 0; }
+.library-references-scroll .dep-list li { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); padding-inline: 16px; }
+.library-references-scroll .dep-name { overflow: visible; white-space: normal; }
+.library-references-scroll .dep-version { min-width: 0; white-space: normal; text-align: right; }
 .graph-empty { color: var(--muted); font-size: 12px; padding: 24px 12px; text-align: center; }
 .fact-rows .dim { color: var(--muted); }
 .perf-list { display: flex; flex-direction: column; gap: 6px; }
@@ -1945,6 +1954,9 @@ kbd {
   .member-nav { grid-template-rows: 40px 34px auto minmax(0, 1fr); }
   .detail-scroll { padding: 22px 18px 60px; }
   .api-surface-head { min-height: 40px; padding-inline: 12px; }
+  .library-references-scroll .dep-list li { grid-template-columns: minmax(0, 1fr); gap: 4px; padding-inline: 12px; }
+  .library-references-scroll .dep-version { text-align: left; }
+  .library-references-scroll > .document-section { padding-inline: 12px; }
   .metadata-surface-head { padding-inline: 12px; }
   .metadata-surface-scroll > .document-section,
   .metadata-surface-scroll > [data-type-graph-surface] > .document-section { padding-inline: 12px; }

--- a/prototypes/inspect-web/test/library-references.test.ts
+++ b/prototypes/inspect-web/test/library-references.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { renderLibraryReferencesSurface, type LibraryReferencesOptions } from "../src/library-references.ts";
+import type { BrowserPackageDependencies } from "../src/facades/inspect-web-package.d.ts";
+
+const data: BrowserPackageDependencies = {
+  package: "Example.Package", version: "1.0.0", activeFramework: "net10.0",
+  assembly: "Example.Core",
+  dependencyGroups: [], dependencyGroupError: null, assemblyReferenceError: null,
+  assemblyReferences: [
+    { name: "System.Runtime", version: "10.0.0.0", culture: null, publicKeyToken: "b03f5f7f11d50a3a" },
+    { name: "Example.Other", version: "1.2.3.4", culture: "fr", publicKeyToken: null },
+  ],
+  compileLibrary: { status: "Selected", targetFramework: "net10.0", message: null },
+};
+
+function render(overrides: Partial<LibraryReferencesOptions> = {}) {
+  return renderLibraryReferencesSurface({
+    assemblyIdentity: "Example.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+    assetPath: "lib/net10.0/Example.Core.dll",
+    coordinate: "net10.0 / Example.Package@1.0.0",
+    loading: false,
+    error: "",
+    data,
+    escapeHtml: value => String(value).replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;").replaceAll("'", "&#39;"),
+    ...overrides,
+  });
+}
+
+test("References uses a single compact heading, direct list, and complete bottom context", () => {
+  const html = render();
+  assert.equal(html.match(/<h1\b/g)?.length, 1);
+  assert.match(html, /<h1 id="library-references-title">References<\/h1>/);
+  assert.match(html, /2 direct references/);
+  assert.match(html, /library-references-scroll"><ul class="dep-list"/);
+  assert.match(html, /System\.Runtime[\s\S]*10\.0\.0\.0.*neutral.*pkt b03f5f7f11d50a3a/);
+  assert.match(html, /Example\.Other[\s\S]*1\.2\.3\.4.*fr.*unsigned/);
+  assert.match(html, /<footer[\s\S]*lib\/net10\.0\/Example.Core.dll.*Example.Core, Version=1.0.0.0/);
+  assert.match(html, /<footer[\s\S]*net10.0 \/ Example.Package@1.0.0/);
+  assert.doesNotMatch(html, /type-heading|section-title|<h2>/);
+});
+
+test("a single direct reference uses a singular count", () => {
+  assert.match(render({ data: { ...data, assemblyReferences: data.assemblyReferences.slice(0, 1) } }),
+    /1 direct reference<\/p>/);
+});
+
+test("successful zero references retain the frame and explicit empty result", () => {
+  const html = render({ data: { ...data, assemblyReferences: [] } });
+  assert.match(html, /0 direct references/);
+  assert.match(html, /No direct references/);
+  assert.match(html, /This assembly declares no direct AssemblyRef rows/);
+  assert.match(html, /<footer/);
+  assert.doesNotMatch(html, /<ul|failed/);
+});
+
+test("reading state takes precedence over retained data or error", () => {
+  const html = render({ loading: true, error: "earlier failure" });
+  assert.match(html, /Reading direct AssemblyRef rows/);
+  assert.match(html, /<footer/);
+  assert.doesNotMatch(html, /System.Runtime|earlier failure|2 direct references/);
+});
+
+test("initial pending state is not rendered as successful zero references", () => {
+  const html = render({ data: null });
+  assert.match(html, /Loading/);
+  assert.match(html, /<footer/);
+  assert.doesNotMatch(html, /0 direct references|No direct references|<ul/);
+});
+
+test("query failure remains visible instead of exposing retained rows", () => {
+  const html = render({ error: "The reference query is unavailable." });
+  assert.match(html, /Query failed/);
+  assert.match(html, /The reference query is unavailable/);
+  assert.match(html, /<footer/);
+  assert.doesNotMatch(html, /<ul|2 direct references/);
+});
+
+test("inspection failure is not a zero-reference result", () => {
+  const html = render({ data: { ...data, assemblyReferenceError: "Cannot decode AssemblyRef." } });
+  assert.match(html, /Inspection failed/);
+  assert.match(html, /Cannot decode AssemblyRef/);
+  assert.match(html, /<footer/);
+  assert.doesNotMatch(html, /<ul|0 direct references|2 direct references/);
+});
+
+test("identity, reference fields, and diagnostics use the existing escape boundary", () => {
+  const html = render({
+    assemblyIdentity: 'Example."Core"',
+    assetPath: "lib/Example&Core.dll",
+    coordinate: "net10.0 / Example<Package>@1",
+    data: { ...data, assemblyReferences: [
+      { name: "Example<Other>", version: "1&2", culture: "a&b", publicKeyToken: "c&d" },
+    ] },
+  });
+  assert.match(html, /title="lib\/Example&amp;Core.dll.*Example.&quot;Core&quot;"/);
+  assert.match(html, /Example&lt;Package&gt;/);
+  assert.match(html, /Example&lt;Other&gt;/);
+  assert.match(html, /1&amp;2.*a&amp;b.*c&amp;d/);
+  assert.match(render({ error: "Read <failed>" }), /Read &lt;failed&gt;/);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -5360,7 +5360,7 @@ test("library metadata uses compact coordinates in a full-area working surface",
     /const contentNavigationIntegrated =[\s\S]*?\|\| libraryMetadataWorkingSurface[\s\S]*?;/);
   assert.match(
     renderLibrary,
-    /if \(state\.libraryLens === "overview"\s*\|\| state\.libraryLens === "metadata"\) return body;/);
+    /if \(state\.libraryLens === "overview"\s*\|\| state\.libraryLens === "references"\s*\|\| state\.libraryLens === "metadata"\) return body;/);
   assert.match(
     renderMetadata,
     /data-platform-metadata-library[\s\S]*?requireSelection: true[\s\S]*?controlsHtml:[\s\S]*?package-metadata-controls[\s\S]*?packageCoordinateFields\(\)/);
@@ -5386,7 +5386,7 @@ test("package dependencies use compact coordinates in a full-area working surfac
     appSource.match(/function renderPackageView\([\s\S]*?\n}\n\nfunction renderWorkspaceView/)?.[0]
     ?? "";
   const renderDependencies =
-    appSource.match(/function renderPackageDependencies\([\s\S]*?\n}\n\nfunction assemblyReferencesSectionHtml/)?.[0]
+    appSource.match(/function renderPackageDependencies\([\s\S]*?\n}\n\nfunction renderLibraryReferences/)?.[0]
     ?? "";
   assert.match(
     appSource,


### PR DESCRIPTION
Give Library References useful full-area space while preserving assembly context, reference facts, and existing navigation.

## Demo

Open `Example.Package` > `Example.Core` > **References** in the production-composition browser fixture.

**Before:** a large Library heading and asset line precede an inset "Assembly references" section; its heading repeats the assembly name and count.

**After:** a compact References/count row sits above an edge-to-edge list. Complete assembly identity, asset path, package/version, and framework move to the bottom row. At 390px the existing Types return shares the header and each row stacks its name above the version/culture/token fields.

**Wide production-UI fixture preview**

![Library References full-area frame at 1440px](https://github.com/user-attachments/assets/cd62e6f4-e085-4222-bdbc-61b7c1e14a6e)

**390px production-UI fixture preview**

![Library References full-area frame at 390px](https://github.com/user-attachments/assets/99211dec-5afc-4640-a53f-b252c8199247)

The browser scenarios also exercise 80 long reference rows: only the content list scrolls, while the header and bottom context stay in place. Loading, query failure, inspection failure, and successful zero-reference results retain that same frame.

**Neighboring scenario:** Package and Library Overview retain their prominent names/icons. Library > Type > Library, parent navigation, history, and the narrow Types/details return retain their behavior, including the parent-navigation changes landed in #6097.

Screenshots are production-UI fixture previews, not a claim of real-package acquisition. A separate deployed-site walkthrough timed out before the Library list appeared; no real-site screenshot is claimed.

## Design basis and scope

Sole normative owner: [`inspect-web-surface-composition.md#library-references`](https://github.com/richlander/dotnet-inspect/blob/ui/library-references-surface/docs/design/inspect-web-surface-composition.md#library-references). Claim: References uses a quiet header, one full-area list scroller, and bottom assembly context.

Supporting contracts retain their existing roles: Library selection and `packageDependenciesSignature()` own query freshness; `BrowserPackageDependencies` supplies the typed result; content-frame navigation owns narrow return/focus; presentation-language heading rules constrain the quiet header. Metadata and Package Dependencies provide the local layout precedents.

The small browser renderer lowers the existing typed result directly to HTML. This explicitly approved browser-only presentation slice introduces no data/analysis substrate or general rendering architecture. The one-step production adoption and retirement tracker is #6165: wire Library References to this frame and retire only its old hero/inset-section composition.

Subject-strip visibility and navigation remain with #6157 and #6158. No query, resolution, dependency graph, or other Library-lens semantics are changed.

## Validation

- `npm run build` (includes TypeScript and published frontend artifact checks).
- `npm run analyze`.
- `node --test test/library-references.test.ts test/spotlight-identity.test.ts test/overview-surface.test.ts`.
- `npx playwright test browser/library-hierarchy.spec.ts --project=firefox --workers=2 --reporter=line`: 35 passed after integrating #6097.
- `npx markdownlint-cli ../../docs/design/inspect-web-surface-composition.md`.

The initial browser run caught a fixture expectation using "Show Types" instead of the existing "Types" accessible name. The expectation was corrected without changing product navigation.

Closes #6165.
