### PR TITLE
Keep the active subject visible during automatic strip layout

### DIFF
--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -193,9 +193,18 @@ that preserves multiple inspectors over a one-label window. A one-inspector
 inventory clamps those requests to one. When no mode can fit two controls,
 SlideStrip's one-item floor applies.
 
-The subject strip's initial anchor is the active subject. The inspector strip's
-initial anchor is the effective inspector. Equal-ranked windows expand toward
-the following item before the preceding item in both strips.
+The subject strip's initial anchor is the active subject. It adopts SlideStrip's
+`anchor-until-slide` policy: ordinary placement and responsive resizing keep
+that subject visible unless an item owns focus or the user has explicitly slid
+the strip. A deliberate slide may move the active subject out of view and
+retains its window across width-only changes and same-subject rendering.
+Focus reveal does not establish a manual window. Changing the active subject
+resets the manual window so ordinary placement follows the new subject.
+These are presentation rules; they neither infer nor change selection.
+
+The inspector strip's initial anchor is the effective inspector and its
+window-continuity policy remains `retain-leading`. Equal-ranked windows expand
+toward the following item before the preceding item in both strips.
 
 When a non-empty inventory has no effective inspector, its first owner-ordered
 inspector is the presentation-priority origin without becoming selected and
@@ -307,10 +316,11 @@ Allocation-button bounds and activation use the currently rendered stable
 level, not an unclamped retained request. An enabled button always selects the
 adjacent Pareto level and therefore cannot converge to the same rendered pair.
 
-The subject strip's window-continuity key is its ordered subject identity
-sequence plus subject-policy version. The inspector strip's key is the active
-subject identity, ordered inspector identity sequence, and inspector-policy
-version. Width and focus movement do not replace either key.
+The subject strip's window-continuity key is the active subject identity, its
+ordered subject identity sequence, and subject-policy version. The inspector
+strip's key is the active subject identity, ordered inspector identity sequence,
+and inspector-policy version. Width and focus movement do not replace either
+key.
 
 The subject tablist uses one tab stop and automatic keyboard activation. Left
 and Right Arrow move focus through the complete installed subject order and
@@ -828,6 +838,16 @@ add and pass these named Inspect Web tests:
   presentation-local window and allocation retention, reduced-motion behavior,
   and focus/tab-stop preservation across allocation changes and asynchronous
   shell replacement.
+- `library-hierarchy.spec.ts`: the `active subject continuity` scenarios exercise
+  the production Browser shell and bindings with deterministic facade results.
+  They cover Package-to-Library activation at 1440px followed by 390px,
+  direct 390px entry and Library URL reload, neighboring wide layout, deliberate
+  subject sliding across resize and same-subject updates, reset on subject
+  changes, and focused-item precedence. This is the second and final production
+  adoption slice for
+  [#6157](https://github.com/richlander/dotnet-inspect/issues/6157), consuming the
+  reusable policy from #6171; it leaves inspector interaction and #6158's
+  broader navigation-model proposal unchanged.
 
 The implementation fixture supplies typed product results through the normal
 navigation boundary. It does not construct a parallel host catalog or bypass

--- a/prototypes/inspect-web/browser/library-hierarchy.spec.ts
+++ b/prototypes/inspect-web/browser/library-hierarchy.spec.ts
@@ -287,6 +287,113 @@ async function installFacades(
 
 const root = "/?package=Example.Package&version=1.0.0&framework=net10.0#pkg";
 
+for (const initialWidth of [1440, 390]) {
+  test(`active subject continuity keeps Library visible from ${initialWidth}px entry`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: initialWidth, height: 844 });
+    await installFacades(page);
+    await page.goto(root);
+    await expect(page.locator('[data-scope="package"]')).toBeVisible();
+    await page.locator('.library-list [data-lib-scope="asset:core"]').click();
+    const libraryTab = page.locator('[data-scope="library"]');
+    await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+    await expect(libraryTab).toBeVisible();
+    await expect(page.locator("#inspector-panel h1")).toHaveText(core.name);
+    const location = page.url();
+    const historyLength = await page.evaluate(() => history.length);
+    const menu = page.getByRole("button", { name: "Application menu", exact: true });
+    await menu.focus();
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(libraryTab).toBeInViewport({ ratio: 1 });
+    await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+    await expect(menu).toBeFocused();
+    await expect(page).toHaveURL(location);
+    expect(await page.evaluate(() => history.length)).toBe(historyLength);
+    await testInfo.attach("active-library-390", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+
+    await page.reload();
+    await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+    await expect(libraryTab).toBeInViewport({ ratio: 1 });
+    await expect(page.locator("#inspector-panel h1")).toHaveText(core.name);
+    await page.setViewportSize({ width: 1440, height: 844 });
+    for (const subject of ["package", "library", "type"]) {
+      await expect(page.locator(`[data-scope="${subject}"]`)).toBeVisible();
+    }
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(libraryTab).toBeInViewport({ ratio: 1 });
+    await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+  });
+}
+
+test("active subject continuity retains explicit browsing until the subject changes", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await installFacades(page);
+  await page.goto(root);
+  await page.locator('.library-list [data-lib-scope="asset:core"]').click();
+  const libraryTab = page.locator('[data-scope="library"]');
+  const packageTab = page.locator('[data-scope="package"]');
+  await expect(libraryTab).toBeVisible();
+  const menu = page.getByRole("button", { name: "Application menu", exact: true });
+  await menu.focus();
+  const location = page.url();
+  const historyLength = await page.evaluate(() => history.length);
+  await page.locator(".slide-strip-subject").hover();
+  await page.mouse.wheel(-100, 0);
+  await expect(packageTab).toBeVisible();
+  await expect(libraryTab).toBeHidden();
+  await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+  await expect(packageTab).toHaveAttribute("aria-selected", "false");
+  await expect(menu).toBeFocused();
+  await expect(page).toHaveURL(location);
+  expect(await page.evaluate(() => history.length)).toBe(historyLength);
+
+  await page.setViewportSize({ width: 1440, height: 844 });
+  await expect(libraryTab).toBeVisible();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(packageTab).toBeVisible();
+  await expect(libraryTab).toBeHidden();
+  await page.locator('[data-library-lens="overview"]').press("ArrowRight");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#inspector-panel")).toContainText("Example.Core.Dependency");
+  await expect(packageTab).toBeVisible();
+  await expect(libraryTab).toBeHidden();
+  await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+
+  await packageTab.click();
+  await expect(packageTab).toHaveAttribute("aria-selected", "true");
+  await page.locator('.library-list [data-lib-scope="asset:other"]').click();
+  await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+  await expect(libraryTab).toBeInViewport({ ratio: 1 });
+  await expect(page.locator("#inspector-panel h1")).toHaveText(other.name);
+});
+
+test("active subject continuity preserves focus without making a manual window", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 844 });
+  await installFacades(page);
+  await page.goto(root);
+  await page.locator('.library-list [data-lib-scope="asset:core"]').click();
+  const libraryTab = page.locator('[data-scope="library"]');
+  const typeTab = page.locator('[data-scope="type"]');
+  await typeTab.focus();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(typeTab).toBeFocused();
+  await expect(typeTab).toBeInViewport({ ratio: 1 });
+  await expect(typeTab).toHaveAttribute("aria-selected", "false");
+  await expect(libraryTab).toHaveAttribute("aria-selected", "true");
+
+  await page.getByRole("button", { name: "Application menu", exact: true }).focus();
+  await page.setViewportSize({ width: 1440, height: 844 });
+  await expect(libraryTab).toBeVisible();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(libraryTab).toBeInViewport({ ratio: 1 });
+  await libraryTab.press("ArrowLeft");
+  await expect(page.locator('[data-scope="package"]')).toBeFocused();
+  await expect(page.locator('[data-scope="package"]')).toHaveAttribute("aria-selected", "true");
+});
+
 async function openIntegrations(page: Page, location = root) {
   await page.goto(location);
   await page.locator('.library-list [data-lib-scope="asset:core"]').click();

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -549,7 +549,7 @@ export function renderScopeBar<TId extends string>(
          aria-label="Subjects and inspectors">
       <div class="slide-strip slide-strip-subject scope-switch"
            data-slide-strip="subject"
-           data-continuity-key="${escapeHtml(`${subjectIds}:v1`)}"
+           data-continuity-key="${escapeHtml(`${scope}:${subjectIds}:v2`)}"
            data-initial-anchor="${subjectAnchor}"
            role="tablist"
            aria-label="Subject">
@@ -620,6 +620,7 @@ function readPolicy(
     initialAnchor,
     preferredDirection: "after",
     continuityKey,
+    ...(subject ? { windowContinuity: "anchor-until-slide" } : {}),
     fallbackVisibilityFloor: subject ? 48 : 28,
     oversizedAlignment: "start",
   };


### PR DESCRIPTION
Keep users oriented in Inspect Web: the active subject remains visible during
automatic responsive layout without taking away deliberate strip browsing.

The subject strip now adopts `anchor-until-slide` and includes the active
subject in its continuity key. Inspector placement, allocation controls,
selection, and navigation history semantics are unchanged.

## Demo

The production Browser shell and bindings are exercised with deterministic
facade data for `Example.Package` / `Example.Core`. The issue's original
`System.Text.Json` screenshot demonstrates the same subject-label sequence.

1. Open Package Overview at 1440px.
2. Open a Library from the Overview inventory.
3. Put focus outside the strip and narrow to 390 x 844.

**Before:** the strip can show only unselected Package while Library Overview
is active. **After:** Library is visible and selected.

| Neighboring scenario | Result |
| --- | --- |
| Start at 390px, open Library, reload its URL | Library remains visible and selected |
| Widen to 1440px and narrow again | Library remains visible and selected |
| Explicitly slide backward to Package while Library is active | Package is visible but unselected; Library selection is unchanged |
| Resize or change the Library inspector after that slide | Deliberately chosen subject window remains |
| Activate Package, then open another Library | Browsing resets; Library is visible again |
| Focus Type without activating it, then narrow | Type keeps focus; Library stays selected |
| Leave that focus and resize without an explicit slide | Automatic placement follows Library again |

Screenshots from the production-composition browser scenarios are attached
separately.

## Design and scope

Normative owner: `docs/design/inspect-web-navigation-presentation.md`,
**Slideable Subject Strip**. Consume the reusable SlideStrip policy from #6171;
do not change that owner's contract here.

Slice 2 of 2 for #6157, stacked on #6171
(`fix/6157-active-subject-visibility`). This completes the two-slice Browser
production adoption path recorded in #6157. No further implementation slice is
needed for this visibility repair. The separate #6158 interaction-model effort
is not implemented here.

Fixes #6157.

## Validation

Run with Node 24 in `prototypes/inspect-web`:

- `npm run build`
- `node --test test/scope-bar.test.ts test/slide-strip.test.ts` — 39 passed.
- `CI=1 npm run test:browser -- library-hierarchy.spec.ts workspace-titlebar.spec.ts --grep 'active subject continuity|production navigation|subject|window continuity|SlideStrip|allocation|manual windows|temporary pressure|tab.*focus|focus.*tab' --workers=2 --retries=0` — 28 passed.
- `npx markdownlint-cli docs/design/inspect-web-navigation-presentation.md`
