### PR TITLE
Repair configured selection CLI expectations

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4018,7 +4018,10 @@ public partial class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("not found", error, StringComparison.OrdinalIgnoreCase);
+        Assert.True(
+            error.Contains("not found", StringComparison.OrdinalIgnoreCase)
+            || error.Contains("valid package ID", StringComparison.OrdinalIgnoreCase),
+            error);
     }
 
     [Theory]
@@ -19268,8 +19271,8 @@ public partial class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("Package 'frobnicate' not found", error);
-        Assert.DoesNotContain("Package '--json' not found", error);
+        Assert.Contains("Package 'frobnicate' selection 'latest'", error);
+        Assert.DoesNotContain("Package '--json' selection", error);
     }
 
     [Fact]
@@ -19279,8 +19282,8 @@ public partial class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("Package 'frobnicate' not found", error);
-        Assert.DoesNotContain("Package 'Widget' not found", error);
+        Assert.Contains("Package 'frobnicate' selection 'latest'", error);
+        Assert.DoesNotContain("Package 'Widget' selection", error);
     }
 
     [Fact]
@@ -23847,7 +23850,8 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AISection_ForAspireOpenAI_ShowsStarterApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.OpenAI", "--library", "-S", "Integration: AI", "--rows", "40");
+            "package", "Aspire.OpenAI", "--preview",
+            "--library", "-S", "Integration: AI", "--rows", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: AI", output);
@@ -23886,7 +23890,8 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_IntegrationsCategory_ForAspireOpenAI_ShowsStarterIntegrations()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.OpenAI", "--library", "-S", "@Integrations", "--rows", "40");
+            "package", "Aspire.OpenAI", "--preview",
+            "--library", "-S", "@Integrations", "--rows", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: AI", output);
@@ -23931,7 +23936,8 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_HostingSection_ForAspireOpenAI_ShowsStarterApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.OpenAI", "--library", "-S", "Integration: Hosting");
+            "package", "Aspire.OpenAI", "--preview",
+            "--library", "-S", "Integration: Hosting");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Hosting", output);


### PR DESCRIPTION
Keeps the 0.25.0 release certification aligned with the configured-source contracts: stable selection remains the default, preview-only packages opt in explicitly, and routing tests recognize the selected-package diagnostics introduced by #6090.

## Demo

Before, Deep Inspect run 34038646030 reported the same six failures in its test, Linux, macOS, and Windows lanes:

```text
Package 'Aspire.OpenAI' selection 'latest' could not be acquired.
Package 'frobnicate' selection 'latest' could not be acquired.
Configured-authority selection requires online mode and a valid package ID.
```

After, the 23 affected cases pass. The three Aspire.OpenAI integration views use `--preview`, matching the package's preview-only publication and the latest-stable default. Neighboring malformed generic selectors continue to fail visibly without broadening to another type.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- 23 targeted `CommandExecutionTests`: 23 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release`: 6,380 total, 0 failed

## Scope

Test-only correction; no product behavior or output changes.
