### PR TITLE
Adopt MTP for Queries tests

### DIFF
--- a/docs/design/member-source-pair-query.md
+++ b/docs/design/member-source-pair-query.md
@@ -109,7 +109,7 @@ producers. Ordinary PDB-first/decompiled-fallback behavior is retained.
 
 ```bash
 dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
-  -class '*AssemblyContextSourceQueryTests'
+  --filter-class '*AssemblyContextSourceQueryTests'
 dotnet run --project src/dotnet-inspect.Tests -c Release -- \
   --filter-class '*SelectedSourceDiffTests' --filter-class '*DiffCommandTests'
 ```

--- a/docs/design/workspace-scope-and-expansion.md
+++ b/docs/design/workspace-scope-and-expansion.md
@@ -91,15 +91,20 @@ The historical-state gate retains both a Preparing snapshot and a committed
 result, awaits actual product retirement settlement, and then checks collection
 of package bindings, content, sessions, and realization resources.
 
-The focused implementation and adjacent-owner regression command is:
+The focused implementation and adjacent-owner regression commands are run
+separately so each named selection has its own nonzero-execution result:
 
 ```bash
 dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
-  -class '*WorkspaceScopeTests' \
-  -class '*ArtifactRootPublicationTests' \
-  -class '*ArtifactRootCorrespondenceTests' \
-  -class '*PackageAssemblyContextRealizationTests' \
-  -class '*WorkspacePackageRootAcquisitionTests'
+  --filter-class '*WorkspaceScopeTests' && \
+dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
+  --filter-class '*ArtifactRootPublicationTests' && \
+dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
+  --filter-class '*ArtifactRootCorrespondenceTests' && \
+dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
+  --filter-class '*PackageAssemblyContextRealizationTests' && \
+dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
+  --filter-class '*WorkspacePackageRootAcquisitionTests'
 ```
 
 The [revision/publication model](models/workspace-scope-revisions/README.md)

--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -200,6 +200,14 @@ verification class through an MTP class filter. These paths reuse the pinned
 outcome-level host gate without changing the suite's service, package, source,
 cache, or resolution evidence.
 
+`DotnetInspector.Queries.Tests` is the ninth migrated adopter. Its required
+Linux and Windows PR commands and all three Deep Inspect platform lanes remain
+unfiltered. Supported package-manifest and source-query instructions use MTP
+method or class filters, while the workspace-scope instructions run each named
+regression class separately so every selection receives its own aggregate
+non-vacuity result. These paths reuse the pinned outcome-level host gate without
+changing query, workspace, package, source, or acquisition evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/eng/package-manifest-corpus.md
+++ b/eng/package-manifest-corpus.md
@@ -28,7 +28,7 @@ oracle disagreement failures without downloading any package content:
 
 ```bash
 dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
-  -method '*PackageManifestCorpusTests*'
+  --filter-method '*PackageManifestCorpusTests*'
 ```
 
 Live verification is explicit:

--- a/src/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj
+++ b/src/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
     <SourceLink>$(MSBuildProjectDirectory)/sourcelink.json</SourceLink>


### PR DESCRIPTION
This advances dotnet-inspect's conventionally sound test foundation by making
empty Queries execution visibly fail without adding a repository-owned gate.

## Demo

Before this change, a stale native xUnit selector reported zero tests and
returned success:

```console
$ dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build -- -method '*DefinitelyMissingQueriesTest*'
DotnetInspector.Queries.Tests  Total: 0
$ echo $?
0
```

After selecting Microsoft Testing Platform through the existing `xunit.v3`
package, the equivalent stale filter is visibly unsuccessful:

```console
$ dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build -- --filter-method '*DefinitelyMissingQueriesTest*'
Test run summary: Zero tests ran
  total: 0
$ echo $?
8
```

A neighboring package-manifest filter runs 7 tests. The workspace-scope
procedure now runs its five independently named regression classes separately,
so each receives its own nonzero-execution result rather than sharing one
aggregate minimum.

## Summary

- select MTP for `DotnetInspector.Queries.Tests` through
  `UseMicrosoftTestingPlatformRunner`;
- retain the existing unfiltered required-CI, Windows, and Deep Inspect
  commands;
- migrate the package-manifest and source-query focused examples to MTP
  grammar;
- split the workspace-scope multi-class example into five MTP executions so
  every named class independently satisfies non-vacuity;
- record Queries as the ninth migrated adopter in the owning test-host design;
  and
- add no direct runner dependency or repository-owned selector preflight.

## Design basis

Normative owner:
`docs/design/xunit-test-host.md#execution-contract` - every repository xUnit
executable uses MTP, test execution expects at least one test, and exit code
`8` remains visible.

`DotnetInspector.Queries.Tests` and its focused designs continue to own their
query, workspace, package, source, and acquisition evidence. This slice changes
only the command-line host and the supported selector grammar.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` - succeeded
- unmatched MTP method filter - zero tests, exit `8`
- focused `PackageManifestCorpusTests` method filter - 7/7 passed
- focused `AssemblyContextSourceQueryTests` class filter - 126/126 passed
- five workspace-scope regression class filters - 36/36, 37/37, 4/4, 42/42,
  and 7/7 passed independently
- unfiltered MTP suite - 1,599 tests discovered; one integrated run passed
  1,599/1,599, while exact-base retries reproduced two timing-sensitive
  baseline failures also observed before this change
- Deep Inspect `Run query tests` step - passed on Linux, macOS, and Windows;
  the three platform jobs were red only in six unrelated CLI expectations
  corrected on `main` by #6175
- `npx markdownlint-cli docs/design/xunit-test-host.md
  docs/design/member-source-pair-query.md
  docs/design/workspace-scope-and-expansion.md eng/package-manifest-corpus.md`
- `git diff --check`

Part of #5379.
