### PR TITLE
Present Member Exception regions as responsive evidence rows

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -392,7 +392,26 @@ safety verdicts, or inferred navigation.
 This trades some vertical density for complete visible evidence. A successful
 empty result retains the section, zero count, and existing absence message;
 it does not assert that the method is safe. Loading and failure remain separate
-top-level Facts states. Exception regions and subsequent detail sections retain
+top-level Facts states.
+
+Exception regions continues the same readable measure and separator treatment.
+Each returned metadata entry retains its supplied Region number and raw Clause,
+with labeled Caught type, Try, Handler, and Filter values. All six fields remain
+visible in returned order, including shared ranges and repeated records.
+Constrained panes place region identity above the properties; long types,
+region numbers, and range strings wrap within the row.
+
+Null Caught type and Filter values are explicitly `not supplied`, not inferred
+`not applicable` or a wildcard catch. Range strings retain their supplied
+spelling; the presentation does not parse them, infer nesting, reconstruct
+C# try/catch blocks, or create navigation targets.
+
+The section count describes returned region entries, not distinct try blocks
+or runtime exceptions. The successful empty section retains its zero count
+and existing absence message, which does not assert that the method cannot
+throw. Loading and failure remain separate top-level Facts states.
+The additional row height is an explicit trade for complete visible values
+without horizontal scrolling. Performance opportunities and diagnostics retain
 their existing presentation.
 
 #### Graph Explore

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -46,7 +46,7 @@ import { renderMemberFacts } from "../src/member-facts.ts";
 import { renderOverviewSurface } from "../src/overview-surface.ts";
 import { renderPackageNav } from "../src/package-view.ts";
 import { renderPackageDocuments } from "../src/doc-viewer.ts";
-import { allocationFactsFixture, callFactsFixture, memberFactsFixture, safetyFactsFixture } from "../test/member-facts-fixture.ts";
+import { allocationFactsFixture, callFactsFixture, exceptionRegionsFixture, memberFactsFixture, safetyFactsFixture } from "../test/member-facts-fixture.ts";
 import {
   bindWorkspaceSubject,
   focusWorkspace,
@@ -115,6 +115,7 @@ const memberFactsMode = params.get("member-facts");
 const allocationFactsMode = params.get("allocation-facts");
 const callFactsMode = params.get("call-facts");
 const safetyFactsMode = params.get("safety-facts");
+const exceptionRegionsMode = params.get("exception-regions");
 const memberDocumentationMode = params.get("member-docs") ?? "missing";
 const longSignatureMode = params.has("long-signature");
 const emptyMode = params.has("empty");
@@ -247,7 +248,7 @@ let activeTypeLens: TypeLens = sourceMode
     : "api";
 let activeMemberSection: MemberSection = sourceMode
   ? "source"
-  : memberFactsMode || allocationFactsMode || callFactsMode || safetyFactsMode ? "facts" : "overview";
+  : memberFactsMode || allocationFactsMode || callFactsMode || safetyFactsMode || exceptionRegionsMode ? "facts" : "overview";
 let contentFramePane: ContentFramePane = "detail";
 let contentFrameFocusOwner: ContentFrameFocusOwner = null;
 let contentFrameReplacementFocusOwner: ContentFrameFocusOwner = null;
@@ -498,7 +499,9 @@ function detailHtml() {
           ? callFactsFixture(callFactsMode === "long" ? "long" : "populated")
           : safetyFactsMode
             ? safetyFactsFixture(safetyFactsMode === "long" ? "long" : "populated")
-            : memberFactsFixture(mode);
+            : exceptionRegionsMode
+              ? exceptionRegionsFixture(exceptionRegionsMode === "long" ? "long" : "populated")
+              : memberFactsFixture(mode);
       return `<section class="member-surface" aria-labelledby="member-surface-title">
         <header class="api-surface-head member-surface-head">
           <h1 id="member-surface-title">DeserializeSync</h1>

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { callFactsFixture, safetyFactsFixture } from "../test/member-facts-fixture.ts";
+import { callFactsFixture, exceptionRegionsFixture, safetyFactsFixture } from "../test/member-facts-fixture.ts";
 
 async function box(page: Page, selector: string) {
   const value = await page.locator(selector).boundingBox();
@@ -542,11 +542,17 @@ test("Member Facts keeps zero, loading, and failure states distinct", async ({
       await expect(page.locator(".safety-empty"))
         .toHaveText("No unsafe operations or declaration evidence were found.");
       await expect(page.locator(".safety-row")).toHaveCount(0);
+      await expect(page.locator(".exception-regions > header > span"))
+        .toHaveText("0 regions");
+      await expect(page.locator(".exception-empty"))
+        .toHaveText("No exception regions were found in this method.");
+      await expect(page.locator(".exception-row")).toHaveCount(0);
     } else {
       await expect(page.locator(".facts-summary")).toHaveCount(0);
       await expect(page.locator(".allocation-facts")).toHaveCount(0);
       await expect(page.locator(".call-facts")).toHaveCount(0);
       await expect(page.locator(".safety-facts")).toHaveCount(0);
+      await expect(page.locator(".exception-regions")).toHaveCount(0);
       await expect(page.locator(".member-surface-scroll h2"))
         .toHaveText(mode === "loading" ? "Analyzing method…" : "Facts query failed");
       if (mode === "error") {
@@ -613,7 +619,7 @@ test("Member Facts allocation rows preserve all nine fields in occurrence order"
   }
   await expect(page.locator(".allocation-facts a, .allocation-facts button, .allocation-facts details"))
     .toHaveCount(0);
-  await expect(page.locator(".call-facts h2, .safety-facts h2, .fact-group h2"))
+  await expect(page.locator(".call-facts h2, .safety-facts h2, .exception-regions h2"))
     .toHaveText(["Calls", "Safety facts", "Exception regions"]);
   const section = await box(page, ".allocation-facts");
   const summary = await box(page, ".facts-summary");
@@ -672,7 +678,7 @@ test("Member Facts call rows preserve all five fields and repeated callees", asy
   }
   await expect(page.locator(".call-facts a, .call-facts button, .call-facts details"))
     .toHaveCount(0);
-  await expect(page.locator(".safety-facts h2, .fact-group h2"))
+  await expect(page.locator(".safety-facts h2, .exception-regions h2"))
     .toHaveText(["Safety facts", "Exception regions"]);
   const calls = await box(page, ".call-facts");
   const allocations = await box(page, ".allocation-facts");
@@ -734,7 +740,7 @@ test("Member Facts safety rows preserve all five fields and explicit absent offs
   }
   await expect(page.locator(".safety-facts a, .safety-facts button, .safety-facts details"))
     .toHaveCount(0);
-  await expect(page.locator(".fact-group h2")).toHaveText("Exception regions");
+  await expect(page.locator(".exception-regions h2")).toHaveText("Exception regions");
   const safety = await box(page, ".safety-facts");
   const calls = await box(page, ".call-facts");
   expect(safety.width).toBeCloseTo(calls.width, 0);
@@ -769,6 +775,71 @@ test("Member Facts safety rows reflow by pane width without hiding long values",
     await expect(page.locator(".safety-operation")).toHaveText(facts.safety.map(fact => fact.operation));
     await expect(page.locator(".safety-location code").last()).toHaveText("IL_12345678");
     await expect(page.locator(".safety-no-offset")).toHaveCount(2);
+  }
+});
+
+test("Member Facts exception rows preserve all six fields and nullable values", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto("/browser/workspace-titlebar.html?member=1&exception-regions=populated");
+  const facts = exceptionRegionsFixture();
+  await expect(page.locator(".exception-regions > header > span")).toHaveText("4 regions");
+  await expect(page.locator(".exception-row")).toHaveCount(4);
+  for (const [index, region] of facts.exceptionRegions.entries()) {
+    const row = page.locator(".exception-row").nth(index);
+    await expect(row.locator(".exception-identity > span")).toHaveText(`Region ${region.region}`);
+    await expect(row.locator(".exception-clause")).toHaveText(region.clause);
+    await expect(row.locator("dt")).toHaveText(["Caught type", "Try", "Handler", "Filter"]);
+    await expect(row.locator("dd")).toHaveText([
+      region.caughtType ?? "not supplied", region.tryRange, region.handlerRange,
+      region.filterRange ?? "not supplied",
+    ]);
+  }
+  await expect(page.locator(".exception-regions a, .exception-regions button, .exception-regions details"))
+    .toHaveCount(0);
+  await expect(page.locator(".safety-facts h2")).toHaveText("Safety facts");
+  await expect(page.locator(".performance-facts h2")).toHaveText("Performance opportunities");
+  const regions = await box(page, ".exception-regions");
+  const safety = await box(page, ".safety-facts");
+  expect(regions.width).toBeCloseTo(safety.width, 0);
+  expect(regions.height).toBeLessThanOrEqual(300);
+  expect(regions.y - (safety.y + safety.height)).toBeCloseTo(20, 0);
+});
+
+test("Member Facts exception rows reflow by pane width without hiding long values", async ({
+  page,
+}) => {
+  const facts = exceptionRegionsFixture("long");
+  for (const width of [1440, 900, 600, 360]) {
+    await page.setViewportSize({ width, height: 1100 });
+    await page.goto("/browser/workspace-titlebar.html?member=1&exception-regions=long");
+    const identity = await box(page, ".exception-row:first-child .exception-identity");
+    const type = await box(page, ".exception-row:first-child .exception-type");
+    if (width === 900 || width === 360) {
+      expect(type.y).toBeGreaterThanOrEqual(identity.y + identity.height);
+      expect(type.x).toBeCloseTo(identity.x, 0);
+    } else {
+      expect(type.x).toBeGreaterThan(identity.x + identity.width);
+    }
+    for (const selector of [
+      ".exception-regions", ".exception-row", ".exception-identity",
+      ".exception-identity > *", ".exception-main", ".exception-type",
+      ".exception-type dd", ".exception-ranges", ".exception-ranges > div",
+      ".exception-ranges dd", ".member-surface-scroll",
+    ]) {
+      expect(await page.locator(selector).evaluateAll(elements =>
+        elements.every(element => element.scrollWidth <= element.clientWidth)),
+      `${selector} at ${width}px`).toBe(true);
+    }
+    await expect(page.locator(".exception-identity > span").first())
+      .toHaveText("Region 123456789");
+    for (const [index, region] of facts.exceptionRegions.entries()) {
+      await expect(page.locator(".exception-row").nth(index).locator("dd")).toHaveText([
+        region.caughtType ?? "not supplied", region.tryRange, region.handlerRange,
+        region.filterRange ?? "not supplied",
+      ]);
+    }
   }
 });
 

--- a/prototypes/inspect-web/src/member-facts.ts
+++ b/prototypes/inspect-web/src/member-facts.ts
@@ -55,11 +55,7 @@ export function renderMemberFacts(
     ${renderAllocationFacts(facts.allocations)}
     ${renderCallFacts(facts.calls)}
     ${renderSafetyFacts(facts.safety)}
-    ${renderFactTable("Exception regions", facts.exceptionRegions, [
-      ["Region", "region"], ["Clause", "clause"], ["Try", "tryRange"],
-      ["Handler", "handlerRange"], ["Filter", row => row.filterRange || ""],
-      ["Caught type", row => row.caughtType || ""]
-    ], "No exception regions were found in this method.")}
+    ${renderExceptionRegions(facts.exceptionRegions)}
     <section class="document-section performance-facts">
       <div class="section-title"><h2>Performance opportunities</h2><span>ranked judgments · ${facts.performanceOpportunities.length}</span></div>
       ${facts.performanceOpportunities.length
@@ -143,23 +139,27 @@ function renderSafetyFacts(safety: MemberFacts["safety"]) {
   </section>`;
 }
 
-type FactTableColumn<T> =
-  readonly [label: string, field: keyof T | ((row: T) => unknown)];
-
-function renderFactTable<T extends object>(
-  title: string,
-  rows: readonly T[],
-  columns: readonly FactTableColumn<T>[],
-  emptyText: string,
-) {
-  return `<section class="document-section fact-group">
-    <div class="section-title"><h2>${escapeHtml(title)}</h2><span>${rows.length}</span></div>
-    ${rows.length
-      ? `<div class="fact-table" style="--fact-columns:${columns.length}">${columns.map(([label]) => `<strong>${escapeHtml(label)}</strong>`).join("")}${rows.map(row => columns.map(([, field]) => {
-          const value = typeof field === "function" ? field(row) : row[field];
-          return `<code>${escapeHtml(value ?? "")}</code>`;
-        }).join("")).join("")}</div>`
-      : `<div class="empty-fact-group">${escapeHtml(emptyText)}</div>`}
+function renderExceptionRegions(regions: MemberFacts["exceptionRegions"]) {
+  return `<section class="exception-regions" aria-labelledby="exception-regions-title">
+    <header><h2 id="exception-regions-title">Exception regions</h2><span>${regions.length} ${regions.length === 1 ? "region" : "regions"}</span></header>
+    ${regions.length
+      ? `<ol class="exception-rows">${regions.map(region => `
+        <li class="exception-row">
+          <div class="exception-identity"><span>Region <code>${escapeHtml(region.region)}</code></span><code class="exception-clause">${escapeHtml(region.clause)}</code></div>
+          <div class="exception-main">
+            <dl class="exception-type"><div><dt>Caught type</dt><dd>${region.caughtType == null
+              ? '<span class="exception-unavailable">not supplied</span>'
+              : `<code>${escapeHtml(region.caughtType)}</code>`}</dd></div></dl>
+            <dl class="exception-ranges">${[
+              ["Try", region.tryRange],
+              ["Handler", region.handlerRange],
+              ["Filter", region.filterRange],
+            ].map(([label, value]) => `<div><dt>${escapeHtml(label)}</dt><dd>${value == null
+              ? '<span class="exception-unavailable">not supplied</span>'
+              : `<code>${escapeHtml(value)}</code>`}</dd></div>`).join("")}</dl>
+          </div>
+        </li>`).join("")}</ol>`
+      : '<p class="exception-empty">No exception regions were found in this method.</p>'}
   </section>`;
 }
 

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1432,27 +1432,31 @@ kbd {
 .facts-metadata-identity { display: flex; flex-wrap: wrap; gap: 6px 12px; margin: 10px 0 0; font-size: 12px; }
 .facts-metadata-identity > span { color: var(--muted); }
 .facts-metadata-identity code { min-width: 0; color: var(--text); font: 12px var(--mono); overflow-wrap: anywhere; }
-.allocation-facts, .call-facts, .safety-facts { max-width: 900px; margin-top: 20px; font-size: 13px; line-height: 1.5; }
-.allocation-facts > header, .call-facts > header, .safety-facts > header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
-.allocation-facts h2, .call-facts h2, .safety-facts h2 { margin: 0; font-size: 14px; font-weight: 600; }
-.allocation-facts > header > span, .call-facts > header > span, .safety-facts > header > span { color: var(--muted); font-size: 12px; }
-.allocation-rows, .call-rows, .safety-rows { list-style: none; padding: 0; margin: 0; border-top: 1px solid var(--line); }
-.allocation-row, .call-row, .safety-row { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: 14px; padding: 10px 0; border-bottom: 1px solid var(--line); }
-.allocation-location, .call-location, .safety-location { display: flex; flex-direction: column; align-items: flex-start; gap: 5px; min-width: 0; }
+.allocation-facts, .call-facts, .safety-facts, .exception-regions { max-width: 900px; margin-top: 20px; font-size: 13px; line-height: 1.5; }
+.allocation-facts > header, .call-facts > header, .safety-facts > header, .exception-regions > header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
+.allocation-facts h2, .call-facts h2, .safety-facts h2, .exception-regions h2 { margin: 0; font-size: 14px; font-weight: 600; }
+.allocation-facts > header > span, .call-facts > header > span, .safety-facts > header > span, .exception-regions > header > span { color: var(--muted); font-size: 12px; }
+.allocation-rows, .call-rows, .safety-rows, .exception-rows { list-style: none; padding: 0; margin: 0; border-top: 1px solid var(--line); }
+.allocation-row, .call-row, .safety-row, .exception-row { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: 14px; padding: 10px 0; border-bottom: 1px solid var(--line); }
+.allocation-location, .call-location, .safety-location, .exception-identity { display: flex; flex-direction: column; align-items: flex-start; gap: 5px; min-width: 0; }
 .allocation-location code, .call-location code, .safety-location code { color: var(--muted); font: 12px/1.5 var(--mono); overflow-wrap: anywhere; }
-.allocation-location > span, .safety-location > span { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; }
-.allocation-main, .call-main, .safety-main { min-width: 0; }
+.allocation-location > span, .safety-location > span, .exception-identity > span { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; }
+.allocation-main, .call-main, .safety-main, .exception-main { min-width: 0; }
 .allocation-type { margin-bottom: 7px; overflow-wrap: anywhere; }
-.allocation-type code, .call-callee code, .safety-operation code { color: var(--text); font: 13px/1.5 var(--mono); }
+.allocation-type code, .call-callee code, .safety-operation code, .exception-type code { color: var(--text); font: 13px/1.5 var(--mono); }
 .allocation-properties { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 5px 16px; margin: 0; }
-.allocation-properties > div, .call-properties > div, .safety-properties > div { display: flex; flex-wrap: wrap; align-items: baseline; gap: 2px 7px; min-width: 0; }
-.allocation-properties dt, .call-properties dt, .safety-properties dt { color: var(--muted); font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
+.allocation-properties > div, .call-properties > div, .safety-properties > div, .exception-type > div, .exception-ranges > div { display: flex; flex-wrap: wrap; align-items: baseline; gap: 2px 7px; min-width: 0; }
+.allocation-properties dt, .call-properties dt, .safety-properties dt, .exception-type dt, .exception-ranges dt { color: var(--muted); font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
 .allocation-properties dd, .call-properties dd, .safety-properties dd { min-width: 0; margin: 0; font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
-.allocation-properties code, .call-properties code, .safety-properties code { color: var(--text); font: 12px/1.5 var(--mono); }
-.allocation-unavailable { color: var(--muted); font-size: 12px; }
-.allocation-empty, .call-empty, .safety-empty { margin: 0; padding: 10px 0; border-top: 1px solid var(--line); color: var(--muted); font-size: 13px; }
+.allocation-properties code, .call-properties code, .safety-properties code, .exception-ranges code { color: var(--text); font: 12px/1.5 var(--mono); }
+.allocation-unavailable, .exception-unavailable { color: var(--muted); font-size: 12px; }
+.allocation-empty, .call-empty, .safety-empty, .exception-empty { margin: 0; padding: 10px 0; border-top: 1px solid var(--line); color: var(--muted); font-size: 13px; }
 .call-callee, .safety-operation { margin-bottom: 5px; overflow-wrap: anywhere; }
-.call-properties, .safety-properties { display: flex; flex-wrap: wrap; gap: 4px 24px; margin: 0; }
+.call-properties, .safety-properties, .exception-ranges { display: flex; flex-wrap: wrap; gap: 4px 24px; margin: 0; }
+.exception-identity code { font: 12px/1.5 var(--mono); overflow-wrap: anywhere; }
+.exception-clause { color: var(--text); }
+.exception-type { margin: 0 0 5px; }
+.exception-type dd, .exception-ranges dd { min-width: 0; margin: 0; overflow-wrap: anywhere; }
 @container member-surface (max-width: 760px) {
   .allocation-properties { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 5px 14px; }
 }
@@ -1460,8 +1464,8 @@ kbd {
   .facts-summary-list > div { grid-template-columns: minmax(0, 48%) minmax(0, 1fr); gap: 12px; }
   .facts-summary-list dd { flex-direction: column; gap: 4px; }
   .facts-summary-value { flex-basis: auto; max-width: 100%; }
-  .allocation-row, .call-row, .safety-row { grid-template-columns: minmax(0, 1fr); gap: 6px; }
-  .allocation-location, .call-location, .safety-location { flex-direction: row; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
+  .allocation-row, .call-row, .safety-row, .exception-row { grid-template-columns: minmax(0, 1fr); gap: 6px; }
+  .allocation-location, .call-location, .safety-location, .exception-identity { flex-direction: row; flex-wrap: wrap; gap: 6px 12px; align-items: baseline; }
 }
 .assembly-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
 .assembly-grid .assembly-cell { display: flex; flex-direction: column; gap: 6px; padding: 14px 12px; background: var(--panel); min-width: 0; }

--- a/prototypes/inspect-web/test/member-facts-fixture.ts
+++ b/prototypes/inspect-web/test/member-facts-fixture.ts
@@ -214,3 +214,51 @@ export function safetyFactsFixture(
     ],
   };
 }
+
+export function exceptionRegionsFixture(
+  mode: "populated" | "long" = "populated",
+): MemberFacts {
+  const facts = memberFactsFixture();
+  const long = mode === "long";
+  const regions: MemberFacts["exceptionRegions"] = [
+    {
+      region: long ? 123456789 : 1,
+      clause: "catch",
+      tryRange: long ? "IL_01234567..IL_12345678" : "IL_0000..IL_0020",
+      handlerRange: long ? "IL_23456789..IL_3456789A" : "IL_0020..IL_0030",
+      filterRange: null,
+      caughtType: long
+        ? "Example.Serialization.BufferedDocumentReader<System.Collections.Generic.Dictionary<System.String,System.Collections.Generic.List<System.Text.Json.JsonElement>>>.NestedReadException"
+        : "System.Text.Json.JsonException",
+    },
+    {
+      region: 2,
+      clause: "filter",
+      tryRange: "IL_0000..IL_0020",
+      handlerRange: "IL_0040..IL_0050",
+      filterRange: "IL_0030..IL_0040",
+      caughtType: null,
+    },
+    {
+      region: 3,
+      clause: "finally",
+      tryRange: "IL_0000..IL_0050",
+      handlerRange: "IL_0050..IL_005A",
+      filterRange: null,
+      caughtType: null,
+    },
+    {
+      region: 4,
+      clause: "fault",
+      tryRange: "IL_0060..IL_0070",
+      handlerRange: "IL_0070..IL_007A",
+      filterRange: null,
+      caughtType: null,
+    },
+  ];
+  return {
+    ...facts,
+    signals: { ...facts.signals, catches: 1, finallys: long ? 0 : 1 },
+    exceptionRegions: long ? regions.slice(0, 2) : regions,
+  };
+}

--- a/prototypes/inspect-web/test/member-facts.test.ts
+++ b/prototypes/inspect-web/test/member-facts.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { renderMemberFacts } from "../src/member-facts.ts";
 import type { MemberFacts } from "../src/member-detail-inspection.ts";
-import { allocationFactsFixture, callFactsFixture, memberFactsFixture, safetyFactsFixture } from "./member-facts-fixture.ts";
+import { allocationFactsFixture, callFactsFixture, exceptionRegionsFixture, memberFactsFixture, safetyFactsFixture } from "./member-facts-fixture.ts";
 
 function render(facts: MemberFacts = memberFactsFixture()) {
   return renderMemberFacts({
@@ -75,6 +75,9 @@ test("member Facts keeps explicit zero results distinct from loading and failure
   assert.match(html, /<h2 id="safety-facts-title">Safety facts<\/h2><span>0 facts<\/span>/);
   assert.match(html, /No unsafe operations or declaration evidence were found\./);
   assert.doesNotMatch(html, /<ol class="safety-rows">/);
+  assert.match(html, /<h2 id="exception-regions-title">Exception regions<\/h2><span>0 regions<\/span>/);
+  assert.match(html, /No exception regions were found in this method\./);
+  assert.doesNotMatch(html, /<ol class="exception-rows">/);
 
   const loading = renderMemberFacts({
     memberFacts: memberFactsFixture(),
@@ -82,7 +85,7 @@ test("member Facts keeps explicit zero results distinct from loading and failure
     memberFactsError: "",
   });
   assert.match(loading, /Analyzing method/);
-  assert.doesNotMatch(loading, /facts-summary|Metadata token|allocation-facts|call-facts|safety-facts/);
+  assert.doesNotMatch(loading, /facts-summary|Metadata token|allocation-facts|call-facts|safety-facts|exception-regions/);
 
   const failure = renderMemberFacts({
     memberFacts: null,
@@ -91,7 +94,7 @@ test("member Facts keeps explicit zero results distinct from loading and failure
   });
   assert.match(failure, /Facts query failed/);
   assert.match(failure, /Could not decode &lt;method&gt;\./);
-  assert.doesNotMatch(failure, /facts-summary|No direct call sites|allocation-facts|call-facts|safety-facts/);
+  assert.doesNotMatch(failure, /facts-summary|No direct call sites|allocation-facts|call-facts|safety-facts|exception-regions/);
   assert.match(renderMemberFacts({
     memberFacts: null,
     memberFactsLoading: false,
@@ -242,5 +245,50 @@ test("safety facts preserve returned order and repeated records", () => {
     [...html.matchAll(/class="safety-location">(?:<code>([^<]*)<\/code>|<span class="safety-no-offset">([^<]+)<\/span>)/g)]
       .map(match => match[1] ?? match[2]),
     safety.map(fact => fact.offset ?? "No IL offset"),
+  );
+});
+
+test("exception regions preserve all six fields and distinguish entries from shared try ranges", () => {
+  const facts = exceptionRegionsFixture();
+  const html = render(facts);
+  assert.match(html, /<h2 id="exception-regions-title">Exception regions<\/h2><span>4 regions<\/span>/);
+  const rows = [...html.matchAll(/<li class="exception-row">([\s\S]*?)<\/li>/g)]
+    .map(match => match[1]!);
+  assert.equal(rows.length, 4);
+  for (const [index, region] of facts.exceptionRegions.entries()) {
+    const row = rows[index]!;
+    assert.ok(row.includes(`<span>Region <code>${region.region}</code></span>`));
+    assert.ok(row.includes(`<code class="exception-clause">${region.clause}</code>`));
+    for (const [label, value] of [
+      ["Caught type", region.caughtType],
+      ["Try", region.tryRange],
+      ["Handler", region.handlerRange],
+      ["Filter", region.filterRange],
+    ] as const) {
+      assert.ok(summaryRow(row, label).includes(`>${value ?? "not supplied"}</`));
+    }
+  }
+  assert.doesNotMatch(rows.join(""), /<a\b|<button\b|<details\b/);
+  assert.match(render({ ...facts, exceptionRegions: [facts.exceptionRegions[0]!] }),
+    /<span>1 region<\/span>/);
+});
+
+test("exception regions preserve supplied numbers, returned order, repeats, and null caught types", () => {
+  const facts = exceptionRegionsFixture();
+  const exceptionRegions = [
+    facts.exceptionRegions[1]!,
+    { ...facts.exceptionRegions[0]!, region: 17, caughtType: null },
+    facts.exceptionRegions[1]!,
+  ];
+  const html = render({ ...facts, exceptionRegions });
+  assert.match(html, /<span>3 regions<\/span>/);
+  assert.deepEqual(
+    [...html.matchAll(/class="exception-identity"><span>Region <code>([^<]+)<\/code>/g)]
+      .map(match => Number(match[1])),
+    [2, 17, 2],
+  );
+  assert.equal(
+    (html.match(/<dt>Caught type<\/dt><dd><span class="exception-unavailable">not supplied<\/span>/g) ?? []).length,
+    3,
   );
 });


### PR DESCRIPTION
Make method exception-region evidence readable without horizontal scrolling or
invented control-flow structure. This implements the approved proposal in
#6179 and continues the top-down Inspect Web refinement.

Closes #6179.

## Demo

The six-column Exception regions strip becomes compact rows consistent with
Allocation facts, Calls, and Safety facts. Region number and raw Clause
identify each row, with Caught type and labeled Try, Handler, and Filter values.
All six fields remain visible in returned order.

The four-entry example includes catch, filter, finally, and fault clauses.
Shared Try ranges stay separate; `4 regions` counts returned metadata entries,
not distinct try blocks or runtime exceptions. Null Filter and Caught type
values explicitly say `not supplied`, without inferring applicability or a
wildcard catch.

At a 600px window, the old table needs another 295px of horizontal scrolling.
The new rows show every field within the 576px detail measure, trading 69px
of height for visibility. On desktop the section grows from 245px to 291px:
this is not a claim of greater density.

Both before and after images execute production renderers with the same
illustrative typed fixture, not live inspection results for the shell's named
member. The baseline is pinned to
`99de5daf2220e847e2b6ff1d16e1564b31bafc1f`; after captures use authored
implementation `4d033217e`, not the proposal mockup. The final integration of
#6172 adds Library References presentation and does not alter these Member
Facts rendering inputs or CSS declarations.

### Before: 1440px window

![Before Exception regions at 1440px](https://github.com/user-attachments/assets/7fb7fa7c-6d81-472c-b747-2e9e89453d8a)

### After: 1440px window

![Implemented Exception regions at 1440px](https://github.com/user-attachments/assets/81c5332e-edc0-46af-a8b2-48fc5a4a9066)

### Before: 600px window

![Before Exception regions at 600px](https://github.com/user-attachments/assets/6a3b8c26-0237-44ec-b6b9-cb2a00bce17d)

### After: 600px window

![Implemented Exception regions at 600px](https://github.com/user-attachments/assets/276af227-e2fd-4075-97f8-0302a7d3489b)

### Constrained pane: 900px window with navigation retained

![Implemented Exception regions in a constrained pane](https://github.com/user-attachments/assets/7592ac56-9803-43b9-a2df-7a94385484f5)

### Long type, region number, and ranges: 360px window

![Implemented Exception regions with long values](https://github.com/user-attachments/assets/ee2fc730-edda-428c-8b4b-7d3e22b7c461)

### Successful empty result beside populated Calls

![Implemented empty Exception regions](https://github.com/user-attachments/assets/cbe4af7c-6cfb-406f-8f24-584c960e56e9)

## Design basis and scope

**Sole normative owner:** `docs/design/inspect-web-surface-composition.md`,
**Working surfaces > Type and Member API**. Owned claim: pane-responsive
six-field Exception regions presentation preserving supplied region numbers,
returned order, and explicit nullable-value disclosure.

Supporting roles: `BrowserExceptionRegion` supplies the unchanged typed browser
input; `PdbContext.ResolveExceptionRegions` supplies metadata-order region
entries, clause spellings, and optional values; `AnalysisExports.QueryMemberFacts`
formats the range strings; member inspection state owns query state;
`member-facts.ts` lowers typed records to HTML; the shell owns identity and
scrolling; CSS owns reflow.

The landed Allocation, Calls, and Safety rows are the local convention.
Identical declarations are shared through grouped selectors without changing
their existing values. This is the same browser-specific interactive DOM/CSS
path, not a new substrate, host path, broad rendering domain, or overall
application model. The existing typed records survive to the HTML lowering
boundary; this does not introduce a Markout or other multi-format renderer.

Issue #6179 is the focused end-to-end tracker. User approval of the visual
proposal and browser-only scope is recorded at
https://github.com/richlander/dotnet-inspect/issues/6179#issuecomment-5560803808.
Production-host adoption is one step, completed here: replace the Exception
regions table invocation in the existing `renderMemberFacts` consumer. Its
private generic table helper and column type are now unused and are removed.
No later adoption or retirement step is needed.

Range strings are not parsed or reinterpreted as C# control flow, and the rows
gain no navigation or expanders. A successful empty result retains the
existing message and zero count; it does not claim the method cannot throw.
Loading and failure remain separate top-level Facts states.

Query, DTO, metadata, analysis, CLI, and navigation changes are outside this
slice. Other Facts sections, including Performance opportunities and
diagnostics, retain their presentation.

## Validation

- Twelve Member Facts unit cases, including all six Exception fields, explicit
  nulls, supplied numbering, returned order, repeated records, singular/plural/
  zero counts, escaping, and distinct empty/loading/failure states.
- Focused Node suite: `member-facts.test.ts`,
  `member-detail-inspection.test.ts`, `type-panel.test.ts`, and
  `spotlight-identity.test.ts`; repeated after final integration with the
  adjacent `library-references.test.ts` suite.
- All eleven Member Facts Firefox scenarios, including existing Summary,
  Allocation, Calls, and Safety coverage, and new Exception field/reflow cases.
- Post-integration browser run: all 22 selected scenarios pass, comprising
  the eleven Facts cases and eleven production Library References cases.
- Existing production build and source/test/configuration type checks:
  `npm run build`; repeated after final integration.
- Existing static analysis: `npm run analyze`; repeated after final integration.
- Owning-design `markdownlint`, including after integration.
- Seven actual before/after captures. The capture probe compares all
  non-Exception section DOM with the pinned baseline, checks all six rendered
  fields and containment, and confirms the approved dimensions exactly.

## Candidate state

Round 1 is complete and **review-clean**, with no qualifying findings and no
review-driven changes.

- Frozen candidate: `00b7f047b31c99d1833b98a4185c9363b6eb3cc7`.
- Effective base: `69b316f8e5b48e8b23f995681682fa0d504134ee`.
- Authored diff: seven files, 244 insertions and 51 deletions.
- All local gates, including post-integration browser coverage, pass.
- Current-head `ci-required` succeeded at `2026-09-06T17:37:24Z`, confirmed
  again at `17:50:09Z`.
- Exactly two reviewers, GPT-5.6 Sol and Claude Opus 5, both returned
  **CLEAN**. Opus supplied the other model family.
- Opus noted unused legacy `.fact-table` CSS as optional cleanup, not a
  behavioral defect or landing requirement. The reviewed head is unchanged.
- GitHub reported the expected open/non-draft head, `MERGEABLE`, and `CLEAN`
  at `2026-09-06T17:49:42Z`. The live base remains the effective base.
- Round start: `2026-09-06T17:43:39Z`; end: `17:50:09Z`; duration: 00:06:30.
- Recommendation: merge. The advisory label alone does not establish readiness.
- No merge or auto-merge authorization is recorded.
