### PR TITLE
Set security headers on MSDL API responses

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1405,8 +1405,8 @@ because the site is deployed from that copy rather than from the source file.
 The word "static" there is a real boundary, not hedging. Azure Static Web Apps
 does not apply `globalHeaders` to responses produced by the managed functions
 under `/api/*`, which carry whatever headers the function sets for itself. The
-MSDL proxy is such a function, so these four headers do not cover its responses.
-Giving the proxy its own headers is tracked in #5119.
+MSDL proxy sets its own [response headers](msdl-proxy/README.md#response-security)
+for function-produced responses, with a separate gate in `MsdlProxyFunctionTests`.
 
 Prism is delivered through the same npm/Vite pipeline as mermaid, marked, and
 DOMPurify. `src/prism-csharp.ts` registers the clike and C# grammars in order;

--- a/prototypes/inspect-web/msdl-proxy.Tests/MsdlProxyFunctionTests.cs
+++ b/prototypes/inspect-web/msdl-proxy.Tests/MsdlProxyFunctionTests.cs
@@ -1,9 +1,13 @@
 using System.Net;
 using System.Reflection;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MsdlProxy.Tests;
 
@@ -48,22 +52,119 @@ public sealed class MsdlProxyFunctionTests
 
         Assert.IsType<BadRequestObjectResult>(result);
         Assert.Equal(0, handler.RequestCount);
+        _ = await ExecuteWithSecurityHeadersAsync(request, result);
+        Assert.Equal(StatusCodes.Status400BadRequest, request.HttpContext.Response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.OK, false, StatusCodes.Status200OK)]
+    [InlineData(HttpStatusCode.NotFound, false, StatusCodes.Status404NotFound)]
+    [InlineData(HttpStatusCode.InternalServerError, false, StatusCodes.Status502BadGateway)]
+    [InlineData(HttpStatusCode.OK, true, StatusCodes.Status413PayloadTooLarge)]
+    public async Task GetSymbolAsync_EmitsSecurityHeadersForUpstreamOutcomes(
+        HttpStatusCode upstreamStatus,
+        bool oversized,
+        int expectedStatus)
+    {
+        byte[] symbolBytes = Encoding.UTF8.GetBytes("symbol bytes");
+        var handler = new CountingHandler(() =>
+        {
+            var response = new HttpResponseMessage(upstreamStatus)
+            {
+                Content = new ByteArrayContent(symbolBytes),
+            };
+            if (oversized)
+                response.Content.Headers.ContentLength = 9 * 1024 * 1024;
+            return response;
+        });
+        using var client = new HttpClient(handler);
+        var function = new MsdlProxyFunction(new StubHttpClientFactory(client));
+        var request = new DefaultHttpContext().Request;
+
+        IActionResult result = await function.GetSymbolAsync(
+            request, "example.pdb", new string('A', 33),
+            TestContext.Current.CancellationToken);
+        byte[] body = await ExecuteWithSecurityHeadersAsync(request, result);
+
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(expectedStatus, request.HttpContext.Response.StatusCode);
+        if (expectedStatus == StatusCodes.Status200OK)
+        {
+            Assert.Equal("application/octet-stream", request.HttpContext.Response.ContentType);
+            Assert.Equal(symbolBytes, body);
+        }
+        else
+        {
+            Assert.Empty(body);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetSymbolAsync_EmitsSecurityHeadersOnTransportFailure(bool timeout)
+    {
+        var handler = new CountingHandler(() =>
+        {
+            if (timeout)
+                throw new TaskCanceledException();
+            throw new HttpRequestException();
+        });
+        using var client = new HttpClient(handler);
+        var function = new MsdlProxyFunction(new StubHttpClientFactory(client));
+        var request = new DefaultHttpContext().Request;
+
+        IActionResult result = await function.GetSymbolAsync(
+            request, "example.pdb", new string('A', 33),
+            TestContext.Current.CancellationToken);
+        _ = await ExecuteWithSecurityHeadersAsync(request, result);
+
+        Assert.Equal(StatusCodes.Status502BadGateway, request.HttpContext.Response.StatusCode);
     }
 
     [Fact]
-    public void Health_ReturnsPlainTextSuccess()
+    public async Task Health_ReturnsPlainTextSuccess()
     {
+        using var client = new HttpClient();
         var function =
             new MsdlProxyFunction(
-                new StubHttpClientFactory(new HttpClient()));
+                new StubHttpClientFactory(client));
+        var request = new DefaultHttpContext().Request;
 
         var result =
             Assert.IsType<ContentResult>(
-                function.Health(new DefaultHttpContext().Request));
+                function.Health(request));
 
         Assert.Equal(StatusCodes.Status200OK, result.StatusCode);
         Assert.Equal("text/plain", result.ContentType);
         Assert.Equal("ok", result.Content);
+        byte[] body = await ExecuteWithSecurityHeadersAsync(request, result);
+        Assert.Equal(StatusCodes.Status200OK, request.HttpContext.Response.StatusCode);
+        Assert.Equal("ok", Encoding.UTF8.GetString(body));
+    }
+
+    private static async Task<byte[]> ExecuteWithSecurityHeadersAsync(
+        HttpRequest request, IActionResult result)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMvcCore();
+        using ServiceProvider provider = services.BuildServiceProvider();
+        request.HttpContext.RequestServices = provider;
+        using var body = new MemoryStream();
+        request.HttpContext.Response.Body = body;
+
+        await result.ExecuteResultAsync(
+            new ActionContext(request.HttpContext, new RouteData(), new ActionDescriptor()));
+
+        IHeaderDictionary headers = request.HttpContext.Response.Headers;
+        Assert.Equal("nosniff", headers["X-Content-Type-Options"].ToString());
+        Assert.Equal("no-referrer", headers["Referrer-Policy"].ToString());
+        Assert.Equal("DENY", headers["X-Frame-Options"].ToString());
+        Assert.Equal(
+            "max-age=63072000; includeSubDomains",
+            headers["Strict-Transport-Security"].ToString());
+        return body.ToArray();
     }
 
     private sealed class StubHttpClientFactory(HttpClient client)
@@ -76,7 +177,8 @@ public sealed class MsdlProxyFunctionTests
         }
     }
 
-    private sealed class CountingHandler : HttpMessageHandler
+    private sealed class CountingHandler(Func<HttpResponseMessage>? respond = null)
+        : HttpMessageHandler
     {
         public int RequestCount { get; private set; }
 
@@ -86,7 +188,7 @@ public sealed class MsdlProxyFunctionTests
         {
             RequestCount++;
             return Task.FromResult(
-                new HttpResponseMessage(HttpStatusCode.NotFound));
+                respond?.Invoke() ?? new HttpResponseMessage(HttpStatusCode.NotFound));
         }
     }
 }

--- a/prototypes/inspect-web/msdl-proxy/MsdlProxyFunction.cs
+++ b/prototypes/inspect-web/msdl-proxy/MsdlProxyFunction.cs
@@ -17,7 +17,7 @@ public sealed class MsdlProxyFunction(IHttpClientFactory httpClientFactory)
         string symbolKey,
         CancellationToken cancellationToken)
     {
-        _ = request;
+        ApplySecurityHeaders(request.HttpContext.Response);
         if (!MsdlRequestValidator.IsValidPdbFileName(pdbFileName)
             || !MsdlRequestValidator.IsValidSymbolKey(symbolKey))
         {
@@ -41,12 +41,21 @@ public sealed class MsdlProxyFunction(IHttpClientFactory httpClientFactory)
             Route = "healthz")]
         HttpRequest request)
     {
-        _ = request;
+        ApplySecurityHeaders(request.HttpContext.Response);
         return new ContentResult
         {
             Content = "ok",
             ContentType = "text/plain",
             StatusCode = StatusCodes.Status200OK,
         };
+    }
+
+    private static void ApplySecurityHeaders(HttpResponse response)
+    {
+        IHeaderDictionary headers = response.Headers;
+        headers["X-Content-Type-Options"] = "nosniff";
+        headers["Referrer-Policy"] = "no-referrer";
+        headers["X-Frame-Options"] = "DENY";
+        headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains";
     }
 }

--- a/prototypes/inspect-web/msdl-proxy/README.md
+++ b/prototypes/inspect-web/msdl-proxy/README.md
@@ -44,6 +44,26 @@ independent implementation rather than referencing `DotnetInspector.Packages`,
 so the externally facing function does not acquire the product library's wider
 surface.
 
+### Response security
+
+Responses produced by the symbol and health functions carry these headers,
+including validation failures, missing symbols, oversized declarations, and
+handled upstream failures:
+
+| Header | Value |
+| --- | --- |
+| `X-Content-Type-Options` | `nosniff` |
+| `Referrer-Policy` | `no-referrer` |
+| `X-Frame-Options` | `DENY` |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` |
+
+This function-owned policy covers public symbol bytes returned from our origin.
+The values match the static site's baseline, but Azure Static Web Apps does not
+apply `globalHeaders` to managed API responses. `MsdlProxyFunctionTests` executes
+the MVC results and checks the headers, status codes, and successful bodies in
+Release. Responses generated outside these functions, such as platform routing
+errors or unhandled host failures, are outside this gate.
+
 ## Development
 
 Run the executable xUnit project:


### PR DESCRIPTION
## Summary

Set the four baseline headers on function-produced symbol/health responses, including handled errors. Host/platform-generated responses remain outside the contract.

## Demo

Before: `curl -i https://dotnet-inspect.net/api/healthz` returns 200 without nosniff/referrer/frame headers.

After, from the real function through local MVC execution (not deployed yet):

```text
Health via MVC: 200
Referrer-Policy: no-referrer
Strict-Transport-Security: max-age=63072000; includeSubDomains
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Body: ok
```

Neighboring invalid-symbol response: 400 with the same headers.

## Validation

- Eight regression failures before; **39/39 proxy tests pass** after.
- `dotnet run --project prototypes/inspect-web/msdl-proxy.Tests -c Release`
- Both READMEs pass markdownlint.

Closes #5119. Maximum three review rounds.