### PR TITLE
Document approved CLI-first package content identity adoption

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -2197,6 +2197,34 @@ correspondence are gated by
 `RidSpecificImplementation_UsesSeparateNeutralCompileRole`; Browser adoption
 is gated by `RidSpecificPackage_SeparatesCompileAndImplementationAssets`.
 
+#### Durable package-content identity adoption
+
+[#5484](https://github.com/richlander/dotnet-inspect/issues/5484) tracks the
+durable content-identity prerequisite for the existing CLI
+`PackageInspector -> PackageIndexCache` consumer. The user
+[approved CLI-first production adoption on 2026-09-06](https://github.com/richlander/dotnet-inspect/issues/5484#issuecomment-5560862576).
+This exception concerns the initial consumer and host, not portability:
+acquisition remains host-neutral and all existing Browser/Wasm compatibility
+requirements remain in force. No browser persistent-result cache, UI, or
+browser delivery commitment is introduced.
+
+The package-index workstream of
+[#3738](https://github.com/richlander/dotnet-inspect/issues/3738) has two
+remaining production-adoption steps:
+
+1. Acquisition supplies the retained-content identity tracked by #5484,
+   reusing the existing configured authority and acquired-payload carriers.
+2. The CLI producer/cache path adopts that subject under the
+   [package-index contract](package-index-cache.md), retiring the predecessor
+   namespace and establishing its cold/warm-equivalence gate.
+
+This is sequencing between owners, not a new definition of either owner's
+internals. The existing extraction result already carries `Authority` and
+`AcquiredPayload`; their presence does not itself supply the durable identity
+or bind a filesystem-scanning producer to one retained subject. The durable
+identity and consumer adoption remain unimplemented. Rendering is unchanged:
+the prerequisite carries typed acquisition evidence, not presentation.
+
 #### Sparse selected-assembly projection
 
 [#5798](https://github.com/richlander/dotnet-inspect/issues/5798) owns the

--- a/docs/design/package-index-cache.md
+++ b/docs/design/package-index-cache.md
@@ -4,10 +4,12 @@
 
 Target design for the `PackageIndexCache` slice of
 [#3738](https://github.com/richlander/dotnet-inspect/issues/3738).
-The current `pkg-index-v16` implementation supplies format fencing, source
-producer separation, inert-description persistence, malformed-entry rejection,
-and request-time RID reverification. It does not yet carry the package-owned
-authority and retained-content identity required by this contract.
+The current `pkg-index-v16` implementation supplies format fencing,
+configured-authority key routing on adopted acquisition paths, legacy producer
+separation on unbound paths, inert-description persistence, malformed-entry
+rejection, and request-time RID reverification. The extraction result now
+carries the configured authority and acquired payload, but the cache still
+lacks the retained-content subject and complete projection required here.
 [Issue #5484](https://github.com/richlander/dotnet-inspect/issues/5484) tracks
 the acquisition-owned durable content prerequisite. The complete contract is
 therefore **unverified**.
@@ -41,9 +43,11 @@ end-to-end tracker for that consumer's adoption. The browser/Wasm host does not
 participate in the changed surface: both the owner and consumer are existing
 types under `src/dotnet-inspect`, and the target changes that existing call
 path without introducing a shared API. No browser enablement plan or
-single-host substrate exception is therefore created here. Any shared
-acquisition capability proposed by #5484 must make its own consumer and host
-classification before implementation.
+single-host substrate exception is therefore created here. The shared
+acquisition capability proposed by #5484 has its own
+[approved CLI-first adoption scope](artifact-acquisition-and-workspaces.md#durable-package-content-identity-adoption);
+that exception does not change this cache owner's contract or waive the
+acquisition layer's Browser/Wasm compatibility requirements.
 
 Rendering is unchanged. The cache continues to return the existing typed
 `InspectionResult` data consumed by the existing Markout-backed package
@@ -414,12 +418,19 @@ keeps that broader reuse honest without turning the cache into an authority.
 
 ## Current implementation gap
 
-`pkg-index-v16` keys entries by NuGetFetch producer key, lowercased package ID,
-and version. `PackageExtractionResult` does not carry a package-owned durable
-authority key, `PackageContentGenerationIdentity`, or durable identity for the
-exact inspected tree into `PackageInspector`. It also permits a global-packages
-foreign tree to seed or consume the cache, persists `Snupkg`, `Msdl`, and
-`Other` PDB observations plus aggregates that can include them, omits
+`pkg-index-v16` keys entries by a caller-supplied cache scope, lowercased package
+ID, and version. Following #5971 and #6090, configured acquisition supplies
+`PackageExtractionResult.Authority` and `AcquiredPayload`.
+`PackageInspector` uses `CacheScopeKey`: the authority's persistent key when an
+authority exists, or the producer key on unbound legacy paths. An authority
+without a persistent key skips lookup and publication.
+
+The acquired payload exposes content and its process-local
+`PackageContentGenerationIdentity`, but `PackageInspector` still scans
+`ExtractPath`; lookup, cold production, and publication are not bound to the
+durable retained-content subject required above. The cache has no
+content-origin eligibility check for the inspected tree. It persists `Snupkg`,
+`Msdl`, and `Other` PDB observations plus aggregates that can include them, omits
 `RuntimeDependencies` entirely, persists the process-time-zone interpretation
 of `BuiltDate`, and has neither an explicit complete-entry record nor a
 production-success receipt. A per-DLL binary scan failure can therefore publish
@@ -427,29 +438,32 @@ partial counters, while a warm hit can silently lose the complete Runtime
 Dependencies section. The current namespace cannot satisfy the target subject
 or projection and must be fenced rather than relabeled when adoption lands.
 
-Adoption depends on #3738 carrying package authority and provenance through
-derived inspection and #5484 issuing exact durable package-content identity.
-Until both inputs exist, the correct successor behavior is cold-path-only
-rather than fallback to `pkg-index-v16`.
+The configured-authority and acquired-payload bridge is therefore existing
+mechanism to reuse, not a missing wrapper to recreate. Remaining adoption
+depends on #5484 issuing exact durable package-content identity and #3738's
+package-index workstream binding the CLI producer and successor cache to the
+complete subject. Until all required inputs exist, the correct successor
+behavior is cold-path-only rather than fallback to `pkg-index-v16`.
 
 The existing `pkg-index-v16` behavior ships unchanged until that implementation
-slice. It remains a legacy producer-scoped namespace, and no existing Release
-gate proves configured-authority separation. The package source model's target
-`LegacyProducerScopedCache_IsNotReinterpretedAsAuthorityScoped` gate is not
-implemented, so interim authority containment is **unverified**. Existing tests
-prove only predecessor-category fencing and separation between distinct
-producer keys; neither makes producer identity an authority.
+slice. Authority-key routing does not certify its content identity or
+projection. On configured acquisition paths, legacy producer-key entries are
+not reinterpreted as authority-key entries, and producer identity does not
+become authority.
 
 Existing tests establish useful partial properties:
 
 - `EqualCoordinatesFromDifferentProducersDoNotShareInspectionResults`;
+- `InspectAsync_ConfiguredAuthoritiesDoNotShareProducerIndexes`, covering
+  distinct local-authority keys, noncacheable HTTP authorities, and exclusion
+  of the seeded legacy producer entry on those configured paths;
 - `RidAvailability_IsNotPersisted`;
 - `Description_RoundTripsAsContainedProse`;
 - `Description_MalformedEnvelopeRejectsTheWholeCacheEntry`;
 - `Description_NullAndEmptyRemainDistinct`.
 
-They do not prove package authority, retained-content identity, projection
-completeness, or current-subject wiring.
+They do not prove the complete authority/content subject, retained-content
+identity, projection completeness, or current-subject wiring.
 `Description_TruncatedValueRequiresHigherProvenancePersistence` instead records
 the current exception that target adoption must replace with nonpublication.
 


### PR DESCRIPTION
Give the durable package-content identity work a real, bounded production
consumer instead of inventing a browser cache or rebuilding acquisition
plumbing that has already landed.

Related: #5484. End-to-end package-index workstream: #3738.
Both remain open for future implementation.

## Demo

Documentation-only planning mockup, not new product output:

```text
Before
  Missing carrier: authority + acquired payload
  Browser adoption: unresolved
  Next: classify the proposed shared capability

After
  Existing carrier: Authority + AcquiredPayload + CacheScopeKey
  Approved initial consumer: PackageInspector -> PackageIndexCache (CLI)
  Remaining steps:
    1. Acquisition-owned retained-content identity (#5484)
    2. Coherent CLI producer/cache adoption and old-namespace retirement (#3738)
```

What to notice: the missing capability is durable identity for the content
actually inspected, not another authority/payload wrapper. The API remains
host-neutral and subject to existing Browser/Wasm compatibility requirements;
the approval narrows initial production adoption only.

Neighbor: browser session package caching and saved workspace packets retain
their existing roles. They are not renamed as a persistent package-derived
result cache, and this scope does not add one.

## Basis and scope

Normative owner:
`docs/design/artifact-acquisition-and-workspaces.md`,
"Durable package-content identity adoption." Its sole new claim is the
approved initial consumer/host scope and counted adoption path, not a new
identity algorithm, cache policy, lifetime mechanism, or platform exception.

The user [explicitly approved the CLI-first exception](https://github.com/richlander/dotnet-inspect/issues/5484#issuecomment-5560862576)
after the [consumer survey](https://github.com/richlander/dotnet-inspect/issues/5484#issuecomment-5560783138).
The existing CLI consumer is named; the inspected browser paths do not
establish a corresponding package-level persistent derived-result consumer.
Adding one would be new capability scope, not an adoption step to assume.

Supporting contracts retain their roles:
`package-index-cache.md` owns cache subject/projection/reuse and retirement;
`inspection-space.md` owns the shared retained-subject rule; package source
authority and content generation retain their existing owners. The cache
document changes correct its current-baseline description, not its target
contract. The two steps are owner handoffs, not a cross-owner specification.

## Existing mechanism and remaining gap

Acquisition already populates `PackageExtractionResult.Authority` and
`AcquiredPayload`: #5971 supplied authority/cache-scope routing, and #6102
added the acquired-payload carrier. `PackageInspector` uses `CacheScopeKey`, preferring the
authority's persistent key and skipping the index when that authority has no
such key. Unbound legacy paths retain producer-key behavior.

The acquired content exposes process-local generation identity, but the CLI
producer still scans paths. That handle alone does not establish the durable
one-retained-subject contract. The target package-index contract remains
unverified and its successor implementation remains future work.

## Compatibility and non-actions

Markdown only. No product code, interface, cache namespace, serializer, CLI
behavior, dependency, or rendering path changes. Existing typed output and
Markout remain untouched. No new Browser/Wasm consumer, UI, or platform
incompatibility is approved or implemented.

Issue #5484 now records the approval and corrected baseline. The package-index
workstream of #3738 records the same two remaining steps without reclassifying
its separate packs/PDB/symbol workstreams. Neither issue is closed here.

## Validation

Both changed repository documents pass the existing markdownlint gate.
The baseline statements were checked against PackageExtractionResult,
ConfiguredPackageExtractionSession, PackageInspector, IPackageContent, and
the existing configured-authority index test. No new runtime behavior is
claimed and no .NET test/build or SDK installation is needed for this
documentation-only scope correction.

Round 1 reviewed exact head `dc6431eb1f5ea0bea7a00e100250913d2c64cf33`
against base `69b316f8e5b48e8b23f995681682fa0d504134ee`.
GPT-6 Astra and Claude Opus 5 both returned **CLEAN** for the full candidate
under the Markdown fast path. No review-driven head change was needed.
ci-required succeeded at 17:31:57Z; the 17:41:15Z observation showed no
pending or non-green checks. No merge is authorized.
