### PR TITLE
Give Library Integrations a full-area working surface

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -671,6 +671,47 @@ geometry, long names and identities, many/zero rows, pending and failed results,
 and Library navigation. Subject-strip behavior and other Library lenses are
 separate work.
 
+### Library Integrations
+
+Library Integrations uses a quiet count/state header, an optional platform
+Library selector, one full-area results scroller, and bottom assembly context.
+It replaces the generic Library hero, repeated summary heading/noninteractive
+category chips, and inset signal cards.
+
+```text
+Integrations                             category/signal count or state
+optional platform Library selector
+category headings and full-width signal rows
+Library asset and assembly identity              TFM · package@version
+```
+
+Existing category order, type-first signal sorting, name/qualifier splitting,
+shape/kind badges, and category/total counts remain. The platform selector stays
+above scrolling results and keeps its existing acquisition and selection
+behavior. The footer retains the Library asset path, full assembly identity,
+and package/version/framework context.
+
+Loading and query failure retain the same frame. Incomplete results retain their
+available categories and diagnostics, visibly marked as partial. An incomplete
+scan with no returned signals does not claim established absence; only a
+complete empty result says no integrations were detected.
+
+At narrow widths the existing Types/details control shares the quiet header.
+Category names, signal names/qualifiers, and kind text wrap within the pane.
+Many rows scroll locally while header, selector, and bottom context stay put.
+
+The explicitly approved browser-only presentation scope has
+[one adoption step](https://github.com/richlander/dotnet-inspect/issues/6202):
+wire production Library Integrations to this frame and retire only that
+consumer's old composition. Browser HTML lowering consumes the existing typed
+`BrowserPackageIntegrations` result. References and Metadata supply the local
+layout conventions; this is not a new inspection or rendering architecture.
+
+Focused renderer and production-composition browser gates cover wide/narrow,
+long/many results, state distinctions, Library switching, and platform controls.
+Scan classification, catalog ownership, other lenses, and subject-strip
+interaction remain separate work.
+
 ### Package Metadata
 
 Package Metadata uses the complete package inspector area. It does not retain

--- a/prototypes/inspect-web/browser/library-hierarchy.spec.ts
+++ b/prototypes/inspect-web/browser/library-hierarchy.spec.ts
@@ -100,6 +100,7 @@ async function installFacades(
   model = surface,
   additionalSurfaces: readonly BrowserPackageSurface[] = [],
   references: "ready" | "long" | "empty" | "query-error" | "inspection-error" | "deferred" = "ready",
+  integrations: "ready" | "long" | "empty" | "partial" | "partial-empty" | "query-error" | "deferred" = "ready",
 ) {
   const common = "export async function initializeRuntime() {}";
   const surfaceLookup = `
@@ -127,6 +128,16 @@ async function installFacades(
         };
       }
       export async function queryPackageVersions() { return ["1.0.0"]; }
+      export async function loadRuntimePack(framework, version) {
+        const surface = surfaceFor("Microsoft.NETCore.App");
+        return JSON.stringify({ ...surface, activeFramework: framework, version: version || surface.version });
+      }
+      export async function loadRuntimePackAssembly(framework, version, file) {
+        const surface = surfaceFor("Microsoft.NETCore.App");
+        const selected = surface.assemblies.find(item => item.name + ".dll" === file);
+        if (!selected) throw new Error("Unknown platform library: " + file);
+        return JSON.stringify({ ...surface, defaultAssemblyId: selected.id, activeFramework: framework, version: version || surface.version });
+      }
       export function clearWorkspacePackageOccurrences() {}
       export function packageCacheStats() {
         return { packages: 1, resident: 1, workspaces: 1, residentBytes: 0 };
@@ -181,7 +192,51 @@ async function installFacades(
         document.documentElement.dataset.tableRequest = asset;
         return { index, name: "Module", rowCount: 1, startRowId, columns: [], rows: [], error: null };
       }`,
-    analysis: "",
+    analysis: `
+      ${surfaceLookup}
+      export async function queryPackageIntegrations(id, version, framework, asset) {
+        document.documentElement.dataset.integrationRequest = asset;
+        const surface = surfaceFor(id);
+        const selected = surface.assemblies.find(item => item.id === asset);
+        if (!selected) throw new Error("Unknown library: " + asset);
+        const scenario = ${JSON.stringify(integrations)};
+        if (scenario === "deferred") {
+          await new Promise(resolve => document.addEventListener(
+            "fixture-integrations-ready:" + asset, resolve, { once: true }));
+        }
+        if (scenario === "query-error") throw new Error("Integration query unavailable.");
+        const categories = scenario === "empty" || scenario === "partial-empty" ? [] : [
+          { integration: "Dependency Injection", signals: [
+            { name: selected.name + ".ServiceExtensions.AddWidgets(IServiceCollection services)", shape: "Method", kind: "Extension method" },
+            { name: selected.name + ".WidgetService", shape: "Type", kind: "Implementation" }
+          ] },
+          { integration: "Logging", signals: [
+            { name: selected.name + ".WidgetLogger.Write(ILogger logger)", shape: "Method", kind: "Parameter" }
+          ] }
+        ];
+        if (scenario === "long") {
+          categories[0].integration += "." + "LongCategory".repeat(30);
+          categories[0].signals = Array.from({ length: 80 }, (_, index) => ({
+            name: selected.name + "." + "LongNamespace.".repeat(20)
+              + "Add" + "LongSignalName".repeat(15) + index + "(IServiceCollection services)",
+            shape: "Method", kind: "LongKind".repeat(30)
+          }));
+        }
+        const partial = scenario.startsWith("partial");
+        return {
+          package: id, version, framework, categories,
+          totalSignals: categories.reduce((total, category) => total + category.signals.length, 0),
+          isComplete: !partial, inspectionError: partial ? "A library participant could not be inspected." : null,
+          compileLibrary: surface.compileLibrary
+        };
+      }
+      export async function queryPlatformIntegrations(framework, version, file, pack) {
+        document.documentElement.dataset.platformIntegrationRequest = file + ":" + pack;
+        const surface = surfaceFor("Microsoft.NETCore.App");
+        const selected = surface.assemblies.find(item => item.name + ".dll" === file);
+        if (!selected) throw new Error("Unknown platform library: " + file);
+        return queryPackageIntegrations(surface.package, version, framework, selected.id);
+      }`,
     source: "",
     "call-graph": "",
     catalog: `
@@ -211,7 +266,16 @@ async function installFacades(
       import.meta.url)),
   }));
   await page.route("**/assets/platform-index.tsv", route =>
-    route.fulfill({ status: 404, body: "Platform catalog is not part of this fixture." }));
+    route.fulfill(model.package === "Microsoft.NETCore.App" ? {
+      contentType: "text/tab-separated-values",
+      body: [
+        "tfm\tpack\tassembly\tfile\tkind\tforwardsTo\tversion\tpublicTypes",
+        ...model.assemblies.map(item => [
+          model.activeFramework, item.platformPack ?? "netcore.app",
+          item.name, `${item.name}.dll`, "impl", "", item.version, item.publicTypes,
+        ].join("\t")),
+      ].join("\n"),
+    } : { status: 404, body: "Platform catalog is not part of this fixture." }));
   await page.route("**/*", route =>
     route.request().resourceType() === "document"
       ? route.fulfill({
@@ -222,6 +286,142 @@ async function installFacades(
 }
 
 const root = "/?package=Example.Package&version=1.0.0&framework=net10.0#pkg";
+
+async function openIntegrations(page: Page, location = root) {
+  await page.goto(location);
+  await page.locator('.library-list [data-lib-scope="asset:core"]').click();
+  await page.locator('[data-library-lens="overview"]').press("ArrowRight");
+  if (await page.locator('[data-library-lens="references"]').count()) {
+    await page.keyboard.press("ArrowRight");
+  }
+  await page.keyboard.press("Enter");
+  await expect(page.locator('[data-library-lens="integrations"]')).toHaveAttribute("aria-selected", "true");
+}
+
+for (const width of [1440, 390]) {
+  test(`production Integrations retains selected Library results at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    await installFacades(page);
+    await openIntegrations(page);
+    await expect(page.locator("#inspector-panel .signal-row")).toHaveCount(3);
+    await expect(page.locator("#inspector-panel .signal-name").first()).toHaveText("WidgetService");
+    await expect(page.locator("#inspector-panel")).toContainText("Dependency Injection");
+    await expect(page.locator("#inspector-panel")).toContainText("Logging");
+    await expect(page.locator("html")).toHaveAttribute("data-integration-request", "asset:core");
+    const frame = page.locator(".library-integrations-surface");
+    await expect(frame.locator("header")).toContainText("2 categories");
+    await expect(frame.locator("header")).toContainText("3 signals");
+    await expect(frame.locator("footer")).toContainText(core.asset);
+    await expect(frame.locator("footer")).toContainText("Example.Core, Version=1.0.0.0");
+    await expect(page.locator("#inspector-panel > .type-heading")).toHaveCount(0);
+    const panelBox = await page.locator("#inspector-panel").boundingBox();
+    const frameBox = await frame.boundingBox();
+    const rowBox = await frame.locator(".signal-row").first().boundingBox();
+    expect(Math.abs(frameBox!.height - panelBox!.height)).toBeLessThanOrEqual(2);
+    expect(Math.abs(frameBox!.width - panelBox!.width)).toBeLessThanOrEqual(2);
+    expect(Math.abs(rowBox!.width - frameBox!.width)).toBeLessThanOrEqual(2);
+    expect(Math.abs(rowBox!.x - frameBox!.x)).toBeLessThanOrEqual(1);
+    await page.screenshot({ path: testInfo.outputPath("integrations.png") });
+    if (width === 390) {
+      const back = page.getByRole("button", { name: "Types", exact: true });
+      await back.click();
+      await expect(page.locator("#type-list")).toBeFocused();
+      await page.getByRole("button", { name: "Show details", exact: true }).click();
+      await expect(back).toBeFocused();
+      await expect(frame).toBeVisible();
+    }
+  });
+
+  test(`production Integrations contains long fields and keeps its frame while scrolling at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    const longCore = library(core.id, "Example." + "LongLibraryName".repeat(25), 1);
+    await installFacades(page, {
+      ...surface, assemblies: [longCore], types: [type("Example.Widget", longCore)], totalMembers: 1,
+    }, [], "ready", "long");
+    await openIntegrations(page);
+    const frame = page.locator(".library-integrations-surface");
+    await expect(frame.locator(".signal-row")).toHaveCount(81);
+    const header = await frame.locator("header").boundingBox();
+    const footer = await frame.locator("footer").boundingBox();
+    const scroll = frame.locator(".library-integrations-scroll");
+    const geometry = await scroll.evaluate(element => ({
+      width: element.clientWidth, scrollWidth: element.scrollWidth,
+      height: element.clientHeight, scrollHeight: element.scrollHeight,
+      pageWidth: document.documentElement.clientWidth, pageScrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.width + 1);
+    expect(geometry.pageScrollWidth).toBeLessThanOrEqual(geometry.pageWidth + 1);
+    expect(geometry.scrollHeight).toBeGreaterThan(geometry.height);
+    await scroll.evaluate(element => { element.scrollTop = element.scrollHeight; });
+    await expect(frame.locator(".signal-row").last()).toBeInViewport();
+    expect(await frame.locator("header").boundingBox()).toEqual(header);
+    expect(await frame.locator("footer").boundingBox()).toEqual(footer);
+  });
+
+  for (const scenario of ["empty", "partial", "partial-empty", "query-error"] as const) {
+    test(`production Integrations retains its ${scenario} state at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 900 });
+      await installFacades(page, surface, [], "ready", scenario);
+      await openIntegrations(page);
+      const frame = page.locator(".library-integrations-surface");
+      if (scenario === "partial") {
+        await expect(frame.locator(".signal-row")).toHaveCount(3);
+        await expect(frame.locator("header")).toContainText("partial");
+      } else {
+        await expect(frame.locator("h2")).toHaveText(scenario === "empty"
+          ? "No ecosystem integrations detected" : scenario === "partial-empty"
+            ? "Integration scan incomplete" : "Integration scan failed");
+        await expect(frame.locator(".signal-row")).toHaveCount(0);
+      }
+      if (scenario.startsWith("partial")) {
+        await expect(frame).toContainText("A library participant could not be inspected.");
+        await expect(frame).not.toContainText("No ecosystem integrations detected");
+      }
+      await expect(frame.locator("footer")).toBeInViewport();
+    });
+  }
+
+  test(`production Integrations keeps platform Library selection outside the scroller at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    const platform = {
+      ...surface, package: "Microsoft.NETCore.App",
+      assemblies: surface.assemblies.map(item => ({ ...item, platformPack: "netcore.app" })),
+    };
+    await installFacades(page, platform);
+    await openIntegrations(page, root.replace("Example.Package", platform.package));
+    const frame = page.locator(".library-integrations-surface");
+    await expect(frame.locator(".signal-row")).toHaveCount(3);
+    const picker = frame.locator(".library-integrations-controls select");
+    await expect(picker).toBeVisible();
+    await expect(picker).toHaveValue(core.name);
+    await picker.selectOption(other.name);
+    await expect(frame.locator(".signal-ns").first()).toContainText(other.name);
+    await expect(frame.locator("footer")).toContainText(other.asset);
+    await expect(page.locator("html")).toHaveAttribute("data-platform-integration-request", "Example.Other.dll:netcore.app");
+    const controls = await frame.locator(".library-integrations-controls").boundingBox();
+    const content = await frame.locator(".library-integrations-scroll").boundingBox();
+    expect(controls!.y + controls!.height).toBeLessThanOrEqual(content!.y + 1);
+  });
+}
+
+test("production Integrations keeps deferred Library results out of the incoming scan", async ({ page }) => {
+  await installFacades(page, surface, [], "ready", "deferred");
+  await openIntegrations(page);
+  await expect(page.locator(".library-integrations-surface")).toContainText("Scanning integrations");
+  await expect(page.locator(".library-integrations-surface footer")).toContainText(core.asset);
+  await page.evaluate(() => document.dispatchEvent(new Event("fixture-integrations-ready:asset:core")));
+  await expect(page.locator(".library-integrations-scroll .signal-row")).toHaveCount(3);
+  await page.locator('[data-subject-tab]:not([hidden])').first().press("Home");
+  await page.locator('.library-list [data-lib-scope="asset:other"]').click();
+  await page.locator('[data-library-lens="overview"]').press("ArrowRight");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("Enter");
+  await expect(page.locator(".library-integrations-surface")).toContainText("Scanning integrations");
+  await expect(page.locator(".library-integrations-surface footer")).toContainText(other.asset);
+  await expect(page.locator(".library-integrations-surface")).not.toContainText(core.name);
+  await page.evaluate(() => document.dispatchEvent(new Event("fixture-integrations-ready:asset:other")));
+  await expect(page.locator(".library-integrations-scroll .signal-ns").first()).toContainText(other.name);
+});
 
 async function openReferences(page: Page) {
   await page.goto(root);

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -225,6 +225,7 @@ import {
 import { createDocumentInspectionCoordinator } from "./document-inspection.ts";
 import { renderOverviewSurface } from "./overview-surface.ts";
 import { renderLibraryReferencesSurface } from "./library-references.ts";
+import { renderLibraryIntegrationsSurface } from "./library-integrations.ts";
 import {
   captureMemberFocus,
   createMemberFocusRestorer,
@@ -3515,6 +3516,8 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     activeScope === "library" && state.libraryLens === "metadata";
   const libraryReferencesWorkingSurface =
     activeScope === "library" && state.libraryLens === "references";
+  const libraryIntegrationsWorkingSurface =
+    activeScope === "library" && state.libraryLens === "integrations";
   const currentMember = current ? selectedMember(current) : undefined;
   const memberOverloadPicker =
     currentMember !== undefined
@@ -3553,6 +3556,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     || packageDependenciesWorkingSurface
     || libraryMetadataWorkingSurface
     || libraryReferencesWorkingSurface
+    || libraryIntegrationsWorkingSurface
     || memberWorkingSurface;
 
   if (scopeBarOwnsFocus) {
@@ -3638,7 +3642,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
           ${contentFrameEnabled
             ? renderContentNavigationBar(contentNavigationLabel)
             : ""}
-          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}${apiWorkingSurface ? " api-working-surface" : ""}${metadataWorkingSurface ? " metadata-working-surface" : ""}${overviewWorkingSurface ? " overview-working-surface" : ""}${packageDependenciesWorkingSurface ? " package-dependencies-working-surface" : ""}${libraryMetadataWorkingSurface ? " package-metadata-working-surface" : ""}${libraryReferencesWorkingSurface ? " library-references-working-surface" : ""}${memberWorkingSurface ? " member-working-surface" : ""}"${inspectorPanelSemantics}>
+          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}${apiWorkingSurface ? " api-working-surface" : ""}${metadataWorkingSurface ? " metadata-working-surface" : ""}${overviewWorkingSurface ? " overview-working-surface" : ""}${packageDependenciesWorkingSurface ? " package-dependencies-working-surface" : ""}${libraryMetadataWorkingSurface ? " package-metadata-working-surface" : ""}${libraryReferencesWorkingSurface ? " library-references-working-surface" : ""}${libraryIntegrationsWorkingSurface ? " library-integrations-working-surface" : ""}${memberWorkingSurface ? " member-working-surface" : ""}"${inspectorPanelSemantics}>
             ${renderLens(current)}
           </article>
         </section>
@@ -4223,6 +4227,7 @@ function renderLibraryView() {
   const body = libraryLensBody();
   if (state.libraryLens === "overview"
     || state.libraryLens === "references"
+    || state.libraryLens === "integrations"
     || state.libraryLens === "metadata") return body;
   return `${libraryHeading()}${body}`;
 }
@@ -4590,72 +4595,24 @@ function packageIntegrationsSignature() {
 
 function renderPackageIntegrations() {
   const pkg = currentPackage();
-  const isPlatform = pkg.isRuntimePack;
+  const library = selectedLibrary();
   const scopedLib = scopedPlatformLibrary();
-  // On the Platform the scan targets one library at a time (the whole shared framework is
-  // ~160 assemblies). Offer a picker to switch libraries; when nothing is scoped yet, prompt
-  // for a choice instead of scanning.
-  const platformPicker = isPlatform
-    ? `<section class="document-section"><div class="library-picker platform-library-picker overview-library-picker">${platformLibrarySelectHtml({ dataAttr: "data-platform-integrations-library", selected: scopedLib || "" })}</div></section>`
-    : "";
-  if (isPlatform && !scopedLib) {
-    return `${platformPicker}<section class="document-section empty-document"><span class="large-glyph">◈</span><h2>Pick a library to scan</h2><p>Choose a .NET platform library above to scan its public surface for DI, logging, OpenTelemetry, ASP.NET Core, AI, or hosting integration signals.</p></section>`;
-  }
-  const library = selectedLibraryName();
-  const scanScope = `${escapeHtml(library)} · ${escapeHtml(pkg.activeFramework)}`;
   const current = packageIntegrationsSignature();
   const fresh = state.packageIntegrationsKey === current;
-  if (state.packageIntegrationsLoading && fresh) {
-    return `${platformPicker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning integrations…</h2><p>Reading the public surface of ${escapeHtml(library)} for ecosystem signals.</p></section>`;
-  }
-  if (fresh && state.packageIntegrationsError) {
-    return `${platformPicker}<section class="document-section empty-document"><span class="large-glyph">◈</span><h2>Integration scan failed</h2><p>${escapeHtml(state.packageIntegrationsError)}</p></section>`;
-  }
-  const data = fresh ? state.packageIntegrations : null;
-  if (!data) {
-    return `${platformPicker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
-  }
-
-  const categories = data.categories || [];
-  const warning = data.inspectionError
-    ? `<section class="document-section metadata-warning"><strong>⚠ This library could not be scanned completely</strong><ul><li><code>${escapeHtml(data.inspectionError)}</code></li></ul></section>`
-    : "";
-
-  if (!categories.length) {
-    return `${platformPicker}${warning}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No ecosystem integrations detected</h2><p>The public surface of ${escapeHtml(library)} shows no known DI, logging, OpenTelemetry, ASP.NET Core, AI, or hosting signals.</p></section>`;
-  }
-
-  const summary = `
-    <section class="document-section">
-      <div class="section-title"><h2>Ecosystem integrations</h2><span>${categories.length} categor${categories.length === 1 ? "y" : "ies"} · ${data.totalSignals} signal${data.totalSignals === 1 ? "" : "s"} · ${scanScope}</span></div>
-      <div class="type-chip-list">${categories.map(category => `<span class="type-chip">${escapeHtml(category.integration)} <span class="ns-count">${category.signals.length}</span></span>`).join("")}</div>
-    </section>`;
-
-  const blocks = categories.map(category => {
-    const signals = [...category.signals].sort((a, b) => {
-      const rank = (shape: string) => /type/i.test(shape) ? 0 : 1;
-      return rank(a.shape) - rank(b.shape) || a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name);
-    });
-    const typeCount = signals.filter(signal => /type/i.test(signal.shape)).length;
-    const apiCount = signals.length - typeCount;
-    const rows = signals.map(signal => {
-      const isType = /type/i.test(signal.shape);
-      const { short, qualifier } = splitSignalName(signal.name);
-      return `
-        <div class="signal-row" title="${escapeHtml(signal.name)} · ${escapeHtml(signal.shape)} · ${escapeHtml(signal.kind)}">
-          <span class="signal-badge signal-${isType ? "type" : "api"}">${isType ? "T" : "ƒ"}</span>
-          <span class="signal-body"><span class="signal-name">${escapeHtml(short)}</span>${qualifier ? `<span class="signal-ns">${escapeHtml(qualifier)}</span>` : ""}</span>
-          <span class="signal-kind">${escapeHtml(signal.kind)}</span>
-        </div>`;
-    }).join("");
-    return `
-    <section class="document-section">
-      <div class="section-title"><h2>${escapeHtml(category.integration)}</h2><span>${typeCount} type${typeCount === 1 ? "" : "s"} · ${apiCount} API${apiCount === 1 ? "" : "s"}</span></div>
-      <div class="signal-list">${rows}</div>
-    </section>`;
-  }).join("");
-
-  return `${platformPicker}${warning}${summary}${blocks}`;
+  return renderLibraryIntegrationsSurface({
+    libraryName: library?.name ?? "",
+    assemblyIdentity: library ? libraryIdentity(library) : "No library selected",
+    assetPath: library?.asset ?? "",
+    coordinate: `${pkg.activeFramework} · ${pkg.id}@${pkg.version}`,
+    requireLibrary: pkg.isRuntimePack && !scopedLib,
+    pickerHtml: pkg.isRuntimePack
+      ? platformLibrarySelectHtml({ dataAttr: "data-platform-integrations-library", selected: scopedLib || "" })
+      : "",
+    loading: state.packageIntegrationsLoading && fresh,
+    error: fresh ? state.packageIntegrationsError : "",
+    data: fresh ? state.packageIntegrations : null,
+    escapeHtml,
+  });
 }
 
 async function loadPackageIntegrations() {
@@ -5756,23 +5713,6 @@ function shortTypeName(fullName: string) {
   const tail = generic < 0 ? "" : fullName.slice(generic);
   const dot = head.lastIndexOf(".");
   return (dot < 0 ? head : head.slice(dot + 1)) + tail;
-}
-
-// Split an integration signal's fully-qualified name into its short member/type name and a
-// declaring qualifier. Cuts off a method parameter list or generic argument list before the
-// last-dot split so a dot inside "(...)" or "<...>" never gets mistaken for the name boundary.
-function splitSignalName(fullName: string) {
-  const paren = fullName.indexOf("(");
-  const angle = fullName.indexOf("<");
-  const bounds = [paren, angle].filter(i => i >= 0);
-  const cut = bounds.length ? Math.min(...bounds) : -1;
-  const head = cut < 0 ? fullName : fullName.slice(0, cut);
-  const suffix = cut < 0 ? "" : fullName.slice(cut);
-  const dot = head.lastIndexOf(".");
-  return {
-    short: (dot < 0 ? head : head.slice(dot + 1)) + suffix,
-    qualifier: dot < 0 ? "" : head.slice(0, dot),
-  };
 }
 
 function kindIcon(kind: string) {

--- a/prototypes/inspect-web/src/library-integrations.ts
+++ b/prototypes/inspect-web/src/library-integrations.ts
@@ -1,0 +1,96 @@
+import type { BrowserPackageIntegrations } from "./facades/inspect-web-analysis.d.ts";
+
+export interface LibraryIntegrationsOptions {
+  libraryName: string;
+  assemblyIdentity: string;
+  assetPath: string;
+  coordinate: string;
+  requireLibrary: boolean;
+  pickerHtml: string;
+  loading: boolean;
+  error: string;
+  data: BrowserPackageIntegrations | null;
+  escapeHtml: (value: unknown) => string;
+}
+
+export function renderLibraryIntegrationsSurface(options: LibraryIntegrationsOptions): string {
+  const {
+    libraryName, assemblyIdentity, assetPath, coordinate,
+    requireLibrary, pickerHtml, loading, error, data, escapeHtml,
+  } = options;
+  let status: string;
+  let content: string;
+  if (requireLibrary) {
+    status = "Select a library";
+    content = `<section class="document-section empty-document"><span class="large-glyph">&#x25C8;</span><h2>Pick a library to scan</h2><p>Choose a .NET platform library above to scan its public surface for DI, logging, OpenTelemetry, ASP.NET Core, AI, or hosting integration signals.</p></section>`;
+  } else if (loading) {
+    status = "Scanning integrations\u2026";
+    content = `<section class="document-section source-progress"><span class="loader"></span><h2>Scanning integrations&hellip;</h2><p>Reading the public surface of ${escapeHtml(libraryName)} for ecosystem signals.</p></section>`;
+  } else if (error) {
+    status = "Scan failed";
+    content = `<section class="document-section empty-document"><span class="large-glyph">&#x25C8;</span><h2>Integration scan failed</h2><p>${escapeHtml(error)}</p></section>`;
+  } else if (!data) {
+    status = "Loading\u2026";
+    content = `<section class="document-section empty-document"><span class="loader"></span><h2>Loading&hellip;</h2></section>`;
+  } else {
+    const categories = data.categories;
+    const partial = !data.isComplete || Boolean(data.inspectionError);
+    status = `${categories.length.toLocaleString()} categor${categories.length === 1 ? "y" : "ies"} \u00b7 ${data.totalSignals.toLocaleString()} signal${data.totalSignals === 1 ? "" : "s"}${partial ? " \u00b7 partial" : ""}`;
+    const warning = partial
+      ? `<section class="document-section metadata-warning"><strong>&#x26A0; This library could not be scanned completely</strong>${data.inspectionError ? `<ul><li><code>${escapeHtml(data.inspectionError)}</code></li></ul>` : ""}</section>`
+      : "";
+    const blocks = categories.map((category, index) => {
+      const signals = [...category.signals].sort((a, b) => {
+        const rank = (shape: string) => /type/i.test(shape) ? 0 : 1;
+        return rank(a.shape) - rank(b.shape) || a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name);
+      });
+      const typeCount = signals.filter(signal => /type/i.test(signal.shape)).length;
+      const apiCount = signals.length - typeCount;
+      const rows = signals.map(signal => {
+        const isType = /type/i.test(signal.shape);
+        const { short, qualifier } = splitSignalName(signal.name);
+        return `<div class="signal-row" role="listitem" title="${escapeHtml(signal.name)} &middot; ${escapeHtml(signal.shape)} &middot; ${escapeHtml(signal.kind)}">
+          <span class="signal-badge signal-${isType ? "type" : "api"}">${isType ? "T" : "&#402;"}</span>
+          <span class="signal-body"><span class="signal-name">${escapeHtml(short)}</span>${qualifier ? `<span class="signal-ns">${escapeHtml(qualifier)}</span>` : ""}</span>
+          <span class="signal-kind">${escapeHtml(signal.kind)}</span>
+        </div>`;
+      }).join("");
+      return `<section class="integration-category" aria-labelledby="integration-category-${index}">
+        <div class="section-title"><h2 id="integration-category-${index}">${escapeHtml(category.integration)}</h2><span>${typeCount} type${typeCount === 1 ? "" : "s"} &middot; ${apiCount} API${apiCount === 1 ? "" : "s"}</span></div>
+        <div class="signal-list" role="list">${rows}</div>
+      </section>`;
+    }).join("");
+    const empty = partial
+      ? `<section class="document-section empty-document"><h2>Integration scan incomplete</h2><p>No integration signals are available from this incomplete scan.</p></section>`
+      : `<section class="document-section empty-document"><span class="large-glyph">&#x25C7;</span><h2>No ecosystem integrations detected</h2><p>The public surface of ${escapeHtml(libraryName)} shows no known DI, logging, OpenTelemetry, ASP.NET Core, AI, or hosting signals.</p></section>`;
+    content = `${warning}${categories.length ? blocks : empty}`;
+  }
+  const identity = assetPath ? `${assetPath} \u00b7 ${assemblyIdentity}` : assemblyIdentity;
+  return `<section class="library-integrations-surface${pickerHtml ? " library-integrations-with-controls" : ""}" aria-labelledby="library-integrations-title">
+    <header class="api-surface-head">
+      <h1 id="library-integrations-title">Integrations</h1>
+      <p title="${escapeHtml(status)}">${escapeHtml(status)}</p>
+    </header>
+    ${pickerHtml ? `<section class="library-integrations-controls" aria-label="Integration scan library">${pickerHtml}</section>` : ""}
+    <div class="library-integrations-scroll">${content}</div>
+    <footer class="metadata-surface-footer">
+      <span title="${escapeHtml(identity)}">${escapeHtml(identity)}</span>
+      <span title="${escapeHtml(coordinate)}">${escapeHtml(coordinate)}</span>
+    </footer>
+  </section>`;
+}
+
+// Split before parameter/generic lists so their dots cannot become the name boundary.
+function splitSignalName(fullName: string) {
+  const paren = fullName.indexOf("(");
+  const angle = fullName.indexOf("<");
+  const bounds = [paren, angle].filter(i => i >= 0);
+  const cut = bounds.length ? Math.min(...bounds) : -1;
+  const head = cut < 0 ? fullName : fullName.slice(0, cut);
+  const suffix = cut < 0 ? "" : fullName.slice(cut);
+  const dot = head.lastIndexOf(".");
+  return {
+    short: (dot < 0 ? head : head.slice(dot + 1)) + suffix,
+    qualifier: dot < 0 ? "" : head.slice(0, dot),
+  };
+}

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1009,6 +1009,7 @@ kbd {
 .detail-scroll.member-working-surface { min-height: 0; overflow: hidden; padding: 0; }
 .detail-scroll.overview-working-surface,
 .detail-scroll.library-references-working-surface,
+.detail-scroll.library-integrations-working-surface,
 .detail-scroll.package-dependencies-working-surface,
 .detail-scroll.package-metadata-working-surface { min-height: 0; overflow: hidden; padding: 0; }
 
@@ -1091,10 +1092,13 @@ kbd {
 .metadata-surface-head p { min-width: 0; flex: 0 1 auto; overflow: hidden; margin: 0; color: var(--dim); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .api-surface-head p span,
 .metadata-surface-head p span { margin-left: 6px; }
+.library-integrations-surface,
 .library-references-surface,
 .metadata-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: 40px minmax(0, 1fr) 34px; background: var(--bg); }
+.library-integrations-scroll,
 .library-references-scroll,
 .metadata-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
+.library-integrations-scroll > .document-section,
 .library-references-scroll > .document-section,
 .metadata-surface-scroll > .document-section,
 .metadata-surface-scroll > [data-type-graph-surface] > .document-section { padding: 24px 16px 0; }
@@ -1534,6 +1538,18 @@ kbd {
 .signal-name { font: 13px var(--mono); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .signal-ns { font-size: 11px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .signal-kind { flex: 0 0 auto; font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--line); color: var(--dim); }
+.library-integrations-with-controls { grid-template-rows: 40px auto minmax(0, 1fr) 34px; }
+.library-integrations-controls { min-width: 0; padding: 8px 16px; border-bottom: 1px solid var(--line); }
+.library-integrations-controls .platform-library-select { min-width: 0; width: 100%; max-width: 420px; height: 30px; }
+.library-integrations-scroll { overflow-wrap: anywhere; }
+.integration-category > .section-title { min-width: 0; flex-wrap: wrap; gap: 4px 12px; margin: 0; padding: 12px 16px; border-bottom: 1px solid var(--line); }
+.integration-category > .section-title h2 { min-width: 0; }
+.library-integrations-scroll .signal-list { gap: 0; padding: 0; border-top: 0; }
+.library-integrations-scroll .signal-row { display: grid; grid-template-columns: 24px minmax(0, 1fr) minmax(0, auto); align-items: start; margin: 0; padding: 12px 16px; border: 0; border-bottom: 1px solid var(--line); border-radius: 0; background: transparent; }
+.library-integrations-scroll .signal-name,
+.library-integrations-scroll .signal-ns { overflow: visible; white-space: normal; }
+.library-integrations-scroll .signal-kind { min-width: 0; max-width: 24ch; justify-self: end; padding: 0; border: 0; border-radius: 0; }
+.library-integrations-scroll > .metadata-warning { margin: 0; padding: 14px 16px; border-inline: 0; border-top: 0; border-radius: 0; }
 .opp-list { display: flex; flex-direction: column; gap: 6px; padding: 12px 10px; border-top: 1px solid var(--line); }
 .opp-row { display: flex; align-items: flex-start; gap: 12px; padding: 9px 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); }
 .opp-body { flex: 1 1 auto; display: flex; flex-direction: column; gap: 8px; min-width: 0; }
@@ -1957,6 +1973,12 @@ kbd {
   .library-references-scroll .dep-list li { grid-template-columns: minmax(0, 1fr); gap: 4px; padding-inline: 12px; }
   .library-references-scroll .dep-version { text-align: left; }
   .library-references-scroll > .document-section { padding-inline: 12px; }
+  .library-integrations-controls,
+  .integration-category > .section-title,
+  .library-integrations-scroll > .document-section { padding-inline: 12px; }
+  .library-integrations-scroll .signal-row { grid-template-columns: 24px minmax(0, 1fr); gap: 4px 12px; padding-inline: 12px; }
+  .library-integrations-scroll .signal-badge { grid-row: 1 / span 2; }
+  .library-integrations-scroll .signal-kind { grid-column: 2; justify-self: start; max-width: 100%; }
   .metadata-surface-head { padding-inline: 12px; }
   .metadata-surface-scroll > .document-section,
   .metadata-surface-scroll > [data-type-graph-surface] > .document-section { padding-inline: 12px; }

--- a/prototypes/inspect-web/test/library-integrations.test.ts
+++ b/prototypes/inspect-web/test/library-integrations.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { renderLibraryIntegrationsSurface, type LibraryIntegrationsOptions } from "../src/library-integrations.ts";
+import type { BrowserPackageIntegrations } from "../src/facades/inspect-web-analysis.d.ts";
+
+const data: BrowserPackageIntegrations = {
+  package: "Example.Package", version: "1.0.0", framework: "net10.0",
+  categories: [
+    { integration: "Dependency Injection", signals: [
+      { name: "Example.Extensions.ZAdd()", shape: "Method", kind: "Extension method" },
+      { name: "Example.Service", shape: "Type", kind: "Implementation" },
+      { name: "Example.Extensions.Add()", shape: "Method", kind: "Extension method" },
+    ] },
+    { integration: "Logging", signals: [
+      { name: "Example.Logger.Write(ILogger logger)", shape: "Method", kind: "Parameter" },
+    ] },
+  ],
+  totalSignals: 4, isComplete: true, inspectionError: null,
+  compileLibrary: { status: "Selected", targetFramework: "net10.0", message: null },
+};
+
+function render(overrides: Partial<LibraryIntegrationsOptions> = {}) {
+  return renderLibraryIntegrationsSurface({
+    libraryName: "Example.Core",
+    assemblyIdentity: "Example.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+    assetPath: "lib/net10.0/Example.Core.dll",
+    coordinate: "net10.0 / Example.Package@1.0.0",
+    requireLibrary: false, pickerHtml: "", loading: false, error: "", data,
+    escapeHtml: value => String(value).replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;").replaceAll("'", "&#39;"),
+    ...overrides,
+  });
+}
+
+test("Integrations uses one quiet heading and bottom identity instead of duplicate summaries", () => {
+  const html = render();
+  assert.equal(html.match(/<h1\b/g)?.length, 1);
+  assert.match(html, /<h1 id="library-integrations-title">Integrations<\/h1>/);
+  assert.match(html, /2 categories.*4 signals/);
+  assert.match(html, /library-integrations-scroll"><section class="integration-category"/);
+  assert.match(html, /<footer[\s\S]*lib\/net10.0\/Example.Core.dll.*Example.Core, Version=1.0.0.0/);
+  assert.match(html, /<footer[\s\S]*net10.0 \/ Example.Package@1.0.0/);
+  assert.doesNotMatch(html, /type-heading|type-chip-list|Ecosystem integrations|library-integrations-controls/);
+});
+
+test("category order, type-first sorting, kind/name sorting and counts are retained without mutating data", () => {
+  const original = JSON.stringify(data);
+  const html = render();
+  const names = [...html.matchAll(/class="signal-name">([^<]*)<\/span>/g)].map(match => match[1]);
+  assert.deepEqual(names, ["Service", "Add()", "ZAdd()", "Write(ILogger logger)"]);
+  assert.ok(html.indexOf(">Dependency Injection</h2>") < html.indexOf(">Logging</h2>"));
+  assert.match(html, /1 type &middot; 2 APIs/);
+  assert.match(html, /0 types &middot; 1 API/);
+  assert.match(html, /signal-badge signal-type">T/);
+  assert.match(html, /signal-badge signal-api">&#402;/);
+  assert.match(html, /role="listitem" title="Example.Extensions.Add\(\).*Method.*Extension method"/);
+  assert.equal(JSON.stringify(data), original);
+});
+
+test("generic and parameter suffixes stay on the short name", () => {
+  const html = render({ data: {
+    ...data, totalSignals: 1,
+    categories: [{ integration: "Example", signals: [
+      { name: "Acme.Widget.Make<Acme.Item>(System.String input)", shape: "Method", kind: "Factory" },
+    ] }],
+  } });
+  assert.match(html, /1 category.*1 signal/);
+  assert.match(html, /class="signal-name">Make&lt;Acme.Item&gt;\(System.String input\)<\/span>/);
+  assert.match(html, /class="signal-ns">Acme.Widget<\/span>/);
+});
+
+test("platform selection stays outside the scroller and takes precedence over retained results", () => {
+  const pickerHtml = '<select class="scope-select platform-library-select" data-platform-integrations-library aria-label="Select a platform library"><option>Example.Core</option></select>';
+  const html = render({ requireLibrary: true, pickerHtml, loading: true, error: "earlier failure" });
+  assert.match(html, /library-integrations-with-controls/);
+  assert.match(html, /library-integrations-controls[\s\S]*data-platform-integrations-library[\s\S]*library-integrations-scroll/);
+  assert.match(html, /Pick a library to scan/);
+  assert.match(html, /<footer/);
+  assert.doesNotMatch(html, /role="listitem"|earlier failure|4 signals/);
+});
+
+for (const [name, overrides, expected] of [
+  ["loading", { loading: true, error: "earlier failure" }, /Reading the public surface of Example.Core/],
+  ["query failure", { error: "Scan unavailable." }, /Integration scan failed[\s\S]*Scan unavailable/],
+  ["pending", { data: null }, /Loading/],
+] satisfies Array<[string, Partial<LibraryIntegrationsOptions>, RegExp]>) {
+  test(`${name} retains the frame without exposing retained results or successful absence`, () => {
+    const html = render(overrides);
+    assert.match(html, expected);
+    assert.match(html, /<footer/);
+    assert.doesNotMatch(html, /role="listitem"|4 signals|No ecosystem integrations detected/);
+  });
+}
+
+test("a complete empty scan retains its explicit absence result", () => {
+  const html = render({ data: { ...data, categories: [], totalSignals: 0 } });
+  assert.match(html, /0 categories.*0 signals/);
+  assert.match(html, /No ecosystem integrations detected/);
+  assert.doesNotMatch(html, /metadata-warning|partial/);
+});
+
+test("partial results retain rows and diagnostics without claiming completeness", () => {
+  const html = render({ data: { ...data, isComplete: false, inspectionError: "Cannot read <participant>." } });
+  assert.match(html, /4 signals.*partial/);
+  assert.match(html, /This library could not be scanned completely/);
+  assert.match(html, /Cannot read &lt;participant&gt;/);
+  assert.equal(html.match(/role="listitem"/g)?.length, 4);
+});
+
+test("incomplete zero-row scans do not claim absence, even without diagnostic text", () => {
+  for (const inspectionError of [null, "Participant unavailable."]) {
+    const html = render({ data: { ...data, isComplete: false, inspectionError, categories: [], totalSignals: 0 } });
+    assert.match(html, /Integration scan incomplete/);
+    assert.match(html, /This library could not be scanned completely/);
+    assert.doesNotMatch(html, /No ecosystem integrations detected|shows no known/);
+  }
+});
+
+test("rendered facts, context and errors use the supplied text escape boundary", () => {
+  const html = render({
+    assemblyIdentity: 'Example."Core"', assetPath: "lib/Core&Other.dll",
+    coordinate: "Example<Package>@1", error: "Read <failed>",
+  });
+  assert.match(html, /title="lib\/Core&amp;Other.dll.*Example.&quot;Core&quot;"/);
+  assert.match(html, /Example&lt;Package&gt;/);
+  assert.match(html, /Read &lt;failed&gt;/);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -5357,7 +5357,7 @@ test("library metadata uses compact coordinates in a full-area working surface",
     /const contentNavigationIntegrated =[\s\S]*?\|\| libraryMetadataWorkingSurface[\s\S]*?;/);
   assert.match(
     renderLibrary,
-    /if \(state\.libraryLens === "overview"\s*\|\| state\.libraryLens === "references"\s*\|\| state\.libraryLens === "metadata"\) return body;/);
+    /if \(state\.libraryLens === "overview"\s*\|\| state\.libraryLens === "references"\s*\|\| state\.libraryLens === "integrations"\s*\|\| state\.libraryLens === "metadata"\) return body;/);
   assert.match(
     renderMetadata,
     /data-platform-metadata-library[\s\S]*?requireSelection: true[\s\S]*?controlsHtml:[\s\S]*?package-metadata-controls[\s\S]*?packageCoordinateFields\(\)/);


### PR DESCRIPTION
Give Library Integrations useful full-area space while retaining category evidence, assembly context, and existing scan/navigation behavior.

## Demo

Open `Example.Package` > `Example.Core` > **Integrations**.

**Before:** a large Library hero, repeated ecosystem summary and category chips, and rounded signal cards nested inside the content page.

**After:** a quiet category/signal count header, full-width category sections and signal rows, and bottom assembly/source-coordinate context. At 390px the existing Types return shares the header; names, qualifiers, and kind text wrap within each row.

Before/after screenshots use the actual production composition root with deterministic facade results. They are UI fixture evidence, not a real-package acquisition claim.

### 1440px

| Before | After |
| --- | --- |
| ![Integrations before at 1440px](https://github.com/user-attachments/assets/1ae9bb28-3822-4485-af1a-2300f3064b34) | ![Integrations after at 1440px](https://github.com/user-attachments/assets/1deaec8a-6776-46c6-8468-2c0ac066c5a5) |

### 390px

| Before | After |
| --- | --- |
| ![Integrations before at 390px](https://github.com/user-attachments/assets/2ba7429a-cbf0-40f0-bead-8174e529070d) | ![Integrations after at 390px](https://github.com/user-attachments/assets/c362426c-3534-448e-9409-5c8dd12c98c2) |

**Boundary example:** 81 signals include long category names, Library names, namespaces, signatures, and kind text. The result scroller contains those values while the header/footer remain in place. Platform Library selection remains in its own row above the scroller.

**Failure example:** partial results retain their available rows and diagnostics. An incomplete scan returning no signals says **Integration scan incomplete**, not **No ecosystem integrations detected**. The latter is reserved for a complete empty scan.

**Neighboring scenario:** Library References retains its new full-area frame. Package/Library Overview keeps local names/icons, and the existing Library/Type parent navigation and narrow Types/details focus behavior remain.

## Design basis and scope

Sole normative owner: `docs/design/inspect-web-surface-composition.md#library-integrations`. Claim: quiet count/state header, optional platform selector, one full-area result scroller, and bottom assembly/source-coordinate context.

Library selection and `packageIntegrationsSignature()` retain freshness ownership. The existing `BrowserPackageIntegrations` result supplies ordered categories, signals, counts, and completeness. Type-first/kind/name sorting and name/qualifier splitting move unchanged into the small pure renderer. Content-frame navigation and presentation-language heading rules retain their roles; References and Metadata are the local layout precedents.

The user explicitly approved this browser-only layout. One production adoption step, tracked by #6202, wires Library Integrations to this frame and retires only its generic hero, duplicated noninteractive summary, and inset signal cards. This is HTML placement over the existing typed result, not a new inspection substrate or multi-format architecture.

The incomplete-empty wording and completeness notice are the directly related behavior correction: a failed or partial scan must not make a successful absence claim.

Catalog ownership work (#2033), scan classification, other Library lenses, and subject-strip interaction (#6157/#6158) are outside this change.

## Validation

- `npm run build`.
- `npm run typecheck`.
- `npm run analyze`.
- `node --test test/library-integrations.test.ts test/library-references.test.ts test/package-inspection.test.ts test/spotlight-identity.test.ts` — 231 passed.
- `npx playwright test browser/library-hierarchy.spec.ts --project=firefox --workers=2 --reporter=line` — 50 passed, including 15 Integrations scenarios.
- `npx markdownlint-cli ../../docs/design/inspect-web-surface-composition.md`.

The production browser fixture covers package and platform selection, ready/empty/partial/query-error states, deferred scans across Library switching, long/many results, and 1440px/390px geometry.

Closes #6202.
