### PR TITLE
Restore legacy source-identity inventory after Browser retention changes

### DIFF
--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -107,23 +108,17 @@ internal static class BrowserPackageWorkspace
     {
         Timeout = Timeout.InfiniteTimeSpan,
     };
-    static readonly PackageSourceAssociation GalleryAssociation =
-        PackageSourceAssociation.Create();
     static readonly PackageSourceIdentity GalleryConfiguredIdentity =
         PackageSourceIdentity.NuGetOrg;
-    static readonly IReadOnlyDictionary<
+    static readonly ConcurrentDictionary<
         PackageSourceAssociation,
         PackageSourceIdentity> ConfiguredSourceIdentities =
-        new Dictionary<PackageSourceAssociation, PackageSourceIdentity>(
-            ReferenceEqualityComparer.Instance)
-        {
-            [GalleryAssociation] = GalleryConfiguredIdentity,
-        };
+        new ConcurrentDictionary<PackageSourceAssociation, PackageSourceIdentity>(
+            ReferenceEqualityComparer.Instance);
     static readonly UniformPackageSourceAuthorization SourceAuthorization =
         new([PackageSource.NuGetOrg]);
     internal static readonly IPackageSourceClient Gallery =
-        PackageSourceClientFactory.CreateGallery(
-            GalleryAssociation,
+        CreateGallerySource(
             new NuGetFetchOptions
             {
                 RequestTimeout = GalleryOperationTimeout,
@@ -227,6 +222,18 @@ internal static class BrowserPackageWorkspace
                 cancellationToken),
             PackageOperationTimeout,
             cancellationToken);
+
+    internal static Task<BrowserPackage> AcquireAsync(
+        string packageId,
+        string? version,
+        IPackageSourceClient source,
+        TimeSpan operationTimeout) =>
+        AcquireAsync(
+            packageId,
+            version,
+            source,
+            ConfiguredSourceIdentityFor(source),
+            operationTimeout);
 
     internal static Task<BrowserPackage> AcquireAsync(
         string packageId,
@@ -340,6 +347,48 @@ internal static class BrowserPackageWorkspace
         };
     }
 
+    /// <summary>
+    /// Creates one NuGet Gallery source client and registers its association
+    /// with the configured Browser source identity it acquires against, so
+    /// acquisition callers pass the client alone.
+    /// </summary>
+    internal static IPackageSourceClient CreateGallerySource(
+        NuGetFetchOptions options)
+    {
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        return RegisterGallerySource(
+            association,
+            PackageSourceClientFactory.CreateGallery(association, options));
+    }
+
+    /// <summary>
+    /// Creates one NuGet Gallery source client over a caller-owned,
+    /// credential-free transport and registers its association with the
+    /// configured Browser source identity it acquires against.
+    /// </summary>
+    internal static IPackageSourceClient CreateGallerySource(
+        HttpMessageHandler ownedCredentialFreeTransport,
+        NuGetFetchOptions options)
+    {
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        return RegisterGallerySource(
+            association,
+            PackageSourceClientFactory.CreateGallery(
+                association,
+                ownedCredentialFreeTransport,
+                options));
+    }
+
+    static IPackageSourceClient RegisterGallerySource(
+        PackageSourceAssociation association,
+        IPackageSourceClient source)
+    {
+        ConfiguredSourceIdentities[association] = GalleryConfiguredIdentity;
+        return source;
+    }
+
     static PackageSourceIdentity ConfiguredSourceIdentityFor(
         IPackageSourceClient source)
     {
@@ -373,6 +422,20 @@ internal static class BrowserPackageWorkspace
             package,
             package.CreateRootBinding(targetFramework));
     }
+
+    internal static Task<BrowserPackageCoordinate> ResolveAsync(
+        string packageId,
+        string? version,
+        string? targetFramework,
+        IPackageSourceClient source,
+        TimeSpan operationTimeout) =>
+        ResolveAsync(
+            packageId,
+            version,
+            targetFramework,
+            source,
+            ConfiguredSourceIdentityFor(source),
+            operationTimeout);
 
     internal static async Task<BrowserPackageCoordinate> ResolveAsync(
         string packageId,

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -6525,7 +6525,6 @@ public sealed class BrowserEngineBoundaryTests
                 packageId,
                 "1.0.0",
                 client,
-                PackageSourceIdentity.NuGetOrg,
                 TimeSpan.FromSeconds(5));
     }
 
@@ -6569,7 +6568,6 @@ public sealed class BrowserEngineBoundaryTests
                 packageId,
                 "1.0.0",
                 client,
-                PackageSourceIdentity.NuGetOrg,
                 TimeSpan.FromSeconds(5));
     }
 
@@ -6586,12 +6584,12 @@ public sealed class BrowserEngineBoundaryTests
         Assert.Equal(firstSource.Source.Producer, secondSource.Source.Producer);
 
         BrowserPackage first = await BrowserPackageWorkspace.AcquireAsync(
-            packageId, "1.0.0", firstSource, PackageSourceIdentity.NuGetOrg,
+            packageId, "1.0.0", firstSource,
             TimeSpan.FromSeconds(5));
         IPackageContent second = await QueryContent(secondSource);
         IPackageContent firstAgain = await QueryContent(firstSource);
         BrowserPackage secondAgain = await BrowserPackageWorkspace.AcquireAsync(
-            packageId, "1.0.0", secondSource, PackageSourceIdentity.NuGetOrg,
+            packageId, "1.0.0", secondSource,
             TimeSpan.FromSeconds(5));
 
         Assert.False(second.FromCache);
@@ -6621,7 +6619,7 @@ public sealed class BrowserEngineBoundaryTests
                     TestContext.Current.CancellationToken);
             return Assert.IsType<PackageQueryContentResult.Available>(
                 await BrowserPackageWorkspace.AcquirePackageQueryContentAsync(
-                    package, source, PackageSourceIdentity.NuGetOrg, deadline)).Content;
+                    package, source, deadline)).Content;
         }
     }
 
@@ -6721,7 +6719,7 @@ public sealed class BrowserEngineBoundaryTests
 
         Task<BrowserPackage> Acquire(IPackageSourceClient source) =>
             BrowserPackageWorkspace.AcquireAsync(
-                packageId, "1.0.0", source, PackageSourceIdentity.NuGetOrg,
+                packageId, "1.0.0", source,
                 TimeSpan.FromSeconds(30));
     }
 
@@ -6764,7 +6762,7 @@ public sealed class BrowserEngineBoundaryTests
             BrowserPackageWorkspace.LeaseRetainedPackageScope(
                 packageId, "1.0.0", first.Framework));
         BrowserPackage firstCached = await BrowserPackageWorkspace.AcquireAsync(
-            packageId, "1.0.0", firstSource, PackageSourceIdentity.NuGetOrg,
+            packageId, "1.0.0", firstSource,
             TimeSpan.FromSeconds(5));
         Assert.True(firstCached.Content.FromCache);
         Assert.Same(first.Package.Content.GenerationIdentity, firstCached.Content.GenerationIdentity);
@@ -6801,7 +6799,7 @@ public sealed class BrowserEngineBoundaryTests
 
         Task<BrowserPackageCoordinate> Resolve(IPackageSourceClient source) =>
             BrowserPackageWorkspace.ResolveAsync(
-                packageId, "1.0.0", "net11.0", source, PackageSourceIdentity.NuGetOrg,
+                packageId, "1.0.0", "net11.0", source,
                 TimeSpan.FromSeconds(5));
     }
 
@@ -8471,8 +8469,7 @@ public sealed class BrowserEngineBoundaryTests
          """;
 
     static IPackageSourceClient Gallery(HttpMessageHandler handler) =>
-        PackageSourceClientFactory.CreateGallery(
-            PackageSourceAssociation.Create(),
+        BrowserPackageWorkspace.CreateGallerySource(
             handler,
             new NuGetFetchOptions
             {


### PR DESCRIPTION
Restores the no-new-legacy-reader contract that the Browser retention changes
in #6132 broke, without weakening the migration rule or moving an expected
count. Fixes #6206.

## Demo

The enrolled inventory gate, at `origin/main` before this change:

```console
$ dotnet run --project tests/NuGetFetch.Tests -c Release -- \
    --filter-method '*LegacyPackageSourceIdentitySurfaceMatchesMigrationSet'
failed NuGetFetch.Tests.LegacyPackageSourceIdentityMigrationTests.LegacyPackageSourceIdentitySurfaceMatchesMigrationSet (47s 908ms)
  Legacy package-source identity migration inventory mismatch: unlisted [];
  stale []; reference drift
  [prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
   expected 20 explicit/0 implicit for #4805, observed 28 explicit/0 implicit].
```

The same gate at this head:

```console
$ dotnet run --project tests/NuGetFetch.Tests -c Release -- --filter-method '*Legacy*'
Test run summary: Passed!
  total: 10  failed: 0  succeeded: 10  skipped: 0
```

The neighbouring case — a Browser acquisition against a caller-created Gallery
client — reads as the client alone, with the workspace resolving its configured
source identity:

```csharp
using IPackageSourceClient source = Gallery(handler);

BrowserPackage package = await BrowserPackageWorkspace.AcquireAsync(
    packageId, "1.0.0", source, TimeSpan.FromSeconds(5));
```

## Claim

`BrowserPackageWorkspace` owns construction of the Gallery sources it acquires
against, and registers each association with the configured Browser source
identity for that source. Acquisition, resolution, and package-query content
therefore take the source client alone.

The retention coverage in #6132 used clients built directly through
`PackageSourceClientFactory.CreateGallery`. Those associations were never
registered, so `ConfiguredSourceIdentityFor` could not answer for
them and each new call site had to pass `PackageSourceIdentity.NuGetOrg` in —
eight new legacy readers in one enrolled file, taking it from 20 to 28.

The registry, its reference-equality keying, and the throw for an unregistered
association are unchanged from #4805; only the entry point that populates it is
new. Registration reuses the existing `GalleryConfiguredIdentity` field, so it
introduces no legacy reader of its own.

## Non-action boundary

- The `#4805` migration rule is untouched: no expected count moves in
  `LegacyPackageSourceIdentityMigrationTests.cs`, in either direction.
- The 20 references enrolled for `BrowserEngineBoundaryTests.cs` and the 12 for
  `BrowserPackageWorkspace.cs` are unchanged. Retiring the remaining enrolled
  readers is #4805's staged migration, not this correction; the identity-free
  overloads are the path they will take.
- Retention and association behaviour is unchanged. Every gate named in
  `docs/design/browser-package-sources.md`, "Browser retained-acquisition
  association", keeps its name and its assertions.
- The design document is unchanged: the association-to-identity registry is a
  Browser host implementation detail that the document does not specify.
- Separate from #6185's committed-Root query-access change.

## Validation

| Gate | Result |
| --- | --- |
| `dotnet run --project tests/NuGetFetch.Tests -c Release -- --filter-method '*Legacy*'` | Passed, 10/10 |
| `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` | Passed, 378/378 |
| `dotnet run --project tests/NuGetFetch.Tests -c Release` | Passed, 1055/1066 (11 skipped) |

Release configuration, macOS arm64, .NET 11.0.0-preview.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jVMrMfwFPU2eiG82YYa8Y
