### PR TITLE
Move adversarial review to one seat, GPT-6 Astra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ development model and rationale. The binding summary:
 - **Use the Markdown fast path.** For Markdown-only PRs at non-boundary rounds,
   `markdownlint` replaces `ci-required` as the pre-review and per-round gate.
 - **Use bounded adversarial review to find design and implementation gaps.**
-  Every non-trivial change gets two seats; repeated findings are evidence to
-  revisit design, and six rounds ends the current review block.
+  Every non-trivial change gets one seat, GPT-6 Astra; repeated findings are
+  evidence to revisit design, and six rounds ends the current review block.
 - **Keep security work inside the repository threat model.** Focus on
   untrusted internet-origin data and construction-time containment, not local
   or intra-repository actors unless an owning design explicitly opts in.
@@ -487,10 +487,10 @@ as a normal round), and **merge conflict requiring semantic resolution**
 | Tier | Requirement |
 | --- | --- |
 | Trivial | No review. State why the change is trivial. |
-| Everything else | **GPT-6 Astra**, always, plus one other roster reviewer (Claude Opus or Gemini Pro). |
+| Everything else | **GPT-6 Astra**, one seat. |
 
-When uncertain, use the standard round. Second-seat selection by prior clean
-count lives in
+When uncertain, use the standard round. Substitution when GPT-6 Astra is
+unavailable lives in
 [Reviewer roster](docs/round-orchestration.md#reviewer-roster); dispatch IDs live
 in [Agent model mapping](docs/agent-models.md). A MAI-Code
 quick read on unsettled work is neither tier: it gets no isolated worktree or
@@ -501,8 +501,8 @@ feedback, since the settled PR still requires its full round.
 
 Start every reviewer prompt with the complete canonical
 [adversarial-review prompt](docs/adversarial-review-prompt.md); do not omit,
-paraphrase, reorder, or precede it with domain instructions. Append the same
-self-contained candidate instructions for every seat, directly or with the
+paraphrase, reorder, or precede it with domain instructions. Append the
+self-contained candidate instructions for the seat, directly or with the
 optional [fill-in template](docs/templates/adversarial-review-prompt.md). Follow
 [running a round](docs/round-orchestration.md#running-a-round) for mechanics
 and reporting.

--- a/docs/agent-models.md
+++ b/docs/agent-models.md
@@ -3,7 +3,8 @@
 This file maps names in current contributor guidance to dispatch model IDs.
 [AGENTS.md](../AGENTS.md#how-many-reviewers-and-from-which-models) owns review
 requirements; [Reviewer roster](round-orchestration.md#reviewer-roster) owns
-seat selection and substitutions. This mapping does not change either policy.
+the single review seat and its substitutions. This mapping does not change
+either policy.
 
 ## Model names and IDs
 
@@ -18,8 +19,10 @@ availability in another session or agent host.
 | MAI-Code | MAI-Code 1.1 Flash | `mai-code-1.1-flash` |
 | Gemini Pro | Resolve an available Pro model | Not pinned; use the runtime-advertised Pro ID. |
 
-GPT-6 Astra replaces GPT-5.6 Sol in current guidance. Historical review
-attributions keep their original model names.
+GPT-6 Astra holds the sole review seat and replaces GPT-5.6 Sol in current
+guidance. Claude Opus and Gemini Pro remain mapped as substitutes when GPT-6
+Astra is unavailable; MAI-Code is the quick-read model, which fills no review
+seat. Historical review attributions keep their original model names.
 
 ## Resolving a dispatch
 

--- a/docs/agent-session-state.md
+++ b/docs/agent-session-state.md
@@ -131,7 +131,7 @@ Update both window-scoped options whenever state changes:
 tmux set -w -t "${TMUX_PANE:?}" @agent \
   "theme agent-session-clarity; round 6 on PR 4405, waiting on CI"
 tmux set -w -t "${TMUX_PANE:?}" @agent_state \
-  "theme=agent-session-clarity pr=4405 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
+  "theme=agent-session-clarity pr=4405 head=595e5d4b round=6 reviews=0/1 blocked=4597,4611 rec=wait"
 
 # Clear when this window no longer owns the PR.
 tmux set -w -t "${TMUX_PANE:?}" -u @agent

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -276,7 +276,7 @@ accumulate patches indefinitely.
 Requested work hot-starts through branch, commit, push, PR, and eligible review
 without separate approval. Markdown-only changes use `markdownlint` as their
 non-boundary pre-review and per-round gate. Every non-trivial change receives
-two-seat adversarial review, and review blocks stop after six rounds so an
+one-seat adversarial review, and review blocks stop after six rounds so an
 unclosed design becomes an explicit decision rather than an endless loop.
 
 The exact candidate, eligibility, reconciliation, status, and recovery rules

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -286,20 +286,16 @@ snapshot satisfies the prerequisite. The duration context comes from
 ### Reviewer roster
 
 [How many reviewers, and from which models](../AGENTS.md#how-many-reviewers-and-from-which-models)
-states the binding tier table and roster names. Pick the second seat from the
-prior round's clean count, using [Agent model mapping](agent-models.md) to
-resolve names to dispatch IDs:
+states the binding tier table and roster name. Review is one seat, GPT-6 Astra,
+for every non-trivial change; there is no second seat and no clean-count-based
+selection. Use [Agent model mapping](agent-models.md) to resolve the name to a
+dispatch ID.
 
-- **No prior round, or 0/2 clean:** prefer GPT-6 Astra again for the second
-  seat.
-- **1/2 clean:** keep GPT-6 Astra fixed, rule out last round's second seat,
-  then prefer a different family than the author (the author's family only as
-  a fallback) at that model's highest available quality.
-
-Record the choice and its reasoning on the PR. If a roster model is
-unavailable, substitute another model for that seat, report the substitution
-on the PR, and proceed without approval — a substituted seat still counts as
-filled. One round evaluates one settled head with all required reviewers.
+If GPT-6 Astra is unavailable, substitute another model at its highest
+available quality, preferring a different family than the author, report the
+substitution and its reasoning on the PR, and proceed without approval — a
+substituted seat still counts as filled. One round evaluates one settled head
+with its required reviewer.
 
 ### Dispatch
 
@@ -351,9 +347,9 @@ changed surfaces, and exact-head diff. If required fields cannot be filled or
 non-applicability cannot be established, return to design or scope
 clarification before spending a review round.
 
-Give every seat the same completed prompt except for its worktree path. State
-candidate facts rather than rewarding findings; the canonical prompt already
-makes reporting CLEAN an explicit successful outcome.
+Give the seat the completed prompt and its worktree path. State candidate
+facts rather than rewarding findings; the canonical prompt already makes
+reporting CLEAN an explicit successful outcome.
 
 Isolate every reviewer in a separate linked review worktree under the primary
 checkout's `.worktrees/` directory or an operating-system temporary directory;
@@ -374,18 +370,10 @@ brief. An exploit-tutorial-style prompt can trip a model's content filter, and
 response with a clean worktree, which is indistinguishable from a broken model
 or a stalled harness.
 
-This has happened here, and it cost most of a day. A seat returned empty
-several times across two heads and was nearly reported to the user as a
-non-functional model in need of repinning. A reviewer from a different family
-then failed with an explicit message naming content filtering as the cause,
-which is the only reason the real explanation surfaced at all. The prompt had
-been written as a catalog of concrete strings to try against a gate that rejects
-markup able to run unreviewed code. Rewording it -- same surfaces, same required
-evidence, same rigor -- produced full reports from both seats on the first
-attempt.
-
-The reviewer was refusing the prompt, not the work. Keep prompts in terms of the
-property:
+This has happened here and cost most of a day, so treat it as a live hazard
+rather than a theoretical one. The reviewer is refusing the prompt, not the
+work, and rewording it costs no surfaces, no required evidence, and no rigor.
+Keep prompts in terms of the property:
 
 - **Say what the property actually is.** If the gate enforces static-analysis
   coverage, say that, and say the concern is unreviewed code rather than
@@ -442,7 +430,7 @@ prompt:
 ```text
 Round <n> is complete for PR <number>.
 - Theme: <one-sentence session theme>.
-- Review models <model-a> and <model-b> were used for adversarial review.
+- Review model <model> was used for adversarial review.
 - Design basis: normative owner <path#section> — <owned claim>; supporting
   <path and role for each model, adjacent contract, constraint, or consumer>.
 - Review feedback is: [converging, diverging, neutral, clean].
@@ -470,7 +458,7 @@ Classification must match the reviewer outcomes:
   `neutral`, even when every finding was dismissed and the head stayed
   unchanged. Explain dismissals in the public reconciliation.
 
-`Reviews` records the dual-clean count that GitHub cannot observe. Every
+`Reviews` records the clean count that GitHub cannot observe. Every
 `Blocked` entry must be an existing PR or issue; file one before citing a new
 shared failure. `Waiting` records one or more comma-separated predicates tooling
 can evaluate, such as `check:<name>`, `checks`, `merge`, or `review`; it is not
@@ -629,7 +617,7 @@ Before requesting another block, answer:
    findings retired, and confidence gained. Separate durable progress from
    churn.
 2. **Are reviews converging?** Cite clean counts and repeated versus new finding
-   categories. State why dual-clean is or is not likely in the next block.
+   categories. State why a clean round is or is not likely in the next block.
 3. **Are the foundations sound?** Classify remaining findings as architectural,
    coverage gaps, contract expansion, or harness-only concerns.
 4. **Should implementation pause for a docs-only design PR?** Recommend it when


### PR DESCRIPTION
Adversarial review moves from two seats to one: **GPT-6 Astra**, for every
non-trivial change. There is no second seat and no clean-count-based selection
ladder. Claude Opus and Gemini Pro stay mapped as substitutes for when GPT-6
Astra is unavailable; MAI-Code remains the quick-read model that fills no seat
and satisfies no tier.

## Demo

Documentation-only change, so the demo is the guidance an agent actually reads
at dispatch time and the report it emits afterward.

**Before** — the tier table sent the agent into a two-step selection ladder:

```text
| Everything else | GPT-6 Astra, always, plus one other roster reviewer (Claude Opus or Gemini Pro). |

- No prior round, or 0/2 clean: prefer GPT-6 Astra again for the second seat.
- 1/2 clean: keep GPT-6 Astra fixed, rule out last round's second seat, then
  prefer a different family than the author (the author's family only as a
  fallback) at that model's highest available quality.
```

**After** — one seat, and the only remaining choice is substitution:

```text
| Everything else | GPT-6 Astra, one seat. |

Review is one seat, GPT-6 Astra, for every non-trivial change; there is no
second seat and no clean-count-based selection.

If GPT-6 Astra is unavailable, substitute another model at its highest
available quality, preferring a different family than the author, report the
substitution and its reasoning on the PR, and proceed without approval.
```

**Neighboring case — the round report an agent emits.** The template no longer
asks for a model it will not have, and the clean count generalizes:

```text
- Review model gpt-6-astra was used for adversarial review.
...
Reviews: 1/1 clean — gpt-6-astra: CLEAN at <head>
```

What to notice: `Reviews: <clean>/<required>` keeps its fraction rather than
collapsing to a clean/not-clean word, because the surrounding recovery and
classification text keys off "every required reviewer" and stays correct when
the required count is one. A substituted seat still counts as filled, so the
denominator is the seat count, not a GPT-6 Astra count.

## Changes

- **`AGENTS.md`** — binding summary bullet, the tier table row, and the pointer
  that used to lead to second-seat selection now leads to substitution.
- **`docs/round-orchestration.md`** — Reviewer roster rewritten; dispatch
  wording, the round-report model line, the `Reviews` gloss (clean count, not
  dual-clean), and block-approval checkpoint question 2 follow.
- **`docs/agent-models.md`** — table unchanged; a note records that GPT-6 Astra
  holds the sole seat and what the other mappings are now for.
- **`docs/development-practices.md`** — "two-seat" to "one-seat".
- **`docs/agent-session-state.md`** — `@agent_state` example reads `reviews=0/1`.

Also condenses the prompt-wording incident in "Wording the prompt" from a
nine-line narrative to the two facts an agent needs: the hazard is real and
cost most of a day, and the reviewer refuses the prompt rather than the work.
Every operative rule under it — the four wording rules, the write-up
discipline, the empty-response diagnostic, and "do not propose repinning on
empty-response evidence alone" — is unchanged.

## Non-action boundary

Historical review attributions keep their original form, per the standing rule
in `docs/agent-models.md`. Round records under `docs/design/` that name two
seats or two models are records of what happened and are not rewritten; the one
remaining in-repo mention outside those records is the roster line that
explicitly negates a second seat.

This changes seat count and selection only. Round eligibility, the six-round
block, review-clean semantics, recovery transitions, reconciliation, and the
canonical adversarial-review prompt itself are untouched.

## Validation

- `npx markdownlint-cli AGENTS.md docs/agent-models.md docs/agent-session-state.md docs/development-practices.md docs/round-orchestration.md` — exit 0, no output.
- `grep` sweep for `two seats`, `two-seat`, `second seat`, `dual-clean`, `0/2 clean`, `1/2 clean`, `model-a`, `Claude Opus or Gemini Pro` across non-`docs/design/` Markdown returns only the roster line that negates a second seat.

Markdown-only PR: `markdownlint` is the pre-review and per-round gate under the
Markdown fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff7gEjjJMvCFzbSyM9eWJA
