### PR TITLE
Run repository-wide guards for every pre-merge candidate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,14 @@ jobs:
           dotnet-version: '11.0.x'
           dotnet-quality: 'preview'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Run repository line-ending guard
         run: >
           dotnet run --project src/dotnet-inspect.Tests -c Release --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           fi
           jq -e '
             type == "object"
-            and .schemaVersion == 2
+            and .schemaVersion == 3
             and .status == "planned"
           ' <<< "$plan" > /dev/null
           printf 'plan=%s\n' "$plan" >> "$GITHUB_OUTPUT"
@@ -522,6 +522,35 @@ jobs:
       - name: Run embedded skill tests
         shell: bash
         run: dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class "DotnetInspector.Tests.SkillCommandTests"
+
+  # These tests inspect repository paths outside their owning projects. Run
+  # them for every pre-merge candidate so their selection is never narrower
+  # than the repository surface they validate.
+  repository-guards:
+    needs: changes
+    if: fromJSON(needs.changes.outputs.plan).validations.repositoryGuards
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Run repository line-ending guard
+        run: >
+          dotnet run --project src/dotnet-inspect.Tests -c Release --
+          --filter-class "DotnetInspector.Tests.RepositoryLineEndingTests"
+          --minimum-expected-tests 2
+
+      - name: Run legacy source-identity guard
+        run: >
+          dotnet run --project tests/NuGetFetch.Tests -c Release --
+          --filter-method "*LegacyPackageSourceIdentitySurfaceMatchesMigrationSet"
+          --minimum-expected-tests 1
 
   # Build and run the PR test matrix on Ubuntu 24.04. Windows, macOS, and Ubuntu
   # 26.04 compatibility suites run daily in Deep Inspect, where
@@ -1576,13 +1605,15 @@ jobs:
       - markdownlint
       - inspect-web
       - skill-gate
+      - repository-guards
       - test
       - dependency-policy
       - tla-plus
       # Path-gated jobs report `skipped` when their input class is absent; all
       # expensive jobs except inspect-web and dependency-policy skip on pushes
-      # to main. That passes the gate by design; the allow list below distinguishes
-      # "correctly not run" from "ran and failed".
+      # to main. The focused repository-guards job also skips on pushes. That
+      # passes the gate by design; the allow list below distinguishes "correctly
+      # not run" from "ran and failed".
       - build-net10
       - decompiler-gates
       - csharp-diff-smoke

--- a/docs/design/ci-change-plan.md
+++ b/docs/design/ci-change-plan.md
@@ -194,6 +194,16 @@ focused consumer rebuilds and checks the composed Release graph after merge;
 pull-request and merge-group candidates instead run the same policy inside
 their selected pre-merge test job.
 
+A validation's selection set must cover its entire scan set. A repository-wide
+scan therefore selects every pre-merge candidate rather than deriving
+relevance from narrower project ownership. Accordingly, every pull-request and
+merge-group candidate selects `repositoryGuards` independently of changed
+paths. Its focused consumer runs tests whose asserted surfaces are wider than
+their owning projects: the tracked repository tree for line endings and every
+non-excluded top-level source root for legacy package-source identity. This
+does not broaden the ordinary `test` lane for documentation-only or
+inspect-web-only candidates.
+
 Two conservative inventory policies are current and named. When
 `eng/inspect-web-gate-projects.txt` is missing or malformed, every `src`
 change broadens to the Browser/Wasm lane. When
@@ -290,7 +300,7 @@ Conceptually:
 
 ```json
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "status": "planned",
   "provenance": {
     "kind": "pullRequestSyntheticCandidate",
@@ -303,6 +313,7 @@ Conceptually:
   },
   "validations": {
     "test": true,
+    "repositoryGuards": true,
     "dependencyPolicy": false,
     "markdownlint": false,
     "ilRoundtrip": true,
@@ -326,13 +337,14 @@ Path corpora and refusal diagnostics remain outside the plan.
 Concretely, the serialized plan is one compact UTF-8 JSON object containing
 only printable ASCII, with deterministic property order, lower camel member
 names, no newline, and lowercase digests. Its `validations` member always
-carries every field — `test`, `dependencyPolicy`, `csharpDiffSmoke`,
-`decompilerGates`, `markdownlint`, `ilDiffSmoke`, `ilRoundTrip`, `pack`,
-`buildNet10`, `inspectWeb`, `skillGate`, `tla`, `codeqlActions`,
-`codeqlCSharp`, and `codeqlJavaScript` — so a consumer never distinguishes
-"false" from "absent". `ilRoundTrip` implies `test` as a construction
-invariant. A scope descriptor names its artifact, record framing, record
-count, and digest; the TLA+ artifact is `ci-plan-tla-paths0`. The plan
+carries every field — `test`, `repositoryGuards`, `dependencyPolicy`,
+`csharpDiffSmoke`, `decompilerGates`, `markdownlint`, `ilDiffSmoke`,
+`ilRoundTrip`, `pack`, `buildNet10`, `inspectWeb`, `skillGate`, `tla`,
+`codeqlActions`, `codeqlCSharp`, and `codeqlJavaScript` — so a consumer never
+distinguishes "false" from "absent". `ilRoundTrip` implies `test` as a
+construction invariant. A scope descriptor names its artifact, record
+framing, record count, and digest; the TLA+ artifact is
+`ci-plan-tla-paths0`. The plan
 publisher writes scoped evidence and then the single plan line only after the
 serialized bytes have been re-parsed and revalidated by the strict plan
 reader, so a plan a consumer would reject never reaches one.
@@ -467,8 +479,8 @@ The planner implementation gate must also cover:
   candidate endpoints;
 - the deliberate failure-contract change from all-true recovery to a blocking
   refusal; and
-- a neighboring docs-only candidate that selects documentation validation
-  without unrelated content gates.
+- a neighboring docs-only candidate that selects documentation validation and
+  repository-wide guards without ordinary content gates.
 
 Workflow-adoption evidence separately demonstrates that GitHub accepts the
 workflow, the non-matrix producer publishes exactly one compact plan, and
@@ -477,12 +489,14 @@ event or path policy. Review checks the fail-closed publication boundary,
 execution-local conditions such as matrix placement, and aggregate handling of
 a planner job that fails, is skipped, is cancelled, or never starts.
 
-The repository intentionally does not parse workflow YAML to pin the projection
-text or reimplement GitHub expression semantics. The actual PR workflow run and
-adversarial review are the wiring evidence, while planner values and aggregate
-result safety remain persistently gated. Consequently, the absence of
-arbitrary future duplicate routing expressions is specified and review-owned,
-not claimed as a persistently enforced repository invariant.
+The workflow contract parses YAML to pin consumers to their intended
+`validations.*` projections and reject independently routed consumer steps. It
+does not reimplement GitHub expression semantics. The actual PR workflow run
+and adversarial review are the execution evidence, while planner values and
+aggregate result safety remain persistently gated. Consequently, the absence
+of arbitrary future duplicate routing expressions outside covered consumers
+is specified and review-owned, not claimed as a persistently enforced
+repository invariant.
 
 The demo is one planner invocation for the #5347 rename-into-model fixture. Its
 plan selects TLA+, and the TLA+ job verifies and consumes the planner-assigned

--- a/eng/CiChangeDetection/Planning/ChangePlan.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlan.cs
@@ -163,7 +163,7 @@ internal sealed class ChangePlan
     /// <summary>
     /// The only schema version this repository produces or consumes.
     /// </summary>
-    internal const int CurrentSchemaVersion = 2;
+    internal const int CurrentSchemaVersion = 3;
 
     /// <summary>
     /// The only status valid in a serialized plan.

--- a/eng/CiChangeDetection/Planning/ChangePlanSerializer.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlanSerializer.cs
@@ -14,6 +14,7 @@ internal static class ChangePlanSerializer
     private static readonly string[] ValidationNames =
     [
         "test",
+        "repositoryGuards",
         "dependencyPolicy",
         "csharpDiffSmoke",
         "decompilerGates",
@@ -246,7 +247,8 @@ internal static class ChangePlanSerializer
                 values[11],
                 values[12],
                 values[13],
-                values[14]);
+                values[14],
+                values[15]);
 
             JsonElement scopesElement =
                 RequireObject(root.GetProperty("scopes"), "scopes");
@@ -311,6 +313,7 @@ internal static class ChangePlanSerializer
     private static bool[] ValidationValues(ValidationSelections validations) =>
     [
         validations.Test,
+        validations.RepositoryGuards,
         validations.DependencyPolicy,
         validations.CSharpDiffSmoke,
         validations.DecompilerGates,

--- a/eng/CiChangeDetection/Planning/ChangePlanTestSuite.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlanTestSuite.cs
@@ -377,6 +377,7 @@ internal static class ChangePlanTestSuite
             ValidationSelections selections =
                 ValidationSelections.FromRouting(all, kind);
             if (!(selections.Test
+                && selections.RepositoryGuards
                 && !selections.DependencyPolicy
                 && selections.CSharpDiffSmoke
                 && selections.DecompilerGates
@@ -398,6 +399,7 @@ internal static class ChangePlanTestSuite
         ValidationSelections pushed =
             ValidationSelections.FromRouting(all, PlanEventKind.Push);
         if (pushed.Test
+            || pushed.RepositoryGuards
             || !pushed.DependencyPolicy
             || pushed.CSharpDiffSmoke
             || pushed.DecompilerGates
@@ -418,11 +420,12 @@ internal static class ChangePlanTestSuite
         }
 
         // A neighbouring documentation-only candidate selects documentation
-        // validation and no content gate.
+        // validation and the repository-wide guards, but no content gate.
         ValidationSelections docsOnly = ValidationSelections.FromRouting(
             policy.Route(Evidence("docs/design/ci-change-plan.md")),
             PlanEventKind.PullRequestSyntheticCandidate);
         if (!docsOnly.Markdownlint
+            || !docsOnly.RepositoryGuards
             || docsOnly.Test
             || docsOnly.DecompilerGates
             || docsOnly.InspectWeb
@@ -430,6 +433,17 @@ internal static class ChangePlanTestSuite
         {
             throw new InvalidOperationException(
                 "A documentation-only candidate selected a content gate.");
+        }
+
+        ValidationSelections emptyPreMerge =
+            ValidationSelections.FromRouting(
+                policy.Route(ChangeEvidence.Create([])),
+                PlanEventKind.MergeGroup);
+        if (!emptyPreMerge.RepositoryGuards || emptyPreMerge.Test)
+        {
+            throw new InvalidOperationException(
+                "An empty pre-merge candidate did not select only the "
+                + "repository-wide guards.");
         }
     }
 
@@ -465,6 +479,7 @@ internal static class ChangePlanTestSuite
             PlanRefusalCategory.PlanSerialization,
             () => new ValidationSelections(
                 test: false,
+                repositoryGuards: false,
                 dependencyPolicy: false,
                 cSharpDiffSmoke: false,
                 decompilerGates: false,
@@ -576,7 +591,7 @@ internal static class ChangePlanTestSuite
             policy);
 
         const string Golden =
-            "{\"schemaVersion\":2,\"status\":\"planned\",\"provenance\":"
+            "{\"schemaVersion\":3,\"status\":\"planned\",\"provenance\":"
             + "{\"kind\":\"pullRequestSyntheticCandidate\",\"baseObjectId\":"
             + "\"1111111111111111111111111111111111111111\","
             + "\"candidateObjectId\":"
@@ -584,6 +599,7 @@ internal static class ChangePlanTestSuite
             + "{\"recordCount\":2,\"sha256\":"
             + "\"e2942177c268e91967eeb66ed6c48b8e8e426158f30a8f3371de8322"
             + "439a2a05\"},\"validations\":{\"test\":false,"
+            + "\"repositoryGuards\":true,"
             + "\"dependencyPolicy\":false,"
             + "\"csharpDiffSmoke\":false,\"decompilerGates\":false,"
             + "\"markdownlint\":true,\"ilDiffSmoke\":false,"
@@ -686,12 +702,12 @@ internal static class ChangePlanTestSuite
                     "\"status\": \"planned\"")),
             ("non-canonical property order",
                 text.Replace(
-                    "{\"schemaVersion\":2,\"status\":\"planned\"",
-                    "{\"status\":\"planned\",\"schemaVersion\":2")),
+                    "{\"schemaVersion\":3,\"status\":\"planned\"",
+                    "{\"status\":\"planned\",\"schemaVersion\":3")),
             ("escaped member name",
                 text.Replace("schemaVersion", "schema\\u0056ersion")),
             ("non-canonical number",
-                text.Replace("\"schemaVersion\":2", "\"schemaVersion\":2e0")),
+                text.Replace("\"schemaVersion\":3", "\"schemaVersion\":3e0")),
             ("control character", $"\n{text}"),
             ("truncated document", text[..^1]),
             ("unknown member",
@@ -699,13 +715,13 @@ internal static class ChangePlanTestSuite
             ("missing member", text.Replace(",\"diagnostics\":[]", "")),
             ("duplicate member",
                 text.Replace(
-                    "\"schemaVersion\":2",
-                    "\"schemaVersion\":2,\"schemaVersion\":2")),
+                    "\"schemaVersion\":3",
+                    "\"schemaVersion\":3,\"schemaVersion\":3")),
             ("mistyped boolean", text.Replace("\"test\":false", "\"test\":0")),
             ("mistyped count",
                 text.Replace("\"recordCount\":1", "\"recordCount\":\"1\"")),
             ("unsupported version",
-                text.Replace("\"schemaVersion\":2", "\"schemaVersion\":3")),
+                text.Replace("\"schemaVersion\":3", "\"schemaVersion\":4")),
             ("unsupported status",
                 text.Replace("\"planned\"", "\"refused\"")),
             ("invalid digest",

--- a/eng/CiChangeDetection/Planning/ValidationSelections.cs
+++ b/eng/CiChangeDetection/Planning/ValidationSelections.cs
@@ -37,6 +37,7 @@ internal sealed class ValidationSelections
 {
     internal ValidationSelections(
         bool test,
+        bool repositoryGuards,
         bool dependencyPolicy,
         bool cSharpDiffSmoke,
         bool decompilerGates,
@@ -60,6 +61,7 @@ internal sealed class ValidationSelections
         }
 
         Test = test;
+        RepositoryGuards = repositoryGuards;
         DependencyPolicy = dependencyPolicy;
         CSharpDiffSmoke = cSharpDiffSmoke;
         DecompilerGates = decompilerGates;
@@ -77,6 +79,8 @@ internal sealed class ValidationSelections
     }
 
     internal bool Test { get; }
+
+    internal bool RepositoryGuards { get; }
 
     internal bool DependencyPolicy { get; }
 
@@ -118,10 +122,13 @@ internal sealed class ValidationSelections
     internal bool CodeqlJavaScript { get; }
 
     /// <summary>
-    /// Applies the repository's event rules to raw routing selections. A push
-    /// runs the focused dependency-policy composition gate rather than the
-    /// pre-merge test matrix; documentation lint, the Browser/Wasm lane, the
-    /// TLA+ lane, and the CodeQL lanes have no event gate. CodeQL keeps
+    /// Applies the repository's event rules to raw routing selections. Every
+    /// pre-merge candidate runs the focused repository guards because their
+    /// tests scan the repository beyond ordinary path ownership. A push runs
+    /// the focused dependency-policy composition gate rather than the
+    /// pre-merge test matrix or repository guards; documentation lint, the
+    /// Browser/Wasm lane, the TLA+ lane, and the CodeQL lanes have no event
+    /// gate. CodeQL keeps
     /// running on a push because code scanning alerts are reported against
     /// the default branch: gating it on the pre-merge event would leave that
     /// baseline frozen at whatever last ran before the merge.
@@ -136,6 +143,7 @@ internal sealed class ValidationSelections
         bool preMerge = kind != PlanEventKind.Push;
         return new ValidationSelections(
             test: selections.Code && preMerge,
+            repositoryGuards: preMerge,
             dependencyPolicy: kind == PlanEventKind.Push,
             cSharpDiffSmoke: selections.CSharpDiff && preMerge,
             decompilerGates: selections.Decompiler && preMerge,

--- a/eng/CiChangeDetection/WorkflowContract.Consumers.cs
+++ b/eng/CiChangeDetection/WorkflowContract.Consumers.cs
@@ -11,6 +11,7 @@ internal static partial class WorkflowContract
         [
             "markdownlint",
             "skill-gate",
+            "repository-guards",
             "test",
             "dependency-policy",
             "build-net10",
@@ -36,8 +37,120 @@ internal static partial class WorkflowContract
         }
 
         ValidateConsumerStepGuards(jobs, jobNames);
+        ValidateRepositoryGuardsJob(jobs);
         ValidateDependencyPolicyJob(jobs);
         ValidateIlDiffTestStep(jobs);
+    }
+
+    private static void ValidateRepositoryGuardsJob(YamlMappingNode jobs)
+    {
+        YamlMappingNode job = GetRequiredMapping(
+            jobs,
+            "repository-guards",
+            "jobs");
+        RequireExactKeys(
+            job,
+            ["needs", "if", "runs-on", "timeout-minutes", "steps"],
+            "jobs.repository-guards");
+        RequireScalarValue(
+            job,
+            "needs",
+            "changes",
+            "jobs.repository-guards");
+        RequireScalarValue(
+            job,
+            "if",
+            "fromJSON(needs.changes.outputs.plan).validations.repositoryGuards",
+            "jobs.repository-guards");
+        RequireScalarValue(
+            job,
+            "runs-on",
+            "ubuntu-24.04",
+            "jobs.repository-guards");
+        RequireScalarValue(
+            job,
+            "timeout-minutes",
+            "15",
+            "jobs.repository-guards");
+
+        YamlSequenceNode steps = GetRequiredSequence(
+            job,
+            "steps",
+            "jobs.repository-guards");
+        if (steps.Children.Count != 4)
+        {
+            throw new InvalidOperationException(
+                "jobs.repository-guards must contain exactly four steps.");
+        }
+
+        YamlMappingNode checkout = RequireMapping(
+            steps.Children[0],
+            "jobs.repository-guards checkout step");
+        RequireExactKeys(
+            checkout,
+            ["uses"],
+            "jobs.repository-guards checkout step");
+        RequireScalarValue(
+            checkout,
+            "uses",
+            "actions/checkout@v7",
+            "jobs.repository-guards checkout step");
+
+        YamlMappingNode setup = RequireMapping(
+            steps.Children[1],
+            "jobs.repository-guards setup step");
+        RequireExactKeys(
+            setup,
+            ["name", "uses", "with"],
+            "jobs.repository-guards setup step");
+        RequireScalarValue(
+            setup,
+            "name",
+            "Setup .NET",
+            "jobs.repository-guards setup step");
+        RequireScalarValue(
+            setup,
+            "uses",
+            "actions/setup-dotnet@v6",
+            "jobs.repository-guards setup step");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                setup,
+                "with",
+                "jobs.repository-guards setup step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dotnet-version"] = "11.0.x",
+                ["dotnet-quality"] = "preview",
+            },
+            "jobs.repository-guards setup step.with");
+
+        RequireNamedRunStep(
+            steps.Children[2],
+            "Run repository line-ending guard",
+            "dotnet run --project src/dotnet-inspect.Tests -c Release -- " +
+                "--filter-class \"DotnetInspector.Tests.RepositoryLineEndingTests\" " +
+                "--minimum-expected-tests 2\n",
+            "jobs.repository-guards line-ending step");
+        RequireNamedRunStep(
+            steps.Children[3],
+            "Run legacy source-identity guard",
+            "dotnet run --project tests/NuGetFetch.Tests -c Release -- " +
+                "--filter-method \"*LegacyPackageSourceIdentitySurfaceMatchesMigrationSet\" " +
+                "--minimum-expected-tests 1\n",
+            "jobs.repository-guards source-identity step");
+    }
+
+    private static void RequireNamedRunStep(
+        YamlNode node,
+        string name,
+        string run,
+        string context)
+    {
+        YamlMappingNode step = RequireMapping(node, context);
+        RequireExactKeys(step, ["name", "run"], context);
+        RequireScalarValue(step, "name", name, context);
+        RequireScalarValue(step, "run", run, context);
     }
 
     private static void ValidateDependencyPolicyJob(YamlMappingNode jobs)

--- a/eng/CiChangeDetection/WorkflowContract.Consumers.cs
+++ b/eng/CiChangeDetection/WorkflowContract.Consumers.cs
@@ -77,10 +77,10 @@ internal static partial class WorkflowContract
             job,
             "steps",
             "jobs.repository-guards");
-        if (steps.Children.Count != 4)
+        if (steps.Children.Count != 5)
         {
             throw new InvalidOperationException(
-                "jobs.repository-guards must contain exactly four steps.");
+                "jobs.repository-guards must contain exactly five steps.");
         }
 
         YamlMappingNode checkout = RequireMapping(
@@ -125,15 +125,49 @@ internal static partial class WorkflowContract
             },
             "jobs.repository-guards setup step.with");
 
-        RequireNamedRunStep(
+        YamlMappingNode cache = RequireMapping(
             steps.Children[2],
+            "jobs.repository-guards cache step");
+        RequireExactKeys(
+            cache,
+            ["name", "uses", "with"],
+            "jobs.repository-guards cache step");
+        RequireScalarValue(
+            cache,
+            "name",
+            "Cache NuGet packages",
+            "jobs.repository-guards cache step");
+        RequireScalarValue(
+            cache,
+            "uses",
+            "actions/cache@v4",
+            "jobs.repository-guards cache step");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                cache,
+                "with",
+                "jobs.repository-guards cache step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["path"] = "~/.nuget/packages",
+                ["key"] =
+                    "nuget-${{ runner.os }}-${{ runner.arch }}-" +
+                    "${{ hashFiles('**/*.csproj', '**/*.props', " +
+                    "'**/*.targets', '**/*.slnx') }}",
+                ["restore-keys"] =
+                    "nuget-${{ runner.os }}-${{ runner.arch }}-\n",
+            },
+            "jobs.repository-guards cache step.with");
+
+        RequireNamedRunStep(
+            steps.Children[3],
             "Run repository line-ending guard",
             "dotnet run --project src/dotnet-inspect.Tests -c Release -- " +
                 "--filter-class \"DotnetInspector.Tests.RepositoryLineEndingTests\" " +
                 "--minimum-expected-tests 2\n",
             "jobs.repository-guards line-ending step");
         RequireNamedRunStep(
-            steps.Children[3],
+            steps.Children[4],
             "Run legacy source-identity guard",
             "dotnet run --project tests/NuGetFetch.Tests -c Release -- " +
                 "--filter-method \"*LegacyPackageSourceIdentitySurfaceMatchesMigrationSet\" " +


### PR DESCRIPTION
## Demo

PR #6221 is the pathological case. It repaired legacy source-identity inventory under `prototypes/inspect-web/**`, but that path selected `inspectWeb` without selecting the `test` job that owned the repository-wide inventory gate.

Before:

| Candidate | `test` | Repository-wide guards |
| --- | ---: | ---: |
| inspect-web-only PR | false | not represented |
| docs-only PR | false | not represented |

After:

| Candidate | `test` | `repositoryGuards` |
| --- | ---: | ---: |
| inspect-web-only PR | false | true |
| docs-only PR | false | true |
| push to `main` | false | false |

The focused pre-merge lane runs the actual scan-wide tests:

```text
RepositoryLineEndingTests: total 2, succeeded 2
LegacyPackageSourceIdentitySurfaceMatchesMigrationSet: total 1, succeeded 1
```

Notice that ordinary `test` routing stays narrow; a neighboring docs-only candidate selects Markdown plus the repository guards, not the full product test matrix.

## Summary

- Require every validation selection set to cover its scan set in the CI planner design.
- Add schema-v3 `repositoryGuards`, selected for every pull-request and merge-group candidate.
- Add a focused aggregate-required job for the tracked-tree line-ending guard and top-level C# legacy source-identity inventory.
- Pin event semantics, canonical serialization, empty/docs-only canaries, and exact workflow consumer commands in the CI self-test.
- Audit other repository-root test consumers; their scan roots remain covered by existing `code` routing.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class "DotnetInspector.Tests.RepositoryLineEndingTests" --minimum-expected-tests 2`
- `dotnet run --project tests/NuGetFetch.Tests -c Release -- --filter-method "*LegacyPackageSourceIdentitySurfaceMatchesMigrationSet" --minimum-expected-tests 1`
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx markdownlint-cli docs/design/ci-change-plan.md`
- `dotnet run eng/test-ci-change-detection.cs` passed at this exact head in an isolated worktree after regenerating the independently stale decompiler skip inventory.

Current `origin/main` at `17b799910` fails the last command before reaching this change: `src/DotnetInspector.SourceSelection` is both decompiler-reachable and skip-listed. The same failure reproduces in a clean base worktree. That inventory repair is intentionally not included here.