### PR TITLE
Regenerate the decompiler gate skip-list after the SourceSelection edge

### DIFF
--- a/eng/decompiler-gate-skip-projects.txt
+++ b/eng/decompiler-gate-skip-projects.txt
@@ -81,7 +81,6 @@ src/DotnetInspector.Queries.Tests
 src/DotnetInspector.Sections
 src/DotnetInspector.Services.Tests
 src/DotnetInspector.SourceDelegation
-src/DotnetInspector.SourceSelection
 src/DotnetInspector.Vocabulary
 src/ILInspector.Analysis.App
 src/ILInspector.Analysis.Tests


### PR DESCRIPTION
`main` has been failing `ci-required` since #6138 landed. The always-on `changes`
job aborts before planning anything, so every downstream job skips and every PR
branched from `main` inherits a red aggregate. This regenerates the one manifest
that went stale, using the documented generator.

#6138 added a `DotnetInspector.Queries` → `DotnetInspector.SourceSelection`
project reference. That pulls `src/DotnetInspector.SourceSelection` into the
evaluated Release `ILInspector.Decompiler.Tests` closure, while
`eng/decompiler-gate-skip-projects.txt` — made generated, not hand-maintained,
by #6154 — still exempted it. `DecompilerProjectGraphPolicy.Validate` rejects an
exemption whose project tree overlaps the closure, by design: an exempt project
that the decompiler tests actually compile is a silent gate hole.

## Demo

Before, on `main` at `8b845e131`:

```console
$ dotnet run eng/test-ci-change-detection.cs
Unhandled exception. System.InvalidOperationException: eng/decompiler-gate-skip-projects.txt
exempts project trees overlapping projects in the evaluated Release
ILInspector.Decompiler.Tests graph: [src/DotnetInspector.SourceSelection].
   at CiChangeDetection.DecompilerProjectGraphPolicy.Validate(String repository)
   at CiChangeDetection.WorkflowContract.Load(String repository, String workflowText, Boolean validateProvenancePin)
   at CiChangeDetection.ChangeDetectionApp.LoadContract(String repository, String workflowText, Boolean validateProvenancePin)
   at CiChangeDetection.ChangeDetectionApp.Run(String[] args)
   at Program.<Main>$(String[] args)
```

After:

```console
$ dotnet run eng/test-ci-change-detection.cs
CI aggregate fail-safe, path canaries, provenance pin mutations,
change-planner construction, and workflow scope transport passed.
```

The manifest is regenerated, not hand-edited:

```console
$ dotnet run eng/test-ci-change-detection.cs -- --refresh-decompiler-skip-projects
Refreshed eng/decompiler-gate-skip-projects.txt from the evaluated Release
decompiler project closure.
```

The generator removes exactly one line, and no other:

```diff
 src/DotnetInspector.Services.Tests
 src/DotnetInspector.SourceDelegation
-src/DotnetInspector.SourceSelection
 src/DotnetInspector.Vocabulary
```

Neighboring case — `src/DotnetInspector.SourceDelegation`, immediately above,
stays exempt: it is a sibling source project that the decompiler tests do not
compile, so the generator leaves it alone. The single deletion is exactly the
project whose closure membership changed.

The observable routing consequence: a change under
`src/DotnetInspector.SourceSelection` now selects `decompiler-gates`. That is
the correct routing for a project the decompiler tests compile, and it is the
coverage the stale exemption was suppressing.

## Design and implementation

**Normative owner:**
[Decompiler correctness pipeline — the `decompiler-gates` job](docs/decompiler-correctness-pipeline.md):

> That manifest is generated, not hand-maintained […] Re-run it and commit the
> result whenever a project is added, removed, or re-wired.

This PR is that documented re-run. It adds no policy, no new exemption
mechanism, and no bypass. `DecompilerProjectGraphPolicy` is unchanged and keeps
asserting the same invariant; the manifest is simply brought back into
agreement with the project graph it is derived from.

## Scope and deliberate boundaries

This restores the generated manifest only. It does not revisit #6138's
`Queries` → `SourceSelection` reference, which is a legitimate dependency, and
it does not change the decompiler gate's coverage policy or the change planner.

Worth noting separately, and deliberately **not** fixed here: #6138 could land
while making this manifest stale because its own PR run predated the graph edge
it introduced, and nothing re-evaluates the closure at merge time. That is a
merge-queue/gate-freshness question, not a manifest question, and it is the
same class of adjacent-landing interaction that repeatedly reaches `main`.

## Validation

- `dotnet run eng/test-ci-change-detection.cs`: **passed** (fails on `main` at
  `8b845e131` with the exception above).
- `dotnet run eng/test-ci-change-detection.cs -- --refresh-decompiler-skip-projects`
  re-run after committing: reports the manifest is already current, so the
  committed file is a generator fixed point.
- Diff is one deleted line in one generated file; no source, test, or workflow
  change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jVMrMfwFPU2eiG82YYa8Y
