### PR TITLE
Refresh decompiler skip inventory after query rewiring

### DIFF
--- a/eng/decompiler-gate-skip-projects.txt
+++ b/eng/decompiler-gate-skip-projects.txt
@@ -81,7 +81,6 @@ src/DotnetInspector.Queries.Tests
 src/DotnetInspector.Sections
 src/DotnetInspector.Services.Tests
 src/DotnetInspector.SourceDelegation
-src/DotnetInspector.SourceSelection
 src/DotnetInspector.Vocabulary
 src/ILInspector.Analysis.App
 src/ILInspector.Analysis.Tests


### PR DESCRIPTION
## Demo

Before, current `main` fails its CI planner self-test:

```text
eng/decompiler-gate-skip-projects.txt exempts project trees overlapping projects in the evaluated Release ILInspector.Decompiler.Tests graph: [src/DotnetInspector.SourceSelection].
```

PR #6138 added `DotnetInspector.Queries -> DotnetInspector.SourceSelection`, making SourceSelection part of the evaluated decompiler test closure while the generated skip inventory still exempted it.

After regenerating the inventory:

```text
CI aggregate fail-safe, path canaries, provenance pin mutations, change-planner construction, and workflow scope transport passed.
```

Neighboring idempotence check:

```text
eng/decompiler-gate-skip-projects.txt is already current.
```

## Summary

Remove `src/DotnetInspector.SourceSelection` from the generated decompiler gate skip inventory now that it is reachable from `ILInspector.Decompiler.Tests`.

This is a trivial generated one-line repair with no handwritten code or design change, so the repository review tier requires no adversarial seat.

## Validation

- `dotnet run eng/test-ci-change-detection.cs`
- `dotnet run eng/test-ci-change-detection.cs -- --refresh-decompiler-skip-projects`