### PR TITLE
Normalize platform-sensitive plaintext assertions

### DIFF
--- a/src/dotnet-inspect.Tests/ApiHeaderProvenanceTests.cs
+++ b/src/dotnet-inspect.Tests/ApiHeaderProvenanceTests.cs
@@ -65,7 +65,7 @@ public class ApiHeaderProvenanceTests
             CreateType(), "lib/net10.0/Example.dll", "Example.Package", "2.0.0",
             "NuGet", "net10.0", options, output);
 
-        string text = output.ToString();
+        string text = output.ToString().ReplaceLineEndings("\n");
         Assert.Equal(0, exit);
         Assert.DoesNotContain("(Example.Package", text);
         if (focused)
@@ -106,7 +106,7 @@ public class ApiHeaderProvenanceTests
             CreateType(), "lib/net10.0/Example.dll", "Example.Package", "2.0.0",
             "NuGet", "net10.0", options, output);
 
-        string text = output.ToString();
+        string text = output.ToString().ReplaceLineEndings("\n");
         Assert.Equal(0, exit);
         Assert.Contains("Run", text);
         Assert.DoesNotContain("(Example.Package", text);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3757,7 +3757,9 @@ public partial class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.StartsWith("System.Text.Json.JsonSerializer\n\n", output);
+        Assert.StartsWith(
+            "System.Text.Json.JsonSerializer\n\n",
+            output.ReplaceLineEndings("\n"));
         AssertLibraryAsset(output, "System.Text.Json");
         Assert.Contains("Source: Platform", output);
         Assert.Contains("Version:", output);


### PR DESCRIPTION
Keep release certification trustworthy across operating systems while preserving platform-native product output.

## Demo

Before, the Windows platform lane compared native CRLF output with LF-only literals:

```text
Expected: System.Text.Json.JsonSerializer\n\n
Actual:   System.Text.Json.JsonSerializer\r\n\r\n
```

After, the tests normalize rendered text before checking its logical layout. The CLI continues to emit native line endings, and Markdown and provenance content remain unchanged.

## Summary

- Normalize the single-type plaintext header comparison before asserting its layout.
- Normalize plaintext/provenance output in the two API-header tests that cover eight additional Windows cases.
- Keep the legacy package-source identity migration inventory unchanged; current `main` already contains #6221, which removed the eight references reported by the prior release candidate.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- Exact affected CLI methods: 15 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build`: 6,610 total, 6,579 passed, 31 skipped
- Legacy package-source identity migration gate: 4 passed
- Offline NuGetFetch suite: 1,062 total, 1,060 passed, 2 Windows-only skipped
