### PR TITLE
Run CodeQL analysis nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1511,99 +1511,6 @@ jobs:
   # `skipped` and pass a PR on which no test ran at all. `changes` reporting
   # `failure` or `skipped` is what closes that path.
   #
-  # CodeQL code scanning. Each language is a separate lane so a change can
-  # pay only for the extractors its file types need: the C# lane alone costs
-  # roughly nine minutes and is a fixed cost, unrelated to how much C#
-  # changed. Lane selection is by file extension rather than by the project
-  # graph the build gates use, because CodeQL analyzes whole source trees.
-  #
-  # These lanes are not gated on the pre-merge event. Code scanning alerts are
-  # reported against the default branch, so skipping analysis on pushes to
-  # main would freeze that baseline at whatever last ran before a merge. A
-  # push applies this same routing rather than re-analyzing the whole tree, so
-  # it does not bound a mis-routed lane; the weekly full analysis in
-  # codeql-scheduled.yml is that bound.
-  #
-  # Push-time analysis is skipped for Dependabot-authored commits. This
-  # repository allows only squash merging, so merging a Dependabot pull
-  # request produces a Dependabot-authored commit on main, and GitHub gives
-  # workflows running on such a commit read-only permissions. The SARIF upload
-  # needs security-events: write, which a job cannot grant itself, so the job
-  # would fail with "403: Resource not accessible by integration" and turn
-  # ci-required red on main. Both identities are checked because they differ:
-  # on a squash merge the actor is the maintainer who merged, not Dependabot,
-  # so an actor-only guard would never fire. The pull-request run still
-  # analyzes the change: code scanning always accepts uploads from a
-  # pull_request event. Only the default-branch baseline refresh is deferred,
-  # to the weekly scan.
-  # https://docs.github.com/en/code-security/reference/code-scanning/troubleshoot-analysis-errors/resource-not-accessible
-  codeql-actions:
-    needs: changes
-    if: >-
-      fromJSON(needs.changes.outputs.plan).validations.codeqlActions
-      && !(github.event_name == 'push'
-        && (github.actor == 'dependabot[bot]'
-          || github.event.head_commit.author.name == 'dependabot[bot]'))
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v4
-        with:
-          languages: actions
-      - uses: github/codeql-action/analyze@v4
-        with:
-          category: /language:actions
-
-  codeql-csharp:
-    needs: changes
-    if: >-
-      fromJSON(needs.changes.outputs.plan).validations.codeqlCSharp
-      && !(github.event_name == 'push'
-        && (github.actor == 'dependabot[bot]'
-          || github.event.head_commit.author.name == 'dependabot[bot]'))
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v4
-        with:
-          languages: csharp
-          # Buildless extraction, matching what default setup ran here. It
-          # needs no SDK and no restored solution, so this lane does not
-          # duplicate the build the test matrix already performs.
-          build-mode: none
-      - uses: github/codeql-action/analyze@v4
-        with:
-          category: /language:csharp
-
-  codeql-javascript:
-    needs: changes
-    if: >-
-      fromJSON(needs.changes.outputs.plan).validations.codeqlJavaScript
-      && !(github.event_name == 'push'
-        && (github.actor == 'dependabot[bot]'
-          || github.event.head_commit.author.name == 'dependabot[bot]'))
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v4
-        with:
-          languages: javascript-typescript
-      - uses: github/codeql-action/analyze@v4
-        with:
-          category: /language:javascript-typescript
-
   # Like `changes`, this always-run terminal gate uses the GA image so preview
   # capacity cannot leave an otherwise-complete PR waiting for its required
   # status. Path-gated jobs retain ubuntu-26.04 coverage.
@@ -1627,9 +1534,6 @@ jobs:
       - csharp-diff-smoke
       - il-diff-smoke
       - pack
-      - codeql-actions
-      - codeql-csharp
-      - codeql-javascript
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           fi
           jq -e '
             type == "object"
-            and .schemaVersion == 3
+            and .schemaVersion == 4
             and .status == "planned"
           ' <<< "$plan" > /dev/null
           printf 'plan=%s\n' "$plan" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codeql-scheduled.yml
+++ b/.github/workflows/codeql-scheduled.yml
@@ -1,19 +1,11 @@
-name: CodeQL scheduled
+name: CodeQL nightly
 
-# The per-language CodeQL lanes in ci.yml are gated on the CI change plan, so
-# they analyze what a candidate changed. This workflow keeps the other half of
-# what default setup provided: a periodic full analysis that re-runs current
-# queries against code nobody touched, so a newly published query reaches this
-# repository without waiting for someone to edit a matching file.
-#
-# It is separate from ci.yml rather than another trigger on it because the
-# change planner accepts only the pull_request, merge_group, and push events;
-# a schedule event has no base commit to plan against and would fail the
-# `changes` job, taking the whole aggregate red.
+# CodeQL is intentionally outside pull-request CI. A daily full analysis
+# re-runs current queries against every supported language without making this
+# rarely-changing signal part of the merge gate.
 on:
   schedule:
-    # Weekly, matching the cadence the CodeQL default setup used here.
-    - cron: '38 4 * * 1'
+    - cron: '38 4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/docs/design/ci-change-plan.md
+++ b/docs/design/ci-change-plan.md
@@ -220,59 +220,10 @@ Inventory roots are unique canonical repository-relative lines. A duplicate
 root makes the inventory malformed even though the legacy shell reader would
 tolerate it; the conservative policy above then applies.
 
-The three CodeQL lanes route on file-extension families rather than a project
-inventory, because CodeQL's unit of analysis is a language, not a project:
-`codeqlActions` on workflow and composite-action YAML, `codeqlCSharp` on the
-input families the C# extractor enumerates for itself, and `codeqlJavaScript`
-on the JavaScript extractor's own published default inclusion set. Both
-language lanes mirror the extractor rather than the file types this repository
-happens to contain, so that the lists do not drift as the repository gains file
-types; families that are absent simply never match. The C# set is wider than
-C# sources: buildless extraction still resolves dependencies, so it covers
-MSBuild and solution inputs, Razor views, resource files, and the
-`global.json`, `NuGet.Config`, and `packages.config` inputs that decide which
-packages and feeds participate. The enumerated families deliberately not
-routed are DLL files, which are build outputs rather than tracked sources, and
-small non-binary files. That last family is every text file in the repository —
-3,662 of 3,704 tracked files when this policy was written. The extractor scans
-it for package references and project settings that can influence dependency
-inference, so excluding it is a real narrowing of the mirror rather than a
-technicality: a documentation example containing a `PackageReference` element
-does not select the lane. It is excluded because routing it would select C#
-analysis on nearly every candidate, reinstating the ten-minute cost on
-documentation-only changes that this policy exists to remove. Both exclusions
-are bounded by the weekly scan rather than by per-candidate routing.
-The
-JavaScript set is wider than JavaScript and TypeScript sources: it also covers
-HTML and its templates, YAML,
-and named inputs such as `package.json` and `tsconfig.json`. YAML therefore
-selects both `codeqlActions` and `codeqlJavaScript`.
-The one documented inclusion deliberately not
-routed is "all extension-less files", which would select the lane for ordinary
-metadata on nearly every candidate. Matching folds ASCII case, so an
-uppercase spelling of either an extension or a named input such as
-`NuGet.Config` cannot silently skip a lane. Like `markdownlint`,
-`inspectWeb`, and `tla`, these lanes carry no pre-merge event condition, so a
-push to `main` analyzes whichever languages that push touched.
-
-Push-time analysis is skipped for Dependabot-authored commits. This repository
-allows only squash merging, so merging a Dependabot pull request produces a
-Dependabot-authored commit on `main`, and GitHub gives workflows running on
-such a commit read-only permissions. Because uploading SARIF for a branch
-requires `security-events: write`, the lane would fail rather than publish, so
-the workflow does not start it. The condition tests both the actor and the head
-commit's author, because they differ: on a squash merge the actor is the
-maintainer who merged rather than Dependabot, so an actor-only guard would
-never fire. The pull-request run still analyzes the change,
-since code scanning always accepts uploads from a `pull_request` event; only
-the default-branch baseline refresh is deferred to the weekly scan.
-
-Routing a whole-program analyzer is a scheduling decision rather than a
-coverage one. The weekly scan in `codeql-scheduled.yml` analyzes all three
-languages unconditionally, so a language this policy fails to select on some
-candidate delays a finding to the next scheduled scan rather than dropping it.
-That bound is what makes extension-family routing acceptable here even though
-it is coarser than the project-closure inventories used elsewhere.
+CodeQL does not consume the change plan. Its daily workflow analyzes Actions,
+C#, and JavaScript/TypeScript unconditionally against the default branch.
+Keeping the whole-program analyzer outside pull-request CI preserves alert
+publication while removing a rarely-changing signal from the merge gate.
 
 Jobs and named in-job validation units consume selections, not paths.
 Domain-specific interpretation begins only after routing. For example, the
@@ -339,11 +290,10 @@ only printable ASCII, with deterministic property order, lower camel member
 names, no newline, and lowercase digests. Its `validations` member always
 carries every field — `test`, `repositoryGuards`, `dependencyPolicy`,
 `csharpDiffSmoke`, `decompilerGates`, `markdownlint`, `ilDiffSmoke`,
-`ilRoundTrip`, `pack`, `buildNet10`, `inspectWeb`, `skillGate`, `tla`,
-`codeqlActions`, `codeqlCSharp`, and `codeqlJavaScript` — so a consumer never
-distinguishes "false" from "absent". `ilRoundTrip` implies `test` as a
-construction invariant. A scope descriptor names its artifact, record
-framing, record count, and digest; the TLA+ artifact is
+`ilRoundTrip`, `pack`, `buildNet10`, `inspectWeb`, `skillGate`, and `tla`, so a
+consumer never distinguishes "false" from "absent". `ilRoundTrip` implies
+`test` as a construction invariant. A scope descriptor names its artifact,
+record framing, record count, and digest; the TLA+ artifact is
 `ci-plan-tla-paths0`. The plan
 publisher writes scoped evidence and then the single plan line only after the
 serialized bytes have been re-parsed and revalidated by the strict plan

--- a/eng/CiChangeDetection/Planning/ChangePlan.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlan.cs
@@ -163,7 +163,7 @@ internal sealed class ChangePlan
     /// <summary>
     /// The only schema version this repository produces or consumes.
     /// </summary>
-    internal const int CurrentSchemaVersion = 3;
+    internal const int CurrentSchemaVersion = 4;
 
     /// <summary>
     /// The only status valid in a serialized plan.

--- a/eng/CiChangeDetection/Planning/ChangePlanSerializer.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlanSerializer.cs
@@ -26,9 +26,6 @@ internal static class ChangePlanSerializer
         "inspectWeb",
         "skillGate",
         "tla",
-        "codeqlActions",
-        "codeqlCSharp",
-        "codeqlJavaScript",
     ];
 
     /// <summary>
@@ -245,10 +242,7 @@ internal static class ChangePlanSerializer
                 values[9],
                 values[10],
                 values[11],
-                values[12],
-                values[13],
-                values[14],
-                values[15]);
+                values[12]);
 
             JsonElement scopesElement =
                 RequireObject(root.GetProperty("scopes"), "scopes");
@@ -325,9 +319,6 @@ internal static class ChangePlanSerializer
         validations.InspectWeb,
         validations.SkillGate,
         validations.Tla,
-        validations.CodeqlActions,
-        validations.CodeqlCSharp,
-        validations.CodeqlJavaScript,
     ];
 
     /// <summary>

--- a/eng/CiChangeDetection/Planning/ChangePlanTestSuite.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlanTestSuite.cs
@@ -70,64 +70,64 @@ internal static class ChangePlanTestSuite
         (string Path, string Selected)[] canaries =
         [
             ("src/NetworkDestinationPolicy.cs",
-                "code,decompiler,shipped,web,codeqlcsharp"),
+                "code,decompiler,shipped,web"),
             ("src/UnionPolyfill.cs",
-                "code,decompiler,shipped,web,codeqlcsharp"),
-            ("src/dotnet-inspect/Program.cs", "code,shipped,codeqlcsharp"),
+                "code,decompiler,shipped,web"),
+            ("src/dotnet-inspect/Program.cs", "code,shipped"),
             ("src/ILInspector.Decompiler/Raise.cs",
-                "code,csharpdiff,decompiler,shipped,web,codeqlcsharp"),
+                "code,csharpdiff,decompiler,shipped,web"),
             ("src/ILInspector.Metadata/Reader.cs",
-                "code,decompiler,ilroundtrip,shipped,web,codeqlcsharp"),
+                "code,decompiler,ilroundtrip,shipped,web"),
             ("src/DotnetInspector.Core/Core.cs",
-                "code,decompiler,ilroundtrip,shipped,web,codeqlcsharp"),
+                "code,decompiler,ilroundtrip,shipped,web"),
             ("src/dotnet-inspect/dotnet-inspect.csproj",
-                "code,packaging,shipped,codeqlcsharp"),
+                "code,packaging,shipped"),
             ("src/Directory.Build.props",
                 "code,csharpdiff,decompiler,ildiff,ilroundtrip,packaging,"
-                + "shipped,codeqlcsharp"),
+                + "shipped"),
             ("src/DotnetInspector.Queries.Tests/Q.cs",
-                "code,codeqlcsharp"),
+                "code"),
             ("fixtures/diff/DiffFixtures.V1/F.cs",
-                "code,csharpdiff,decompiler,ildiff,codeqlcsharp"),
+                "code,csharpdiff,decompiler,ildiff"),
             ("fixtures/diff/DiffFixtures.V2/F.cs",
-                "code,csharpdiff,decompiler,ildiff,codeqlcsharp"),
+                "code,csharpdiff,decompiler,ildiff"),
             ("fixtures/shared/DotnetInspector.Fixtures/BodyShapeFixture.cs",
-                "code,codeqlcsharp"),
+                "code"),
             ("tests/ILInspector.MetadataPrimitives.PlatformProbe/P.cs",
-                "code,web,codeqlcsharp"),
+                "code,web"),
             ("tests/DotnetInspector.Artifacts.Local.PlatformProbe/P.cs",
-                "code,web,codeqlcsharp"),
+                "code,web"),
             ("fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/F.ts",
-                "code,web,codeqljavascript"),
+                "code,web"),
             ("fixtures/js-export/ILInspector.JsExportSurface.Fixtures/F.cs",
-                "code,codeqlcsharp"),
+                "code"),
             ("tests/ILInspector.JsExportSurface.Tests/Fixtures/"
-                + "ts-jsexport-runtime/R.ts", "code,web,codeqljavascript"),
+                + "ts-jsexport-runtime/R.ts", "code,web"),
             ("tests/DotnetInspector.ILRoundtrip.Tests/T.cs",
-                "code,ilroundtrip,codeqlcsharp"),
-            ("tests/Other/T.cs", "code,decompiler,codeqlcsharp"),
+                "code,ilroundtrip"),
+            ("tests/Other/T.cs", "code,decompiler"),
             ("tools/DecompilerHarness/Notes.md", "docs"),
             ("tools/DecompilerHarness/Baseline.txt", "decompiler,docs"),
             ("tools/DecompilerHarness/Harness.cs",
-                "code,decompiler,codeqlcsharp"),
+                "code,decompiler"),
             ("tools/CatalogChangeBenchmark.cs",
-                "code,decompiler,codeqlcsharp"),
+                "code,decompiler"),
             ("tools/CSharpDiffHarness/H.cs",
-                "csharpdiff,codeqlcsharp"),
-            ("tools/IlDiffHarness/H.cs", "ildiff,codeqlcsharp"),
+                "csharpdiff"),
+            ("tools/IlDiffHarness/H.cs", "ildiff"),
             ("tools/DiffHarnessCommon/C.cs",
-                "csharpdiff,ildiff,codeqlcsharp"),
-            ("eng/test-ci-change-detection.cs", "code,codeqlcsharp"),
+                "csharpdiff,ildiff"),
+            ("eng/test-ci-change-detection.cs", "code"),
             ("eng/inspect-web-gate-projects.txt", "code,docs,web"),
             ("eng/CiChangeDetection/PromotionWorkflowContract.cs",
-                "code,web,codeqlcsharp"),
+                "code,web"),
             ("eng/CiChangeDetection/Planning/ChangeRoutingPolicy.cs",
-                "code,codeqlcsharp"),
+                "code"),
             ("eng/CiChangeDetection/Planning/ChangePlanTestSuite.cs",
-                "code,codeqlcsharp"),
+                "code"),
             ("eng/package-fixtures/a.nupkg", "code"),
             ("eng/package-manifest-corpus.json", "code"),
-            ("eng/verify-package-manifest-corpus.cs", "code,codeqlcsharp"),
+            ("eng/verify-package-manifest-corpus.cs", "code"),
             ("eng/prepare-decompiler-assertion-corpus.sh", "code"),
             ("eng/prepare-decompiler-corpus.sh", "code"),
             ("eng/prepare-decompiler-opt-in-corpus.sh", "code"),
@@ -135,7 +135,7 @@ internal static class ChangePlanTestSuite
             ("eng/prepare-authored-source-oracles.sh", "code"),
             ("eng/report-decompiler-opt-in-corpus-drift.sh", "code"),
             ("eng/prepare-decompiler-package-sweep.cs",
-                "code,codeqlcsharp"),
+                "code"),
             ("eng/prepare-evil-corpus.sh", "code"),
             ("docs/data/nuget-top-packages.lock.json", "code,docs"),
             ("docs/data/nuget-top-packages.json", "code,docs"),
@@ -150,51 +150,50 @@ internal static class ChangePlanTestSuite
             ("eng/test-inspect-web-multi-facade-canary.sh", "web"),
             ("eng/generate-inspect-web-managed-operation-bridge-canary.sh", "web"),
             ("eng/test-inspect-web-managed-operation-bridge-canary.sh", "web"),
-            ("eng/validate-inspect-web-promotion.cs", "web,codeqlcsharp"),
+            ("eng/validate-inspect-web-promotion.cs", "web"),
             ("eng/validate-inspect-web-promotion.sh", "web"),
             ("eng/generate-inspect-web-engine-facade.sh", "web"),
             ("eng/InspectWebAsyncLoweringReceipt.targets",
-                "code,csharpdiff,decompiler,ildiff,ilroundtrip,web,"
-                + "codeqlcsharp"),
+                "code,csharpdiff,decompiler,ildiff,ilroundtrip,web"),
             ("eng/verify-inspect-web-async-deployment.sh", "web"),
             ("eng/BannedSymbols.txt", "code,docs,web"),
             (".gitattributes", "code"),
             ("install.ps1", "code"),
             ("eng/decompiler-gate-expected-classes.txt",
                 "code,decompiler,docs"),
-            ("eng/check-decompiler-gate.cs", "decompiler,codeqlcsharp"),
+            ("eng/check-decompiler-gate.cs", "decompiler"),
             ("eng/decompiler-gate-known-red.txt", "decompiler,docs"),
             ("eng/decompiler-gate-skip-projects.txt", "decompiler,docs"),
             ("eng/restore-ilassembler.sh", "code,ilroundtrip"),
             ("prototypes/inspect-web/README.md", "docs"),
-            ("prototypes/inspect-web/index.html", "web,codeqljavascript"),
+            ("prototypes/inspect-web/index.html", "web"),
             ("prototypes/annotated-source-viewer/app.js",
-                "web,codeqljavascript"),
+                "web"),
             ("Directory.Build.props",
                 "code,csharpdiff,decompiler,ildiff,ilroundtrip,packaging,"
-                + "shipped,web,codeqlcsharp"),
+                + "shipped,web"),
             ("Directory.Build.targets",
                 "code,csharpdiff,decompiler,ildiff,ilroundtrip,packaging,"
-                + "shipped,web,codeqlcsharp"),
+                + "shipped,web"),
             ("Directory.Packages.props",
                 "code,csharpdiff,decompiler,ildiff,ilroundtrip,packaging,"
-                + "shipped,web,codeqlcsharp"),
+                + "shipped,web"),
             ("dotnet-inspect.slnx",
-                "code,csharpdiff,decompiler,ildiff,ilroundtrip,web,codeqlcsharp"),
-            ("global.json", "decompiler,packaging,shipped,codeqlcsharp"),
+                "code,csharpdiff,decompiler,ildiff,ilroundtrip,web"),
+            ("global.json", "decompiler,packaging,shipped"),
             (".github/workflows/ci.yml",
                 "code,csharpdiff,decompiler,ildiff,packaging,shipped,web,"
-                + "skills,tla,codeqlactions,codeqljavascript"),
+                + "skills,tla"),
             (".github/workflows/release.yml",
-                "code,packaging,codeqlactions,codeqljavascript"),
+                "code,packaging"),
             (".github/workflows/deploy-inspect-web.yml",
-                "web,codeqlactions,codeqljavascript"),
+                "web"),
             (".github/workflows/deploy-inspect-web-coreclr.yml",
-                "web,codeqlactions,codeqljavascript"),
+                "web"),
             (".github/workflows/promote-inspect-web.yml",
-                "web,codeqlactions,codeqljavascript"),
-            (".github/workflows/other.yml", "code,codeqlactions,codeqljavascript"),
-            (".markdownlint.yaml", "docs,codeqlactions,codeqljavascript"),
+                "web"),
+            (".github/workflows/other.yml", "code"),
+            (".markdownlint.yaml", "docs"),
             ("docs/.markdownlint-cli2.jsonc", "docs"),
             ("docs/design/ci-change-plan.md", "docs"),
             ("skills/a/SKILL.md", "docs,skills"),
@@ -210,44 +209,6 @@ internal static class ChangePlanTestSuite
             ("eng/tla-module-overrides.txt", "docs,tla"),
             ("eng/tla-expected-exit-codes.txt", "docs,tla"),
             ("docs/design/models/m/README.md", "docs"),
-            ("misc/probe.csx", "codeqlcsharp"),
-            ("misc/probe.csproj", "codeqlcsharp"),
-            ("misc/probe.mjs", "codeqljavascript"),
-            ("misc/probe.cts", "codeqljavascript"),
-            ("misc/probe.html", "codeqljavascript"),
-            ("misc/probe.htm", "codeqljavascript"),
-            ("misc/config.yaml", "codeqlactions,codeqljavascript"),
-            // Case folding: an uppercase extension must not skip a lane.
-            ("misc/probe.CS", "codeqlcsharp"),
-            ("misc/probe.JS", "codeqljavascript"),
-            // Dependency and compiler inputs for the JavaScript extractor.
-            ("misc/package.json", "codeqljavascript"),
-            ("misc/tsconfig.node.json", "codeqljavascript"),
-            // Families the extractor indexes that this repository does not
-            // currently contain. They cost nothing and stop the routing list
-            // from drifting away from the published inclusion set.
-            ("misc/probe.vue", "codeqljavascript"),
-            ("misc/probe.hbs", "codeqljavascript"),
-            ("misc/probe.ejs", "codeqljavascript"),
-            ("misc/probe.njk", "codeqljavascript"),
-            ("misc/probe.HBS", "codeqljavascript"),
-            ("misc/probe.EJS", "codeqljavascript"),
-            ("misc/probe.NJK", "codeqljavascript"),
-            ("misc/probe.jsp", "codeqljavascript"),
-            ("misc/probe.raml", "codeqljavascript"),
-            ("misc/manifest.json", "codeqljavascript"),
-            ("misc/.eslintrc.json", "codeqljavascript"),
-            // Input families the C# extractor enumerates. Razor views carry
-            // C# source; the dependency-resolution inputs decide which
-            // packages and feeds participate in buildless extraction.
-            ("misc/probe.razor", "codeqlcsharp"),
-            ("misc/probe.cshtml", "codeqlcsharp"),
-            ("misc/probe.resx", "codeqlcsharp"),
-            ("misc/packages.config", "codeqlcsharp"),
-            ("misc/nuget.config", "codeqlcsharp"),
-            ("misc/global.json", "codeqlcsharp"),
-            // Case folding on a basename match, not just an extension.
-            ("misc/NuGet.Config", "codeqlcsharp"),
             ("misc/notes.rst", ""),
         ];
 
@@ -265,7 +226,7 @@ internal static class ChangePlanTestSuite
 
         // A change set is the union of its records.
         if (Render(policy.Route(Evidence("README.md", "src/a/b.cs")))
-            != "code,decompiler,docs,shipped,codeqlcsharp")
+            != "code,decompiler,docs,shipped")
         {
             throw new InvalidOperationException(
                 "Multi-record routing did not union its records.");
@@ -300,7 +261,7 @@ internal static class ChangePlanTestSuite
             // A missing inspect-web inventory broadens `web` to every src
             // change rather than narrowing it.
             if (Render(policy.Route(Evidence("src/dotnet-inspect/Program.cs")))
-                != "code,decompiler,shipped,web,codeqlcsharp")
+                != "code,decompiler,shipped,web")
             {
                 throw new InvalidOperationException(
                     "A missing inspect-web inventory did not broaden the "
@@ -490,10 +451,7 @@ internal static class ChangePlanTestSuite
                 buildNet10: false,
                 inspectWeb: false,
                 skillGate: false,
-                tla: false,
-                codeqlActions: false,
-                codeqlCSharp: false,
-                codeqlJavaScript: false));
+                tla: false));
     }
 
     /// <summary>
@@ -591,7 +549,7 @@ internal static class ChangePlanTestSuite
             policy);
 
         const string Golden =
-            "{\"schemaVersion\":3,\"status\":\"planned\",\"provenance\":"
+            "{\"schemaVersion\":4,\"status\":\"planned\",\"provenance\":"
             + "{\"kind\":\"pullRequestSyntheticCandidate\",\"baseObjectId\":"
             + "\"1111111111111111111111111111111111111111\","
             + "\"candidateObjectId\":"
@@ -604,9 +562,7 @@ internal static class ChangePlanTestSuite
             + "\"csharpDiffSmoke\":false,\"decompilerGates\":false,"
             + "\"markdownlint\":true,\"ilDiffSmoke\":false,"
             + "\"ilRoundTrip\":false,\"pack\":false,\"buildNet10\":false,"
-            + "\"inspectWeb\":false,\"skillGate\":false,\"tla\":true,"
-            + "\"codeqlActions\":false,\"codeqlCSharp\":false,"
-            + "\"codeqlJavaScript\":false},"
+            + "\"inspectWeb\":false,\"skillGate\":false,\"tla\":true},"
             + "\"scopes\":{\"tla\":{\"artifact\":\"ci-plan-tla-paths0\","
             + "\"framing\":\"pathBytesNulTerminated\",\"recordCount\":1,"
             + "\"sha256\":\"c2965478b65cc2a4d5329c0634d39a072c6d0adf0669a2"
@@ -702,12 +658,12 @@ internal static class ChangePlanTestSuite
                     "\"status\": \"planned\"")),
             ("non-canonical property order",
                 text.Replace(
-                    "{\"schemaVersion\":3,\"status\":\"planned\"",
-                    "{\"status\":\"planned\",\"schemaVersion\":3")),
+                    "{\"schemaVersion\":4,\"status\":\"planned\"",
+                    "{\"status\":\"planned\",\"schemaVersion\":4")),
             ("escaped member name",
                 text.Replace("schemaVersion", "schema\\u0056ersion")),
             ("non-canonical number",
-                text.Replace("\"schemaVersion\":3", "\"schemaVersion\":3e0")),
+                text.Replace("\"schemaVersion\":4", "\"schemaVersion\":4e0")),
             ("control character", $"\n{text}"),
             ("truncated document", text[..^1]),
             ("unknown member",
@@ -715,13 +671,13 @@ internal static class ChangePlanTestSuite
             ("missing member", text.Replace(",\"diagnostics\":[]", "")),
             ("duplicate member",
                 text.Replace(
-                    "\"schemaVersion\":3",
-                    "\"schemaVersion\":3,\"schemaVersion\":3")),
+                    "\"schemaVersion\":4",
+                    "\"schemaVersion\":4,\"schemaVersion\":4")),
             ("mistyped boolean", text.Replace("\"test\":false", "\"test\":0")),
             ("mistyped count",
                 text.Replace("\"recordCount\":1", "\"recordCount\":\"1\"")),
             ("unsupported version",
-                text.Replace("\"schemaVersion\":3", "\"schemaVersion\":4")),
+                text.Replace("\"schemaVersion\":4", "\"schemaVersion\":5")),
             ("unsupported status",
                 text.Replace("\"planned\"", "\"refused\"")),
             ("invalid digest",
@@ -1527,21 +1483,6 @@ internal static class ChangePlanTestSuite
         if (selections.Tla)
         {
             selected.Add("tla");
-        }
-
-        if (selections.CodeqlActions)
-        {
-            selected.Add("codeqlactions");
-        }
-
-        if (selections.CodeqlCSharp)
-        {
-            selected.Add("codeqlcsharp");
-        }
-
-        if (selections.CodeqlJavaScript)
-        {
-            selected.Add("codeqljavascript");
         }
 
         return string.Join(',', selected);

--- a/eng/CiChangeDetection/Planning/ChangeRoutingPolicy.cs
+++ b/eng/CiChangeDetection/Planning/ChangeRoutingPolicy.cs
@@ -99,9 +99,6 @@ internal sealed class ChangeRoutingPolicy
 
         return new RoutingSelections(
             state.Code,
-            state.CodeqlActions,
-            state.CodeqlCSharp,
-            state.CodeqlJavaScript,
             state.CSharpDiff,
             state.Decompiler,
             state.Docs,
@@ -177,127 +174,6 @@ internal sealed class ChangeRoutingPolicy
         RouteIlRoundtrip(path, ref state);
         RoutePackaging(path, ref state);
         RouteShipped(path, ref state);
-        RouteCodeql(path, ref state);
-    }
-
-    // CodeQL analyzes whole source trees, so each lane is selected by the
-    // extensions its extractor reads rather than by the project graph the
-    // build gates use. The lists are deliberately whole extension families:
-    // a lane that runs when it did not have to costs analysis minutes, while
-    // a lane that fails to run leaves the change unscanned until the weekly
-    // full analysis in codeql-scheduled.yml. A push to the default branch
-    // applies this same routing rather than re-analyzing the whole tree, so
-    // the scheduled scan is the only routing-independent backstop.
-    private static void RouteCodeql(
-        ReadOnlySpan<byte> path,
-        ref RoutingState state)
-    {
-        // Folded so that an uppercase extension cannot silently skip a lane.
-        ReadOnlySpan<byte> folded = BytePattern.AsciiFold(path);
-        if (BytePattern.MatchesAny(
-            folded,
-            // This list mirrors the input families the C# extractor
-            // enumerates for itself rather than the file types this
-            // repository happens to contain. Running the lane logs one
-            // "Found N <kind> files" line per family it reads: source,
-            // project, solution, resource, packages.config, nuget.config,
-            // global.json, DLL, Razor view, and small non-binary files.
-            // Two enumerated families are deliberately not routed. DLL
-            // files are build outputs rather than tracked sources. Small
-            // non-binary files are every text file in the repository
-            // (3,662 of 3,704 tracked files at the time of writing); the
-            // extractor scans them for package and project settings that
-            // can influence dependency inference, but routing them would
-            // select this lane on nearly every candidate and reinstate the
-            // ten-minute analysis on documentation-only changes that this
-            // policy exists to avoid. The weekly scan is the backstop for
-            // both exclusions.
-            "*.cs",
-            "*.csx",
-            "*.csproj",
-            // Buildless C# extraction still resolves dependencies, so the
-            // MSBuild and SDK inputs that decide which packages and sources
-            // participate change what the analysis sees.
-            "*.props",
-            "*.targets",
-            "*.slnx",
-            "*.sln",
-            // Razor extraction is default-on, so views carry C# source.
-            "*.cshtml",
-            "*.razor",
-            "*.resx",
-            // Dependency-resolution inputs decide which packages and feeds
-            // participate. Matched at the root and at any depth because a
-            // pattern is tested against the whole path.
-            "global.json",
-            "*/global.json",
-            "nuget.config",
-            "*/nuget.config",
-            "packages.config",
-            "*/packages.config"))
-        {
-            state.CodeqlCSharp = true;
-        }
-
-        // This list mirrors the JavaScript extractor's own default inclusion
-        // set rather than the file types this repository happens to contain,
-        // because the extractor indexes considerably more than JavaScript.
-        // Follow FileExtractor.FileType and AutoBuild's defaultExtract loop
-        // in github/codeql; AutoBuild's prose extension list can lag the code.
-        // Families this repository does not use simply never match.
-        //
-        // The one documented inclusion deliberately not routed is "all
-        // extension-less files". Routing it would select this lane for
-        // ordinary metadata such as LICENSE or CODEOWNERS on nearly every
-        // candidate, and the weekly scan already bounds a missed lane.
-        if (BytePattern.MatchesAny(
-            folded,
-            "*.js",
-            "*.jsx",
-            "*.mjs",
-            "*.cjs",
-            "*.es",
-            "*.es6",
-            "*.xsjs",
-            "*.xsjslib",
-            "*.ts",
-            "*.tsx",
-            "*.mts",
-            "*.cts",
-            // The extractor reads script embedded in HTML and its templates.
-            "*.htm",
-            "*.html",
-            "*.xhtm",
-            "*.xhtml",
-            "*.vue",
-            "*.hbs",
-            "*.ejs",
-            "*.njk",
-            "*.html.erb",
-            "*.html.dot",
-            "*.jsp",
-            // The extractor indexes YAML, so YAML selects this lane as well
-            // as the Actions lane.
-            "*.yml",
-            "*.yaml",
-            "*.raml",
-            // Named dependency, compiler, and configuration inputs.
-            "*package.json",
-            "*tsconfig*.json",
-            "*codeql-javascript-*.json",
-            "*.eslintrc*",
-            "*.xsaccess",
-            "*xs-app.json",
-            "*.view.json",
-            "*manifest.json"))
-        {
-            state.CodeqlJavaScript = true;
-        }
-
-        if (BytePattern.MatchesAny(folded, "*.yml", "*.yaml"))
-        {
-            state.CodeqlActions = true;
-        }
     }
 
     private static void RouteLanes(
@@ -671,9 +547,6 @@ internal sealed class ChangeRoutingPolicy
     private struct RoutingState
     {
         internal bool Code;
-        internal bool CodeqlActions;
-        internal bool CodeqlCSharp;
-        internal bool CodeqlJavaScript;
         internal bool CSharpDiff;
         internal bool Decompiler;
         internal bool Docs;

--- a/eng/CiChangeDetection/Planning/ValidationSelections.cs
+++ b/eng/CiChangeDetection/Planning/ValidationSelections.cs
@@ -7,9 +7,6 @@ namespace CiChangeDetection.Planning;
 /// </summary>
 internal readonly record struct RoutingSelections(
     bool Code,
-    bool CodeqlActions,
-    bool CodeqlCSharp,
-    bool CodeqlJavaScript,
     bool CSharpDiff,
     bool Decompiler,
     bool Docs,
@@ -25,8 +22,8 @@ internal readonly record struct RoutingSelections(
     /// Gets the selections that a change set of every routed kind produces.
     /// </summary>
     internal static RoutingSelections All { get; } = new(
-        true, true, true, true, true, true, true,
-        true, true, true, true, true, true, true);
+        true, true, true, true, true, true,
+        true, true, true, true, true);
 }
 
 /// <summary>
@@ -48,10 +45,7 @@ internal sealed class ValidationSelections
         bool buildNet10,
         bool inspectWeb,
         bool skillGate,
-        bool tla,
-        bool codeqlActions,
-        bool codeqlCSharp,
-        bool codeqlJavaScript)
+        bool tla)
     {
         if (ilRoundTrip && !test)
         {
@@ -73,9 +67,6 @@ internal sealed class ValidationSelections
         InspectWeb = inspectWeb;
         SkillGate = skillGate;
         Tla = tla;
-        CodeqlActions = codeqlActions;
-        CodeqlCSharp = codeqlCSharp;
-        CodeqlJavaScript = codeqlJavaScript;
     }
 
     internal bool Test { get; }
@@ -105,33 +96,12 @@ internal sealed class ValidationSelections
     internal bool Tla { get; }
 
     /// <summary>
-    /// Gets a value indicating whether CodeQL analyzes GitHub Actions
-    /// workflows.
-    /// </summary>
-    internal bool CodeqlActions { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether CodeQL analyzes C# sources.
-    /// </summary>
-    internal bool CodeqlCSharp { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether CodeQL analyzes JavaScript and
-    /// TypeScript sources.
-    /// </summary>
-    internal bool CodeqlJavaScript { get; }
-
-    /// <summary>
     /// Applies the repository's event rules to raw routing selections. Every
     /// pre-merge candidate runs the focused repository guards because their
     /// tests scan the repository beyond ordinary path ownership. A push runs
     /// the focused dependency-policy composition gate rather than the
     /// pre-merge test matrix or repository guards; documentation lint, the
-    /// Browser/Wasm lane, the TLA+ lane, and the CodeQL lanes have no event
-    /// gate. CodeQL keeps
-    /// running on a push because code scanning alerts are reported against
-    /// the default branch: gating it on the pre-merge event would leave that
-    /// baseline frozen at whatever last ran before the merge.
+    /// Browser/Wasm lane and the TLA+ lane have no event gate.
     /// </summary>
     /// <param name="selections">The raw routing selections.</param>
     /// <param name="kind">The provenance kind supplying the event rule.</param>
@@ -154,9 +124,6 @@ internal sealed class ValidationSelections
             buildNet10: selections.Shipped && preMerge,
             inspectWeb: selections.Web,
             skillGate: selections.Skills && preMerge,
-            tla: selections.Tla,
-            codeqlActions: selections.CodeqlActions,
-            codeqlCSharp: selections.CodeqlCSharp,
-            codeqlJavaScript: selections.CodeqlJavaScript);
+            tla: selections.Tla);
     }
 }


### PR DESCRIPTION
Closes #6241.

CodeQL now runs as one daily full-tree matrix instead of three change-routed jobs in pull-request CI. Actions, C#, and JavaScript/TypeScript coverage, buildless extraction, SARIF categories, manual dispatch, and alert publication are unchanged. The CI change plan no longer carries selections with no consumer; its schema advances from 3 to 4.

## Demo

Before, `ci.yml` contained `codeql-actions`, `codeql-csharp`, and `codeql-javascript`, and the full-tree workflow ran weekly.

After, the workflow contract reports:

```text
CI has no CodeQL jobs; nightly covers actions, csharp, javascript-typescript
cron: 38 4 * * *
```

The neighboring manual-dispatch scenario remains available, and the aggregate self-test still proves that `ci-required` depends on every remaining CI job.

## Validation

- `dotnet run eng/test-ci-change-detection.cs`
- `npx markdownlint-cli docs/design/ci-change-plan.md`
- Parsed both changed workflow files and asserted the nightly language matrix plus absence of CodeQL jobs from `ci.yml`.
- `git diff --check`