### PR TITLE
Fix scope bar crash on empty subject ladder (Demos page)

### DIFF
--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -542,11 +542,8 @@ export function renderScopeBar<TId extends string>(
     : (emptyStripLabel
         ? `<span class="lens-context">${escapeHtml(emptyStripLabel)}</span>`
         : "");
-  return `
-    <nav class="lensbar"
-         data-scope-bar
-         data-allocation-key="${escapeHtml(`${scope}:${inspectorIds}`)}"
-         aria-label="Subjects and inspectors">
+  const subjectHtml = subjects.length > 0
+    ? `
       <div class="slide-strip slide-strip-subject scope-switch"
            data-slide-strip="subject"
            data-continuity-key="${escapeHtml(`${scope}:${subjectIds}:v2`)}"
@@ -565,7 +562,14 @@ export function renderScopeBar<TId extends string>(
               escapeHtml)).join("")}
         </div>
         ${edgeIndicators()}
-      </div>
+      </div>`
+    : "";
+  return `
+    <nav class="lensbar"
+         data-scope-bar
+         data-allocation-key="${escapeHtml(`${scope}:${inspectorIds}`)}"
+         aria-label="Subjects and inspectors">
+      ${subjectHtml}
       ${strip.length > 0
         ? `<div class="slide-strip-allocation" data-slide-strip-allocation hidden>
             <button type="button" data-more-subjects aria-label="Show more subjects">‹</button>
@@ -717,15 +721,23 @@ class ScopeBarController implements ScopeBarBinding {
 
   static create(root: ParentNode, state: ScopeBarState): ScopeBarController | null {
     const navigation = root.querySelector<HTMLElement>("[data-scope-bar]");
-    return navigation ? new ScopeBarController(navigation, state) : null;
-  }
-
-  private constructor(navigation: HTMLElement, state: ScopeBarState) {
-    this.navigation = navigation;
-    this.state = state;
+    if (!navigation) return null;
+    // An empty subject ladder (e.g. the workspace-only catalog, which has nothing to switch
+    // between) renders no subject strip at all; there is nothing to allocate in that case.
     const subjectElement = navigation.querySelector<HTMLElement>(
       '[data-slide-strip="subject"]');
-    if (!subjectElement) throw new Error("Scope bar requires a subject strip.");
+    return subjectElement
+      ? new ScopeBarController(navigation, subjectElement, state)
+      : null;
+  }
+
+  private constructor(
+    navigation: HTMLElement,
+    subjectElement: HTMLElement,
+    state: ScopeBarState,
+  ) {
+    this.navigation = navigation;
+    this.state = state;
     const subjectItems = readItems(subjectElement);
     this.subject = new SlideStripDomController(
       subjectElement,

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -32,9 +32,25 @@ class FakeElement {
   rendered = true;
   tabIndex = 0;
   private readonly listeners = new Map<string, EventListener[]>();
+  private readonly children = new Map<string, FakeElement[]>();
 
   constructor(dataset: Record<string, string | undefined> = {}) {
     this.dataset = dataset;
+  }
+
+  // Registers descendants for a given selector so this element can act as a query root, the
+  // same way FakeRoot does; needed to exercise ScopeBarController.create against a nav element.
+  add(selector: string, ...elements: FakeElement[]) {
+    this.children.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.children.get(selector)?.[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    return this.children.get(selector) ?? [];
   }
 
   addEventListener(type: string, listener: EventListener) {
@@ -73,6 +89,10 @@ class FakeRoot {
   add(selector: string, ...elements: FakeElement[]) {
     this.elements.set(selector, elements);
     return elements;
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.elements.get(selector)?.[0] ?? null;
   }
 
   querySelectorAll(selector: string) {
@@ -395,6 +415,32 @@ test("workspace-only availability leaves the separate subject ladder empty", () 
   assert.doesNotMatch(
     html,
     /data-scope="workspace"|data-scope="package"|data-scope="library"|data-scope="type"/);
+  // The subject slide-strip itself must be omitted (not merely emptied) when there is nothing
+  // to switch between; otherwise it renders with an empty anchor that SlideStripDomController
+  // rejects at bind time. See "scope bar binding tolerates an empty subject ladder" below.
+  assert.doesNotMatch(html, /data-slide-strip="subject"/);
+});
+
+test("scope bar binding tolerates an empty subject ladder", () => {
+  // Regression test: the workspace-only catalog page (the "Demos" view) renders a scope bar
+  // with no subject strip and no inspector strip, since there is nothing to switch between.
+  // ScopeBarController.create used to assume a subject strip always exists and threw
+  // "SlideStrip markup requires anchor and continuity key" whenever this page bound its scope
+  // bar -- reproducing the "Startup failed" crash seen navigating home -> demos.
+  const root = new FakeRoot();
+  const navigation = new FakeElement();
+  root.add("[data-scope-bar]", navigation);
+  const state = {
+    subject: { key: "" },
+    inspector: { key: "" },
+    allocationKey: "",
+    allocationOrdinal: 0,
+  };
+
+  assert.doesNotThrow(() => bindScopeBar(
+    fakeDom.parentNode(root),
+    recordingActions([]),
+    state));
 });
 
 test("type scope marks the type segment and renders the fixed type lenses", () => {


### PR DESCRIPTION
## Demo

Before: navigating home → Demos → home → Demos throws inside the scope bar
binder and surfaces as the top-level error boundary:

```
Startup failed
Couldn't start the inspection engine. Retry, or open a different package.

Error: SlideStrip markup requires anchor and continuity key.
```

After: the Demos page's scope bar binds cleanly with no subject ladder (there
is nothing to switch between on that page), and the crash no longer occurs.

## Root cause

The workspace-only catalog page (`renderWorkspaceCatalogView`, i.e. "Demos")
renders its scope bar with `availableScopes: ["workspace"]`. `subjectDefinitions()`
never includes `"workspace"` itself (it lists package/library/type/member), so
this filtered the subject switcher down to zero items — but the subject
`<div data-slide-strip="subject">` was still rendered unconditionally, with an
empty `data-initial-anchor`.

`ScopeBarController`'s constructor unconditionally built a
`SlideStripDomController` for that element, and its `readPolicy` throws when
the anchor is falsy. This reproduced deterministically whenever the scope bar
was (re)bound on the Demos page.

## Fix

- Omit the subject slide-strip markup entirely when there are no subjects,
  mirroring the existing pattern already used for the inspector strip
  (`strip.length > 0 ? ... : ""`).
- `ScopeBarController.create` now returns `null` gracefully when no subject
  strip element exists, instead of assuming one always exists and throwing.

## Validation

- Added `scope bar binding tolerates an empty subject ladder`, a regression
  test that reproduces the original throw without the fix (verified) and
  passes with it.
- `npm run typecheck` — clean.
- `node --test` in `prototypes/inspect-web` — 1499/1503 pass; the 4 failures
  are pre-existing, unrelated `toolchain.test.ts` bundler-audit failures,
  confirmed identical on `main` before this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
