### PR TITLE
Restore fail-closed SRI validation

### DIFF
--- a/prototypes/inspect-web/.htmlvalidate.json
+++ b/prototypes/inspect-web/.htmlvalidate.json
@@ -5,8 +5,5 @@
     "html-validate:standard",
     "html-validate:document",
     "html-validate:a11y"
-  ],
-  "rules": {
-    "require-sri": ["error", { "target": "crossorigin" }]
-  }
+  ]
 }

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1294,9 +1294,13 @@ of `.ts` files and Oxlint is handed a list of source paths, so nothing read
 `index.html` at all before this. The committed `.htmlvalidate.json` extends the
 `standard`, `document`, and `a11y` presets, which bring validity, element
 conformance, document structure, and WCAG rules. It sets `root: true` so
-configuration outside the project cannot merge into it, and makes one option
-change: `require-sri` uses `target: "crossorigin"`, so third-party bytes must
-carry a digest while same-origin files Vite emits are not asked for one.
+configuration outside the project cannot merge into it and makes no
+project-wide rule changes. The standard `require-sri` default therefore
+requires a digest on every external stylesheet and script reference without
+first classifying its URL as same-origin or cross-origin. The same-origin
+stylesheet and module inputs in `index.html` and the eight browser harness entry
+pages carry scoped `disable-next require-sri` directives because Vite rewrites
+those source references at build time, when no stable source digest exists.
 `.htmlvalidateignore` names only generated output — `/dist`, `node_modules`,
 `bin` and `obj`. Only `dist` is anchored: it is generated at the project root
 only, so an unanchored entry would also exclude an authored `src/dist`. The
@@ -1315,17 +1319,16 @@ surfaced on CI: without them html-validate was linting `engine/bin/**` and
 output that no one authored and no one can fix.
 
 Eight toolchain tests hold that wiring honest. They pin the preset list, the
-`root: true` setting, and the *whole* `rules` object — `require-sri` is the only
-entry, so a second rule relaxed beside it fails rather than slipping past an
-assertion aimed at one key. They also pin the file's whole *key set*, because
-rules are not the only way the presets get weaker: an `elements` entry changes
-the HTML metadata the stock rules check against, so a rule can stay on and
-simply have nothing left to say about an element. They require the lint glob to
-reach a document of each covered extension, both nested and under `src/dist`;
-require the committed configuration to reject a specimen *by the name of the
-rule that must reject it* (`close-order`, `element-required-attributes`,
-`wcag/h37`, `require-sri`, `attribute-allowed-values`); and require every
-document the project owns to sit outside the ignore file.
+`root: true` setting, the absence of project-wide rule changes, and the file's
+whole *key set*, because rules are not the only way the presets get weaker: an
+`elements` entry changes the HTML metadata the stock rules check against, so a
+rule can stay on and simply have nothing left to say about an element. They
+require the lint glob to reach a document of each covered extension, both
+nested and under `src/dist`; require the committed configuration to reject a
+specimen *by the name of the rule that must reject it* (`close-order`,
+`element-required-attributes`, `wcag/h37`, `require-sri`,
+`attribute-allowed-values`), including a whitespace-prefixed remote script;
+and require every document the project owns to sit outside the ignore file.
 
 The rest close the gap between "the linter ran" and "the linter saw this file".
 One states the property directly, in two passes with different jobs. Both run
@@ -1375,22 +1378,22 @@ authored document. That is precisely the case the `--dump-source` passes catch
 and a walk structurally cannot, which is why the property is asserted directly
 rather than by enumerating one more placement.
 
-The `<link rel="preload" id="webassembly">` element in `index.html` carries a
-scoped `html-validate-disable-next` directive for `element-required-attributes`.
-It is a genuinely incomplete element on purpose: the .NET Wasm publish step
-rewrites it to inject the runtime `href`, and three workflows plus
-`PromotionWorkflowContract.cs` pin it by id. The directive names that one rule
-on that one element.
+Nineteen elements carry scoped `html-validate-disable-next` directives. The
+Wasm preload is genuinely incomplete until the .NET publish step injects its
+runtime `href`; three workflows plus `PromotionWorkflowContract.cs` pin it by
+id. The nine same-origin stylesheet and nine module references are Vite source
+inputs whose final asset names and bytes do not exist until build. Each
+directive names one rule on the immediately following element.
 
-That directive is the whole suppression budget, and the last toolchain test pins
-it as such. A directive is written in the document rather than in a config file,
-so none of the reads above can see one, and `no-unused-disable` cannot help when
-the suppression is genuinely used: widening this one from `disable-next` to a
-file-wide `disable` silences the rule for every element below it, and a second
-directive next to a fresh violation is equally invisible. So the test
-inventories every directive in every authored document and pins the set,
-including the action — a different rule, a second entry, or a wider action all
-fail.
+Those directives are the whole suppression budget, and the last toolchain test
+pins them as such. A directive is written in the document rather than in a
+config file, so none of the reads above can see one, and `no-unused-disable`
+cannot help when the suppression is genuinely used: widening one from
+`disable-next` to a file-wide `disable` silences the rule for every element
+below it, and a new directive next to a fresh violation is equally invisible.
+So the test inventories every directive in every authored document and pins
+the set, including the action — a different rule, another entry, or a wider
+action all fail.
 
 CSS is not linted. Adopting Stylelint is tracked separately.
 

--- a/prototypes/inspect-web/browser/annotated-source.html
+++ b/prototypes/inspect-web/browser/annotated-source.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Annotated Source browser gate</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="../src/styles.css">
   </head>
   <body>
     <div id="app"></div>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="./annotated-source-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/browser/dependency-graph-explorer.html
+++ b/prototypes/inspect-web/browser/dependency-graph-explorer.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dependency Graph Explore browser gate</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="../src/styles.css">
   </head>
   <body>
     <div id="app"></div>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="./dependency-graph-explorer-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/browser/graph-explorer.html
+++ b/prototypes/inspect-web/browser/graph-explorer.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Graph Explore browser gate</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="../src/styles.css">
   </head>
   <body>
     <div id="app"></div>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="./graph-explorer-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/browser/package-removal.html
+++ b/prototypes/inspect-web/browser/package-removal.html
@@ -4,11 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Package removal harness</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
   <body>
     <main id="app"></main>
     <p id="notice" role="status"></p>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="./package-removal-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/browser/saved-workspaces.html
+++ b/prototypes/inspect-web/browser/saved-workspaces.html
@@ -4,12 +4,14 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Saved Workspace interaction fixture</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="/src/styles.css">
   </head>
   <body>
     <button id="other-workspace" type="button">Load a different Workspace</button>
     <p id="notice" role="status"></p>
     <main id="app"></main>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="/browser/saved-workspaces-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/browser/type-graph-explorer.html
+++ b/prototypes/inspect-web/browser/type-graph-explorer.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Type Graph Explore browser gate</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="../src/styles.css">
   </head>
   <body>
     <main id="app"></main>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="./type-graph-explorer-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/browser/workspace-add-package.html
+++ b/prototypes/inspect-web/browser/workspace-add-package.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Workspace Add-package interaction fixture</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="/src/styles.css">
   </head>
   <body>
@@ -11,6 +12,7 @@
     <p id="notice" role="status"></p>
     <main id="app"></main>
     <div id="overlay"></div>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="/browser/workspace-add-package-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/browser/workspace-titlebar.html
+++ b/prototypes/inspect-web/browser/workspace-titlebar.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Inspect Web workspace title bar harness</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build] -->
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
   <body>
     <div id="app"></div>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin test module at build] -->
     <script type="module" src="./workspace-titlebar-harness.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/index.html
+++ b/prototypes/inspect-web/index.html
@@ -9,6 +9,7 @@
     />
     <base href="/" />
     <title>dotnet-inspect -- Inspect any NuGet package: types, methods, metadata, decompilation.</title>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin stylesheet at build; see README "Static analysis"] -->
     <link rel="stylesheet" href="/src/styles.css" />
     <!-- [html-validate-disable-next element-required-attributes -- the Wasm publish step injects href; see README "Static analysis"] -->
     <link rel="preload" id="webassembly" />
@@ -23,6 +24,7 @@
       aria-live="assertive"
       aria-atomic="true"
     ></div>
+    <!-- [html-validate-disable-next require-sri -- Vite rewrites this same-origin module entry at build; see README "Static analysis"] -->
     <script type="module" src="/src/bootstrap.ts"></script>
   </body>
 </html>

--- a/prototypes/inspect-web/test/toolchain.test.ts
+++ b/prototypes/inspect-web/test/toolchain.test.ts
@@ -2450,8 +2450,9 @@ test("no authored document sits where the lint glob cannot reach it", () => {
 // Neither is visible to `no-unused-disable`, because both suppressions are genuinely used.
 //
 // So the directives are inventoried and pinned as a set, action included. This project
-// needs exactly one, for one element, for one rule.
-test("authored documents carry only the one suppression this project explains", () => {
+// needs the Wasm preload exception plus the Vite stylesheet and module references in
+// the production entry page and eight browser harness entry pages.
+test("authored documents carry only the suppressions this project explains", () => {
   const root = fileURLToPath(new URL("../", import.meta.url));
   const documents = projectSourceFiles(root, htmlDocumentExtensions, unprunedRoots);
   assert.ok(documents.length > 0,
@@ -2469,11 +2470,30 @@ test("authored documents carry only the one suppression this project explains", 
     });
   }).sort();
 
-  assert.deepEqual(found, [
+  const browserHarnesses = [
+    "browser/annotated-source.html",
+    "browser/dependency-graph-explorer.html",
+    "browser/graph-explorer.html",
+    "browser/package-removal.html",
+    "browser/saved-workspaces.html",
+    "browser/type-graph-explorer.html",
+    "browser/workspace-add-package.html",
+    "browser/workspace-titlebar.html",
+  ];
+  const expected = [
+    ...browserHarnesses.flatMap(document => [
+      `${document}: disable-next require-sri`,
+      `${document}: disable-next require-sri`,
+    ]),
     "index.html: disable-next element-required-attributes",
-  ], "a directive is stock analysis switched off for the markup underneath it; a second "
-    + "one, a different rule, or a wider action than `disable-next` is a rule this "
-      + "project stopped running with nothing else here reporting the change");
+    "index.html: disable-next require-sri",
+    "index.html: disable-next require-sri",
+  ].sort();
+
+  assert.deepEqual(found, expected,
+    "a directive is stock analysis switched off for the markup underneath it; an "
+      + "unlisted directive, a different rule, or a wider action than `disable-next` "
+      + "is a rule this project stopped running with nothing else reporting the change");
 });
 
 // Every gate above reasons about where a control file may sit, which extension a glob
@@ -2589,6 +2609,10 @@ test("the committed html-validate configuration rejects what it is kept for", ()
       "<head><script src=\"https://cdn.example/x.js\" "
         + "crossorigin=\"anonymous\"></script></head>",
     ],
+    [
+      "require-sri",
+      "<head><script src=\" https://cdn.example/x.js\"></script></head>",
+    ],
     ["attribute-allowed-values", "<body><input type=\"nonsense\" /></body>"],
   ] as const;
 
@@ -2606,20 +2630,12 @@ test("the committed html-validate configuration rejects what it is kept for", ()
   }
 });
 
-// `require-sri` is the one rule this project configures away from its default, and the
-// reason is the only same-origin case that would otherwise fail: the local stylesheet and
-// the module entry point are files Vite emits, not third-party bytes to pin.
-//
-// The whole `rules` object is pinned, not that one entry. Round 2 (Sol, seat A) added
-// `"no-dup-id": "off"` beside it and kept `npm run lint` and all 35 tests green: an
-// assertion about one key says nothing about a second one added next to it, and every
-// specimen below names a rule that was still on. Pinning the object makes any further
-// relaxation of the stock presets land here.
-test("html-validate still demands a digest on third-party bytes", () => {
-  assert.deepEqual(htmlValidateConfig.rules, {
-    "require-sri": ["error", { target: "crossorigin" }],
-  }, "the only intended relaxation is same-origin; `target: all`, the rule being off, or "
-    + "a second rule configured beside it are all different properties");
+// This project uses the stock rule configuration. Same-origin references Vite rewrites
+// carry scoped source directives instead of weakening `require-sri` globally. Pinning
+// the absence of a `rules` object makes any project-wide relaxation land here.
+test("html-validate keeps its standard rule configuration", () => {
+  assert.equal(htmlValidateConfig.rules, undefined,
+    "stock rules must not be disabled, narrowed, or reconfigured project-wide");
   assert.deepEqual([...(htmlValidateConfig.extends ?? [])],
     ["html-validate:standard", "html-validate:document", "html-validate:a11y"],
     "the presets are what this adoption is for; narrowing them is not a config tweak");
@@ -2627,14 +2643,11 @@ test("html-validate still demands a digest on third-party bytes", () => {
     "without this html-validate walks up and merges configuration from outside the "
       + "project, so the committed file is not the one that runs");
 
-  // Rules are not the only way this file weakens the presets. Round 3 (Sol, both seats)
-  // added an `elements` entry that dropped `<button>`'s `type` metadata: the presets
-  // still resolved, every rule above was still on, and `attribute-allowed-values` simply
-  // had nothing left to check that element against. `plugins`, `transform` and `aria`
-  // reach the same place by other routes, so the key set is pinned rather than the three
-  // keys that happen to be interesting.
+  // Rules are not the only way this file can weaken the presets. `elements`, `plugins`,
+  // `transform`, and `aria` can change what the stock rules check without changing the
+  // preset list, so the whole key set is pinned.
   assert.deepEqual(Object.keys(htmlValidateConfig).sort(),
-    ["$schema", "extends", "root", "rules"],
+    ["$schema", "extends", "root"],
     "a key here that is not one of these -- `elements`, `plugins`, `transform`, `aria` "
       + "-- changes what the stock presets are checking against without changing any "
       + "rule, preset or severity the assertions above read");


### PR DESCRIPTION
Closes #5250

## Summary

- Remove the project-wide `require-sri` URL classifier override so `html-validate:standard` runs fail-closed.
- Scope exceptions to the nine Vite stylesheet inputs and nine Vite module inputs whose final bytes do not exist until build.
- Pin the absence of project-wide rule changes, the exact suppression inventory, and a whitespace-prefixed remote-script specimen.

## Demo

Before this change, the committed configuration accepted a remote script when its URL began with whitespace:

```html
<script src=" https://cdn.example.test/app.js"></script>
```

After this change, the same canonical `html-validate --config .htmlvalidate.json` invocation reports `require-sri` and exits 1. Ordinary remote script references without `integrity` remain rejected as a neighboring case.

What to notice: the fix comes from the stock `html-validate` rule behavior, not a repository-owned URL normalizer. Same-origin Vite source references are visible, element-scoped exceptions rather than a global classifier relaxation.

## Scope

This does not change `html-validate` internals, add bespoke URL classification, or attempt runtime SRI for assets whose names and bytes Vite has not produced yet. The exact exception budget is one Wasm preload plus eighteen Vite source references.

## Validation

- `npm run lint`
- `npm run build`
- `node --test --test-name-pattern='html-validate|authored documents carry only' test/toolchain.test.ts`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- Pathological whitespace-prefixed remote-script probe

Four unrelated Node 26 bundler read-set probes also fail on untouched `origin/main`; they are not changed here.