### PR TITLE
Retire superseded member Source scaffolding

### DIFF
--- a/docs/design/direct-member-comparison.md
+++ b/docs/design/direct-member-comparison.md
@@ -186,7 +186,7 @@ this update. These are outcomes, not a promise of eight PRs:
 | 8 | Cut over CLI `match --body`, including presentation and removal of its replaced dispatch/wrapper | Complete: #5967 |
 | 9 | Add the Browser managed facade, explicit pair interaction, and typed result view | Complete: #5990 |
 | 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | #6044 retires the unconsumed body-signal population profile |
-| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Remaining; retained tool/Source callers still constrain deletion; #5125 identity cleanup landed in #6099 |
+| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Remaining after #6250 removes the uncalled member-plus-PDB wrapper; assembly/generalized callers still constrain deletion; #5125 identity cleanup landed in #6099 |
 
 Each host path contains **5 milestones, all complete**:
 1, 18, 5, 6, then 8 or 9. The two scoped cleanups close the selected route,
@@ -230,12 +230,14 @@ the public query (#6177), retaining its native outcomes under the tools-owned
 This is internal harness adoption, not new product UX or RTS replacement
 readiness.
 
-Research `CompareMembers` still serves the supported PDB-source composition.
-Native result
-translations still serve CLI or harness presentation. These are retained
-caller obligations, not unused placeholders. The focused Research body-index
-association cleanup #5125 landed in #6099; neither that cleanup nor this
-comparison-tools migration completes broader retirement.
+Research assembly-level `WithPdbSourceComparisons` still serves broad CLI
+PDB-source enrichment. The uncalled `CompareMembersWithPdbSource` wrapper and
+its Source-specific member-result scaffolding are removed by #6250 after the
+paired CLI and browser adopters landed. Native result translations still serve
+CLI or harness presentation. These are retained caller obligations, not unused
+placeholders. The focused Research body-index association cleanup #5125 landed
+in #6099; neither that cleanup nor this Source cleanup completes broader
+retirement.
 
 ### Broader migration snapshot
 
@@ -263,7 +265,7 @@ and deletion commits to the tracker.
 | `ReturnToSender.CompareMemberBodies`, including `AuthoredRebuildFidelity` | Comparison tools step 10, RTS slice implemented in #6177 | Consume the public query and retain its native outcomes, replacing `BuildImplementationDiff` and its nullable legacy-result translation. Preserve the pathless donor, sibling resolution, target selection, compilation, and independent harness oracle. |
 | Browser managed facade and explicit two-member workspace comparison | Browser step 9, coordinated with #5083 | Expose the same public query as observable browser behavior. Inventory actual routes then; this plan does not invent a currently existing legacy browser caller. Remove a replaced route if one exists. |
 | `ImplementationComparisonQuery.Execute`, `DiffCommand`, and `DiffSections` assembly-wide paths | Steps 7-9; Source tail 13-15 | Separate from rank 5. Their public execution and result/output adoption precede final shared-shape retirement. |
-| `ImplementationDiff.CompareMembersWithPdbSource` | Source steps 12-15 and Research retirement step 17 | Its call to `CompareMembers` is an explicit deletion blocker even if its present direct callers are tests. Migrate its supported Source composition or record an explicit owner/user decision to remove that behavior; do not keep a hidden legacy C#/IL route. |
+| `ImplementationDiff.CompareMembersWithPdbSource` | Source steps 12-15 and Research retirement step 17 | Removed by #6250 after the selected CLI and browser Source consumers adopted `AssemblyContextMemberSourcePairQuery`; broad assembly enrichment remains on `WithPdbSourceComparisons`. |
 | `ImplementationDiff.CompareMembers`, dependent legacy member-result shapes, and independent old/new query forms | Queries step 16 and Research step 17 | Delete superseded orchestration and shapes after the refreshed caller inventory, including Source and tests, has a disposition. Preserve only APIs justified by a current owner-local contract. #5125 was reconciled independently by the identity cleanup in #6099. |
 
 Native `CSharpBodyDiff`, `IlAssemblyDiff`, Findings payloads, and useful aligned

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -1492,12 +1492,18 @@ This boundary does not define:
 
 ## Research authored-source comparison
 
-**Status:** target design for [#5901](https://github.com/richlander/dotnet-inspect/issues/5901),
-Research delivery step 12 of
+**Status:** bounded selected-member contract for
+[#5901](https://github.com/richlander/dotnet-inspect/issues/5901), Research
+delivery step 12 of
 [#4706](https://github.com/richlander/dotnet-inspect/issues/4706), advancing
 Slice 4 of [#2673](https://github.com/richlander/dotnet-inspect/issues/2673).
-The independent-population and bounded selected-member behavior below are
-**unimplemented and unverified**.
+The paired query and CLI adopter landed in
+[#5984](https://github.com/richlander/dotnet-inspect/pull/5984), the browser
+facade and view landed in
+[#6096](https://github.com/richlander/dotnet-inspect/pull/6096), and
+[#6250](https://github.com/richlander/dotnet-inspect/issues/6250) owns the
+resulting scoped retirement. Broader independent-population integration
+remains **unimplemented and unverified**.
 `ILInspector.Research` is the single owner.
 
 The claim is:
@@ -1509,12 +1515,13 @@ The claim is:
 
 ### Existing behavior and design basis
 
-The `Source` mechanism and CLI `--pdb-source` already exist. Research's
-`WithPdbSourceComparisons` can retain a Source-only member, but the CLI currently
-acquires source only for `ImplementationDiffResult.Members`: the local
-changed-member projection. No local changes means no Source acquisition.
-That is enrichment of known implementation changes, not independent discovery
-of authored changes across two versions.
+The `Source` mechanism and CLI `--pdb-source` predate this contract. Research's
+`WithPdbSourceComparisons` retains Source evidence for broad assembly-level
+enrichment. Before the paired query landed, CLI acquisition was limited to
+`ImplementationDiffResult.Members`, the local changed-member projection, so no
+local changes meant no Source acquisition. The bounded exact-member CLI and
+browser paths now use the paired query instead; broader CLI selections still
+use the existing enrichment path.
 
 The smallest sufficient change is to compose Source over the requested
 targets rather than that changed-row list. Conventional two-revision text
@@ -1688,8 +1695,13 @@ Preserve supported broader comparisons and typed failures while their
 consumers remain unmigrated; inventory them explicitly rather than claim a
 complete cutover. Scoped cleanup removes replaced dispatch and unused
 Source-specific scaffolding, not ordinary single-version Source or same-member
-PDB-versus-decompiled comparison. `CompareMembersWithPdbSource` and generalized
-Queries/Research retirement remain in #4706 until their actual callers move.
+PDB-versus-decompiled comparison.
+[#6250](https://github.com/richlander/dotnet-inspect/issues/6250) removes the
+uncalled `CompareMembersWithPdbSource` wrapper, its member-only Source flags and
+result fields, and the test dedicated to that wrapper. It retains
+`WithPdbSourceComparisons`, `PdbSourceComparisonInput`, assembly-level
+`ImplementationDiffMember.SourceComparison`, and generalized Queries/Research
+retirement in #4706.
 
 Structured endpoint outcomes, native comparisons, and provenance survive to
 presentation. Host adoptions use the shared Markout lowering for ordinary CLI
@@ -1727,10 +1739,10 @@ The browser's two-version Source selection consumes the same Source evidence,
 not CLI output. In a Source-only request, C# and IL are not requested, not
 reported unchanged.
 
-Planned Release gates below are **unimplemented and unverified**. The existing
-`ResearchDiffTests` Source comparison cases and
-`DiffCommandTests.BuildImplementationDiffView_LabelsPdbSourceAsIndependentLane`
-cover legacy projection only; they do not prove population independence.
+The bounded paired-query, CLI, and browser Release gates below are implemented.
+The existing `ResearchDiffTests` and broad `DiffCommandTests` Source cases cover
+the retained enrichment path; they do not prove broader population
+independence, which remains **unimplemented and unverified**.
 
 | Gate owner | Required observation |
 | --- | --- |
@@ -1878,11 +1890,13 @@ member result keeps the typed C# diff, typed IL diff, joined implementation
 changes, and a single `ResearchSubjectKey`; exact members return an empty
 change list with `IsExact` set.
 
-Use `CompareMembersWithPdbSource` when the caller also has old/new
-`FindingInspection<string>` envelopes from Services. Use
-`WithPdbSourceComparisons` to enrich an assembly comparison. These APIs
-preserve `Complete`, `Absent`, and `Failed` independently and retain the native
-line comparison. Research does not fetch source.
+Use `WithPdbSourceComparisons` to enrich an assembly comparison with old/new
+`FindingInspection<string>` envelopes from Services. It preserves `Complete`,
+`Absent`, and `Failed` independently and retains the native line comparison.
+Exact selected-member two-version comparison uses the Queries-owned
+`AssemblyContextMemberSourcePairQuery`, which retains each endpoint's
+resolution, acquisition, provenance, and non-success. Research does not fetch
+source.
 
 Finding acquisition and cross-validation failures use
 `ResearchChangeKind.Failed`; they are operational diagnostics, never semantic

--- a/docs/design/inspect-web-source-comparison.md
+++ b/docs/design/inspect-web-source-comparison.md
@@ -19,7 +19,9 @@ the browser experience tracker
 [#5083](https://github.com/richlander/dotnet-inspect/issues/5083).
 S1-S3 already landed, including the shared query and its CLI consumer in
 [#5984](https://github.com/richlander/dotnet-inspect/pull/5984).
-S6 is subsequent scoped retirement, not permission to delete broader callers.
+S6 is the separate scoped retirement in
+[#6250](https://github.com/richlander/dotnet-inspect/issues/6250), not
+permission to delete broader callers.
 
 ## Basis and consumed boundaries
 

--- a/docs/design/member-source-pair-query.md
+++ b/docs/design/member-source-pair-query.md
@@ -86,11 +86,18 @@ is not claimed migrated or removed by this bounded cutover.
 The single delivery ledger is
 [#4706](https://github.com/richlander/dotnet-inspect/issues/4706):
 S1 contract alignment (landed), S2 this query, S3 CLI adoption, S4 browser
-facade, S5 browser view/state, S6 scoped retirement. Six milestones total;
+facade, S5 browser view/state, and S6 scoped retirement in
+[#6250](https://github.com/richlander/dotnet-inspect/issues/6250). Six
+milestones total;
 CLI adoption uses S1-S3 and browser adoption S1/S2/S4/S5. S2 and S3 travel
 together in [#5970](https://github.com/richlander/dotnet-inspect/issues/5970)
 rather than leaving another unconsumed substrate. Browser ownership
 remains under [#5083](https://github.com/richlander/dotnet-inspect/issues/5083).
+
+S6 removes the now-uncalled Research member-plus-PDB wrapper and its
+Source-specific member-result scaffolding. It deliberately retains broad CLI
+assembly enrichment, typed unavailable and failed Source rows, ordinary
+single-version Source, and same-member PDB-versus-decompiled comparison.
 
 CLI rendering consumes the typed pair alongside unchanged native C#/IL
 results and lowers into its existing Markout Implementation Diff rows.

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -2274,38 +2274,6 @@ public class ResearchDiffTests
     }
 
     [Fact]
-    public void ImplementationDiff_PdbSourceIsIndependentPeerMechanism()
-    {
-        using var source = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
-        var stable = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "Stable");
-        var oldInspection = new FindingInspection<string>.Complete(
-            [.. TextFindings.Inspect("return 1;", new FindingSubject("old", "old"))]);
-        var newInspection = new FindingInspection<string>.Complete(
-            [.. TextFindings.Inspect("return 2;", new FindingSubject("new", "new"))]);
-        var result = ImplementationDiff.CompareMembersWithPdbSource(
-            source,
-            stable,
-            source,
-            stable,
-            oldInspection,
-            newInspection);
-
-        Assert.True(result.HasSourceChanges);
-        Assert.False(result.HasCSharpChanges);
-        Assert.False(result.HasIlChanges);
-        Assert.NotNull(result.SourceComparison);
-        Assert.Contains(result.Changes, change =>
-            change.Mechanism == ResearchChangeMechanism.Source
-            && ImplementationDiff.UnifiedLines(change).Any(line =>
-                line.Contains("return 2", StringComparison.Ordinal)));
-        Assert.Single(result.RetainedComparisons.Get<string>(TextFindings.LineDescriptor));
-        Assert.Single(result.RetainedComparisons.Get<CSharpCanonicalLine>(
-            CSharpFindings.LineDescriptor));
-        Assert.Single(result.RetainedComparisons.Get<CanonicalIlOperation>(
-            IlFindings.OperationDescriptor));
-    }
-
-    [Fact]
     public void ImplementationDiff_PdbSourcePreservesAbsentStateWithoutChangingCSharp()
     {
         var subject = new ResearchSubjectKey(

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -18,9 +18,7 @@ public enum ImplementationDiffMechanism
     None = 0,
     CSharp = 1,
     IlBody = 2,
-    Source = 4,
     All = CSharp | IlBody,
-    AllAvailable = All | Source,
 }
 
 public sealed record ImplementationDiffOptions(
@@ -68,23 +66,17 @@ public sealed record ImplementationMemberDiffResult(
     IReadOnlyList<ResearchChange> Changes,
     RetainedFindingComparisonSet RetainedComparisons)
 {
-    public FindingComparison<string>? SourceComparison { get; init; }
-
     public bool HasCSharpChanges
         => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
 
     public bool HasIlChanges
         => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.IlBody);
 
-    public bool HasSourceChanges
-        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.Source);
-
     public bool IsExact
         => Changes.Count == 0
            && (CSharpDiff is null || CSharpDiff.IsExact)
            && (IlDiff is null || IlDiff.Diff.IsExact)
-           && RetainedComparisons.Items.All(comparison => comparison.IsExact)
-           && (SourceComparison is null || SourceComparison.IsExact);
+           && RetainedComparisons.Items.All(comparison => comparison.IsExact);
 }
 
 /// <summary>
@@ -233,45 +225,6 @@ public static class ImplementationDiff
             ilDiff,
             changes.ToImmutable(),
             new RetainedFindingComparisonSet(retainedComparisons));
-    }
-
-    public static ImplementationMemberDiffResult CompareMembersWithPdbSource(
-        MetadataSource oldSource,
-        MethodDefinitionHandle oldMethod,
-        MetadataSource newSource,
-        MethodDefinitionHandle newMethod,
-        FindingInspection<string> oldPdbSource,
-        FindingInspection<string> newPdbSource,
-        ImplementationDiffMechanism mechanisms = ImplementationDiffMechanism.AllAvailable,
-        ResearchSubjectKey? subject = null)
-    {
-        ArgumentNullException.ThrowIfNull(oldPdbSource);
-        ArgumentNullException.ThrowIfNull(newPdbSource);
-
-        var result = CompareMembers(
-            oldSource,
-            oldMethod,
-            newSource,
-            newMethod,
-            mechanisms & ~ImplementationDiffMechanism.Source,
-            subject);
-        if (!mechanisms.HasFlag(ImplementationDiffMechanism.Source))
-            return result;
-
-        var comparison = FindingComparison.Compare(
-            oldPdbSource,
-            newPdbSource);
-        var retained = result.RetainedComparisons.Items.ToBuilder();
-        retained.Add(new RetainedFindingComparison<string>(
-            result.Subject,
-            TextFindings.LineDescriptor,
-            comparison));
-        return result with
-        {
-            Changes = [.. result.Changes, .. ToSourceChanges(comparison, result.Subject)],
-            RetainedComparisons = new RetainedFindingComparisonSet(retained),
-            SourceComparison = comparison,
-        };
     }
 
     public static ImplementationDiffResult Compare(


### PR DESCRIPTION
Closes #6250.

Removes the unused member-level PDB Source wrapper after the selected CLI and
browser consumers adopted `AssemblyContextMemberSourcePairQuery` in #5984 and
#6096. This retires only the superseded Research orchestration: broad CLI
Source enrichment and the ordinary single-member Source experiences remain.

The change removes:

- `ImplementationDiff.CompareMembersWithPdbSource`;
- its `ImplementationDiffMechanism.Source` and `AllAvailable` flags;
- Source-only state from `ImplementationMemberDiffResult`; and
- the direct Research test whose only purpose was the removed wrapper.

It retains `ImplementationDiff.WithPdbSourceComparisons`,
`PdbSourceComparisonInput`, `ImplementationDiffMember.SourceComparison`,
typed unavailable/failed broad Source rows, single-version Source inspection,
and same-member PDB-versus-decompiled comparison. The owning designs now record
that boundary and leave generalized #4706 retirement open.

## Demo

The selected exact-member path still finds an authored Source-only change even
when native C# and IL are unchanged:

```text
dotnet-inspect diff \
  --library SourceDiffFixture.v1.dll..SourceDiffFixture.v2.dll \
  --type SourceDiffFixture.Counter \
  --member Value \
  -S "Implementation Diff" \
  --pdb-source

Summary: 1 selected member; 0 decompiled C#, 0 IL,
         and 2 PDB Source evidence rows.

- public int Value() => 1 + 2;
+ public int Value() => 3;
```

The neighboring type-wide invocation still takes the retained broad
enrichment path:

```text
dotnet-inspect diff \
  --library SourceDiffFixture.v1.dll..SourceDiffFixture.v2.dll \
  --type SourceDiffFixture.Counter \
  -S "Implementation Diff" \
  --pdb-source

Summary: 4 changed members; 7 decompiled C#, 6 IL,
         and 5 PDB Source evidence rows.
```

That output includes PDB Source evidence for the removed `BeforeOnly` member
and changed `MovedBlockAndEdit`/`Reordered` declarations, demonstrating that
the broader fallback and its typed Source projection remain live.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Research.Tests -c Release -- --filter-class '*ResearchDiffTests'` — 101 passed
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- --filter-class '*AssemblyContextSourceQueryTests'` — 126 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class '*SelectedSourceDiffTests' --filter-class '*DiffCommandTests'` — 167 passed
- `npx markdownlint-cli docs/design/implementation-diff.md docs/design/member-source-pair-query.md docs/design/inspect-web-source-comparison.md docs/design/direct-member-comparison.md`
- source caller inventory: no C# references remain to
  `CompareMembersWithPdbSource`,
  `ImplementationDiffMechanism.Source`, or
  `ImplementationDiffMechanism.AllAvailable`
