### PR TITLE
Make archive containment recognizable to CodeQL

### DIFF
--- a/src/DotnetInspector.Packages/PackageContentAdmission.cs
+++ b/src/DotnetInspector.Packages/PackageContentAdmission.cs
@@ -327,6 +327,10 @@ internal static class PackageContentAdmission
         HashSet<string> expectedDirs = new(pathComparer);
         try
         {
+            string fullRoot = Path.GetFullPath(root);
+            string rootPrefix = Path.EndsInDirectorySeparator(fullRoot)
+                ? fullRoot
+                : fullRoot + Path.DirectorySeparatorChar;
             using var zip = new ZipArchive(
                 new MemoryStream(archive, writable: false),
                 ZipArchiveMode.Read);
@@ -357,9 +361,10 @@ internal static class PackageContentAdmission
                 archiveFiles.Add(relative);
                 RememberDirectoryParents(expectedDirs, relative);
 
-                string onDisk = Path.Combine(
-                    root,
-                    relative.Replace('/', Path.DirectorySeparatorChar));
+                string onDisk = Path.GetFullPath(relative, fullRoot);
+                if (!onDisk.StartsWith(rootPrefix, PathComparison))
+                    return false;
+
                 if (!File.Exists(onDisk) || IsReparsePoint(onDisk))
                     return false;
 

--- a/src/DotnetInspector.Services.Tests/PackageExtractorAdmissionTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageExtractorAdmissionTests.cs
@@ -288,25 +288,10 @@ public sealed class PackageExtractorAdmissionTests
     {
         try
         {
-            using var archive = ZipFile.OpenRead(nupkgPath);
-            foreach (ZipArchiveEntry entry in archive.Entries)
-            {
-                string relative = entry.FullName.Replace('\\', '/');
-                if (string.IsNullOrEmpty(relative) || relative.EndsWith('/'))
-                    continue;
-                if (relative.Contains("..", StringComparison.Ordinal)
-                    || Path.IsPathRooted(relative))
-                {
-                    return false;
-                }
-
-                string target = Path.Combine(
-                    destination,
-                    relative.Replace('/', Path.DirectorySeparatorChar));
-                Directory.CreateDirectory(Path.GetDirectoryName(target)!);
-                entry.ExtractToFile(target, overwrite: true);
-            }
-
+            ZipFile.ExtractToDirectory(
+                nupkgPath,
+                destination,
+                overwriteFiles: true);
             return true;
         }
         catch (Exception ex) when (ex is InvalidDataException or IOException)

--- a/src/NuGetFetch/PackageExtractor.cs
+++ b/src/NuGetFetch/PackageExtractor.cs
@@ -53,6 +53,9 @@ public static class PackageExtractor
     private static void ExtractWithValidation(string zipPath, string destinationPath)
     {
         string fullDestination = Path.GetFullPath(destinationPath);
+        string destinationPrefix = Path.EndsInDirectorySeparator(fullDestination)
+            ? fullDestination
+            : fullDestination + Path.DirectorySeparatorChar;
 
         using ZipArchive archive = ZipFile.OpenRead(zipPath);
 
@@ -71,10 +74,9 @@ public static class PackageExtractor
                 throw new InvalidDataException($"Zip entry '{entry.FullName}' contains invalid path components.");
             }
 
-            string targetPath = Path.GetFullPath(Path.Combine(fullDestination, entry.FullName));
+            string targetPath = Path.GetFullPath(entry.FullName, fullDestination);
 
-            if (!targetPath.StartsWith(fullDestination + Path.DirectorySeparatorChar, StringComparison.Ordinal)
-                && !targetPath.Equals(fullDestination, StringComparison.Ordinal))
+            if (!targetPath.StartsWith(destinationPrefix, StringComparison.Ordinal))
             {
                 throw new InvalidDataException($"Zip entry '{entry.FullName}' would extract outside the target directory.");
             }


### PR DESCRIPTION
Closes #6252

## Summary

- Rewrite the two product path checks as `Path.GetFullPath(relative, root)` followed by a simple true-path `StartsWith(rootPrefix)` containment gate, matching the sanitizer modeled by CodeQL.
- Preserve `NuGetFetch.PackageExtractor` public traversal behavior and exception type.
- Replace the test-only custom extraction loop with .NET’s traversal-aware `ZipFile.ExtractToDirectory`.

## Demo

Before this change, the nightly scan reports three high-severity `cs/zipslip` alerts:

```text
#26 src/DotnetInspector.Packages/PackageContentAdmission.cs:336
#27 src/DotnetInspector.Services.Tests/PackageExtractorAdmissionTests.cs:294
#28 src/NuGetFetch/PackageExtractor.cs:74
```

The existing NuGetFetch traversal fixture still rejects `../../../etc/evil.txt` with `InvalidDataException`, while ordinary package extraction succeeds. Hosted CodeQL run `34147425833` completed successfully on this exact head: the C# analysis (`1737176800`) reported `results_count: 0`, and the branch-specific open `cs/zipslip` alert query returned `[]`.

What to notice: the change does not add another archive policy. It uses the exact canonical-path and true-guard form recognized by the off-the-shelf query, and removes the test-only custom extraction sink entirely.

## Design basis

`docs/design/untrusted-data-threat-model.md#package-archives-use-traversal-aware-extraction` owns the claim that archive-derived paths remain inside their extraction root. The runtime extractor and explicit canonical containment checks implement that existing claim; no new threat boundary or archive policy is introduced.

## Scope

This PR addresses only the three reported `cs/zipslip` paths. It does not add custom CodeQL models, broaden archive validation, or change the extraction API contract.

## Validation

- `dotnet run --project tests/NuGetFetch.Tests -c Release` — 1,078 passed, 11 environment-dependent tests skipped
- Focused `PackageExtractorAdmissionTests` — 4 passed
- Focused archive-backed tree containment tests — 2 passed
- `dotnet build dotnet-inspect.slnx -c Release`
- `git diff --check`
- Manual hosted CodeQL run `34147425833` — C# analysis succeeded with zero results; no branch `cs/zipslip` alerts