### PR TITLE
Retire superseded Research direct-member wrapper

### DIFF
--- a/docs/design/direct-member-comparison.md
+++ b/docs/design/direct-member-comparison.md
@@ -35,9 +35,9 @@ and a presentation-neutral result. The analogous
 [member source comparison query](member-source-comparison-query.md) preserves
 endpoint outcomes without turning failure into empty text. Its one-member,
 PDB-versus-decompilation operation is not this two-method, local C#/IL operation.
-`ImplementationDiff.CompareMembers` is the behavioral baseline for explicit
-pairing; its direct caller-to-Research orchestration is the retirement target,
-not the native C# or IL algorithms.
+`ImplementationDiff.CompareMembers` was the behavioral baseline for explicit
+pairing. After every caller migrated, #6255 retires its direct
+caller-to-Research orchestration, not the native C# or IL algorithms.
 
 The adapter exists to replace repeated caller orchestration with one exact
 association and failure-preserving boundary. It does not need a second
@@ -174,8 +174,8 @@ for unrelated package-role, whole-assembly, body-signal, or Source migrations.
 It does not invoke root-to-terminal forwarding composition. Those scenarios
 remain separate; a physical `ExactAddress` is not retargeted.
 
-The selected route has **8 delivery milestones: 6 complete, 2 remaining** at
-this update. These are outcomes, not a promise of eight PRs:
+The selected route has **8 delivery milestones, all complete** after #6255.
+These are outcomes, not a promise of eight PRs:
 
 | Tracker step | Selected outcome | Status |
 | --- | --- | --- |
@@ -185,16 +185,16 @@ this update. These are outcomes, not a promise of eight PRs:
 | 6 | Implement the physical-pair Queries adapter | Complete: #5967 |
 | 8 | Cut over CLI `match --body`, including presentation and removal of its replaced dispatch/wrapper | Complete: #5967 |
 | 9 | Add the Browser managed facade, explicit pair interaction, and typed result view | Complete: #5990 |
-| 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | #6044 retires the unconsumed body-signal population profile |
-| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Remaining after #6250 removes the uncalled member-plus-PDB wrapper; assembly/generalized callers still constrain deletion; #5125 identity cleanup landed in #6099 |
+| 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | Complete: #6047 retires the unconsumed body-signal population profile |
+| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Complete: #6099 removes legacy body-index identity heuristics; #6251 removes uncalled member Source scaffolding; #6255 removes the superseded direct-member wrapper |
 
 Each host path contains **5 milestones, all complete**:
 1, 18, 5, 6, then 8 or 9. The two scoped cleanups close the selected route,
 not all global retirement in #4706.
 
-Landing the scoped Queries cleanup completes seven of this route's eight
-milestones. It does not complete whole-assembly or body-signal execution
-migration, comparison-tool adoption, or global Queries retirement.
+Completing both scoped cleanups does not complete whole-assembly or body-signal
+execution migration, the remaining comparison-tool work, or global Queries and
+Research retirement.
 
 Keep the first publication and adapter runtime together with the CLI
 adopting change; the bounded first-adopter exception permits that focused
@@ -236,8 +236,10 @@ its Source-specific member-result scaffolding are removed by #6250 after the
 paired CLI and browser adopters landed. Native result translations still serve
 CLI or harness presentation. These are retained caller obligations, not unused
 placeholders. The focused Research body-index association cleanup #5125 landed
-in #6099; neither that cleanup nor this Source cleanup completes broader
-retirement.
+in #6099. After ReturnToSender migrated in #6181, #6255 removes the remaining
+uncalled `ImplementationDiff.CompareMembers` orchestration and
+`ImplementationMemberDiffResult`. These scoped deletions close this bounded
+route; they do not complete broader retirement.
 
 ### Broader migration snapshot
 
@@ -266,7 +268,8 @@ and deletion commits to the tracker.
 | Browser managed facade and explicit two-member workspace comparison | Browser step 9, coordinated with #5083 | Expose the same public query as observable browser behavior. Inventory actual routes then; this plan does not invent a currently existing legacy browser caller. Remove a replaced route if one exists. |
 | `ImplementationComparisonQuery.Execute`, `DiffCommand`, and `DiffSections` assembly-wide paths | Steps 7-9; Source tail 13-15 | Separate from rank 5. Their public execution and result/output adoption precede final shared-shape retirement. |
 | `ImplementationDiff.CompareMembersWithPdbSource` | Source steps 12-15 and Research retirement step 17 | Removed by #6250 after the selected CLI and browser Source consumers adopted `AssemblyContextMemberSourcePairQuery`; broad assembly enrichment remains on `WithPdbSourceComparisons`. |
-| `ImplementationDiff.CompareMembers`, dependent legacy member-result shapes, and independent old/new query forms | Queries step 16 and Research step 17 | Delete superseded orchestration and shapes after the refreshed caller inventory, including Source and tests, has a disposition. Preserve only APIs justified by a current owner-local contract. #5125 was reconciled independently by the identity cleanup in #6099. |
+| `ImplementationDiff.CompareMembers` and its member-result wrapper | Research step 17, scoped route completed by #6255 | Removed after the refreshed inventory confirmed all direct-member hosts and tools consume the public query. |
+| Independent old/new query forms and generalized assembly/body-signal orchestration | Queries step 16 and Research step 17, broader migration | Retain while current CLI and query callers depend on them; remove only after their separate migrations. #5125 was reconciled independently by the identity cleanup in #6099. |
 
 Native `CSharpBodyDiff`, `IlAssemblyDiff`, Findings payloads, and useful aligned
 hunks are not deletion targets merely because they are below Queries.

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -1123,8 +1123,9 @@ mutable-file or local-actor threat model.
 
 ### Designated-pair basis and delivery
 
-The baseline is explicit old/new endpoint comparison, already supported by
-`ImplementationDiff.CompareMembers` and both native endpoint adapters.
+At this design's introduction, explicit old/new endpoint comparison was already
+supported by `ImplementationDiff.CompareMembers` and both native endpoint
+adapters.
 Ordinary Research correspondence is useful analogous evidence precisely
 because it refuses unequal keys: changing that refusal would answer the wrong
 question. An owner-issued pair and a closed alternate work basis are the
@@ -1143,12 +1144,14 @@ The tracker and the
 own those paths and final legacy Queries/Research retirement at steps 16/17.
 The tracker owns subsequent status/count changes.
 
-Adding this substrate does not retire `ImplementationDiff.CompareMembers`,
-its Source-dependent callers, or their projections. Queries population,
-workspace composition, publication, host rendering, and Source adoption remain
-separate work. This section adds no output schema: downstream CLI lowering
-uses the planned shared Markout presentation path, and browser adoption
-consumes typed evidence under its own host contract.
+Adding this substrate did not itself retire `ImplementationDiff.CompareMembers`,
+its Source-dependent callers, or their projections. Those callers subsequently
+migrated, and #6255 removes the wrapper under the current
+[consumer contract](#consumer-contract). Queries population, workspace
+composition, publication, host rendering, and Source adoption were separate
+work. This section adds no output schema: downstream CLI lowering uses the
+shared Markout presentation path, and browser adoption consumes typed evidence
+under its own host contract.
 
 ## Research local producer session and completion
 
@@ -1884,11 +1887,13 @@ the input is a pair of assemblies or `ResearchDiffInput` values. The result is a
 list of changed implementation members. Each member can carry C# changes, IL
 changes, or both; exact members are omitted.
 
-Use `ImplementationDiff.CompareMembers` when the caller already resolved exact
-old/new `MethodDefinitionHandle` values in live `MetadataSource` instances. The
-member result keeps the typed C# diff, typed IL diff, joined implementation
-changes, and a single `ResearchSubjectKey`; exact members return an empty
-change list with `IsExact` set.
+Compare two exact selected methods through the Queries-owned
+`DirectMemberComparisonQuery`. It preserves admitted physical endpoints,
+Research publication, typed non-success, and independent native C# and IL
+outcomes. After every CLI, Browser, RoundTripCompilation, ReturnToSender, and
+authored-rebuild caller migrated, #6255 retires the superseded
+`ImplementationDiff.CompareMembers` orchestration and its member-result wrapper.
+Assembly-wide implementation comparison remains on the APIs above.
 
 Use `WithPdbSourceComparisons` to enrich an assembly comparison with old/new
 `FindingInspection<string>` envelopes from Services. It preserves `Complete`,

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -30,7 +30,7 @@ Four experiences render member bodies, and today each carries its own stack:
 | Skeleton source | `CSharpTypePrinter.Print` | declarations, no bodies |
 | Full source | `MemberBodyProducer.Project` | full C# bodies |
 | Merged IL + C# | `ResearchViews.RenderMixedCore` | C# spine, IL beneath |
-| Implementation diff | `ImplementationDiff.CompareMembers` | per-member C#/IL/source diff |
+| Implementation diff | `DirectMemberComparisonQuery.Execute` | per-member C#/IL diff |
 
 They already agree on the bottom: every C# or IL body path calls
 `IrImporter.Import(MetadataSource, …) → IrFunction` and then projects it. But

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -2227,53 +2227,6 @@ public class ResearchDiffTests
     }
 
     [Fact]
-    public void ImplementationDiff_CompareMembers_SameMemberIsExact()
-    {
-        using var source = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
-        var stable = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "Stable");
-
-        var diff = ImplementationDiff.CompareMembers(source, stable, source, stable);
-
-        Assert.True(diff.IsExact);
-        Assert.Equal("Stable", diff.Subject.MemberName);
-        Assert.NotNull(diff.CSharpDiff);
-        Assert.True(diff.CSharpDiff.IsExact);
-        Assert.NotNull(diff.IlDiff);
-        Assert.True(diff.IlDiff.Diff.IsExact);
-        Assert.Empty(diff.Changes);
-        Assert.True(Assert.Single(diff.RetainedComparisons.Get<CSharpCanonicalLine>(
-            CSharpFindings.LineDescriptor)).IsExact);
-        Assert.True(Assert.Single(diff.RetainedComparisons.Get<CanonicalIlOperation>(
-            IlFindings.OperationDescriptor)).IsExact);
-    }
-
-    [Fact]
-    public void ImplementationDiff_CompareMembers_GroupsCSharpAndIlEvidence()
-    {
-        using var oldSource = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
-        using var newSource = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.NewAssemblyPath());
-        var oldMethod = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "ConstantValue");
-        var newMethod = FindMethodHandle(FixtureCatalog.DiffPair.NewAssemblyPath(), "DiffFixtureSample.DiffSample", "ConstantValue");
-
-        var diff = ImplementationDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-
-        Assert.False(diff.IsExact);
-        Assert.Equal("ConstantValue", diff.Subject.MemberName);
-        Assert.True(diff.HasCSharpChanges);
-        Assert.True(diff.HasIlChanges);
-        Assert.Contains(diff.Changes, change =>
-            change.Mechanism == ResearchChangeMechanism.CSharp
-            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("return 1", StringComparison.Ordinal)));
-        Assert.Contains(diff.Changes, change =>
-            change.Mechanism == ResearchChangeMechanism.IlBody
-            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
-        Assert.False(Assert.Single(diff.RetainedComparisons.Get<CSharpCanonicalLine>(
-            CSharpFindings.LineDescriptor)).IsExact);
-        Assert.False(Assert.Single(diff.RetainedComparisons.Get<CanonicalIlOperation>(
-            IlFindings.OperationDescriptor)).IsExact);
-    }
-
-    [Fact]
     public void ImplementationDiff_PdbSourcePreservesAbsentStateWithoutChangingCSharp()
     {
         var subject = new ResearchSubjectKey(

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -1,6 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection;
-using System.Reflection.Metadata;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -59,26 +57,6 @@ public sealed record PdbSourceComparisonInput(
     FindingInspection<string> OldInspection,
     FindingInspection<string> NewInspection);
 
-public sealed record ImplementationMemberDiffResult(
-    ResearchSubjectKey Subject,
-    CSharpBodyDiffResult? CSharpDiff,
-    IlMemberDiffResult? IlDiff,
-    IReadOnlyList<ResearchChange> Changes,
-    RetainedFindingComparisonSet RetainedComparisons)
-{
-    public bool HasCSharpChanges
-        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
-
-    public bool HasIlChanges
-        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.IlBody);
-
-    public bool IsExact
-        => Changes.Count == 0
-           && (CSharpDiff is null || CSharpDiff.IsExact)
-           && (IlDiff is null || IlDiff.Diff.IsExact)
-           && RetainedComparisons.Items.All(comparison => comparison.IsExact);
-}
-
 /// <summary>
 /// Product-owned implementation diff projection that joins C# source-shape and
 /// IL/body changes by Research member identity.
@@ -103,128 +81,6 @@ public static class ImplementationDiff
             ResearchDiffInput.FromAssembly(oldAssemblyPath),
             ResearchDiffInput.FromAssembly(newAssemblyPath),
             options);
-    }
-
-    public static ImplementationMemberDiffResult CompareMembers(
-        MetadataSource oldSource,
-        MethodDefinitionHandle oldMethod,
-        MetadataSource newSource,
-        MethodDefinitionHandle newMethod,
-        ImplementationDiffMechanism mechanisms = ImplementationDiffMechanism.All,
-        ResearchSubjectKey? subject = null)
-    {
-        ArgumentNullException.ThrowIfNull(oldSource);
-        ArgumentNullException.ThrowIfNull(newSource);
-        if (oldMethod.IsNil)
-            throw new ArgumentException("Old method handle must not be nil.", nameof(oldMethod));
-        if (newMethod.IsNil)
-            throw new ArgumentException("New method handle must not be nil.", nameof(newMethod));
-
-        subject ??= SubjectFromMethod(oldSource, oldMethod);
-        CSharpBodyDiffResult? csharpDiff = null;
-        IlMemberDiffResult? ilDiff = null;
-        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
-        var retainedComparisons = ImmutableArray.CreateBuilder<RetainedFindingComparison>();
-
-        if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
-        {
-            csharpDiff = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-            var semanticChanges = ToCSharpChanges(csharpDiff, subject);
-            changes.AddRange(semanticChanges);
-            var comparison = CSharpFindings.Compare(
-                oldSource,
-                oldMethod,
-                newSource,
-                newMethod,
-                new FindingSubject(subject.Id, subject.Display));
-            retainedComparisons.Add(new RetainedFindingComparison<CSharpCanonicalLine>(
-                subject,
-                CSharpFindings.LineDescriptor,
-                comparison));
-            if (comparison is FindingComparison<CSharpCanonicalLine>.Failed failed)
-            {
-                if (!semanticChanges.Any(change => change.Kind == ResearchChangeKind.Failed))
-                {
-                    changes.Add(FindingFailureChange(
-                        subject,
-                        ResearchChangeMechanism.CSharp,
-                        ResearchChangeCategory.CSharp,
-                        CSharpFindings.InspectionDescriptor,
-                        failed.Failure));
-                }
-            }
-            else if (FindingDivergenceChange(
-                subject,
-                ResearchChangeMechanism.CSharp,
-                ResearchChangeCategory.CSharp,
-                CSharpFindingDivergenceDescriptor,
-                comparison.IsExact,
-                csharpDiff.IsExact) is { } divergence)
-            {
-                changes.Add(divergence);
-            }
-        }
-
-        if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
-        {
-            string label = subject.TypeName is { Length: > 0 } typeName && subject.MemberName is { Length: > 0 } memberName
-                ? $"{typeName}::{memberName}"
-                : subject.Display;
-            ilDiff = IlAssemblyDiff.CompareMembers(
-                oldSource.Pe,
-                oldSource.Reader,
-                oldMethod,
-                newSource.Pe,
-                newSource.Reader,
-                newMethod,
-                oldLabel: label,
-                newLabel: label);
-            var semanticChanges = ToIlChanges(ilDiff, subject);
-            changes.AddRange(semanticChanges);
-            var comparison = IlFindings.Compare(
-                oldSource.Pe,
-                oldSource.Reader,
-                oldMethod,
-                newSource.Pe,
-                newSource.Reader,
-                newMethod,
-                new FindingSubject(subject.Id, subject.Display));
-            retainedComparisons.Add(new RetainedFindingComparison<CanonicalIlOperation>(
-                subject,
-                IlFindings.OperationDescriptor,
-                comparison));
-            if (comparison is FindingComparison<CanonicalIlOperation>.Failed failed)
-            {
-                if (!semanticChanges.Any(change => change.Kind == ResearchChangeKind.Failed))
-                {
-                    changes.Add(FindingFailureChange(
-                        subject,
-                        ResearchChangeMechanism.IlBody,
-                        ResearchChangeCategory.IlBody,
-                        IlFindings.InspectionDescriptor,
-                        failed.Failure));
-                }
-            }
-            else if (MethodHasBody(oldSource, oldMethod)
-                && MethodHasBody(newSource, newMethod)
-                && FindingDivergenceChange(
-                    subject,
-                    ResearchChangeMechanism.IlBody,
-                    ResearchChangeCategory.IlBody,
-                    IlFindingDivergenceDescriptor,
-                    comparison.IsExact,
-                    ilDiff.Diff.IsExact) is { } divergence)
-            {
-                changes.Add(divergence);
-            }
-        }
-
-        return new ImplementationMemberDiffResult(
-            subject,
-            csharpDiff,
-            ilDiff,
-            changes.ToImmutable(),
-            new RetainedFindingComparisonSet(retainedComparisons));
     }
 
     public static ImplementationDiffResult Compare(
@@ -632,82 +488,6 @@ public static class ImplementationDiff
             detail: detail,
             category: ResearchChangeCategory.Source);
 
-    static ImmutableArray<ResearchChange> ToCSharpChanges(
-        CSharpBodyDiffResult diff,
-        ResearchSubjectKey subject)
-    {
-        ArgumentNullException.ThrowIfNull(diff);
-        if (diff.IsExact)
-            return [];
-
-        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
-        foreach (var failure in diff.IdentityFailures.IsDefault
-            ? []
-            : diff.IdentityFailures)
-        {
-            string detail = $"{failure.Side} 0x{failure.SubjectToken:X8} "
-                + $"{failure.Mechanism}/{failure.Kind}: {failure.Detail}";
-            changes.Add(new ResearchChange(
-                subject,
-                ResearchChangeMechanism.CSharp,
-                new FindingDescriptor(
-                    "csharp.diff.identity-resolution-failure",
-                    "Identity resolution failure"),
-                ResearchChangeKind.Failed,
-                oldValue: failure.Side == "old" ? detail : null,
-                newValue: failure.Side == "new" ? detail : null,
-                detail: detail,
-                category: ResearchChangeCategory.CSharp));
-        }
-
-        var failureRows = diff.FailureRows.IsDefault ? [] : diff.FailureRows;
-        var operationalFailureHunks = ResearchDiff.OperationalCSharpFailureHunks(failureRows);
-        foreach (var failure in failureRows)
-        {
-            var kind = ResearchDiff.Direction(failure.Kind);
-            string descriptorId = $"csharp.diff.{ResearchDiff.ToChangeIdPart(failure.Kind.ToString())}";
-            changes.Add(new ResearchChange(
-                subject,
-                ResearchChangeMechanism.CSharp,
-                new FindingDescriptor(descriptorId, failure.Kind.ToString()),
-                kind,
-                oldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
-                newValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
-                detail: failure.Detail ?? failure.Message,
-                category: ResearchChangeCategory.CSharp,
-                cSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(failure)));
-        }
-
-        foreach (var row in diff.Rows.IsDefault ? [] : diff.Rows)
-        {
-            if (operationalFailureHunks.Contains(row.HunkId))
-                continue;
-
-            var kind = row.Kind switch
-            {
-                CSharpDiffKind.Add => ResearchChangeKind.Added,
-                CSharpDiffKind.Remove => ResearchChangeKind.Removed,
-                _ => ResearchChangeKind.Changed,
-            };
-            changes.Add(new ResearchChange(
-                subject,
-                ResearchChangeMechanism.CSharp,
-                new FindingDescriptor(row.ChangeId, row.ChangeId),
-                kind,
-                oldValue: row.OldOperation?.Value
-                    ?? row.OldValue
-                    ?? (kind == ResearchChangeKind.Removed ? row.Text : null),
-                newValue: row.NewOperation?.Value
-                    ?? row.NewValue
-                    ?? (kind == ResearchChangeKind.Added ? row.Text : null),
-                detail: row.Message,
-                category: ResearchChangeCategory.CSharp,
-                cSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
-        }
-
-        return changes.ToImmutable();
-    }
-
     static ResearchChangeMechanism ToResearchMechanisms(ImplementationDiffMechanism mechanisms)
     {
         var research = ResearchChangeMechanism.None;
@@ -753,25 +533,4 @@ public static class ImplementationDiff
                 descriptor,
                 $"{descriptor.Title} from the semantic projection for '{subject.Display}'.");
 
-    static bool MethodHasBody(MetadataSource source, MethodDefinitionHandle method)
-        => source.Reader.GetMethodDefinition(method).RelativeVirtualAddress != 0;
-
-    static ResearchSubjectKey SubjectFromMethod(MetadataSource source, MethodDefinitionHandle methodHandle)
-    {
-        var reader = source.Reader;
-        var method = reader.GetMethodDefinition(methodHandle);
-        var typeHandle = method.GetDeclaringType();
-        var type = reader.GetTypeDefinition(typeHandle);
-        var anchor = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method, IsExtensionMethod(reader, type, method));
-        string typeFullName = reader.GetFullTypeName(type);
-        string memberName = reader.GetString(method.Name);
-        return ResearchMemberIdentity.SubjectFromAnchor(anchor, $"{typeFullName}.{memberName}");
-    }
-
-    static bool IsExtensionMethod(MetadataReader reader, TypeDefinition type, MethodDefinition method)
-        => type.Attributes.HasFlag(TypeAttributes.Abstract)
-           && type.Attributes.HasFlag(TypeAttributes.Sealed)
-           && method.Attributes.HasFlag(MethodAttributes.Static)
-           && AttributeReader.HasExtensionAttribute(reader, type.GetCustomAttributes())
-           && AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
 }


### PR DESCRIPTION
Build robust, capable features that provide foundational capabilities or
compelling user experiences, recognizable as conventionally sound,
delightfully new or unique, or both.

## Summary

Retire the Research-owned direct-member wrapper after every production and tool
consumer migrated to `DirectMemberComparisonQuery`.

- Remove `ImplementationDiff.CompareMembers`,
  `ImplementationMemberDiffResult`, their dedicated tests, and the private
  projection helpers used only by that path.
- Preserve the generalized assembly-wide, body-signal, Source-enrichment,
  native-diff, and presentation APIs that still have runtime consumers.
- Update the owning consumer contract and the direct-member adoption ledger to
  record all eight bounded-route milestones complete without claiming broader
  Queries or Research retirement.

This closes #6255 and completes the scoped Research portion of #4706 step 17
for the bounded physical-pair route.

## Demo

The replacement production route still compares two explicitly selected
methods through the Queries-owned operation:

```console
$ dotnet-inspect match DotnetInspector.Tests.MatchSampleA.Greet \
    DotnetInspector.Tests.MatchSampleA.GreetFormal \
    --library dotnet-inspect.Tests.dll --body --all
# Match: DotnetInspector.Tests.MatchSampleA.Greet vs DotnetInspector.Tests.MatchSampleA.GreetFormal

| Disposition | Completed |
| Relation | Different |
| Outcome | Unrelated |

# Method Body Diff: DotnetInspector.Tests.MatchSampleA.Greet vs DotnetInspector.Tests.MatchSampleA.GreetFormal

| Producer | Work | Native Verdict | Before | After | Findings |
| C# | ProducedCSharp | NotExact | Complete | Complete | Complete; exact: false |
| IL | ProducedIlBody | OperandDiff | Complete | Complete | Complete; exact: false |

| C# | h0 - IL_0000 return string.Concat("Hello, ", name, "!"); |
| C# | h0 + IL_0000 return string.Concat("Good day, ", name, "."); |
| IL | h0 - IL_0000 ldstr string "Hello, " |
| IL | h0 + IL_0000 ldstr string "Good day, " |
```

The neighboring generalized path remains available:

```console
$ dotnet-inspect diff \
    --library DiffFixtures.V1/DiffFixtureSample.dll..DiffFixtures.V2/DiffFixtureSample.dll \
    -S "Implementation Diff" --type DiffSample
# Implementation Diff: DiffFixtureSample

| Summary | 30 changed members; 135 C# and 130 IL evidence rows. |
```

## Evidence and scope

The final exact C# symbol search returns no declaration or call for
`ImplementationDiff.CompareMembers` or `ImplementationMemberDiffResult`.
Release solution compilation provides the compiled-caller half of the
intentionally partial absence coverage; no permanent source-policing gate is
added.

Active callers continue to constrain the retained generalized APIs:

- `ImplementationComparisonQuery` uses `ImplementationDiff.Compare`.
- `BodySignalComparisonQuery` and the CLI use generalized `ResearchDiff`.
- `DiffCommand` uses `WithPdbSourceComparisons`.
- CLI and harness presentation use `UnifiedLines`, `ToSourceChanges`, and
  `ToIlChanges`.

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Research.Tests -c Release --no-build -- --filter-class '*ResearchDiffTests'
  99 passed
dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build -- --filter-class '*DirectMemberComparisonQueryTests'
  23 passed
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- --filter-class '*MatchCommandTests' --filter-class '*DiffCommandTests'
  160 passed
npx markdownlint-cli docs/design/direct-member-comparison.md docs/design/implementation-diff.md docs/design/member-body-substrate.md
```
