### PR TITLE
Remove PackageSourceIdentity readers added by #6205

### DIFF
--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -227,22 +227,17 @@ internal static class BrowserPackageWorkspace
         string packageId,
         string? version,
         IPackageSourceClient source,
-        TimeSpan operationTimeout) =>
+        TimeSpan operationTimeout,
+        CancellationToken cancellationToken,
+        BrowserManagedEpochWorkSource? epochWork) =>
         AcquireAsync(
             packageId,
             version,
             source,
             ConfiguredSourceIdentityFor(source),
-            operationTimeout);
-
-    internal static Task<BrowserPackage> AcquireAsync(
-        string packageId,
-        string? version,
-        IPackageSourceClient source,
-        PackageSourceIdentity configuredSourceIdentity,
-        TimeSpan operationTimeout) =>
-        AcquireAsync(packageId, version, source, configuredSourceIdentity, operationTimeout,
-            CancellationToken.None, epochWork: null);
+            operationTimeout,
+            cancellationToken,
+            epochWork);
 
     internal static Task<BrowserPackage> AcquireAsync(
         string packageId,
@@ -471,7 +466,9 @@ internal static class BrowserPackageWorkspace
             version,
             source,
             configuredSourceIdentity,
-            operationTimeout);
+            operationTimeout,
+            CancellationToken.None,
+            epochWork: null);
         return new BrowserPackageCoordinate(
             package,
             package.CreateRootBinding(targetFramework));

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.AcquisitionLifetime.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.AcquisitionLifetime.cs
@@ -32,7 +32,7 @@ public sealed partial class BrowserEngineBoundaryTests
         using var laterCancellation = new CancellationTokenSource();
         Task<BrowserPackage> Acquire(CancellationToken token) =>
             BrowserPackageWorkspace.AcquireAsync(
-                packageId, "1.0.0", source, PackageSourceIdentity.NuGetOrg,
+                packageId, "1.0.0", source,
                 TimeSpan.FromSeconds(30), token, registration.Source);
 
         try
@@ -93,7 +93,7 @@ public sealed partial class BrowserEngineBoundaryTests
         using var cancellation = new CancellationTokenSource();
         Task<BrowserPackage> Acquire(CancellationToken token) =>
             BrowserPackageWorkspace.AcquireAsync(
-                packageId, "1.0.0", source, PackageSourceIdentity.NuGetOrg,
+                packageId, "1.0.0", source,
                 TimeSpan.FromSeconds(30), token, registration.Source);
 
         try
@@ -143,7 +143,7 @@ public sealed partial class BrowserEngineBoundaryTests
         try
         {
             Task<BrowserPackage> waiting = BrowserPackageWorkspace.AcquireAsync(
-                packageId, "1.0.0", source, PackageSourceIdentity.NuGetOrg,
+                packageId, "1.0.0", source,
                 TimeSpan.FromSeconds(30), cancellation.Token, registration.Source);
             await AcquisitionWithin(handler.PayloadReadStarted.Task);
             cancellation.Cancel();
@@ -224,7 +224,7 @@ public sealed partial class BrowserEngineBoundaryTests
                         await BrowserSourceOperationCoordinator.BeginAsync(
                             token, reason => bridge.RequestCancellation(id, reason));
                     await BrowserPackageWorkspace.AcquireAsync(
-                        packageId, "1.0.0", source, PackageSourceIdentity.NuGetOrg,
+                        packageId, "1.0.0", source,
                         TimeSpan.FromSeconds(30), lease.CancellationToken, epochWork: null);
                     return new BrowserManagedOperationBodyResult<bool, string, string>.Succeeded(true);
                 },
@@ -250,7 +250,7 @@ public sealed partial class BrowserEngineBoundaryTests
 
             release.SetResult();
             BrowserPackage package = await BrowserPackageWorkspace.AcquireAsync(
-                packageId, "1.0.0", source, PackageSourceIdentity.NuGetOrg,
+                packageId, "1.0.0", source,
                 TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken,
                 epochWork: null);
             Assert.Equal(packageId, package.PackageId, ignoreCase: true);

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -5830,7 +5830,9 @@ public sealed partial class BrowserEngineBoundaryTests
             "1.0.0",
             source,
             PackageSourceIdentity.NuGetOrg,
-            TimeSpan.FromMilliseconds(200));
+            TimeSpan.FromMilliseconds(200),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
         await handler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(1),
             TestContext.Current.CancellationToken);
@@ -5862,7 +5864,9 @@ public sealed partial class BrowserEngineBoundaryTests
             version,
             source,
             PackageSourceIdentity.NuGetOrg,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
 
         Assert.Equal(version, package.Version);
         Assert.Equal(archive, package.RetainedBytes);
@@ -6263,7 +6267,9 @@ public sealed partial class BrowserEngineBoundaryTests
                     "1.0.0",
                     source,
                     PackageSourceIdentity.NuGetOrg,
-                    TimeSpan.FromSeconds(5)));
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken,
+                    epochWork: null));
 
         Assert.Contains(
             "transport failed",
@@ -6293,7 +6299,9 @@ public sealed partial class BrowserEngineBoundaryTests
                     "1.0.0",
                     source,
                     PackageSourceIdentity.NuGetOrg,
-                    TimeSpan.FromSeconds(5)));
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken,
+                    epochWork: null));
 
         Assert.Contains(
             "did not declare its byte length",
@@ -6319,7 +6327,9 @@ public sealed partial class BrowserEngineBoundaryTests
             version: null,
             source,
             PackageSourceIdentity.NuGetOrg,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
 
         Assert.Equal(version, package.Version);
         Assert.Equal(2, handler.Requested.Count);
@@ -6354,7 +6364,9 @@ public sealed partial class BrowserEngineBoundaryTests
             version: null,
             source,
             PackageSourceIdentity.NuGetOrg,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
         await handler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(10),
             TestContext.Current.CancellationToken);
@@ -6382,7 +6394,9 @@ public sealed partial class BrowserEngineBoundaryTests
             "1.0.0",
             source,
             PackageSourceIdentity.NuGetOrg,
-            TimeSpan.FromMilliseconds(500));
+            TimeSpan.FromMilliseconds(500),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
         await handler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(1),
             TestContext.Current.CancellationToken);
@@ -6391,7 +6405,9 @@ public sealed partial class BrowserEngineBoundaryTests
             "1.0.0",
             source,
             PackageSourceIdentity.NuGetOrg,
-            TimeSpan.FromMilliseconds(100));
+            TimeSpan.FromMilliseconds(100),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
 
         TimeoutException secondFailure =
             await Assert.ThrowsAsync<TimeoutException>(() => second);
@@ -6482,7 +6498,9 @@ public sealed partial class BrowserEngineBoundaryTests
                 version,
                 stalledSource,
                 PackageSourceIdentity.NuGetOrg,
-                TimeSpan.FromMilliseconds(500));
+                TimeSpan.FromMilliseconds(500),
+                TestContext.Current.CancellationToken,
+                epochWork: null);
         await stalledHandler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(1),
             TestContext.Current.CancellationToken);
@@ -6493,7 +6511,9 @@ public sealed partial class BrowserEngineBoundaryTests
                 version,
                 servingSource,
                 PackageSourceIdentity.NuGetOrg,
-                TimeSpan.FromSeconds(5));
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken,
+                epochWork: null);
 
         Assert.Equal(packageId, served.PackageId);
         Assert.Equal(version, served.Version);
@@ -6525,7 +6545,9 @@ public sealed partial class BrowserEngineBoundaryTests
                 packageId,
                 "1.0.0",
                 client,
-                TimeSpan.FromSeconds(5));
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken,
+                epochWork: null);
     }
 
     [Fact]
@@ -6568,7 +6590,9 @@ public sealed partial class BrowserEngineBoundaryTests
                 packageId,
                 "1.0.0",
                 client,
-                TimeSpan.FromSeconds(5));
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken,
+                epochWork: null);
     }
 
     [Fact]
@@ -6585,12 +6609,16 @@ public sealed partial class BrowserEngineBoundaryTests
 
         BrowserPackage first = await BrowserPackageWorkspace.AcquireAsync(
             packageId, "1.0.0", firstSource,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
         IPackageContent second = await QueryContent(secondSource);
         IPackageContent firstAgain = await QueryContent(firstSource);
         BrowserPackage secondAgain = await BrowserPackageWorkspace.AcquireAsync(
             packageId, "1.0.0", secondSource,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
 
         Assert.False(second.FromCache);
         Assert.True(firstAgain.FromCache);
@@ -6720,7 +6748,9 @@ public sealed partial class BrowserEngineBoundaryTests
         Task<BrowserPackage> Acquire(IPackageSourceClient source) =>
             BrowserPackageWorkspace.AcquireAsync(
                 packageId, "1.0.0", source,
-                TimeSpan.FromSeconds(30));
+                TimeSpan.FromSeconds(30),
+                TestContext.Current.CancellationToken,
+                epochWork: null);
     }
 
     [Fact]
@@ -6763,7 +6793,9 @@ public sealed partial class BrowserEngineBoundaryTests
                 packageId, "1.0.0", first.Framework));
         BrowserPackage firstCached = await BrowserPackageWorkspace.AcquireAsync(
             packageId, "1.0.0", firstSource,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken,
+            epochWork: null);
         Assert.True(firstCached.Content.FromCache);
         Assert.Same(first.Package.Content.GenerationIdentity, firstCached.Content.GenerationIdentity);
         Assert.Same(first.Package.RetainedBytes, firstCached.RetainedBytes);


### PR DESCRIPTION
## Demo

Before this change, main was broken for any PR that touches
`prototypes/inspect-web/**` and integrates current `main`:

```text
dotnet run --project tests/NuGetFetch.Tests -c Release -- \
  --filter-method "*LegacyPackageSourceIdentitySurfaceMatchesMigrationSet" \
  --minimum-expected-tests 1

Legacy package-source identity migration inventory mismatch:
unlisted [prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.AcquisitionLifetime.cs];
stale [];
reference drift [prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
  expected 12 explicit/0 implicit for #4805, observed 13 explicit/0 implicit].
```

After this change, the same command passes, and the new acquisition-lifetime
tests no longer read the legacy `PackageSourceIdentity` surface at all.

## Problem

#6205 added a new `AcquireAsync` overload that redeclared
`PackageSourceIdentity configuredSourceIdentity` as an explicit parameter
(for the new epoch-work/cancellation acquisition path), pushing
`BrowserPackageWorkspace.cs` from 12 to 13 explicit references. Its new test
file, `BrowserEngineBoundaryTests.AcquisitionLifetime.cs`, read
`PackageSourceIdentity.NuGetOrg` directly and was entirely absent from the
migration inventory in `LegacyPackageSourceIdentityMigrationTests.cs`.

## Fix

- Collapsed the two identity-carrying `AcquireAsync` overloads in
  `BrowserPackageWorkspace.cs` back into a single declaration (with required
  `cancellationToken`/`epochWork` parameters), restoring the file to 12
  explicit references. A companion overload resolves the source identity
  internally via the existing `ConfiguredSourceIdentityFor` helper, so
  callers that don't need a custom identity never reference
  `PackageSourceIdentity` explicitly.
- Updated `BrowserEngineBoundaryTests.AcquisitionLifetime.cs` to stop reading
  `PackageSourceIdentity.NuGetOrg` directly (now 0 references — no longer
  unlisted).
- Updated the 18 pre-existing call sites in `BrowserEngineBoundaryTests.cs`
  to pass `TestContext.Current.CancellationToken` and `epochWork` explicitly
  (satisfying `xUnit1051`), keeping that file's already-migrated reference
  count at 20.

No production behavior changes: the epoch-work/cancellation acquisition path
added by #6205 is preserved; only its overload shape and the test call sites
change.

## Root-cause note (why this got through CI)

CI's path-based change-detection routed this PR's changes (all under
`prototypes/inspect-web/**`) only to the `inspect-web` job, and skipped the
repo-wide `test` job — the one that runs `tests/NuGetFetch.Tests`, home of
`LegacyPackageSourceIdentitySurfaceMatchesMigrationSet`. That gate scans the
whole repository for `PackageSourceIdentity` references, so it's a
cross-cutting check whose inputs aren't limited to
`tests/NuGetFetch.Tests/**` or `src/NuGetFetch/**` — the paths the routing
config currently treats as its trigger set. `ci-required` still went green
because it only requires jobs the plan actually scheduled, and the plan
never scheduled `test` for this PR.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — succeeds
- `dotnet run --project tests/NuGetFetch.Tests -c Release -- --filter-method "*LegacyPackageSourceIdentitySurfaceMatchesMigrationSet" --minimum-expected-tests 1` — passes
- `dotnet run --project tests/NuGetFetch.Tests -c Release` — 1089/1089 passed
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release -- -class "InspectWeb.Engine.Tests.BrowserEngineBoundaryTests"` — 194/194 passed

Fixes #6262
