### PR TITLE
Migrate Ecosystems tests to Microsoft Testing Platform

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -208,6 +208,12 @@ regression class separately so every selection receives its own aggregate
 non-vacuity result. These paths reuse the pinned outcome-level host gate without
 changing query, workspace, package, source, or acquisition evidence.
 
+`DotnetInspector.Ecosystems.Tests` is the tenth migrated adopter. Its required
+PR, Windows, Deep Inspect platform, and developer commands remain unfiltered.
+These paths reuse the pinned outcome-level host gate without changing the
+suite's friend-only registry and catalog evidence or the separately compiled
+public-consumer evidence in `DotnetInspector.Ecosystems.Consumer.Tests`.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/DotnetInspector.Ecosystems.Tests/DotnetInspector.Ecosystems.Tests.csproj
+++ b/tests/DotnetInspector.Ecosystems.Tests/DotnetInspector.Ecosystems.Tests.csproj
@@ -10,6 +10,7 @@
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
dotnet-inspect's test evidence should be robust and capable without duplicating
the semantics already owned by its test platform. This tenth migration slice
uses Microsoft Testing Platform's conventional non-vacuity result for the
dedicated Ecosystems test suite.

## Demo

Before this change, a stale native xUnit selector executed no Ecosystems tests
and still succeeded:

```text
DotnetInspector.Ecosystems.Tests  Total: 0
exit 0
```

After selecting MTP, the equivalent stale filter is visible as failed evidence:

```text
Test run summary: Zero tests ran
exit 8
```

A neighboring valid class filter still passes 20 tests, the full dedicated
friend suite passes 89 tests, and the separately compiled public-consumer suite
passes its existing 5 tests.

## Summary

- select the MTP host supplied transitively by the pinned `xunit.v3` package
  for `DotnetInspector.Ecosystems.Tests`
- record the suite as the tenth migrated adopter in the xUnit host design
- leave required CI, Windows, Deep Inspect, and developer commands unfiltered
- preserve the suite's friend-only registry/catalog evidence and the separate
  non-friend consumer boundary

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project tests/DotnetInspector.Ecosystems.Tests -c Release --no-build -- --filter-method '*DefinitelyMissingEcosystemsTest*'  # exit 8
dotnet run --project tests/DotnetInspector.Ecosystems.Tests -c Release --no-build -- --filter-class 'DotnetInspector.Ecosystems.Tests.PackageSetRegistryTests'  # 20 passed
dotnet run --project tests/DotnetInspector.Ecosystems.Tests -c Release --no-build  # 89 passed
dotnet run --project tests/DotnetInspector.Ecosystems.Consumer.Tests -c Release --no-build  # 5 passed
npx --yes markdownlint-cli docs/design/xunit-test-host.md
git diff --check
```

Part of #5379.
