### PR TITLE
Retire Research member comparison wrapper

### DIFF
--- a/docs/design/direct-member-comparison.md
+++ b/docs/design/direct-member-comparison.md
@@ -35,9 +35,9 @@ and a presentation-neutral result. The analogous
 [member source comparison query](member-source-comparison-query.md) preserves
 endpoint outcomes without turning failure into empty text. Its one-member,
 PDB-versus-decompilation operation is not this two-method, local C#/IL operation.
-`ImplementationDiff.CompareMembers` is the behavioral baseline for explicit
-pairing; its direct caller-to-Research orchestration is the retirement target,
-not the native C# or IL algorithms.
+`ImplementationDiff.CompareMembers` was the behavioral baseline for explicit
+pairing when this adapter was designed. Its direct caller-to-Research
+orchestration is retired after adoption; the native C# and IL algorithms remain.
 
 The adapter exists to replace repeated caller orchestration with one exact
 association and failure-preserving boundary. It does not need a second
@@ -174,8 +174,8 @@ for unrelated package-role, whole-assembly, body-signal, or Source migrations.
 It does not invoke root-to-terminal forwarding composition. Those scenarios
 remain separate; a physical `ExactAddress` is not retargeted.
 
-The selected route has **8 delivery milestones: 6 complete, 2 remaining** at
-this update. These are outcomes, not a promise of eight PRs:
+The selected route has **8 delivery milestones, all complete**. These are
+outcomes, not a count of pull requests:
 
 | Tracker step | Selected outcome | Status |
 | --- | --- | --- |
@@ -185,16 +185,16 @@ this update. These are outcomes, not a promise of eight PRs:
 | 6 | Implement the physical-pair Queries adapter | Complete: #5967 |
 | 8 | Cut over CLI `match --body`, including presentation and removal of its replaced dispatch/wrapper | Complete: #5967 |
 | 9 | Add the Browser managed facade, explicit pair interaction, and typed result view | Complete: #5990 |
-| 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | #6044 retires the unconsumed body-signal population profile |
-| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Remaining after #6250 removes the uncalled member-plus-PDB wrapper; assembly/generalized callers still constrain deletion; #5125 identity cleanup landed in #6099 |
+| 16, scoped | Remove unused or superseded Queries substrate established by this route's caller inventory | Complete: #6044 / #6047 |
+| 17, scoped | Remove unused or superseded Research substrate established by this route's caller inventory | Complete: #5125 / #6099, #6250 / #6251, and #6283 |
 
 Each host path contains **5 milestones, all complete**:
 1, 18, 5, 6, then 8 or 9. The two scoped cleanups close the selected route,
 not all global retirement in #4706.
 
-Landing the scoped Queries cleanup completes seven of this route's eight
-milestones. It does not complete whole-assembly or body-signal execution
-migration, comparison-tool adoption, or global Queries retirement.
+The two scoped cleanups complete this bounded route. They do not complete
+whole-assembly or body-signal execution migration or global Queries/Research
+retirement.
 
 Keep the first publication and adapter runtime together with the CLI
 adopting change; the bounded first-adopter exception permits that focused
@@ -236,7 +236,10 @@ its Source-specific member-result scaffolding are removed by #6250 after the
 paired CLI and browser adopters landed. Native result translations still serve
 CLI or harness presentation. These are retained caller obligations, not unused
 placeholders. The focused Research body-index association cleanup #5125 landed
-in #6099; neither that cleanup nor this Source cleanup completes broader
+in #6099. #6283 removes the remaining uncalled `CompareMembers` wrapper and
+`ImplementationMemberDiffResult`. `ImplementationDiff.Compare`,
+`WithPdbSourceComparisons`, and `ToIlChanges` remain for their assembly-wide,
+Source, and harness callers; this scoped completion does not claim broader
 retirement.
 
 ### Broader migration snapshot
@@ -266,7 +269,8 @@ and deletion commits to the tracker.
 | Browser managed facade and explicit two-member workspace comparison | Browser step 9, coordinated with #5083 | Expose the same public query as observable browser behavior. Inventory actual routes then; this plan does not invent a currently existing legacy browser caller. Remove a replaced route if one exists. |
 | `ImplementationComparisonQuery.Execute`, `DiffCommand`, and `DiffSections` assembly-wide paths | Steps 7-9; Source tail 13-15 | Separate from rank 5. Their public execution and result/output adoption precede final shared-shape retirement. |
 | `ImplementationDiff.CompareMembersWithPdbSource` | Source steps 12-15 and Research retirement step 17 | Removed by #6250 after the selected CLI and browser Source consumers adopted `AssemblyContextMemberSourcePairQuery`; broad assembly enrichment remains on `WithPdbSourceComparisons`. |
-| `ImplementationDiff.CompareMembers`, dependent legacy member-result shapes, and independent old/new query forms | Queries step 16 and Research step 17 | Delete superseded orchestration and shapes after the refreshed caller inventory, including Source and tests, has a disposition. Preserve only APIs justified by a current owner-local contract. #5125 was reconciled independently by the identity cleanup in #6099. |
+| `ImplementationDiff.CompareMembers` and `ImplementationMemberDiffResult` | Research step 17 | Removed by #6283 after CLI, browser, RoundTripCompilation, ReturnToSender, AuthoredRebuildFidelity, and Source callers received dispositions. |
+| Independent old/new assembly query forms | Generalized Queries step 16 and Research step 17 | Retain while `ImplementationComparisonQuery`, `DiffCommand`, and `DiffSections` use them; remove only after those assembly-wide callers migrate. |
 
 Native `CSharpBodyDiff`, `IlAssemblyDiff`, Findings payloads, and useful aligned
 hunks are not deletion targets merely because they are below Queries.
@@ -275,9 +279,9 @@ not blanket removal of its containing class.
 
 An adapter-only runtime landing can complete step 6 but is **not production
 adoption**. CLI, browser, and tool adoption close only when their actual
-consumers move and their replaced dispatch is removed. Overall retirement
-remains open through steps 16-17 and the Source-dependent tail. This design
-does not claim that unused legacy APIs have already been removed.
+consumers move and their replaced dispatch is removed. This bounded route is
+complete; generalized assembly-wide Queries/Research retirement and the
+broader Source-dependent architecture remain open.
 
 ## Demo and outcome gates
 
@@ -306,8 +310,9 @@ differently named pair remains `SelectionDrift`, covered by prerequisite #5877.
 The Queries gates below run in `DirectMemberComparisonQueryTests` in Release.
 CLI adoption is covered by `MatchCommandTests` and `MatchDiscoveryTests`.
 Browser gates landed in #5990, including published-Wasm acceptance and
-`BrowserMethodBodyOperationTests`. Comparison-tool adoption gates remain
-**unimplemented and unverified**.
+`BrowserMethodBodyOperationTests`. Comparison-tool adoption gates landed for
+RoundTripCompilation in #6141 and ReturnToSender/AuthoredRebuildFidelity in
+PR #6181.
 These names describe outcomes, not test seams or a source-scanning policy.
 
 | Gate owner | Required observable outcome |
@@ -319,9 +324,8 @@ These names describe outcomes, not test seams or a source-scanning policy.
 | CLI and browser adoption gates in steps 8-9 | Real host invocations show the designated pair and visible unavailable/failure evidence using the public query, including ordinary output selection and the browser facade. |
 | Comparison-tool adoption gates in step 10 | Existing member, scope, and authored-rebuild scenarios consume the public query without changing correspondence or oracle meaning. |
 
-Deletion evidence is the actual migration/removal diff and a refreshed caller
-inventory attached to the tracker. This design adds no universal repository
-API-absence claim or source-policing gate.
+The migration and deletion pull requests are the retirement record. This
+design adds no universal repository API-absence claim or source-policing gate.
 
 ## Non-goals
 

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -1123,8 +1123,9 @@ mutable-file or local-actor threat model.
 
 ### Designated-pair basis and delivery
 
-The baseline is explicit old/new endpoint comparison, already supported by
-`ImplementationDiff.CompareMembers` and both native endpoint adapters.
+The baseline is explicit old/new endpoint comparison, which was supported by
+`ImplementationDiff.CompareMembers` when this design was written and remains
+supported by both native endpoint adapters.
 Ordinary Research correspondence is useful analogous evidence precisely
 because it refuses unequal keys: changing that refusal would answer the wrong
 question. An owner-issued pair and a closed alternate work basis are the
@@ -1143,12 +1144,13 @@ The tracker and the
 own those paths and final legacy Queries/Research retirement at steps 16/17.
 The tracker owns subsequent status/count changes.
 
-Adding this substrate does not retire `ImplementationDiff.CompareMembers`,
-its Source-dependent callers, or their projections. Queries population,
-workspace composition, publication, host rendering, and Source adoption remain
-separate work. This section adds no output schema: downstream CLI lowering
-uses the planned shared Markout presentation path, and browser adoption
-consumes typed evidence under its own host contract.
+Adding this substrate did not itself retire `ImplementationDiff.CompareMembers`
+or its then-current callers. After CLI, browser, comparison-tool, and Source
+adoption, #6283 retires that superseded wrapper and its result shape. Queries
+population, workspace composition, publication, host rendering, and broader
+Source adoption remain separate work. This section adds no output schema:
+downstream CLI lowering uses the shared Markout presentation path, and browser
+adoption consumes typed evidence under its own host contract.
 
 ## Research local producer session and completion
 
@@ -1884,11 +1886,10 @@ the input is a pair of assemblies or `ResearchDiffInput` values. The result is a
 list of changed implementation members. Each member can carry C# changes, IL
 changes, or both; exact members are omitted.
 
-Use `ImplementationDiff.CompareMembers` when the caller already resolved exact
-old/new `MethodDefinitionHandle` values in live `MetadataSource` instances. The
-member result keeps the typed C# diff, typed IL diff, joined implementation
-changes, and a single `ResearchSubjectKey`; exact members return an empty
-change list with `IsExact` set.
+Callers that already resolved exact old/new methods use the Queries-owned
+`DirectMemberComparisonQuery`. Its `LocalComparisonQueryResult` retains the
+designated endpoints, typed native C#/IL outcomes, Findings, and terminal
+non-success without reconstructing an `ImplementationDiffResult`.
 
 Use `WithPdbSourceComparisons` to enrich an assembly comparison with old/new
 `FindingInspection<string>` envelopes from Services. It preserves `Complete`,

--- a/docs/design/inspect-web-method-body-comparison.md
+++ b/docs/design/inspect-web-method-body-comparison.md
@@ -132,7 +132,8 @@ owner; new forwarding-root composition is outside this profile.
 
 The managed feature invokes the shared query once for an accepted comparison,
 requesting both local C# and IL mechanisms. It consumes
-`LocalComparisonQueryResult`; it does not call legacy `CompareMembers`,
+`LocalComparisonQueryResult`; it does not call the retired
+`ImplementationDiff.CompareMembers`,
 reinspect each endpoint, or construct a synthetic `ResearchComparison`.
 The context owner retains acquired input lifetime. Queries and Research retain
 their own access and stage cleanup responsibilities.

--- a/docs/design/local-comparison-publication.md
+++ b/docs/design/local-comparison-publication.md
@@ -187,9 +187,9 @@ first-adopter exception in
 Browser adoption follows as its own immediate owner effort, not after a new
 unconsumed infrastructure chain.
 
-The CLI now consumes the public query instead of its former direct
+The CLI consumes the public query instead of its former direct
 `ImplementationDiff.CompareMembers` dispatch and synthetic `ResearchComparison`
-wrapper. After both hosts work, focused Queries and Research cleanups remove
-the unused remainder established by the actual caller inventory. Existing
-Source and assembly-comparison behavior must remain supported; a future issue
-alone does not justify retaining otherwise unused substrate.
+wrapper. After both hosts and comparison tools adopted the query, focused
+Queries cleanup landed in #6047 and the Research member-wrapper cleanup in
+issue #6283. Existing Source and assembly-comparison behavior remains
+supported.

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -30,7 +30,7 @@ Four experiences render member bodies, and today each carries its own stack:
 | Skeleton source | `CSharpTypePrinter.Print` | declarations, no bodies |
 | Full source | `MemberBodyProducer.Project` | full C# bodies |
 | Merged IL + C# | `ResearchViews.RenderMixedCore` | C# spine, IL beneath |
-| Implementation diff | `ImplementationDiff.CompareMembers` | per-member C#/IL/source diff |
+| Implementation diff | `ImplementationComparisonQuery` / `DirectMemberComparisonQuery` | assembly or selected-member C#/IL/source diff |
 
 They already agree on the bottom: every C# or IL body path calls
 `IrImporter.Import(MetadataSource, …) → IrFunction` and then projects it. But

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -2227,53 +2227,6 @@ public class ResearchDiffTests
     }
 
     [Fact]
-    public void ImplementationDiff_CompareMembers_SameMemberIsExact()
-    {
-        using var source = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
-        var stable = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "Stable");
-
-        var diff = ImplementationDiff.CompareMembers(source, stable, source, stable);
-
-        Assert.True(diff.IsExact);
-        Assert.Equal("Stable", diff.Subject.MemberName);
-        Assert.NotNull(diff.CSharpDiff);
-        Assert.True(diff.CSharpDiff.IsExact);
-        Assert.NotNull(diff.IlDiff);
-        Assert.True(diff.IlDiff.Diff.IsExact);
-        Assert.Empty(diff.Changes);
-        Assert.True(Assert.Single(diff.RetainedComparisons.Get<CSharpCanonicalLine>(
-            CSharpFindings.LineDescriptor)).IsExact);
-        Assert.True(Assert.Single(diff.RetainedComparisons.Get<CanonicalIlOperation>(
-            IlFindings.OperationDescriptor)).IsExact);
-    }
-
-    [Fact]
-    public void ImplementationDiff_CompareMembers_GroupsCSharpAndIlEvidence()
-    {
-        using var oldSource = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
-        using var newSource = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.NewAssemblyPath());
-        var oldMethod = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "ConstantValue");
-        var newMethod = FindMethodHandle(FixtureCatalog.DiffPair.NewAssemblyPath(), "DiffFixtureSample.DiffSample", "ConstantValue");
-
-        var diff = ImplementationDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-
-        Assert.False(diff.IsExact);
-        Assert.Equal("ConstantValue", diff.Subject.MemberName);
-        Assert.True(diff.HasCSharpChanges);
-        Assert.True(diff.HasIlChanges);
-        Assert.Contains(diff.Changes, change =>
-            change.Mechanism == ResearchChangeMechanism.CSharp
-            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("return 1", StringComparison.Ordinal)));
-        Assert.Contains(diff.Changes, change =>
-            change.Mechanism == ResearchChangeMechanism.IlBody
-            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
-        Assert.False(Assert.Single(diff.RetainedComparisons.Get<CSharpCanonicalLine>(
-            CSharpFindings.LineDescriptor)).IsExact);
-        Assert.False(Assert.Single(diff.RetainedComparisons.Get<CanonicalIlOperation>(
-            IlFindings.OperationDescriptor)).IsExact);
-    }
-
-    [Fact]
     public void ImplementationDiff_PdbSourcePreservesAbsentStateWithoutChangingCSharp()
     {
         var subject = new ResearchSubjectKey(

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -1,6 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection;
-using System.Reflection.Metadata;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -59,26 +57,6 @@ public sealed record PdbSourceComparisonInput(
     FindingInspection<string> OldInspection,
     FindingInspection<string> NewInspection);
 
-public sealed record ImplementationMemberDiffResult(
-    ResearchSubjectKey Subject,
-    CSharpBodyDiffResult? CSharpDiff,
-    IlMemberDiffResult? IlDiff,
-    IReadOnlyList<ResearchChange> Changes,
-    RetainedFindingComparisonSet RetainedComparisons)
-{
-    public bool HasCSharpChanges
-        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
-
-    public bool HasIlChanges
-        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.IlBody);
-
-    public bool IsExact
-        => Changes.Count == 0
-           && (CSharpDiff is null || CSharpDiff.IsExact)
-           && (IlDiff is null || IlDiff.Diff.IsExact)
-           && RetainedComparisons.Items.All(comparison => comparison.IsExact);
-}
-
 /// <summary>
 /// Product-owned implementation diff projection that joins C# source-shape and
 /// IL/body changes by Research member identity.
@@ -103,128 +81,6 @@ public static class ImplementationDiff
             ResearchDiffInput.FromAssembly(oldAssemblyPath),
             ResearchDiffInput.FromAssembly(newAssemblyPath),
             options);
-    }
-
-    public static ImplementationMemberDiffResult CompareMembers(
-        MetadataSource oldSource,
-        MethodDefinitionHandle oldMethod,
-        MetadataSource newSource,
-        MethodDefinitionHandle newMethod,
-        ImplementationDiffMechanism mechanisms = ImplementationDiffMechanism.All,
-        ResearchSubjectKey? subject = null)
-    {
-        ArgumentNullException.ThrowIfNull(oldSource);
-        ArgumentNullException.ThrowIfNull(newSource);
-        if (oldMethod.IsNil)
-            throw new ArgumentException("Old method handle must not be nil.", nameof(oldMethod));
-        if (newMethod.IsNil)
-            throw new ArgumentException("New method handle must not be nil.", nameof(newMethod));
-
-        subject ??= SubjectFromMethod(oldSource, oldMethod);
-        CSharpBodyDiffResult? csharpDiff = null;
-        IlMemberDiffResult? ilDiff = null;
-        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
-        var retainedComparisons = ImmutableArray.CreateBuilder<RetainedFindingComparison>();
-
-        if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
-        {
-            csharpDiff = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-            var semanticChanges = ToCSharpChanges(csharpDiff, subject);
-            changes.AddRange(semanticChanges);
-            var comparison = CSharpFindings.Compare(
-                oldSource,
-                oldMethod,
-                newSource,
-                newMethod,
-                new FindingSubject(subject.Id, subject.Display));
-            retainedComparisons.Add(new RetainedFindingComparison<CSharpCanonicalLine>(
-                subject,
-                CSharpFindings.LineDescriptor,
-                comparison));
-            if (comparison is FindingComparison<CSharpCanonicalLine>.Failed failed)
-            {
-                if (!semanticChanges.Any(change => change.Kind == ResearchChangeKind.Failed))
-                {
-                    changes.Add(FindingFailureChange(
-                        subject,
-                        ResearchChangeMechanism.CSharp,
-                        ResearchChangeCategory.CSharp,
-                        CSharpFindings.InspectionDescriptor,
-                        failed.Failure));
-                }
-            }
-            else if (FindingDivergenceChange(
-                subject,
-                ResearchChangeMechanism.CSharp,
-                ResearchChangeCategory.CSharp,
-                CSharpFindingDivergenceDescriptor,
-                comparison.IsExact,
-                csharpDiff.IsExact) is { } divergence)
-            {
-                changes.Add(divergence);
-            }
-        }
-
-        if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
-        {
-            string label = subject.TypeName is { Length: > 0 } typeName && subject.MemberName is { Length: > 0 } memberName
-                ? $"{typeName}::{memberName}"
-                : subject.Display;
-            ilDiff = IlAssemblyDiff.CompareMembers(
-                oldSource.Pe,
-                oldSource.Reader,
-                oldMethod,
-                newSource.Pe,
-                newSource.Reader,
-                newMethod,
-                oldLabel: label,
-                newLabel: label);
-            var semanticChanges = ToIlChanges(ilDiff, subject);
-            changes.AddRange(semanticChanges);
-            var comparison = IlFindings.Compare(
-                oldSource.Pe,
-                oldSource.Reader,
-                oldMethod,
-                newSource.Pe,
-                newSource.Reader,
-                newMethod,
-                new FindingSubject(subject.Id, subject.Display));
-            retainedComparisons.Add(new RetainedFindingComparison<CanonicalIlOperation>(
-                subject,
-                IlFindings.OperationDescriptor,
-                comparison));
-            if (comparison is FindingComparison<CanonicalIlOperation>.Failed failed)
-            {
-                if (!semanticChanges.Any(change => change.Kind == ResearchChangeKind.Failed))
-                {
-                    changes.Add(FindingFailureChange(
-                        subject,
-                        ResearchChangeMechanism.IlBody,
-                        ResearchChangeCategory.IlBody,
-                        IlFindings.InspectionDescriptor,
-                        failed.Failure));
-                }
-            }
-            else if (MethodHasBody(oldSource, oldMethod)
-                && MethodHasBody(newSource, newMethod)
-                && FindingDivergenceChange(
-                    subject,
-                    ResearchChangeMechanism.IlBody,
-                    ResearchChangeCategory.IlBody,
-                    IlFindingDivergenceDescriptor,
-                    comparison.IsExact,
-                    ilDiff.Diff.IsExact) is { } divergence)
-            {
-                changes.Add(divergence);
-            }
-        }
-
-        return new ImplementationMemberDiffResult(
-            subject,
-            csharpDiff,
-            ilDiff,
-            changes.ToImmutable(),
-            new RetainedFindingComparisonSet(retainedComparisons));
     }
 
     public static ImplementationDiffResult Compare(
@@ -753,25 +609,4 @@ public static class ImplementationDiff
                 descriptor,
                 $"{descriptor.Title} from the semantic projection for '{subject.Display}'.");
 
-    static bool MethodHasBody(MetadataSource source, MethodDefinitionHandle method)
-        => source.Reader.GetMethodDefinition(method).RelativeVirtualAddress != 0;
-
-    static ResearchSubjectKey SubjectFromMethod(MetadataSource source, MethodDefinitionHandle methodHandle)
-    {
-        var reader = source.Reader;
-        var method = reader.GetMethodDefinition(methodHandle);
-        var typeHandle = method.GetDeclaringType();
-        var type = reader.GetTypeDefinition(typeHandle);
-        var anchor = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method, IsExtensionMethod(reader, type, method));
-        string typeFullName = reader.GetFullTypeName(type);
-        string memberName = reader.GetString(method.Name);
-        return ResearchMemberIdentity.SubjectFromAnchor(anchor, $"{typeFullName}.{memberName}");
-    }
-
-    static bool IsExtensionMethod(MetadataReader reader, TypeDefinition type, MethodDefinition method)
-        => type.Attributes.HasFlag(TypeAttributes.Abstract)
-           && type.Attributes.HasFlag(TypeAttributes.Sealed)
-           && method.Attributes.HasFlag(MethodAttributes.Static)
-           && AttributeReader.HasExtensionAttribute(reader, type.GetCustomAttributes())
-           && AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
 }


### PR DESCRIPTION
## Summary

Retires the unused Research selected-member wrapper after every inventoried
consumer moved to the shared direct-member query.

- removes `ImplementationDiff.CompareMembers` and
  `ImplementationMemberDiffResult`
- removes their two wrapper-only Research tests and private helper chain
- records the bounded direct-member route as complete without claiming
  assembly-wide Implementation Diff retirement
- preserves native C#/IL producers, assembly-wide comparison, PDB Source
  enrichment, and the ReturnToSender IL projection

The normative owner is
`docs/design/direct-member-comparison.md#adoption-and-retirement-ledger`.
`docs/design/implementation-diff.md` supplies the retained Research consumer
contract. No TLA+ model is needed: this change deletes unused synchronous
orchestration and introduces no protocol or state machine.

## Retirement analysis

The selected-member route had already moved its CLI, Browser,
RoundTripCompilation, ReturnToSender, AuthoredRebuildFidelity, and Source
consumers to shared Queries-owned comparison boundaries. The remaining wrapper
had no runtime callers and only two tests of its own projection.

This deletion closes the bounded eight-milestone direct-member route. It does
not complete generalized #4706 work: `ImplementationDiff.Compare` and
`CompareAssemblies` remain behind `ImplementationComparisonQuery`,
`WithPdbSourceComparisons` remains behind broad CLI Source enrichment, and
`ToIlChanges` remains behind ReturnToSender evidence projection.

Deletion and the merged pull request are the retirement mechanism. This change
does not add a permanent API-absence test or source-policing gate.

## Demo

Selected-member comparison still reaches the shared query and preserves native
C# and IL evidence:

```console
$ dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
    match MatchSampleA.Greet MatchSampleA.GreetFormal \
    --library artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
    --body --all -v:d --tips q
# Match: DotnetInspector.Tests.MatchSampleA.Greet vs DotnetInspector.Tests.MatchSampleA.GreetFormal

| Disposition | Completed |
| Relation | Different |

## Producers

| Producer | Work | Native Verdict | Before | After | Findings |
| C# | ProducedCSharp | NotExact | Complete | Complete | Complete; exact: false |
| IL | ProducedIlBody | OperandDiff | Complete | Complete | Complete; exact: false |

## Body Evidence

| C# | h0 ~ IL_0000 return string.Concat("Hello, ", name, "!") => return string.Concat("Good day, ", name, ".") |
| IL | h0 - IL_0000 ldstr string "Hello, " |
| IL | h0 + IL_0000 ldstr string "Good day, " |
```

The neighboring assembly-wide consumer still reaches retained
`ImplementationDiff.Compare` behavior:

```console
$ dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
    diff \
    --library artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll..artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll \
    -S "Implementation Diff" \
    --type DiffFixtureSample.DiffSample \
    --member ConstantValue --changed -v:d --tips q
# Implementation Diff: DiffFixtureSample

| Summary | 1 changed member; 3 C# and 2 IL evidence rows. |

| Member | Mechanism | Difference | Change | Evidence |
| DiffFixtureSample.DiffSample.ConstantValue() | IL | OperandDiff | changed | h0 - IL_0000 ldc.i4 1 |
| DiffFixtureSample.DiffSample.ConstantValue() | IL | OperandDiff | changed | h0 + IL_0000 ldc.i4 2 |
| DiffFixtureSample.DiffSample.ConstantValue() | C# |  | changed | h0 ~ IL_0000 return 1 => return 2 |
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Research.Tests -c Release -- --filter-class '*ResearchDiffTests'` — 99 passed
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release -- --filter-class '*DirectMemberComparisonQueryTests'` — 23 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class '*MatchCommandTests' --filter-class '*MatchDiscoveryTests'` — 142 passed
- `npx markdownlint-cli docs/design/direct-member-comparison.md docs/design/implementation-diff.md docs/design/local-comparison-publication.md docs/design/inspect-web-method-body-comparison.md docs/design/member-body-substrate.md`

Closes #6283.
