### PR TITLE
Add package input evidence types

### DIFF
--- a/docs/design/package-dependency-evidence.md
+++ b/docs/design/package-dependency-evidence.md
@@ -9,9 +9,12 @@ without making transport or policy learn each artifact format.
 [#6266](https://github.com/richlander/dotnet-inspect/issues/6266). The
 package-manifest and restored-project declaration, comparison, graph,
 package-prefix admission, and failure core is implemented under #5533 as
-`PackageDependencyEvidenceQuery`. Authorship, processing evidence,
-authored-project input, runtime-dependency input, and the larger package shape
-remain unimplemented. Optional owner observations remain dependent on #5315.
+`PackageDependencyEvidenceQuery`. The current query also implements the larger
+input-kind, declaration-basis, authorship, produced-relationship, positive
+processing, and independent phase-count vocabulary for package-manifest and
+restored-project inputs. Authored-project and runtime-dependency providers,
+typed pruning observations, policy composition, and host adoption remain
+staged work. Optional owner observations remain dependent on #5315.
 
 ## Owner
 
@@ -66,9 +69,10 @@ inventory. It does not move pruning policy into this owner.
 Issue #6266 is the end-to-end tracker for the larger shape. Its eight delivery
 steps are:
 
-1. Lock this evolution of the existing owner.
-2. Add input kind, declaration basis, authorship, and processing evidence to
-   the immutable result.
+1. Lock this evolution of the existing owner (complete in #6270).
+2. Add input kind, declaration basis, authorship, normalized produced
+   relationships, processing evidence, and independent phase counts to the
+   immutable result (implemented by the current query).
 3. Add typed pruning-processing evidence to restored-project facts.
 4. Add a typed authored-project declaration provider.
 5. Add a typed runtime-dependency provider for `.deps.json`.
@@ -202,6 +206,19 @@ return their own unknown or not-applicable result.
 Input kind and declaration basis are owner-issued structural currency. They are
 not reconstructed from a path extension, source label, or the presence of a
 particular output row.
+
+The implemented CLR vocabulary keeps one `PackageDependencyEvidence*` family:
+`PackageDependencyEvidenceInputKind`,
+`PackageDependencyEvidenceAcquisitionForm`,
+`PackageDependencyEvidenceDeclarationBasis`,
+`PackageDependencyEvidenceAuthorship`,
+`PackageDependencyEvidenceRelationship`,
+`PackageDependencyEvidenceRelationshipResult`,
+`PackageDependencyEvidenceProcessingObservation`,
+`PackageDependencyEvidenceProcessingResult`, and
+`PackageDependencyEvidencePhaseCounts`. Input kind and declaration basis are
+derived from matching root identity and provenance rather than independently
+settable discriminators.
 
 ### Package manifest
 
@@ -1028,22 +1045,29 @@ Implementation must establish:
   framework identity at a sink; and
 - visible root, declaration, and enrichment failures.
 
-The declaration, comparison, graph, package-profile, root-failure, and
-containment properties are gated in Release by
-`PackageDependencyEvidenceQueryTests`. Owner-enrichment behavior remains
-`unverified` until #5315 supplies its typed input and focused gates. The larger
-input-kind, basis, authorship, relationship, and processing properties remain
-`unverified` until these Release gates land:
+The declaration, comparison, graph, package-profile, root-failure, containment,
+and current larger-shape properties are gated in Release by
+`PackageDependencyEvidenceQueryTests`. The current larger-shape gates are:
 
+- `Execute_CurrentInputKindsAndDeclarationBasesAreExplicit`;
+- `Execute_RestoredGraphProvidesPositiveRestoreResolutionObservation`;
+- `Execute_PreservesSelectedRestoredTargetWhenGraphIsUnavailable`;
+- `PackageInput_InputKindAndBasisRequireMatchingIdentityAndProvenance`;
 - `PackageInput_RequestedConstraintAndResolvedCoordinateRemainIndependent`;
 - `PackageInput_PackageManifestDeclarationsAreLibraryDeclared`;
 - `PackageInput_RestoredRelationshipOriginRequiresOwnerAssociation`;
 - `PackageInput_ProjectNodeRelationshipRemainsUnattributedWithoutAssociation`;
+- `PackageInput_NotApplicableIsNotUnavailableOrCompleteEmpty`.
+
+Owner-enrichment behavior remains `unverified` until #5315 supplies its typed
+input and focused gates. The remaining authored-project, pruning-processing,
+runtime-dependency, and cross-host properties remain `unverified` until these
+Release gates land:
+
 - `PackageInput_AuthoredSyntaxAndEvaluatedBasisRemainDistinct`;
 - `PackageInput_AssetsPruningObservationRequiresTypedPackagesToPruneEvidence`;
 - `PackageInput_AssetsWithoutPruneEvidenceRemainProcessingUnknown`;
 - `PackageInput_DepsAbsenceNeverBecomesPruningEvidence`;
-- `PackageInput_NotApplicableIsNotUnavailableOrCompleteEmpty`; and
 - `PackageInput_CliAndBrowserConsumeTheSameTypedSnapshot`.
 
 ## Existing dependency-evidence adoption sequence

--- a/docs/design/restored-project-dependency-facts.md
+++ b/docs/design/restored-project-dependency-facts.md
@@ -286,10 +286,17 @@ Public graph edges are package-resolving relationships:
 Each edge retains:
 
 - stable edge, parent-node, and dependency-node identities;
+- for a root edge, the exact correlated `project.frameworks` declaration-group
+  identity that supplied its authored constraint;
 - the exact resolved package coordinate;
 - canonical NuGet constraint semantics;
 - the source constraint as `InertString`; and
 - direct or transitive role relative to the restored root.
+
+A non-root edge carries no declaration-group association. The type enforces
+that root edges have the association and non-root edges do not, so a consumer
+can classify application authorship through owner-issued correspondence rather
+than through direct/transitive role.
 
 The package collection contains exactly the package nodes reached from the
 root. A package is direct when a root entry resolves to it; otherwise it is
@@ -401,6 +408,8 @@ The contract is gated by:
   reachable graph nodes;
 - unclassified dependency targets being invalid rather than assumed packages;
 - exact direct and transitive package coordinates plus a diamond edge shape;
+- root edges carrying their correlated declaration-group identity while
+  package- and project-parent edges carry no declaration association;
 - coalescing equal duplicate edges and refusing conflicting ones;
 - complete-empty, incomplete, unavailable, and failed graph outcomes;
 - declaration failure remaining independent of usable graph evidence and the

--- a/src/DotnetInspector.Queries/PackageDependencyEvidenceQuery.cs
+++ b/src/DotnetInspector.Queries/PackageDependencyEvidenceQuery.cs
@@ -7,21 +7,41 @@ using NuGetFetch;
 
 namespace DotnetInspector.Queries;
 
-/// <summary>The declaration-facts owner that supplied one normalized root.</summary>
-public enum PackageDependencyEvidenceRootOwner
+/// <summary>The semantic altitude of one admitted package input.</summary>
+public enum PackageDependencyEvidenceInputKind
 {
-    PackageManifest,
-    RestoredProject,
+    PackageManifest = 0,
+    RestoredProject = 1,
+    AuthoredProject = 2,
+    RuntimeDependencyManifest = 3,
 }
 
 /// <summary>How one root's already-acquired facts reached this composition query.</summary>
-public enum PackageDependencyEvidenceSourceKind
+public enum PackageDependencyEvidenceAcquisitionForm
 {
     PackageArchive,
     DirectNuspec,
     PackageSourceManifest,
     ProjectAssets,
     ProjectLocator,
+}
+
+/// <summary>The fidelity basis claimed by one root's declaration phase.</summary>
+public enum PackageDependencyEvidenceDeclarationBasis
+{
+    PackageManifest,
+    AuthoredProjectSyntax,
+    EvaluatedProject,
+    RestoredProject,
+    NotApplicable,
+}
+
+/// <summary>Who authored the declaration associated with one evidence row.</summary>
+public enum PackageDependencyEvidenceAuthorship
+{
+    ApplicationAuthored,
+    LibraryDeclared,
+    Unattributed,
 }
 
 /// <summary>Whether every fact exposed by one phase was projected.</summary>
@@ -49,7 +69,7 @@ public abstract record PackageDependencyEvidenceInput
     public sealed record Package(
         PackageManifestFacts Manifest,
         PackageDependencyGroups Groups,
-        PackageDependencyEvidenceSourceKind SourceKind,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         InertString? SourceLabel = null,
         PackageSourceResultIdentity? Source = null) :
         PackageDependencyEvidenceInput;
@@ -57,7 +77,7 @@ public abstract record PackageDependencyEvidenceInput
     /// <summary>Restored-project declaration and graph facts.</summary>
     public sealed record RestoredProject(
         RestoredProjectDependencyFacts Facts,
-        PackageDependencyEvidenceSourceKind SourceKind,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         InertString? SourceLabel = null) : PackageDependencyEvidenceInput;
 }
 
@@ -69,13 +89,13 @@ public abstract record PackageDependencyEvidenceRootFailure
     }
 
     public sealed record Package(
-        PackageDependencyEvidenceSourceKind SourceKind,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         PackageSourceCoordinate? Coordinate,
         PackageManifestFailure Failure,
         InertString? SourceLabel = null) : PackageDependencyEvidenceRootFailure;
 
     public sealed record RestoredProject(
-        PackageDependencyEvidenceSourceKind SourceKind,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         RestoredProjectDependencyFailure Failure,
         InertString? SourceLabel = null) : PackageDependencyEvidenceRootFailure;
 
@@ -89,7 +109,7 @@ public abstract record PackageDependencyEvidenceRootFailure
         InertString Message) : PackageDependencyEvidenceRootFailure;
 
     public sealed record Acquisition(
-        PackageDependencyEvidenceSourceKind SourceKind,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         PackageDependencyEvidenceAcquisitionFailureReason Reason,
         PackageSourceCoordinate? Coordinate = null,
         InertString? SourceLabel = null) : PackageDependencyEvidenceRootFailure;
@@ -210,31 +230,22 @@ public abstract record PackageDependencyEvidenceRootProvenance
     {
     }
 
-    public abstract PackageDependencyEvidenceRootOwner Owner { get; }
-
-    public abstract PackageDependencyEvidenceSourceKind SourceKind { get; init; }
+    public abstract PackageDependencyEvidenceAcquisitionForm AcquisitionForm
+        { get; init; }
 
     public abstract InertString? SourceLabel { get; init; }
 
     public sealed record Package(
-        PackageDependencyEvidenceSourceKind SourceKind,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         PackageManifestIdentityProvenance IdentityProvenance,
         InertString? SourceLabel,
         PackageSourceResultIdentity? Source) :
-        PackageDependencyEvidenceRootProvenance
-    {
-        public override PackageDependencyEvidenceRootOwner Owner =>
-            PackageDependencyEvidenceRootOwner.PackageManifest;
-    }
+        PackageDependencyEvidenceRootProvenance;
 
     public sealed record RestoredProject(
-        PackageDependencyEvidenceSourceKind SourceKind,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         RestoredProjectContentProvenance ContentProvenance,
-        InertString? SourceLabel) : PackageDependencyEvidenceRootProvenance
-    {
-        public override PackageDependencyEvidenceRootOwner Owner =>
-            PackageDependencyEvidenceRootOwner.RestoredProject;
-    }
+        InertString? SourceLabel) : PackageDependencyEvidenceRootProvenance;
 }
 
 /// <summary>The semantic framework scope of one logical declaration group.</summary>
@@ -340,7 +351,8 @@ public sealed record PackageDependencyEvidenceDeclaration(
     string CanonicalVersionConstraint,
     InertString SourcePackageIdSpelling,
     InertString SourceVersionConstraintSpelling,
-    int SourceOccurrenceCount)
+    int SourceOccurrenceCount,
+    PackageDependencyEvidenceAuthorship Authorship)
 {
     public int SourceOccurrenceCount { get; } = SourceOccurrenceCount >= 1
         ? SourceOccurrenceCount
@@ -424,6 +436,9 @@ public abstract record PackageDependencyEvidenceDeclarationResult
             Completion == PackageDependencyEvidencePhaseCompletion.Complete;
     }
 
+    public sealed record NotApplicable :
+        PackageDependencyEvidenceDeclarationResult;
+
     public sealed record Unavailable : PackageDependencyEvidenceDeclarationResult;
 
     public sealed record Failed(
@@ -448,21 +463,98 @@ public sealed record PackageDependencyEvidenceSelection(
     InertString? RequestedFramework,
     InertString? SelectedFramework);
 
-/// <summary>The additive restored-graph state for one normalized root.</summary>
-public abstract record PackageDependencyEvidenceGraphResult
+/// <summary>Stable provider-issued identity for one resolved package node.</summary>
+public abstract record PackageDependencyEvidencePackageIdentity
 {
-    private PackageDependencyEvidenceGraphResult()
+    private PackageDependencyEvidencePackageIdentity()
     {
     }
 
-    public sealed record NotApplicable : PackageDependencyEvidenceGraphResult;
+    public sealed record RestoredProject(
+        RestoredProjectPackageNodeIdentity Identity) :
+        PackageDependencyEvidencePackageIdentity;
+}
 
-    public sealed record Available : PackageDependencyEvidenceGraphResult
+/// <summary>The closed parent identity of one produced package relationship.</summary>
+public abstract record PackageDependencyEvidenceRelationshipParentIdentity
+{
+    private PackageDependencyEvidenceRelationshipParentIdentity()
+    {
+    }
+
+    public sealed record Root(PackageDependencyEvidenceRootIdentity Identity) :
+        PackageDependencyEvidenceRelationshipParentIdentity;
+
+    public sealed record Package(PackageDependencyEvidencePackageIdentity Identity) :
+        PackageDependencyEvidenceRelationshipParentIdentity;
+
+    public sealed record Project(RestoredProjectProjectNodeIdentity Identity) :
+        PackageDependencyEvidenceRelationshipParentIdentity;
+}
+
+/// <summary>Stable provider-issued identity for one produced relationship.</summary>
+public abstract record PackageDependencyEvidenceRelationshipIdentity
+{
+    private PackageDependencyEvidenceRelationshipIdentity()
+    {
+    }
+
+    public sealed record RestoredProject(RestoredProjectEdgeIdentity Identity) :
+        PackageDependencyEvidenceRelationshipIdentity;
+}
+
+/// <summary>A provider-owned direct or transitive role for one produced relationship.</summary>
+public enum PackageDependencyEvidenceRelationshipRole
+{
+    Direct,
+    Transitive,
+}
+
+/// <summary>One normalized resolved package node retained by a relationship phase.</summary>
+public sealed record PackageDependencyEvidenceResolvedPackage(
+    PackageDependencyEvidencePackageIdentity Identity,
+    PackageSourceCoordinate Coordinate,
+    PackageDependencyEvidenceRelationshipRole? Role);
+
+/// <summary>One normalized produced package relationship.</summary>
+public sealed record PackageDependencyEvidenceRelationship(
+    PackageDependencyEvidenceRelationshipIdentity Identity,
+    PackageDependencyEvidenceRelationshipParentIdentity Parent,
+    PackageDependencyEvidencePackageIdentity Dependency,
+    string? CanonicalRequestedConstraint,
+    InertString? SourceRequestedConstraintSpelling,
+    PackageSourceCoordinate ResolvedCoordinate,
+    PackageDependencyEvidenceRelationshipRole? Role,
+    PackageDependencyEvidenceAuthorship Authorship,
+    PackageDependencyEvidenceDeclarationIdentity? DeclarationAssociation);
+
+/// <summary>A typed provider failure retained by the relationship phase.</summary>
+public abstract record PackageDependencyEvidenceRelationshipFailure
+{
+    private PackageDependencyEvidenceRelationshipFailure()
+    {
+    }
+
+    public sealed record RestoredProject(RestoredProjectGraphFailure Failure) :
+        PackageDependencyEvidenceRelationshipFailure;
+}
+
+/// <summary>The additive produced-relationship state for one normalized root.</summary>
+public abstract record PackageDependencyEvidenceRelationshipResult
+{
+    private PackageDependencyEvidenceRelationshipResult()
+    {
+    }
+
+    public sealed record NotApplicable :
+        PackageDependencyEvidenceRelationshipResult;
+
+    public sealed record Available : PackageDependencyEvidenceRelationshipResult
     {
         public Available(
-            ImmutableArray<RestoredProjectPackageNode> packages,
-            ImmutableArray<RestoredProjectGraphEdge> edges,
-            ImmutableArray<RestoredProjectGraphFailure> failures,
+            ImmutableArray<PackageDependencyEvidenceResolvedPackage> packages,
+            ImmutableArray<PackageDependencyEvidenceRelationship> relationships,
+            ImmutableArray<PackageDependencyEvidenceRelationshipFailure> failures,
             PackageDependencyEvidencePhaseCompletion completion)
         {
             if (failures.IsDefaultOrEmpty
@@ -474,16 +566,19 @@ public abstract record PackageDependencyEvidenceGraphResult
             }
 
             Packages = packages.IsDefault ? [] : packages;
-            Edges = edges.IsDefault ? [] : edges;
+            Relationships = relationships.IsDefault ? [] : relationships;
             Failures = failures.IsDefault ? [] : failures;
             Completion = completion;
         }
 
-        public ImmutableArray<RestoredProjectPackageNode> Packages { get; }
+        public ImmutableArray<PackageDependencyEvidenceResolvedPackage> Packages
+            { get; }
 
-        public ImmutableArray<RestoredProjectGraphEdge> Edges { get; }
+        public ImmutableArray<PackageDependencyEvidenceRelationship> Relationships
+            { get; }
 
-        public ImmutableArray<RestoredProjectGraphFailure> Failures { get; }
+        public ImmutableArray<PackageDependencyEvidenceRelationshipFailure> Failures
+            { get; }
 
         public PackageDependencyEvidencePhaseCompletion Completion { get; }
 
@@ -491,10 +586,79 @@ public abstract record PackageDependencyEvidenceGraphResult
             Completion == PackageDependencyEvidencePhaseCompletion.Complete;
     }
 
-    public sealed record Unavailable : PackageDependencyEvidenceGraphResult;
+    public sealed record Unavailable :
+        PackageDependencyEvidenceRelationshipResult;
 
-    public sealed record Failed(RestoredProjectGraphFailure Failure) :
-        PackageDependencyEvidenceGraphResult;
+    public sealed record Failed(PackageDependencyEvidenceRelationshipFailure Failure) :
+        PackageDependencyEvidenceRelationshipResult;
+}
+
+/// <summary>One positively evidenced upstream processing semantic.</summary>
+public enum PackageDependencyEvidenceProcessingObservation
+{
+    RestoreResolution,
+    PackagePruningEvaluation,
+    RuntimeDependencyProjection,
+}
+
+/// <summary>A typed failure to associate processing evidence with its input and target.</summary>
+public abstract record PackageDependencyEvidenceProcessingFailure
+{
+    private PackageDependencyEvidenceProcessingFailure()
+    {
+    }
+
+    public sealed record Association(
+        PackageDependencyEvidenceProcessingObservation Observation) :
+        PackageDependencyEvidenceProcessingFailure;
+}
+
+/// <summary>The positive processing-evidence state for one normalized root.</summary>
+public abstract record PackageDependencyEvidenceProcessingResult
+{
+    private PackageDependencyEvidenceProcessingResult()
+    {
+    }
+
+    public sealed record NotApplicable : PackageDependencyEvidenceProcessingResult;
+
+    public sealed record Available : PackageDependencyEvidenceProcessingResult
+    {
+        public Available(
+            ImmutableArray<PackageDependencyEvidenceProcessingObservation>
+                observations,
+            ImmutableArray<PackageDependencyEvidenceProcessingFailure> failures,
+            PackageDependencyEvidencePhaseCompletion completion)
+        {
+            if (failures.IsDefaultOrEmpty
+                != (completion == PackageDependencyEvidencePhaseCompletion.Complete))
+            {
+                throw new ArgumentException(
+                    "A complete processing projection carries no failures and an incomplete projection carries at least one.",
+                    nameof(completion));
+            }
+
+            Observations = observations.IsDefault ? [] : observations;
+            Failures = failures.IsDefault ? [] : failures;
+            Completion = completion;
+        }
+
+        public ImmutableArray<PackageDependencyEvidenceProcessingObservation>
+            Observations { get; }
+
+        public ImmutableArray<PackageDependencyEvidenceProcessingFailure> Failures
+            { get; }
+
+        public PackageDependencyEvidencePhaseCompletion Completion { get; }
+
+        public bool IsComplete =>
+            Completion == PackageDependencyEvidencePhaseCompletion.Complete;
+    }
+
+    public sealed record Unavailable : PackageDependencyEvidenceProcessingResult;
+
+    public sealed record Failed(PackageDependencyEvidenceProcessingFailure Failure) :
+        PackageDependencyEvidenceProcessingResult;
 }
 
 /// <summary>One admitted normalized root.</summary>
@@ -505,7 +669,54 @@ public sealed record PackageDependencyEvidenceRoot(
     PackageDependencyEvidenceDeclarationResult Declaration,
     PackageDependencyEvidenceSelection Selection,
     RestoredProjectSelectedTarget? RestoredTarget,
-    PackageDependencyEvidenceGraphResult Graph);
+    PackageDependencyEvidenceRelationshipResult Relationships,
+    PackageDependencyEvidenceProcessingResult Processing)
+{
+    public PackageDependencyEvidenceRootIdentity Identity { get; } =
+        Identity ?? throw new ArgumentNullException(nameof(Identity));
+
+    public PackageDependencyEvidenceRootProvenance Provenance { get; } =
+        (Identity, Provenance) switch
+        {
+            (PackageDependencyEvidenceRootIdentity.Package _,
+                PackageDependencyEvidenceRootProvenance.Package _) =>
+                    Provenance,
+            (PackageDependencyEvidenceRootIdentity.RestoredProject _,
+                PackageDependencyEvidenceRootProvenance.RestoredProject _) =>
+                    Provenance,
+            _ => throw new ArgumentException(
+                "Root identity and provenance must describe the same semantic input.",
+                nameof(Provenance)),
+        };
+
+    public PackageDependencyEvidenceInputKind InputKind { get; } =
+        (Identity, Provenance) switch
+        {
+            (PackageDependencyEvidenceRootIdentity.Package _,
+                PackageDependencyEvidenceRootProvenance.Package _) =>
+                    PackageDependencyEvidenceInputKind.PackageManifest,
+            (PackageDependencyEvidenceRootIdentity.RestoredProject _,
+                PackageDependencyEvidenceRootProvenance.RestoredProject _) =>
+                    PackageDependencyEvidenceInputKind.RestoredProject,
+            _ => throw new ArgumentException(
+                "Root identity and provenance must describe the same semantic input kind.",
+                nameof(Provenance)),
+        };
+
+    public PackageDependencyEvidenceDeclarationBasis DeclarationBasis { get; } =
+        (Identity, Provenance) switch
+        {
+            (PackageDependencyEvidenceRootIdentity.Package _,
+                PackageDependencyEvidenceRootProvenance.Package _) =>
+                    PackageDependencyEvidenceDeclarationBasis.PackageManifest,
+            (PackageDependencyEvidenceRootIdentity.RestoredProject _,
+                PackageDependencyEvidenceRootProvenance.RestoredProject _) =>
+                    PackageDependencyEvidenceDeclarationBasis.RestoredProject,
+            _ => throw new ArgumentException(
+                "Root identity and provenance must describe the same declaration basis.",
+                nameof(Provenance)),
+        };
+}
 
 /// <summary>Root-set admission accounting kept independent from per-root phase completion.</summary>
 public sealed record PackageDependencyEvidenceRootSetSummary(
@@ -517,17 +728,19 @@ public sealed record PackageDependencyEvidenceRootSetSummary(
     PackageDependencyEvidencePackagePrefixCompletion?
         PackagePrefixCompletion);
 
-/// <summary>Aggregate per-root declaration and graph state counts.</summary>
+/// <summary>Aggregate counts for one independently completed evidence phase.</summary>
+public sealed record PackageDependencyEvidencePhaseCounts(
+    int NotApplicable,
+    int Complete,
+    int Incomplete,
+    int Unavailable,
+    int Failed);
+
+/// <summary>Aggregate per-root declaration, relationship, and processing states.</summary>
 public sealed record PackageDependencyEvidencePhaseSummary(
-    int CompleteDeclarations,
-    int IncompleteDeclarations,
-    int UnavailableDeclarations,
-    int FailedDeclarations,
-    int NotApplicableGraphs,
-    int CompleteGraphs,
-    int IncompleteGraphs,
-    int UnavailableGraphs,
-    int FailedGraphs);
+    PackageDependencyEvidencePhaseCounts Declarations,
+    PackageDependencyEvidencePhaseCounts Relationships,
+    PackageDependencyEvidencePhaseCounts Processing);
 
 /// <summary>The immutable normalized dependency evidence for one supplied root set.</summary>
 public sealed record PackageDependencyEvidenceOutcome(
@@ -582,13 +795,13 @@ public static class PackageDependencyEvidenceQuery
     /// </summary>
     public static PackageDependencyEvidenceInput.Package CreatePackageInput(
         PackageManifestFacts manifest,
-        PackageDependencyEvidenceSourceKind sourceKind,
+        PackageDependencyEvidenceAcquisitionForm acquisitionForm,
         string? requestedTargetFramework = null,
         InertString? sourceLabel = null,
         PackageSourceResultIdentity? source = null)
     {
         ArgumentNullException.ThrowIfNull(manifest);
-        RequirePackageSource(sourceKind, source);
+        RequirePackageAcquisitionForm(acquisitionForm, source);
         string? requested = string.IsNullOrWhiteSpace(requestedTargetFramework)
             ? null
             : requestedTargetFramework;
@@ -597,7 +810,7 @@ public static class PackageDependencyEvidenceQuery
             PackageDependencyGroupsQuery.ProjectDependencyGroups(
                 manifest,
                 requested),
-            sourceKind,
+            acquisitionForm,
             sourceLabel,
             source);
     }
@@ -620,7 +833,7 @@ public static class PackageDependencyEvidenceQuery
 
         return CreatePackageInput(
             match.Manifest,
-            PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+            PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
             requestedTargetFramework,
             sourceLabel,
             match.Source);
@@ -630,14 +843,14 @@ public static class PackageDependencyEvidenceQuery
     public static PackageDependencyEvidenceInput.RestoredProject
         CreateRestoredProjectInput(
             RestoredProjectDependencyFacts facts,
-            PackageDependencyEvidenceSourceKind sourceKind,
+            PackageDependencyEvidenceAcquisitionForm acquisitionForm,
             InertString? sourceLabel = null)
     {
         ArgumentNullException.ThrowIfNull(facts);
-        RequireRestoredSource(sourceKind);
+        RequireRestoredAcquisitionForm(acquisitionForm);
         return new PackageDependencyEvidenceInput.RestoredProject(
             facts,
-            sourceKind,
+            acquisitionForm,
             sourceLabel);
     }
 
@@ -714,11 +927,11 @@ public static class PackageDependencyEvidenceQuery
             switch (failure)
             {
                 case PackageDependencyEvidenceRootFailure.Package package:
-                    RequirePackageSource(package.SourceKind);
+                    RequirePackageAcquisitionForm(package.AcquisitionForm);
                     ArgumentNullException.ThrowIfNull(package.Failure);
                     break;
                 case PackageDependencyEvidenceRootFailure.RestoredProject restored:
-                    RequireRestoredSource(restored.SourceKind);
+                    RequireRestoredAcquisitionForm(restored.AcquisitionForm);
                     ArgumentNullException.ThrowIfNull(restored.Failure);
                     break;
                 case PackageDependencyEvidenceRootFailure.PackageProfile profile:
@@ -732,7 +945,7 @@ public static class PackageDependencyEvidenceQuery
                     }
                     break;
                 case PackageDependencyEvidenceRootFailure.Acquisition acquisition:
-                    RequireKnownSource(acquisition.SourceKind);
+                    RequireKnownAcquisitionForm(acquisition.AcquisitionForm);
                     break;
                 default:
                     throw new InvalidOperationException(
@@ -789,9 +1002,9 @@ public static class PackageDependencyEvidenceQuery
             CompareCore(leftDeclaration.Groups, rightDeclaration.Groups);
         PackageDependencyEvidenceComparisonResult scoped =
             CompareScoped(
-                left.Provenance.Owner,
+                left.InputKind,
                 leftDeclaration.Groups,
-                right.Provenance.Owner,
+                right.InputKind,
                 rightDeclaration.Groups);
         (PackageDependencyEvidenceComparisonResult selectedCore,
             PackageDependencyEvidenceComparisonResult selectedScoped) =
@@ -820,7 +1033,7 @@ public static class PackageDependencyEvidenceQuery
     {
         ArgumentNullException.ThrowIfNull(input.Manifest);
         ArgumentNullException.ThrowIfNull(input.Groups);
-        RequirePackageSource(input.SourceKind, input.Source);
+        RequirePackageAcquisitionForm(input.AcquisitionForm, input.Source);
         RequireMatchingPackageFacts(input.Manifest, input.Groups);
 
         var rootIdentity = new PackageDependencyEvidenceRootIdentity.Package(
@@ -832,7 +1045,7 @@ public static class PackageDependencyEvidenceQuery
         return new PackageDependencyEvidenceRoot(
             rootIdentity,
             new PackageDependencyEvidenceRootProvenance.Package(
-                input.SourceKind,
+                input.AcquisitionForm,
                 input.Manifest.IdentityProvenance,
                 input.SourceLabel,
                 input.Source),
@@ -843,14 +1056,15 @@ public static class PackageDependencyEvidenceQuery
             declaration,
             selection,
             null,
-            new PackageDependencyEvidenceGraphResult.NotApplicable());
+            new PackageDependencyEvidenceRelationshipResult.NotApplicable(),
+            new PackageDependencyEvidenceProcessingResult.NotApplicable());
     }
 
     private static PackageDependencyEvidenceRoot ProjectRestoredProject(
         PackageDependencyEvidenceInput.RestoredProject input)
     {
         ArgumentNullException.ThrowIfNull(input.Facts);
-        RequireRestoredSource(input.SourceKind);
+        RequireRestoredAcquisitionForm(input.AcquisitionForm);
 
         var rootIdentity =
             new PackageDependencyEvidenceRootIdentity.RestoredProject(
@@ -858,7 +1072,7 @@ public static class PackageDependencyEvidenceQuery
         return new PackageDependencyEvidenceRoot(
             rootIdentity,
             new PackageDependencyEvidenceRootProvenance.RestoredProject(
-                input.SourceKind,
+                input.AcquisitionForm,
                 input.Facts.ContentProvenance,
                 input.SourceLabel),
             input.SourceLabel
@@ -871,7 +1085,8 @@ public static class PackageDependencyEvidenceQuery
                 null,
                 null),
             input.Facts.SelectedTarget,
-            ProjectRestoredGraph(input.Facts));
+            ProjectRestoredRelationships(rootIdentity, input.Facts),
+            ProjectRestoredProcessing(input.Facts));
     }
 
     private static PackageDependencyEvidenceDeclarationResult.Available
@@ -1041,7 +1256,8 @@ public static class PackageDependencyEvidenceQuery
                         TextPolicy.Field,
                         rawConstraint,
                         PackageManifestFactsQuery.MaxScalarCharacters),
-                    values.Count));
+                    values.Count,
+                    PackageDependencyEvidenceAuthorship.LibraryDeclared));
         }
 
         return declarations.ToImmutable();
@@ -1154,7 +1370,9 @@ public static class PackageDependencyEvidenceQuery
                             package.CanonicalVersionConstraint,
                             package.SourcePackageIdSpelling,
                             package.SourceVersionConstraintSpelling,
-                            package.SourceOccurrenceCount))
+                            package.SourceOccurrenceCount,
+                            PackageDependencyEvidenceAuthorship
+                                .ApplicationAuthored))
                     .OrderBy(
                         package => package.CanonicalPackageId,
                         StringComparer.Ordinal)
@@ -1190,26 +1408,132 @@ public static class PackageDependencyEvidenceQuery
                 : PackageDependencyEvidencePhaseCompletion.Incomplete);
     }
 
-    private static PackageDependencyEvidenceGraphResult ProjectRestoredGraph(
-        RestoredProjectDependencyFacts facts) =>
+    private static PackageDependencyEvidenceRelationshipResult
+        ProjectRestoredRelationships(
+            PackageDependencyEvidenceRootIdentity.RestoredProject root,
+            RestoredProjectDependencyFacts facts) =>
         facts.Graph switch
         {
             RestoredProjectGraphResult.Available available =>
-                new PackageDependencyEvidenceGraphResult.Available(
-                    available.Packages,
-                    available.Edges,
-                    available.Failures,
+                new PackageDependencyEvidenceRelationshipResult.Available(
+                    [
+                        .. available.Packages.Select(package =>
+                            new PackageDependencyEvidenceResolvedPackage(
+                                new PackageDependencyEvidencePackageIdentity
+                                    .RestoredProject(package.Identity),
+                                package.Identity.Coordinate,
+                                ProjectRelationshipRole(package.Role))),
+                    ],
+                    [
+                        .. available.Edges.Select(edge =>
+                        {
+                            PackageDependencyEvidenceDeclarationIdentity?
+                                declarationAssociation =
+                                    edge.DeclarationAssociation is { } association
+                                        ? new PackageDependencyEvidenceDeclarationIdentity(
+                                            new PackageDependencyEvidenceGroupIdentity
+                                                .RestoredProject(association),
+                                            edge.Dependency.Coordinate.PackageId)
+                                        : null;
+                            return new PackageDependencyEvidenceRelationship(
+                                new PackageDependencyEvidenceRelationshipIdentity
+                                    .RestoredProject(edge.Identity),
+                                ProjectRelationshipParent(root, edge.Parent),
+                                new PackageDependencyEvidencePackageIdentity
+                                    .RestoredProject(edge.Dependency),
+                                edge.CanonicalVersionConstraint,
+                                edge.SourceVersionConstraintSpelling,
+                                edge.Dependency.Coordinate,
+                                ProjectRelationshipRole(edge.Role),
+                                ProjectRelationshipAuthorship(
+                                    edge.Parent,
+                                    declarationAssociation),
+                                declarationAssociation);
+                        }),
+                    ],
+                    [
+                        .. available.Failures.Select(failure =>
+                            new PackageDependencyEvidenceRelationshipFailure
+                                .RestoredProject(failure)),
+                    ],
                     available.IsComplete
                         ? PackageDependencyEvidencePhaseCompletion.Complete
                         : PackageDependencyEvidencePhaseCompletion.Incomplete),
             RestoredProjectGraphResult.Unavailable =>
-                new PackageDependencyEvidenceGraphResult.Unavailable(),
+                new PackageDependencyEvidenceRelationshipResult.Unavailable(),
             RestoredProjectGraphResult.Failed failed =>
-                new PackageDependencyEvidenceGraphResult.Failed(
-                    failed.Failure),
+                new PackageDependencyEvidenceRelationshipResult.Failed(
+                    new PackageDependencyEvidenceRelationshipFailure
+                        .RestoredProject(failed.Failure)),
             _ => throw new InvalidOperationException(
                 "Unknown restored-project graph result."),
         };
+
+    private static PackageDependencyEvidenceRelationshipParentIdentity
+        ProjectRelationshipParent(
+            PackageDependencyEvidenceRootIdentity.RestoredProject root,
+            RestoredProjectGraphParentIdentity parent) =>
+        parent switch
+        {
+            RestoredProjectGraphParentIdentity.Root =>
+                new PackageDependencyEvidenceRelationshipParentIdentity.Root(
+                    root),
+            RestoredProjectGraphParentIdentity.Package package =>
+                new PackageDependencyEvidenceRelationshipParentIdentity.Package(
+                    new PackageDependencyEvidencePackageIdentity.RestoredProject(
+                        package.Identity)),
+            RestoredProjectGraphParentIdentity.Project project =>
+                new PackageDependencyEvidenceRelationshipParentIdentity.Project(
+                    project.Identity),
+            _ => throw new InvalidOperationException(
+                "Unknown restored-project relationship parent."),
+        };
+
+    private static PackageDependencyEvidenceRelationshipRole
+        ProjectRelationshipRole(RestoredProjectDependencyRole role) =>
+        role switch
+        {
+            RestoredProjectDependencyRole.Direct =>
+                PackageDependencyEvidenceRelationshipRole.Direct,
+            RestoredProjectDependencyRole.Transitive =>
+                PackageDependencyEvidenceRelationshipRole.Transitive,
+            _ => throw new InvalidOperationException(
+                "Unknown restored-project dependency role."),
+        };
+
+    private static PackageDependencyEvidenceAuthorship
+        ProjectRelationshipAuthorship(
+            RestoredProjectGraphParentIdentity parent,
+            PackageDependencyEvidenceDeclarationIdentity?
+                declarationAssociation) =>
+        parent switch
+        {
+            RestoredProjectGraphParentIdentity.Root
+                when declarationAssociation.HasValue =>
+                PackageDependencyEvidenceAuthorship.ApplicationAuthored,
+            RestoredProjectGraphParentIdentity.Package
+                when declarationAssociation is null =>
+                PackageDependencyEvidenceAuthorship.LibraryDeclared,
+            RestoredProjectGraphParentIdentity.Project
+                when declarationAssociation is null =>
+                PackageDependencyEvidenceAuthorship.Unattributed,
+            RestoredProjectGraphParentIdentity.Root =>
+                PackageDependencyEvidenceAuthorship.Unattributed,
+            _ => throw new InvalidOperationException(
+                "A non-root relationship cannot carry a root declaration association."),
+        };
+
+    private static PackageDependencyEvidenceProcessingResult
+        ProjectRestoredProcessing(RestoredProjectDependencyFacts facts) =>
+        facts.SelectedTarget is not null
+            ? new PackageDependencyEvidenceProcessingResult.Available(
+                [
+                    PackageDependencyEvidenceProcessingObservation
+                        .RestoreResolution,
+                ],
+                [],
+                PackageDependencyEvidencePhaseCompletion.Complete)
+            : new PackageDependencyEvidenceProcessingResult.Unavailable();
 
     private static PackageDependencyFrameworkScopeIdentity
         CreatePackageFrameworkScope(
@@ -1361,21 +1685,22 @@ public static class PackageDependencyEvidenceQuery
         }
     }
 
-    private static void RequirePackageSource(
-        PackageDependencyEvidenceSourceKind sourceKind,
+    private static void RequirePackageAcquisitionForm(
+        PackageDependencyEvidenceAcquisitionForm acquisitionForm,
         PackageSourceResultIdentity? source = null)
     {
-        if (sourceKind is not (
-            PackageDependencyEvidenceSourceKind.PackageArchive
-            or PackageDependencyEvidenceSourceKind.DirectNuspec
-            or PackageDependencyEvidenceSourceKind.PackageSourceManifest))
+        if (acquisitionForm is not (
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive
+            or PackageDependencyEvidenceAcquisitionForm.DirectNuspec
+            or PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest))
         {
             throw new ArgumentException(
                 "A package-manifest root requires package or package-source provenance.",
-                nameof(sourceKind));
+                nameof(acquisitionForm));
         }
 
-        if (sourceKind == PackageDependencyEvidenceSourceKind.PackageSourceManifest
+        if (acquisitionForm
+                == PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest
             && source is null)
         {
             throw new ArgumentException(
@@ -1384,28 +1709,28 @@ public static class PackageDependencyEvidenceQuery
         }
     }
 
-    private static void RequireRestoredSource(
-        PackageDependencyEvidenceSourceKind sourceKind)
+    private static void RequireRestoredAcquisitionForm(
+        PackageDependencyEvidenceAcquisitionForm acquisitionForm)
     {
-        if (sourceKind is not (
-            PackageDependencyEvidenceSourceKind.ProjectAssets
-            or PackageDependencyEvidenceSourceKind.ProjectLocator))
+        if (acquisitionForm is not (
+            PackageDependencyEvidenceAcquisitionForm.ProjectAssets
+            or PackageDependencyEvidenceAcquisitionForm.ProjectLocator))
         {
             throw new ArgumentException(
                 "A restored-project root requires direct-assets or project-locator provenance.",
-                nameof(sourceKind));
+                nameof(acquisitionForm));
         }
     }
 
-    private static void RequireKnownSource(
-        PackageDependencyEvidenceSourceKind sourceKind)
+    private static void RequireKnownAcquisitionForm(
+        PackageDependencyEvidenceAcquisitionForm acquisitionForm)
     {
-        if (!Enum.IsDefined(sourceKind))
+        if (!Enum.IsDefined(acquisitionForm))
         {
             throw new ArgumentOutOfRangeException(
-                nameof(sourceKind),
-                sourceKind,
-                "Unknown package dependency evidence source kind.");
+                nameof(acquisitionForm),
+                acquisitionForm,
+                "Unknown package dependency evidence acquisition form.");
         }
     }
 
@@ -1449,19 +1774,28 @@ public static class PackageDependencyEvidenceQuery
     private static PackageDependencyEvidencePhaseSummary SummarizePhases(
         ImmutableArray<PackageDependencyEvidenceRoot> roots)
     {
+        int notApplicableDeclarations = 0;
         int completeDeclarations = 0;
         int incompleteDeclarations = 0;
         int unavailableDeclarations = 0;
         int failedDeclarations = 0;
-        int notApplicableGraphs = 0;
-        int completeGraphs = 0;
-        int incompleteGraphs = 0;
-        int unavailableGraphs = 0;
-        int failedGraphs = 0;
+        int notApplicableRelationships = 0;
+        int completeRelationships = 0;
+        int incompleteRelationships = 0;
+        int unavailableRelationships = 0;
+        int failedRelationships = 0;
+        int notApplicableProcessing = 0;
+        int completeProcessing = 0;
+        int incompleteProcessing = 0;
+        int unavailableProcessing = 0;
+        int failedProcessing = 0;
         foreach (PackageDependencyEvidenceRoot root in roots)
         {
             switch (root.Declaration)
             {
+                case PackageDependencyEvidenceDeclarationResult.NotApplicable:
+                    notApplicableDeclarations++;
+                    break;
                 case PackageDependencyEvidenceDeclarationResult.Available
                     { IsComplete: true }:
                     completeDeclarations++;
@@ -1475,39 +1809,77 @@ public static class PackageDependencyEvidenceQuery
                 case PackageDependencyEvidenceDeclarationResult.Failed:
                     failedDeclarations++;
                     break;
+                default:
+                    throw new InvalidOperationException(
+                        "Unknown package dependency declaration result.");
             }
 
-            switch (root.Graph)
+            switch (root.Relationships)
             {
-                case PackageDependencyEvidenceGraphResult.NotApplicable:
-                    notApplicableGraphs++;
+                case PackageDependencyEvidenceRelationshipResult.NotApplicable:
+                    notApplicableRelationships++;
                     break;
-                case PackageDependencyEvidenceGraphResult.Available
+                case PackageDependencyEvidenceRelationshipResult.Available
                     { IsComplete: true }:
-                    completeGraphs++;
+                    completeRelationships++;
                     break;
-                case PackageDependencyEvidenceGraphResult.Available:
-                    incompleteGraphs++;
+                case PackageDependencyEvidenceRelationshipResult.Available:
+                    incompleteRelationships++;
                     break;
-                case PackageDependencyEvidenceGraphResult.Unavailable:
-                    unavailableGraphs++;
+                case PackageDependencyEvidenceRelationshipResult.Unavailable:
+                    unavailableRelationships++;
                     break;
-                case PackageDependencyEvidenceGraphResult.Failed:
-                    failedGraphs++;
+                case PackageDependencyEvidenceRelationshipResult.Failed:
+                    failedRelationships++;
                     break;
+                default:
+                    throw new InvalidOperationException(
+                        "Unknown package dependency relationship result.");
+            }
+
+            switch (root.Processing)
+            {
+                case PackageDependencyEvidenceProcessingResult.NotApplicable:
+                    notApplicableProcessing++;
+                    break;
+                case PackageDependencyEvidenceProcessingResult.Available
+                    { IsComplete: true }:
+                    completeProcessing++;
+                    break;
+                case PackageDependencyEvidenceProcessingResult.Available:
+                    incompleteProcessing++;
+                    break;
+                case PackageDependencyEvidenceProcessingResult.Unavailable:
+                    unavailableProcessing++;
+                    break;
+                case PackageDependencyEvidenceProcessingResult.Failed:
+                    failedProcessing++;
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        "Unknown package dependency processing result.");
             }
         }
 
         return new PackageDependencyEvidencePhaseSummary(
-            completeDeclarations,
-            incompleteDeclarations,
-            unavailableDeclarations,
-            failedDeclarations,
-            notApplicableGraphs,
-            completeGraphs,
-            incompleteGraphs,
-            unavailableGraphs,
-            failedGraphs);
+            new PackageDependencyEvidencePhaseCounts(
+                notApplicableDeclarations,
+                completeDeclarations,
+                incompleteDeclarations,
+                unavailableDeclarations,
+                failedDeclarations),
+            new PackageDependencyEvidencePhaseCounts(
+                notApplicableRelationships,
+                completeRelationships,
+                incompleteRelationships,
+                unavailableRelationships,
+                failedRelationships),
+            new PackageDependencyEvidencePhaseCounts(
+                notApplicableProcessing,
+                completeProcessing,
+                incompleteProcessing,
+                unavailableProcessing,
+                failedProcessing));
     }
 
     private static PackageDependencyEvidenceComparisonResult CompareCore(
@@ -1520,12 +1892,12 @@ public static class PackageDependencyEvidenceQuery
             : new PackageDependencyEvidenceComparisonResult.Unequal();
 
     private static PackageDependencyEvidenceComparisonResult CompareScoped(
-        PackageDependencyEvidenceRootOwner leftOwner,
+        PackageDependencyEvidenceInputKind leftKind,
         ImmutableArray<PackageDependencyEvidenceGroup> left,
-        PackageDependencyEvidenceRootOwner rightOwner,
+        PackageDependencyEvidenceInputKind rightKind,
         ImmutableArray<PackageDependencyEvidenceGroup> right)
     {
-        if (!ScopesAreComparable(leftOwner, left, rightOwner, right))
+        if (!ScopesAreComparable(leftKind, left, rightKind, right))
         {
             return new PackageDependencyEvidenceComparisonResult.NotComparable(
                 PackageDependencyEvidenceNotComparableReason.FrameworkScope);
@@ -1578,9 +1950,9 @@ public static class PackageDependencyEvidenceQuery
         return (
             CompareCore([leftGroup], [rightGroup]),
             CompareScoped(
-                left.Provenance.Owner,
+                left.InputKind,
                 [leftGroup],
-                right.Provenance.Owner,
+                right.InputKind,
                 [rightGroup]));
     }
 
@@ -1596,9 +1968,9 @@ public static class PackageDependencyEvidenceQuery
     }
 
     private static bool ScopesAreComparable(
-        PackageDependencyEvidenceRootOwner leftOwner,
+        PackageDependencyEvidenceInputKind leftKind,
         ImmutableArray<PackageDependencyEvidenceGroup> left,
-        PackageDependencyEvidenceRootOwner rightOwner,
+        PackageDependencyEvidenceInputKind rightKind,
         ImmutableArray<PackageDependencyEvidenceGroup> right)
     {
         ImmutableArray<string> leftOpaque = OpaqueScopeIdentities(left);
@@ -1606,7 +1978,7 @@ public static class PackageDependencyEvidenceQuery
         if (leftOpaque.IsEmpty && rightOpaque.IsEmpty)
             return true;
 
-        return leftOwner == rightOwner
+        return leftKind == rightKind
             && leftOpaque.SequenceEqual(rightOpaque, StringComparer.Ordinal);
     }
 

--- a/src/DotnetInspector.Queries/PackageDependencyTraversalQuery.cs
+++ b/src/DotnetInspector.Queries/PackageDependencyTraversalQuery.cs
@@ -85,7 +85,7 @@ public static class PackageDependencyTraversalQuery
         PackageDependencyEvidenceInput.Package input =
             PackageDependencyEvidenceQuery.CreatePackageInput(
                 facts,
-                PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                 requestedFramework,
                 sourceLabel: null,
                 source: manifest.Source);

--- a/src/DotnetInspector.Queries/RestoredProjectDependencyFactsQuery.cs
+++ b/src/DotnetInspector.Queries/RestoredProjectDependencyFactsQuery.cs
@@ -406,7 +406,20 @@ public sealed record RestoredProjectGraphEdge(
     RestoredProjectPackageNodeIdentity Dependency,
     string CanonicalVersionConstraint,
     InertString SourceVersionConstraintSpelling,
-    RestoredProjectDependencyRole Role);
+    RestoredProjectDependencyRole Role,
+    RestoredProjectDeclarationGroupIdentity? DeclarationAssociation)
+{
+    public RestoredProjectGraphParentIdentity Parent { get; } =
+        Parent ?? throw new ArgumentNullException(nameof(Parent));
+
+    public RestoredProjectDeclarationGroupIdentity? DeclarationAssociation { get; } =
+        (Parent is RestoredProjectGraphParentIdentity.Root)
+            == DeclarationAssociation.HasValue
+                ? DeclarationAssociation
+                : throw new ArgumentException(
+                    "A root edge requires its correlated declaration group, and a non-root edge cannot carry one.",
+                    nameof(DeclarationAssociation));
+}
 
 /// <summary>Why one graph-phase fact could not be represented, or why the whole phase failed.</summary>
 public enum RestoredProjectGraphFailureReason
@@ -961,9 +974,7 @@ public static class RestoredProjectDependencyFactsQuery
             // The group is identified by its exact authored pivot occurrence: canonical text only
             // when the pivot is already exactly its recognized canonical spelling, so case-only
             // variants stay distinct groups instead of colliding into one identity.
-            string pivotIdentity = recognized && string.Equals(normalizedTfm, rawPivot, StringComparison.Ordinal)
-                ? normalizedTfm
-                : RestoredProjectIdentityText.Opaque(rawPivot);
+            string pivotIdentity = DeclarationPivotIdentity(rawPivot, recognized, normalizedTfm);
 
             ImmutableArray<RestoredProjectDeclaredPackage> packages = [];
             if (pivotProperty.Value.TryGetProperty("dependencies", out JsonElement dependencies))
@@ -1011,6 +1022,14 @@ public static class RestoredProjectDependencyFactsQuery
                 ? RestoredProjectPhaseCompletion.Complete
                 : RestoredProjectPhaseCompletion.Incomplete);
     }
+
+    static string DeclarationPivotIdentity(
+        string rawPivot,
+        bool recognized,
+        string normalizedTfm) =>
+        recognized && string.Equals(normalizedTfm, rawPivot, StringComparison.Ordinal)
+            ? normalizedTfm
+            : RestoredProjectIdentityText.Opaque(rawPivot);
 
     /// <summary>How one <c>project.frameworks</c> dependency entry classifies itself.</summary>
     enum DeclaredTargetKind
@@ -1200,6 +1219,7 @@ public static class RestoredProjectDependencyFactsQuery
         var traversal = new GraphTraversal(
             selectedTargetValue,
             correlation.Constraints,
+            correlation.DeclarationGroupPivotIdentity!,
             correlation.LimitExceeded);
         traversal.Traverse(rootEntries);
         return traversal.Build();
@@ -1219,6 +1239,7 @@ public static class RestoredProjectDependencyFactsQuery
     readonly record struct RootConstraintCorrelation(
         RootCorrelationOutcome Outcome,
         Dictionary<string, List<RootConstraint>> Constraints,
+        string? DeclarationGroupPivotIdentity = null,
         bool LimitExceeded = false);
 
     static Dictionary<string, List<RootConstraint>> EmptyRootConstraints =>
@@ -1242,7 +1263,7 @@ public static class RestoredProjectDependencyFactsQuery
             return new RootConstraintCorrelation(RootCorrelationOutcome.Unavailable, EmptyRootConstraints);
         }
 
-        JsonElement? matched = null;
+        JsonProperty? matched = null;
         foreach (JsonProperty pivot in EnumeratePropertiesInCanonicalOrder(frameworks))
         {
             if (pivot.Name.Length == 0
@@ -1255,18 +1276,31 @@ public static class RestoredProjectDependencyFactsQuery
             if (matched is not null)
                 return new RootConstraintCorrelation(RootCorrelationOutcome.Ambiguous, EmptyRootConstraints);
 
-            matched = pivot.Value;
+            matched = pivot;
         }
 
-        if (matched is not { } group)
+        if (matched is not { } matchedProperty)
             return new RootConstraintCorrelation(RootCorrelationOutcome.Unavailable, EmptyRootConstraints);
 
+        JsonElement group = matchedProperty.Value;
         if (group.ValueKind != JsonValueKind.Object)
             return new RootConstraintCorrelation(RootCorrelationOutcome.InvalidShape, EmptyRootConstraints);
 
+        string rawPivot = matchedProperty.Name;
+        bool recognized = NuGetTargetFrameworkIdentity.TryNormalize(
+            rawPivot,
+            out string normalizedTfm);
+        string declarationGroupPivotIdentity =
+            DeclarationPivotIdentity(rawPivot, recognized, normalizedTfm);
+
         var constraints = new Dictionary<string, List<RootConstraint>>(StringComparer.Ordinal);
         if (!group.TryGetProperty("dependencies", out JsonElement dependencies))
-            return new RootConstraintCorrelation(RootCorrelationOutcome.Correlated, constraints);
+        {
+            return new RootConstraintCorrelation(
+                RootCorrelationOutcome.Correlated,
+                constraints,
+                declarationGroupPivotIdentity);
+        }
 
         if (dependencies.ValueKind != JsonValueKind.Object)
             return new RootConstraintCorrelation(RootCorrelationOutcome.InvalidShape, EmptyRootConstraints);
@@ -1316,7 +1350,11 @@ public static class RestoredProjectDependencyFactsQuery
                 occurrences.Add(constraint);
         }
 
-        return new RootConstraintCorrelation(RootCorrelationOutcome.Correlated, constraints, limitExceeded);
+        return new RootConstraintCorrelation(
+            RootCorrelationOutcome.Correlated,
+            constraints,
+            declarationGroupPivotIdentity,
+            limitExceeded);
     }
 
     /// <summary>
@@ -1365,6 +1403,7 @@ public static class RestoredProjectDependencyFactsQuery
     {
         readonly JsonElement _selectedTarget;
         readonly Dictionary<string, List<RootConstraint>> _rootConstraints;
+        readonly string _rootDeclarationGroupPivotIdentity;
         readonly Dictionary<string, string> _uniqueKeyByName = new(StringComparer.OrdinalIgnoreCase);
         readonly HashSet<string> _ambiguousNames = new(StringComparer.OrdinalIgnoreCase);
         readonly Dictionary<string, RestoredProjectPackageNodeIdentity> _packageNodes = new(StringComparer.Ordinal);
@@ -1380,10 +1419,12 @@ public static class RestoredProjectDependencyFactsQuery
         public GraphTraversal(
             JsonElement selectedTarget,
             Dictionary<string, List<RootConstraint>> rootConstraints,
+            string rootDeclarationGroupPivotIdentity,
             bool rootConstraintLimitExceeded)
         {
             _selectedTarget = selectedTarget;
             _rootConstraints = rootConstraints;
+            _rootDeclarationGroupPivotIdentity = rootDeclarationGroupPivotIdentity;
             if (rootConstraintLimitExceeded)
                 _failures.Add(RestoredProjectGraphFailureReason.ConfiguredLimitExceeded);
             IndexTargetNodes();
@@ -1525,7 +1566,8 @@ public static class RestoredProjectDependencyFactsQuery
                     "",
                     packageIdentity,
                     constraint.CanonicalConstraint,
-                    constraint.SourceSpelling);
+                    constraint.SourceSpelling,
+                    _rootDeclarationGroupPivotIdentity);
             }
 
             _directPackages.Add(packageIdentity.Coordinate);
@@ -1634,7 +1676,8 @@ public static class RestoredProjectDependencyFactsQuery
                 parentKey,
                 packageIdentity,
                 range.ToNormalizedString(),
-                new InertString(TextPolicy.Field, rawConstraint, MaxScalarCharacters));
+                new InertString(TextPolicy.Field, rawConstraint, MaxScalarCharacters),
+                declarationGroupPivotIdentity: null);
             Push(matchedKey!, RestoredProjectGraphParentIdentity.CreatePackageParent(packageIdentity));
         }
 
@@ -1648,7 +1691,8 @@ public static class RestoredProjectDependencyFactsQuery
             string parentKey,
             RestoredProjectPackageNodeIdentity dependency,
             string canonicalConstraint,
-            InertString sourceConstraint)
+            InertString sourceConstraint,
+            string? declarationGroupPivotIdentity)
         {
             if (++_edgeOccurrenceCount > MaxGraphEdges)
             {
@@ -1689,7 +1733,12 @@ public static class RestoredProjectDependencyFactsQuery
                 dependency,
                 canonicalConstraint,
                 sourceConstraint,
-                role));
+                role,
+                declarationGroupPivotIdentity is null
+                    ? null
+                    : new RestoredProjectDeclarationGroupIdentity(
+                        default!,
+                        declarationGroupPivotIdentity)));
         }
 
         bool TryBuildPackageIdentity(string matchedKey, out RestoredProjectPackageNodeIdentity identity)
@@ -1859,12 +1908,16 @@ public static class RestoredProjectDependencyFactsQuery
             {
                 RestoredProjectGraphParentIdentity parent = RescopeParent(e.Parent);
                 RestoredProjectPackageNodeIdentity dependency = Rescope(e.Dependency);
-                return e with
-                {
-                    Identity = new RestoredProjectEdgeIdentity(parent, dependency),
-                    Parent = parent,
-                    Dependency = dependency,
-                };
+                return new RestoredProjectGraphEdge(
+                    new RestoredProjectEdgeIdentity(parent, dependency),
+                    parent,
+                    dependency,
+                    e.CanonicalVersionConstraint,
+                    e.SourceVersionConstraintSpelling,
+                    e.Role,
+                    e.DeclarationAssociation is { } association
+                        ? association with { Selection = root.Selection }
+                        : null);
             })];
 
         return new RestoredProjectGraphResult.Available(packages, edges, available.Failures, available.Completion);
@@ -1961,6 +2014,7 @@ public static class RestoredProjectDependencyFactsQuery
                     Field(text, edge.Dependency.Coordinate.Version);
                     Field(text, edge.CanonicalVersionConstraint);
                     Count(text, (int)edge.Role);
+                    Field(text, edge.DeclarationAssociation?.PivotIdentity ?? "");
                 }
 
                 Count(text, available.Failures.Length);

--- a/src/dotnet-inspect.Tests/DependencyEvidenceCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyEvidenceCommandTests.cs
@@ -313,13 +313,13 @@ public sealed class DependencyEvidenceCommandTests
         Assert.Equal(Declared(directAssets), Declared(locator));
 
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageArchive,
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive,
             Assert.Single(archive.Roots).SourceKind);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.ProjectAssets,
+            PackageDependencyEvidenceAcquisitionForm.ProjectAssets,
             Assert.Single(directAssets.Roots).SourceKind);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.ProjectLocator,
+            PackageDependencyEvidenceAcquisitionForm.ProjectLocator,
             Assert.Single(locator.Roots).SourceKind);
     }
 
@@ -679,7 +679,7 @@ public sealed class DependencyEvidenceCommandTests
         var row = new DependencyEvidenceFailureRow(
             DependencyEvidenceFailurePhase.Root,
             "NotFound",
-            PackageDependencyEvidenceSourceKind.DirectNuspec,
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
             null,
             null,
             null,
@@ -1393,7 +1393,7 @@ public sealed class DependencyEvidenceCommandTests
 
         DependencyEvidenceRootRow root = Assert.Single(projection.Roots);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+            PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
             root.SourceKind);
         Assert.Equal("contoso.fallback", root.PackageId);
         Assert.Equal(
@@ -1425,8 +1425,8 @@ public sealed class DependencyEvidenceCommandTests
             Assert.IsType<PackageDependencyEvidenceRootFailure.Package>(
                 Assert.Single(failures));
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageSourceManifest,
-            failure.SourceKind);
+            PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
+            failure.AcquisitionForm);
         Assert.Equal(coordinate, failure.Coordinate);
         Assert.Equal(
             PackageManifestFailureReason.IdentityMismatch,
@@ -1745,7 +1745,7 @@ public sealed class DependencyEvidenceCommandTests
         DependencyEvidenceFailureRow failure = Assert.Single(projection.Failures);
         Assert.Equal(DependencyEvidenceFailurePhase.Root, failure.Phase);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageArchive,
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive,
             failure.SourceKind);
         Assert.Equal(
             PackageDependencyEvidenceAcquisitionFailureReason.ProducerContract
@@ -1892,7 +1892,7 @@ public sealed class DependencyEvidenceCommandTests
         Assert.Equal(1, projection.Summary.FailedRootCount);
         DependencyEvidenceFailureRow failure = Assert.Single(projection.Failures);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.ProjectLocator,
+            PackageDependencyEvidenceAcquisitionForm.ProjectLocator,
             failure.SourceKind);
     }
 
@@ -1933,7 +1933,7 @@ public sealed class DependencyEvidenceCommandTests
         Assert.Equal(1, projection.Summary.FailedRootCount);
         DependencyEvidenceFailureRow failure = Assert.Single(projection.Failures);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+            PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
             failure.SourceKind);
         Assert.Equal("ProducerContract", failure.Reason);
     }
@@ -2046,8 +2046,8 @@ public sealed class DependencyEvidenceCommandTests
             projection.Failures.Select(failure => failure.Reason));
         Assert.Equal(
             [
-                PackageDependencyEvidenceSourceKind.DirectNuspec,
-                PackageDependencyEvidenceSourceKind.ProjectLocator,
+                PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
+                PackageDependencyEvidenceAcquisitionForm.ProjectLocator,
             ],
             projection.Failures.Select(failure => failure.SourceKind).Order());
     }
@@ -2277,7 +2277,7 @@ public sealed class DependencyEvidenceCommandTests
         Assert.Single(projection.Roots);
         DependencyEvidenceFailureRow failure = Assert.Single(projection.Failures);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+            PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
             failure.SourceKind);
         Assert.Equal("AcquisitionFailed", failure.Reason);
     }
@@ -2311,7 +2311,7 @@ public sealed class DependencyEvidenceCommandTests
         Assert.Single(projection.Roots);
         DependencyEvidenceFailureRow failure = Assert.Single(projection.Failures);
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+            PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
             failure.SourceKind);
         Assert.Equal("AcquisitionFailed", failure.Reason);
         Assert.NotEqual("NotFound", failure.Reason);

--- a/src/dotnet-inspect/Commands/DependencyEvidenceAcquisition.cs
+++ b/src/dotnet-inspect/Commands/DependencyEvidenceAcquisition.cs
@@ -383,7 +383,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     PackageDependencyEvidenceAcquisitionFailureReason
                         .ProducerContract,
                     label));
@@ -400,7 +400,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     PackageDependencyEvidenceAcquisitionFailureReason
                         .SourceUnavailable,
                     label));
@@ -424,7 +424,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     PackageDependencyEvidenceAcquisitionFailureReason
                         .SourceUnavailable,
                     label));
@@ -442,7 +442,7 @@ internal static class DependencyEvidenceAcquisition
             // states absence.
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     resolution is PackageCoordinateResolution.Invalid
                         ? PackageDependencyEvidenceAcquisitionFailureReason
                             .ProducerContract
@@ -463,7 +463,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     PackageDependencyEvidenceAcquisitionFailureReason
                         .ProducerContract,
                     label));
@@ -713,7 +713,7 @@ internal static class DependencyEvidenceAcquisition
             roots.Add(
                 PackageDependencyEvidenceQuery.CreatePackageInput(
                     ((PackageManifestFactsResult.Available)facts).Value,
-                    PackageDependencyEvidenceSourceKind
+                    PackageDependencyEvidenceAcquisitionForm
                         .PackageSourceManifest,
                     targetFramework,
                     label,
@@ -724,12 +724,12 @@ internal static class DependencyEvidenceAcquisition
         failures.Add(
             manifestFailure is { } terminal
                 ? new PackageDependencyEvidenceRootFailure.Package(
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     coordinate,
                     terminal,
                     label)
                 : Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     !attempted
                         ? PackageDependencyEvidenceAcquisitionFailureReason
                             .SourceUnavailable
@@ -759,7 +759,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageArchive,
+                    PackageDependencyEvidenceAcquisitionForm.PackageArchive,
                     File.Exists(path)
                         ? PackageDependencyEvidenceAcquisitionFailureReason
                             .AcquisitionFailed
@@ -778,7 +778,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageArchive,
+                    PackageDependencyEvidenceAcquisitionForm.PackageArchive,
                     PackageDependencyEvidenceAcquisitionFailureReason
                         .ProducerContract,
                     label));
@@ -804,7 +804,7 @@ internal static class DependencyEvidenceAcquisition
             {
                 failures.Add(
                     Acquisition(
-                        PackageDependencyEvidenceSourceKind.PackageArchive,
+                        PackageDependencyEvidenceAcquisitionForm.PackageArchive,
                         PackageDependencyEvidenceAcquisitionFailureReason
                             .AcquisitionFailed,
                         label));
@@ -825,7 +825,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.PackageArchive,
+                    PackageDependencyEvidenceAcquisitionForm.PackageArchive,
                     PackageDependencyEvidenceAcquisitionFailureReason
                         .AcquisitionFailed,
                     label));
@@ -834,7 +834,7 @@ internal static class DependencyEvidenceAcquisition
 
         AddManifestRoot(
             manifestBytes,
-            PackageDependencyEvidenceSourceKind.PackageArchive,
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive,
             targetFramework,
             label,
             roots,
@@ -853,7 +853,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.DirectNuspec,
+                    PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
                     PackageDependencyEvidenceAcquisitionFailureReason
                         .ProducerContract,
                     label));
@@ -868,7 +868,7 @@ internal static class DependencyEvidenceAcquisition
         {
             failures.Add(
                 Acquisition(
-                    PackageDependencyEvidenceSourceKind.DirectNuspec,
+                    PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
                     File.Exists(path)
                         ? PackageDependencyEvidenceAcquisitionFailureReason
                             .AcquisitionFailed
@@ -880,7 +880,7 @@ internal static class DependencyEvidenceAcquisition
 
         AddManifestRoot(
             manifestBytes,
-            PackageDependencyEvidenceSourceKind.DirectNuspec,
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
             targetFramework,
             label,
             roots,
@@ -896,9 +896,9 @@ internal static class DependencyEvidenceAcquisition
     {
         InertString label = Label(path);
         bool isDirectAssets = IsDirectAssetsPath(path);
-        PackageDependencyEvidenceSourceKind sourceKind = isDirectAssets
-            ? PackageDependencyEvidenceSourceKind.ProjectAssets
-            : PackageDependencyEvidenceSourceKind.ProjectLocator;
+        PackageDependencyEvidenceAcquisitionForm sourceKind = isDirectAssets
+            ? PackageDependencyEvidenceAcquisitionForm.ProjectAssets
+            : PackageDependencyEvidenceAcquisitionForm.ProjectLocator;
 
         if (IsBlankPath(path))
         {
@@ -993,7 +993,7 @@ internal static class DependencyEvidenceAcquisition
 
     private static void AddManifestRoot(
         byte[] manifestBytes,
-        PackageDependencyEvidenceSourceKind sourceKind,
+        PackageDependencyEvidenceAcquisitionForm sourceKind,
         string? targetFramework,
         InertString label,
         ImmutableArray<PackageDependencyEvidenceInput>.Builder roots,
@@ -1101,7 +1101,7 @@ internal static class DependencyEvidenceAcquisition
         string.IsNullOrWhiteSpace(path);
 
     private static PackageDependencyEvidenceRootFailure.Acquisition Acquisition(
-        PackageDependencyEvidenceSourceKind sourceKind,
+        PackageDependencyEvidenceAcquisitionForm sourceKind,
         PackageDependencyEvidenceAcquisitionFailureReason reason,
         InertString label,
         PackageSourceCoordinate? coordinate = null) =>

--- a/src/dotnet-inspect/Commands/DependencyEvidenceCommand.cs
+++ b/src/dotnet-inspect/Commands/DependencyEvidenceCommand.cs
@@ -671,14 +671,14 @@ public static class DependencyEvidenceCommand
             DependencyEvidenceSections.Roots => true,
             DependencyEvidenceSections.Dependencies
                 or DependencyEvidenceSections.DependencyGroups =>
-                summary.Phases.IncompleteDeclarations == 0
-                && summary.Phases.FailedDeclarations == 0
-                && summary.Phases.UnavailableDeclarations == 0,
+                summary.Phases.Declarations.Incomplete == 0
+                && summary.Phases.Declarations.Failed == 0
+                && summary.Phases.Declarations.Unavailable == 0,
             DependencyEvidenceSections.RestoredEdges
                 or DependencyEvidenceSections.RestoredPackages =>
-                summary.Phases.IncompleteGraphs == 0
-                && summary.Phases.FailedGraphs == 0
-                && summary.Phases.UnavailableGraphs == 0,
+                summary.Phases.Relationships.Incomplete == 0
+                && summary.Phases.Relationships.Failed == 0
+                && summary.Phases.Relationships.Unavailable == 0,
             _ => false,
         };
     }
@@ -712,15 +712,15 @@ public static class DependencyEvidenceCommand
             RejectedRootCount = summary.RejectedRootCount,
             FailedRootCount = summary.FailedRootCount,
             Truncated = summary.IsTruncated,
-            CompleteDeclarations = summary.Phases.CompleteDeclarations,
-            IncompleteDeclarations = summary.Phases.IncompleteDeclarations,
-            UnavailableDeclarations = summary.Phases.UnavailableDeclarations,
-            FailedDeclarations = summary.Phases.FailedDeclarations,
-            NotApplicableGraphs = summary.Phases.NotApplicableGraphs,
-            CompleteGraphs = summary.Phases.CompleteGraphs,
-            IncompleteGraphs = summary.Phases.IncompleteGraphs,
-            UnavailableGraphs = summary.Phases.UnavailableGraphs,
-            FailedGraphs = summary.Phases.FailedGraphs,
+            CompleteDeclarations = summary.Phases.Declarations.Complete,
+            IncompleteDeclarations = summary.Phases.Declarations.Incomplete,
+            UnavailableDeclarations = summary.Phases.Declarations.Unavailable,
+            FailedDeclarations = summary.Phases.Declarations.Failed,
+            NotApplicableGraphs = summary.Phases.Relationships.NotApplicable,
+            CompleteGraphs = summary.Phases.Relationships.Complete,
+            IncompleteGraphs = summary.Phases.Relationships.Incomplete,
+            UnavailableGraphs = summary.Phases.Relationships.Unavailable,
+            FailedGraphs = summary.Phases.Relationships.Failed,
             PrefixText = summary.PackagePrefix?.Prefix,
             PrefixSourceText = summary.PackagePrefix?.Source.Producer.Display,
             PrefixCandidates = summary.PackagePrefix?.Candidates,
@@ -843,10 +843,10 @@ public static class DependencyEvidenceCommand
         return summary.FailedRootCount > 0
             || summary.RejectedRootCount > 0
             || truncatedBeyondRequest
-            || summary.Phases.IncompleteDeclarations > 0
-            || summary.Phases.FailedDeclarations > 0
-            || summary.Phases.IncompleteGraphs > 0
-            || summary.Phases.FailedGraphs > 0
+            || summary.Phases.Declarations.Incomplete > 0
+            || summary.Phases.Declarations.Failed > 0
+            || summary.Phases.Relationships.Incomplete > 0
+            || summary.Phases.Relationships.Failed > 0
                 ? 1
                 : 0;
     }
@@ -864,8 +864,8 @@ public static class DependencyEvidenceCommand
                 $"{failureRecords} typed failure record(s) are reported; run with '-S {DependencyEvidenceSections.Failures}' for the rows.");
         }
 
-        if (summary.Phases.UnavailableDeclarations > 0
-            || summary.Phases.UnavailableGraphs > 0)
+        if (summary.Phases.Declarations.Unavailable > 0
+            || summary.Phases.Relationships.Unavailable > 0)
         {
             CommandError.WriteWarning(
                 "Some optional declaration or restored-graph evidence is unavailable for the supplied roots.");
@@ -903,12 +903,16 @@ public static class DependencyEvidenceCommand
         {
             DependencyEvidenceSections.RestoredEdges
                 or DependencyEvidenceSections.RestoredPackages =>
-                phases.CompleteGraphs + phases.IncompleteGraphs == 0
+                phases.Relationships.Complete
+                    + phases.Relationships.Incomplete
+                    == 0
                     ? "no admitted root carries restored graph evidence."
                     : "the restored graph projected no nodes or edges.",
             DependencyEvidenceSections.Dependencies
                 or DependencyEvidenceSections.DependencyGroups =>
-                phases.CompleteDeclarations + phases.IncompleteDeclarations == 0
+                phases.Declarations.Complete
+                    + phases.Declarations.Incomplete
+                    == 0
                     ? "no admitted root carries a declaration projection."
                     : "the admitted roots declare no direct dependencies.",
             DependencyEvidenceSections.Failures =>

--- a/src/dotnet-inspect/Models/DependencyEvidenceDocument.cs
+++ b/src/dotnet-inspect/Models/DependencyEvidenceDocument.cs
@@ -151,15 +151,15 @@ public sealed record DependencyEvidenceSummaryJson
             RejectedRoots = summary.RejectedRootCount,
             FailedRoots = summary.FailedRootCount,
             Truncated = summary.IsTruncated,
-            CompleteDeclarations = summary.Phases.CompleteDeclarations,
-            IncompleteDeclarations = summary.Phases.IncompleteDeclarations,
-            UnavailableDeclarations = summary.Phases.UnavailableDeclarations,
-            FailedDeclarations = summary.Phases.FailedDeclarations,
-            NotApplicableGraphs = summary.Phases.NotApplicableGraphs,
-            CompleteGraphs = summary.Phases.CompleteGraphs,
-            IncompleteGraphs = summary.Phases.IncompleteGraphs,
-            UnavailableGraphs = summary.Phases.UnavailableGraphs,
-            FailedGraphs = summary.Phases.FailedGraphs,
+            CompleteDeclarations = summary.Phases.Declarations.Complete,
+            IncompleteDeclarations = summary.Phases.Declarations.Incomplete,
+            UnavailableDeclarations = summary.Phases.Declarations.Unavailable,
+            FailedDeclarations = summary.Phases.Declarations.Failed,
+            NotApplicableGraphs = summary.Phases.Relationships.NotApplicable,
+            CompleteGraphs = summary.Phases.Relationships.Complete,
+            IncompleteGraphs = summary.Phases.Relationships.Incomplete,
+            UnavailableGraphs = summary.Phases.Relationships.Unavailable,
+            FailedGraphs = summary.Phases.Relationships.Failed,
             PackagePrefix = summary.PackagePrefix is { } prefix
                 ? DependencyEvidencePrefixJson.Create(prefix, tokens)
                 : null,
@@ -206,9 +206,9 @@ public sealed record DependencyEvidenceDependencyJson
     [JsonConverter(typeof(InertStringJsonConverter))]
     public InertString? RootDisplay { get; init; }
 
-    public required PackageDependencyEvidenceRootOwner Owner { get; init; }
+    public required PackageDependencyEvidenceInputKind Owner { get; init; }
 
-    public required PackageDependencyEvidenceSourceKind SourceKind { get; init; }
+    public required PackageDependencyEvidenceAcquisitionForm SourceKind { get; init; }
 
     /// <summary>The document-stable group occurrence this declaration belongs to.</summary>
     public required int Group { get; init; }
@@ -281,9 +281,9 @@ public sealed record DependencyEvidenceRootJson
     [JsonConverter(typeof(InertStringJsonConverter))]
     public InertString? Display { get; init; }
 
-    public required PackageDependencyEvidenceRootOwner Owner { get; init; }
+    public required PackageDependencyEvidenceInputKind Owner { get; init; }
 
-    public required PackageDependencyEvidenceSourceKind SourceKind { get; init; }
+    public required PackageDependencyEvidenceAcquisitionForm SourceKind { get; init; }
 
     [JsonConverter(typeof(InertStringJsonConverter))]
     public InertString? SourceLabel { get; init; }
@@ -403,7 +403,7 @@ public sealed record DependencyEvidenceGroupJson
     [JsonConverter(typeof(InertStringJsonConverter))]
     public InertString? RootDisplay { get; init; }
 
-    public required PackageDependencyEvidenceRootOwner Owner { get; init; }
+    public required PackageDependencyEvidenceInputKind Owner { get; init; }
 
     /// <summary>The document-stable group occurrence, matching the Dependencies rows.</summary>
     public required int Group { get; init; }
@@ -552,7 +552,7 @@ public sealed record DependencyEvidenceFailureJson
 
     public required string Reason { get; init; }
 
-    public PackageDependencyEvidenceSourceKind? SourceKind { get; init; }
+    public PackageDependencyEvidenceAcquisitionForm? SourceKind { get; init; }
 
     public int? Root { get; init; }
 

--- a/src/dotnet-inspect/Sections/DependencyEvidenceProjection.cs
+++ b/src/dotnet-inspect/Sections/DependencyEvidenceProjection.cs
@@ -8,6 +8,7 @@ namespace DotnetInspector.Sections;
 /// <summary>The closed declaration state of one admitted root, as a projected row value.</summary>
 public enum DependencyEvidenceDeclarationState
 {
+    NotApplicable,
     Available,
     Unavailable,
     Failed,
@@ -50,8 +51,8 @@ public sealed record DependencyEvidenceDependencyRow(
     int RootIndex,
     PackageDependencyEvidenceRootIdentity RootIdentity,
     InertString RootDisplay,
-    PackageDependencyEvidenceRootOwner Owner,
-    PackageDependencyEvidenceSourceKind SourceKind,
+    PackageDependencyEvidenceInputKind Owner,
+    PackageDependencyEvidenceAcquisitionForm SourceKind,
     int GroupIndex,
     PackageDependencyEvidenceGroupIdentity GroupIdentity,
     string GroupOrderKey,
@@ -71,8 +72,8 @@ public sealed record DependencyEvidenceRootRow(
     int RootIndex,
     PackageDependencyEvidenceRootIdentity Identity,
     InertString Display,
-    PackageDependencyEvidenceRootOwner Owner,
-    PackageDependencyEvidenceSourceKind SourceKind,
+    PackageDependencyEvidenceInputKind Owner,
+    PackageDependencyEvidenceAcquisitionForm SourceKind,
     InertString? SourceLabel,
     string? PackageId,
     string? PackageVersion,
@@ -105,7 +106,7 @@ public sealed record DependencyEvidenceGroupRow(
     int RootIndex,
     PackageDependencyEvidenceRootIdentity RootIdentity,
     InertString RootDisplay,
-    PackageDependencyEvidenceRootOwner Owner,
+    PackageDependencyEvidenceInputKind Owner,
     int GroupIndex,
     PackageDependencyEvidenceGroupIdentity Identity,
     string OrderKey,
@@ -157,7 +158,7 @@ public sealed record DependencyEvidenceRestoredPackageRow(
 public sealed record DependencyEvidenceFailureRow(
     DependencyEvidenceFailurePhase Phase,
     string Reason,
-    PackageDependencyEvidenceSourceKind? SourceKind,
+    PackageDependencyEvidenceAcquisitionForm? SourceKind,
     int? RootIndex,
     PackageDependencyEvidenceRootIdentity? RootIdentity,
     PackageDependencyEvidenceGroupIdentity? Group,
@@ -272,6 +273,8 @@ public sealed record DependencyEvidenceProjection(
             {
                 PackageDependencyEvidenceDeclarationResult.Available =>
                     DependencyEvidenceDeclarationState.Available,
+                PackageDependencyEvidenceDeclarationResult.NotApplicable =>
+                    DependencyEvidenceDeclarationState.NotApplicable,
                 PackageDependencyEvidenceDeclarationResult.Unavailable =>
                     DependencyEvidenceDeclarationState.Unavailable,
                 _ => DependencyEvidenceDeclarationState.Failed,
@@ -294,7 +297,7 @@ public sealed record DependencyEvidenceProjection(
                         index,
                         root.Identity,
                         root.Display,
-                        root.Provenance.Owner,
+                        root.InputKind,
                         groupIndex,
                         group.Identity,
                         group.OrderKey,
@@ -319,8 +322,8 @@ public sealed record DependencyEvidenceProjection(
                             index,
                             root.Identity,
                             root.Display,
-                            root.Provenance.Owner,
-                            root.Provenance.SourceKind,
+                            root.InputKind,
+                            root.Provenance.AcquisitionForm,
                             groupIndex,
                             group.Identity,
                             group.OrderKey,
@@ -355,54 +358,81 @@ public sealed record DependencyEvidenceProjection(
                     groupIndexes));
         }
 
-        var graph = root.Graph as PackageDependencyEvidenceGraphResult.Available;
-        if (graph is not null)
+        var relationships =
+            root.Relationships
+                as PackageDependencyEvidenceRelationshipResult.Available;
+        if (relationships is not null)
         {
-            foreach (RestoredProjectPackageNode node in graph.Packages)
+            foreach (PackageDependencyEvidenceResolvedPackage package in
+                relationships.Packages)
             {
+                RestoredProjectPackageNodeIdentity identity =
+                    ReadRestoredPackageIdentity(package.Identity);
                 packages.Add(
                     new DependencyEvidenceRestoredPackageRow(
                         index,
                         root.Identity,
                         root.Display,
-                        node.Identity,
-                        node.Identity.Coordinate.PackageId,
-                        node.Identity.Coordinate.Version,
-                        node.Role));
+                        identity,
+                        package.Coordinate.PackageId,
+                        package.Coordinate.Version,
+                        ReadRestoredRole(package.Role)));
             }
 
-            foreach (RestoredProjectGraphEdge edge in graph.Edges)
+            foreach (PackageDependencyEvidenceRelationship relationship in
+                relationships.Relationships)
             {
+                RestoredProjectGraphParentIdentity parent =
+                    ReadRestoredParent(relationship.Parent);
+                RestoredProjectPackageNodeIdentity dependency =
+                    ReadRestoredPackageIdentity(relationship.Dependency);
                 (DependencyEvidenceEdgeParentKind parentKind,
                     string? parentPackageId,
                     string? parentPackageVersion,
-                    string? parentProjectIdentity) = ReadParent(edge.Parent);
+                    string? parentProjectIdentity) = ReadParent(parent);
                 edges.Add(
                     new DependencyEvidenceRestoredEdgeRow(
                         index,
                         root.Identity,
                         root.Display,
-                        edge.Identity,
+                        ReadRestoredRelationshipIdentity(relationship.Identity),
                         parentKind,
-                        edge.Parent,
+                        parent,
                         parentPackageId,
                         parentPackageVersion,
                         parentProjectIdentity,
-                        edge.Dependency,
-                        edge.Dependency.Coordinate.PackageId,
-                        edge.Dependency.Coordinate.Version,
-                        edge.CanonicalVersionConstraint,
-                        edge.SourceVersionConstraintSpelling,
-                        edge.Role));
+                        dependency,
+                        relationship.ResolvedCoordinate.PackageId,
+                        relationship.ResolvedCoordinate.Version,
+                        relationship.CanonicalRequestedConstraint
+                            ?? throw new InvalidOperationException(
+                                "A restored-project relationship requires a requested constraint."),
+                        relationship.SourceRequestedConstraintSpelling
+                            ?? throw new InvalidOperationException(
+                                "A restored-project relationship requires source constraint evidence."),
+                        ReadRestoredRole(relationship.Role)));
             }
 
-            foreach (RestoredProjectGraphFailure failure in graph.Failures)
-                failures.Add(ProjectGraphFailure(index, root, failure));
+            foreach (PackageDependencyEvidenceRelationshipFailure failure in
+                relationships.Failures)
+            {
+                failures.Add(
+                    ProjectGraphFailure(
+                        index,
+                        root,
+                        ReadRestoredRelationshipFailure(failure)));
+            }
         }
-        else if (root.Graph is PackageDependencyEvidenceGraphResult.Failed
-            failedGraph)
+        else if (root.Relationships
+            is PackageDependencyEvidenceRelationshipResult.Failed
+                failedRelationships)
         {
-            failures.Add(ProjectGraphFailure(index, root, failedGraph.Failure));
+            failures.Add(
+                ProjectGraphFailure(
+                    index,
+                    root,
+                    ReadRestoredRelationshipFailure(
+                        failedRelationships.Failure)));
         }
 
         roots.Add(
@@ -410,8 +440,8 @@ public sealed record DependencyEvidenceProjection(
                 index,
                 root.Identity,
                 root.Display,
-                root.Provenance.Owner,
-                root.Provenance.SourceKind,
+                root.InputKind,
+                root.Provenance.AcquisitionForm,
                 root.Provenance.SourceLabel,
                 coordinate.PackageId,
                 coordinate.Version,
@@ -437,19 +467,19 @@ public sealed record DependencyEvidenceProjection(
                 root.Selection.SelectedSourceOccurrence,
                 root.Selection.RequestedFramework,
                 root.Selection.SelectedFramework,
-                root.Graph switch
+                root.Relationships switch
                 {
-                    PackageDependencyEvidenceGraphResult.NotApplicable =>
+                    PackageDependencyEvidenceRelationshipResult.NotApplicable =>
                         DependencyEvidenceGraphState.NotApplicable,
-                    PackageDependencyEvidenceGraphResult.Available =>
+                    PackageDependencyEvidenceRelationshipResult.Available =>
                         DependencyEvidenceGraphState.Available,
-                    PackageDependencyEvidenceGraphResult.Unavailable =>
+                    PackageDependencyEvidenceRelationshipResult.Unavailable =>
                         DependencyEvidenceGraphState.Unavailable,
                     _ => DependencyEvidenceGraphState.Failed,
                 },
-                graph?.Completion,
-                graph?.Packages.Length ?? 0,
-                graph?.Edges.Length ?? 0,
+                relationships?.Completion,
+                relationships?.Packages.Length ?? 0,
+                relationships?.Relationships.Length ?? 0,
                 root.RestoredTarget?.FrameworkIdentity,
                 root.RestoredTarget?.SourceFrameworkSpelling,
                 root.RestoredTarget?.RuntimeIdentifierIdentity,
@@ -465,7 +495,7 @@ public sealed record DependencyEvidenceProjection(
                 new DependencyEvidenceFailureRow(
                     DependencyEvidenceFailurePhase.Root,
                     package.Failure.Reason.ToString(),
-                    package.SourceKind,
+                    package.AcquisitionForm,
                     null,
                     null,
                     null,
@@ -481,7 +511,7 @@ public sealed record DependencyEvidenceProjection(
                 new DependencyEvidenceFailureRow(
                     DependencyEvidenceFailurePhase.Root,
                     restored.Failure.Reason.ToString(),
-                    restored.SourceKind,
+                    restored.AcquisitionForm,
                     null,
                     null,
                     null,
@@ -499,7 +529,7 @@ public sealed record DependencyEvidenceProjection(
                     profile.ManifestFailureReason is { } manifestReason
                         ? $"{profile.Kind}.{manifestReason}"
                         : profile.Kind.ToString(),
-                    PackageDependencyEvidenceSourceKind.PackageSourceManifest,
+                    PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
                     null,
                     null,
                     null,
@@ -515,7 +545,7 @@ public sealed record DependencyEvidenceProjection(
                 new DependencyEvidenceFailureRow(
                     DependencyEvidenceFailurePhase.Root,
                     acquisition.Reason.ToString(),
-                    acquisition.SourceKind,
+                    acquisition.AcquisitionForm,
                     null,
                     null,
                     null,
@@ -557,7 +587,7 @@ public sealed record DependencyEvidenceProjection(
                 new DependencyEvidenceFailureRow(
                     DependencyEvidenceFailurePhase.Declaration,
                     "ConflictingPackageDeclaration",
-                    root.Provenance.SourceKind,
+                    root.Provenance.AcquisitionForm,
                     index,
                     root.Identity,
                     group,
@@ -575,7 +605,7 @@ public sealed record DependencyEvidenceProjection(
                 new DependencyEvidenceFailureRow(
                     DependencyEvidenceFailurePhase.Declaration,
                     "InvalidPackageDeclaration",
-                    root.Provenance.SourceKind,
+                    root.Provenance.AcquisitionForm,
                     index,
                     root.Identity,
                     group,
@@ -592,7 +622,7 @@ public sealed record DependencyEvidenceProjection(
                 new DependencyEvidenceFailureRow(
                     DependencyEvidenceFailurePhase.Declaration,
                     restored.Failure.Reason.ToString(),
-                    root.Provenance.SourceKind,
+                    root.Provenance.AcquisitionForm,
                     index,
                     root.Identity,
                     null,
@@ -616,7 +646,7 @@ public sealed record DependencyEvidenceProjection(
         new(
             DependencyEvidenceFailurePhase.Graph,
             failure.Reason.ToString(),
-            root.Provenance.SourceKind,
+            root.Provenance.AcquisitionForm,
             index,
             root.Identity,
             null,
@@ -628,6 +658,63 @@ public sealed record DependencyEvidenceProjection(
             root.Provenance.SourceLabel,
             Prose(failure.Message),
             failure.Count);
+
+    private static RestoredProjectPackageNodeIdentity
+        ReadRestoredPackageIdentity(
+            PackageDependencyEvidencePackageIdentity identity) =>
+        identity is PackageDependencyEvidencePackageIdentity.RestoredProject
+            restored
+            ? restored.Identity
+            : throw new InvalidOperationException(
+                "The current CLI restored-package projection requires restored-project identity.");
+
+    private static RestoredProjectEdgeIdentity
+        ReadRestoredRelationshipIdentity(
+            PackageDependencyEvidenceRelationshipIdentity identity) =>
+        identity is PackageDependencyEvidenceRelationshipIdentity.RestoredProject
+            restored
+            ? restored.Identity
+            : throw new InvalidOperationException(
+                "The current CLI restored-edge projection requires restored-project identity.");
+
+    private static RestoredProjectGraphParentIdentity ReadRestoredParent(
+        PackageDependencyEvidenceRelationshipParentIdentity parent) =>
+        parent switch
+        {
+            PackageDependencyEvidenceRelationshipParentIdentity.Root root
+                when root.Identity
+                    is PackageDependencyEvidenceRootIdentity.RestoredProject
+                        restored =>
+                new RestoredProjectGraphParentIdentity.Root(restored.Identity),
+            PackageDependencyEvidenceRelationshipParentIdentity.Package package =>
+                new RestoredProjectGraphParentIdentity.Package(
+                    ReadRestoredPackageIdentity(package.Identity)),
+            PackageDependencyEvidenceRelationshipParentIdentity.Project project =>
+                new RestoredProjectGraphParentIdentity.Project(project.Identity),
+            _ => throw new InvalidOperationException(
+                "The current CLI restored-edge projection requires restored-project parent identity."),
+        };
+
+    private static RestoredProjectDependencyRole ReadRestoredRole(
+        PackageDependencyEvidenceRelationshipRole? role) =>
+        role switch
+        {
+            PackageDependencyEvidenceRelationshipRole.Direct =>
+                RestoredProjectDependencyRole.Direct,
+            PackageDependencyEvidenceRelationshipRole.Transitive =>
+                RestoredProjectDependencyRole.Transitive,
+            _ => throw new InvalidOperationException(
+                "The current CLI restored-graph projection requires a dependency role."),
+        };
+
+    private static RestoredProjectGraphFailure
+        ReadRestoredRelationshipFailure(
+            PackageDependencyEvidenceRelationshipFailure failure) =>
+        failure is PackageDependencyEvidenceRelationshipFailure.RestoredProject
+            restored
+            ? restored.Failure
+            : throw new InvalidOperationException(
+                "The current CLI restored-graph projection requires a restored-project failure.");
 
     private static PackageSourceResultIdentity? RootSource(
         PackageDependencyEvidenceRoot root) =>

--- a/tests/DotnetInspector.Queries.Tests/PackageDependencyCandidateQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/PackageDependencyCandidateQueryTests.cs
@@ -604,7 +604,8 @@ public sealed class PackageDependencyCandidateQueryTests
             constraint,
             InertString.Empty,
             InertString.Empty,
-            SourceOccurrenceCount: 1);
+            SourceOccurrenceCount: 1,
+            PackageDependencyEvidenceAuthorship.LibraryDeclared);
     }
 
     private static PackageVersionDiscoveryResult Discovery(

--- a/tests/DotnetInspector.Queries.Tests/PackageDependencyEvidenceQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/PackageDependencyEvidenceQueryTests.cs
@@ -26,11 +26,11 @@ public sealed class PackageDependencyEvidenceQueryTests
 
         PackageDependencyEvidenceRoot package = NormalizePackage(
             expected,
-            PackageDependencyEvidenceSourceKind.PackageArchive,
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive,
             "net8.0");
         PackageDependencyEvidenceRoot nuspec = NormalizePackage(
             selfAttested,
-            PackageDependencyEvidenceSourceKind.DirectNuspec,
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
             "net8.0");
         PackageDependencyEvidenceComparison comparison =
             PackageDependencyEvidenceQuery.Compare(package, nuspec);
@@ -54,6 +54,145 @@ public sealed class PackageDependencyEvidenceQueryTests
     }
 
     [Fact]
+    public void Execute_CurrentInputKindsAndDeclarationBasesAreExplicit()
+    {
+        PackageDependencyEvidenceRoot package = NormalizePackage(
+            Manifest(
+                """
+                <group targetFramework="net8.0">
+                  <dependency id="Example.Dependency" version="[2.0.0]" />
+                </group>
+                """),
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
+            "net8.0");
+        PackageDependencyEvidenceRoot restored = NormalizeRestored(
+            Available(
+                RestoredProjectDependencyFactsQuery.Execute(
+                    File.ReadAllBytes(
+                        FixtureCatalog.RestoredProjectDependencyFacts.AssetPath(
+                            "project.assets.json")),
+                    new RestoredProjectTargetRequest("net11.0"))));
+
+        Assert.Equal(
+            PackageDependencyEvidenceInputKind.PackageManifest,
+            package.InputKind);
+        Assert.Equal(
+            PackageDependencyEvidenceDeclarationBasis.PackageManifest,
+            package.DeclarationBasis);
+        Assert.Equal(
+            PackageDependencyEvidenceInputKind.RestoredProject,
+            restored.InputKind);
+        Assert.Equal(
+            PackageDependencyEvidenceDeclarationBasis.RestoredProject,
+            restored.DeclarationBasis);
+    }
+
+    [Fact]
+    public void PackageInput_InputKindAndBasisRequireMatchingIdentityAndProvenance()
+    {
+        PackageDependencyEvidenceRoot package = NormalizePackage(
+            Manifest("""<group targetFramework="net8.0" />"""),
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
+        PackageDependencyEvidenceRoot restored = NormalizeRestored(
+            Available(
+                RestoredProjectDependencyFactsQuery.Execute(
+                    File.ReadAllBytes(
+                        FixtureCatalog.RestoredProjectDependencyFacts.AssetPath(
+                            "project.assets.json")),
+                    new RestoredProjectTargetRequest("net11.0"))));
+
+        Assert.Throws<ArgumentException>(() =>
+            new PackageDependencyEvidenceRoot(
+                restored.Identity,
+                package.Provenance,
+                restored.Display,
+                restored.Declaration,
+                restored.Selection,
+                restored.RestoredTarget,
+                restored.Relationships,
+                restored.Processing));
+    }
+
+    [Fact]
+    public void PackageInput_PackageManifestDeclarationsAreLibraryDeclared()
+    {
+        PackageDependencyEvidenceRoot package = NormalizePackage(
+            Manifest(
+                """
+                <group targetFramework="net8.0">
+                  <dependency id="Example.Dependency" version="[2.0.0]" />
+                </group>
+                """),
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
+            "net8.0");
+
+        Assert.All(
+            Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
+                package.Declaration).Groups.SelectMany(group => group.Declarations),
+            declaration => Assert.Equal(
+                PackageDependencyEvidenceAuthorship.LibraryDeclared,
+                declaration.Authorship));
+    }
+
+    [Fact]
+    public void PackageInput_NotApplicableIsNotUnavailableOrCompleteEmpty()
+    {
+        PackageDependencyEvidenceRoot package = NormalizePackage(
+            Manifest(
+                """
+                <group targetFramework="net8.0">
+                  <dependency id="Example.Dependency" version="[2.0.0]" />
+                </group>
+                """),
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
+            "net8.0");
+
+        Assert.IsType<PackageDependencyEvidenceRelationshipResult.NotApplicable>(
+            package.Relationships);
+        Assert.IsNotType<PackageDependencyEvidenceRelationshipResult.Unavailable>(
+            package.Relationships);
+        Assert.IsNotType<PackageDependencyEvidenceRelationshipResult.Available>(
+            package.Relationships);
+        Assert.IsType<PackageDependencyEvidenceProcessingResult.NotApplicable>(
+            package.Processing);
+        Assert.IsNotType<PackageDependencyEvidenceProcessingResult.Unavailable>(
+            package.Processing);
+        Assert.IsNotType<PackageDependencyEvidenceProcessingResult.Available>(
+            package.Processing);
+        Assert.Equal(1, PackageDependencyEvidenceQuery.Execute(
+            new PackageDependencyEvidenceRequest(
+                [
+                    PackageDependencyEvidenceQuery.CreatePackageInput(
+                        Manifest(
+                            """
+                            <group targetFramework="net8.0" />
+                            """),
+                        PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
+                        "net8.0"),
+                ])).Phases.Relationships.NotApplicable);
+    }
+
+    [Fact]
+    public void Execute_RestoredGraphProvidesPositiveRestoreResolutionObservation()
+    {
+        PackageDependencyEvidenceRoot restored = NormalizeRestored(
+            Available(
+                RestoredProjectDependencyFactsQuery.Execute(
+                    File.ReadAllBytes(
+                        FixtureCatalog.RestoredProjectDependencyFacts.AssetPath(
+                            "project.assets.json")),
+                    new RestoredProjectTargetRequest("net11.0"))));
+
+        var processing =
+            Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
+                restored.Processing);
+        Assert.True(processing.IsComplete);
+        Assert.Equal(
+            [PackageDependencyEvidenceProcessingObservation.RestoreResolution],
+            processing.Observations);
+    }
+
+    [Fact]
     public void Compare_FixtureManifestAndRestoredFacts_HaveEqualDeclarations()
     {
         PackageManifestFacts manifest = Available(
@@ -63,7 +202,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                         "manifest.nuspec"))));
         PackageDependencyEvidenceRoot package = NormalizePackage(
             manifest,
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         RestoredProjectDependencyFacts restoredFacts = Available(
             RestoredProjectDependencyFactsQuery.Execute(
                 File.ReadAllBytes(
@@ -103,11 +242,11 @@ public sealed class PackageDependencyEvidenceQueryTests
             PackageDependencyEvidenceQuery.Compare(
                 NormalizePackage(
                     net8,
-                    PackageDependencyEvidenceSourceKind.DirectNuspec,
+                    PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
                     "net8.0"),
                 NormalizePackage(
                     net9,
-                    PackageDependencyEvidenceSourceKind.DirectNuspec,
+                    PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
                     "net9.0"));
 
         Assert.IsType<PackageDependencyEvidenceComparisonResult.Equal>(
@@ -140,10 +279,10 @@ public sealed class PackageDependencyEvidenceQueryTests
             PackageDependencyEvidenceQuery.Compare(
                 NormalizePackage(
                     version1,
-                    PackageDependencyEvidenceSourceKind.DirectNuspec),
+                    PackageDependencyEvidenceAcquisitionForm.DirectNuspec),
                 NormalizePackage(
                     version2,
-                    PackageDependencyEvidenceSourceKind.DirectNuspec));
+                    PackageDependencyEvidenceAcquisitionForm.DirectNuspec));
 
         Assert.IsType<PackageDependencyEvidenceComparisonResult.Unequal>(
             comparison.Core);
@@ -165,7 +304,7 @@ public sealed class PackageDependencyEvidenceQueryTests
 
         PackageDependencyEvidenceRoot root = NormalizePackage(
             facts,
-            PackageDependencyEvidenceSourceKind.DirectNuspec,
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
             "net8.0");
         PackageDependencyEvidenceDeclarationResult.Available declaration =
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
@@ -226,7 +365,7 @@ public sealed class PackageDependencyEvidenceQueryTests
 
         PackageDependencyEvidenceRoot root = NormalizePackage(
             facts,
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceDeclarationResult.Available declaration =
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
                 root.Declaration);
@@ -281,11 +420,11 @@ public sealed class PackageDependencyEvidenceQueryTests
             ]);
         PackageDependencyEvidenceRoot left = NormalizePackage(
             interleaved,
-            PackageDependencyEvidenceSourceKind.DirectNuspec,
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
             "net8.0");
         PackageDependencyEvidenceRoot right = NormalizePackage(
             adjacent,
-            PackageDependencyEvidenceSourceKind.PackageArchive,
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive,
             "net8.0");
 
         PackageDependencyEvidenceComparison comparison =
@@ -314,7 +453,7 @@ public sealed class PackageDependencyEvidenceQueryTests
             ]);
         PackageDependencyEvidenceRoot duplicateRoot = NormalizePackage(
             duplicateFacts,
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceDeclarationResult.Available duplicateDeclaration =
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
                 duplicateRoot.Declaration);
@@ -337,7 +476,7 @@ public sealed class PackageDependencyEvidenceQueryTests
             ]);
         PackageDependencyEvidenceRoot conflictRoot = NormalizePackage(
             conflictFacts,
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceDeclarationResult.Available conflictDeclaration =
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
                 conflictRoot.Declaration);
@@ -361,10 +500,10 @@ public sealed class PackageDependencyEvidenceQueryTests
     {
         PackageDependencyEvidenceRoot twoGroups = NormalizePackage(
             Facts([Group("net8.0"), Group("net8.0")]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceRoot oneGroup = NormalizePackage(
             Facts([Group("net8.0")]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
 
         PackageDependencyEvidenceComparison comparison =
             PackageDependencyEvidenceQuery.Compare(twoGroups, oneGroup);
@@ -380,13 +519,13 @@ public sealed class PackageDependencyEvidenceQueryTests
     {
         PackageDependencyEvidenceRoot first = NormalizePackage(
             Facts([Group("future-one", ("A", "[1.0.0]"))]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceRoot same = NormalizePackage(
             Facts([Group("future-one", ("A", "[1.0.0]"))]),
-            PackageDependencyEvidenceSourceKind.PackageArchive);
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive);
         PackageDependencyEvidenceRoot different = NormalizePackage(
             Facts([Group("future-two", ("A", "[1.0.0]"))]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
 
         Assert.IsType<PackageDependencyEvidenceComparisonResult.Equal>(
             PackageDependencyEvidenceQuery.Compare(first, same).Scoped);
@@ -409,10 +548,10 @@ public sealed class PackageDependencyEvidenceQueryTests
     {
         PackageDependencyEvidenceRoot repeated = NormalizePackage(
             Facts([Group("future-one"), Group("future-one")]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceRoot single = NormalizePackage(
             Facts([Group("future-one")]),
-            PackageDependencyEvidenceSourceKind.PackageArchive);
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive);
 
         PackageDependencyEvidenceComparison comparison =
             PackageDependencyEvidenceQuery.Compare(repeated, single);
@@ -432,14 +571,14 @@ public sealed class PackageDependencyEvidenceQueryTests
                     Group("net8.0", ("A", "[1.0.0]")),
                     Group("future-one", ("B", "[2.0.0]")),
                 ]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceRoot reordered = NormalizePackage(
             Facts(
                 [
                     Group("future-one", ("B", "[2.0.0]")),
                     Group("net8.0", ("A", "[1.0.0]")),
                 ]),
-            PackageDependencyEvidenceSourceKind.PackageArchive);
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive);
 
         PackageDependencyEvidenceComparison comparison =
             PackageDependencyEvidenceQuery.Compare(left, reordered);
@@ -459,7 +598,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                     Group("net8.0", ("A", "[1.0.0]")),
                     Group("future-one", ("A", "[1.0.0]")),
                 ]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         byte[] assets = Encoding.UTF8.GetBytes(
             """
             {
@@ -515,25 +654,95 @@ public sealed class PackageDependencyEvidenceQueryTests
         RestoredProjectGraphResult.Available sourceGraph =
             Assert.IsType<RestoredProjectGraphResult.Available>(facts.Graph);
         PackageDependencyEvidenceRoot root = NormalizeRestored(facts);
-        PackageDependencyEvidenceGraphResult.Available graph =
-            Assert.IsType<PackageDependencyEvidenceGraphResult.Available>(
-                root.Graph);
+        PackageDependencyEvidenceRelationshipResult.Available relationships =
+            Assert.IsType<PackageDependencyEvidenceRelationshipResult.Available>(
+                root.Relationships);
 
-        Assert.True(graph.IsComplete);
-        Assert.Equal(sourceGraph.Packages, graph.Packages);
-        Assert.Equal(sourceGraph.Edges, graph.Edges);
-        RestoredProjectGraphEdge[] diamondEdges =
+        Assert.True(relationships.IsComplete);
+        Assert.Equal(sourceGraph.Packages.Length, relationships.Packages.Length);
+        Assert.Equal(sourceGraph.Edges.Length, relationships.Relationships.Length);
+        PackageDependencyEvidenceRelationship[] diamondRelationships =
         [
-            .. graph.Edges.Where(edge =>
-                edge.Dependency.Coordinate.PackageId == "nuget.versioning"),
+            .. relationships.Relationships.Where(relationship =>
+                relationship.ResolvedCoordinate.PackageId == "nuget.versioning"),
         ];
-        Assert.True(diamondEdges.Length >= 2);
+        Assert.True(diamondRelationships.Length >= 2);
         Assert.Contains(
-            diamondEdges,
-            edge => edge.Parent is RestoredProjectGraphParentIdentity.Package);
+            diamondRelationships,
+            relationship =>
+                relationship.Parent
+                    is PackageDependencyEvidenceRelationshipParentIdentity.Package);
         Assert.Contains(
-            diamondEdges,
-            edge => edge.Parent is RestoredProjectGraphParentIdentity.Project);
+            diamondRelationships,
+            relationship =>
+                relationship.Parent
+                    is PackageDependencyEvidenceRelationshipParentIdentity.Project);
+    }
+
+    [Fact]
+    public void PackageInput_RequestedConstraintAndResolvedCoordinateRemainIndependent()
+    {
+        PackageDependencyEvidenceRelationship relationship =
+            RestoredRelationships().Relationships.First(relationship =>
+                relationship.CanonicalRequestedConstraint is not null);
+
+        Assert.NotNull(relationship.CanonicalRequestedConstraint);
+        Assert.NotNull(relationship.SourceRequestedConstraintSpelling);
+        Assert.NotEqual(
+            relationship.CanonicalRequestedConstraint,
+            relationship.ResolvedCoordinate.Version);
+    }
+
+    [Fact]
+    public void PackageInput_RestoredRelationshipOriginRequiresOwnerAssociation()
+    {
+        ImmutableArray<PackageDependencyEvidenceRelationship> relationships =
+            RestoredRelationships().Relationships;
+        PackageDependencyEvidenceRelationship rootRelationship =
+            relationships.First(relationship =>
+                relationship.Parent
+                    is PackageDependencyEvidenceRelationshipParentIdentity.Root);
+        PackageDependencyEvidenceRelationship packageRelationship =
+            relationships.First(relationship =>
+                relationship.Parent
+                    is PackageDependencyEvidenceRelationshipParentIdentity.Package);
+
+        Assert.Equal(
+            PackageDependencyEvidenceAuthorship.ApplicationAuthored,
+            rootRelationship.Authorship);
+        PackageDependencyEvidenceDeclarationIdentity declarationAssociation =
+            Assert.IsType<PackageDependencyEvidenceDeclarationIdentity>(
+                rootRelationship.DeclarationAssociation);
+        PackageDependencyEvidenceGroupIdentity.RestoredProject groupAssociation =
+            Assert.IsType<PackageDependencyEvidenceGroupIdentity.RestoredProject>(
+                declarationAssociation.Group);
+        Assert.Equal(
+            rootRelationship.ResolvedCoordinate.PackageId,
+            declarationAssociation.CanonicalPackageId);
+        Assert.Equal(
+            Assert.IsType<PackageDependencyEvidenceRootIdentity.RestoredProject>(
+                Assert.IsType<
+                    PackageDependencyEvidenceRelationshipParentIdentity.Root>(
+                        rootRelationship.Parent).Identity).Identity.Selection,
+            groupAssociation.Identity.Selection);
+        Assert.Equal(
+            PackageDependencyEvidenceAuthorship.LibraryDeclared,
+            packageRelationship.Authorship);
+        Assert.Null(packageRelationship.DeclarationAssociation);
+    }
+
+    [Fact]
+    public void PackageInput_ProjectNodeRelationshipRemainsUnattributedWithoutAssociation()
+    {
+        PackageDependencyEvidenceRelationship projectRelationship =
+            RestoredRelationships().Relationships.First(relationship =>
+                relationship.Parent
+                    is PackageDependencyEvidenceRelationshipParentIdentity.Project);
+
+        Assert.Equal(
+            PackageDependencyEvidenceAuthorship.Unattributed,
+            projectRelationship.Authorship);
+        Assert.Null(projectRelationship.DeclarationAssociation);
     }
 
     [Fact]
@@ -553,8 +762,14 @@ public sealed class PackageDependencyEvidenceQueryTests
         PackageDependencyEvidenceRoot root = NormalizeRestored(facts);
 
         Assert.Equal(facts.SelectedTarget, root.RestoredTarget);
-        Assert.IsType<PackageDependencyEvidenceGraphResult.Unavailable>(
-            root.Graph);
+        Assert.IsType<PackageDependencyEvidenceRelationshipResult.Unavailable>(
+            root.Relationships);
+        PackageDependencyEvidenceProcessingResult.Available processing =
+            Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
+                root.Processing);
+        Assert.Equal(
+            [PackageDependencyEvidenceProcessingObservation.RestoreResolution],
+            processing.Observations);
     }
 
     [Fact]
@@ -602,13 +817,15 @@ public sealed class PackageDependencyEvidenceQueryTests
                         .. variants.Select(variant =>
                             new PackageDependencyEvidenceInput.RestoredProject(
                                 variant,
-                                PackageDependencyEvidenceSourceKind.ProjectAssets)),
+                                PackageDependencyEvidenceAcquisitionForm.ProjectAssets)),
                     ]));
 
-        Assert.Equal(1, outcome.Phases.CompleteGraphs);
-        Assert.Equal(1, outcome.Phases.IncompleteGraphs);
-        Assert.Equal(1, outcome.Phases.UnavailableGraphs);
-        Assert.Equal(1, outcome.Phases.FailedGraphs);
+        Assert.Equal(1, outcome.Phases.Relationships.Complete);
+        Assert.Equal(1, outcome.Phases.Relationships.Incomplete);
+        Assert.Equal(1, outcome.Phases.Relationships.Unavailable);
+        Assert.Equal(1, outcome.Phases.Relationships.Failed);
+        Assert.Equal(4, outcome.Phases.Processing.Complete);
+        Assert.Equal(0, outcome.Phases.Processing.Unavailable);
         Assert.All(outcome.Roots, root => Assert.NotNull(root.RestoredTarget));
         PackageDependencyEvidenceRoot baseline = outcome.Roots[0];
         Assert.All(
@@ -682,11 +899,11 @@ public sealed class PackageDependencyEvidenceQueryTests
                     [
                         PackageDependencyEvidenceQuery.CreatePackageInput(
                             facts,
-                            PackageDependencyEvidenceSourceKind.DirectNuspec),
+                            PackageDependencyEvidenceAcquisitionForm.DirectNuspec),
                     ],
                     [
                         new PackageDependencyEvidenceRootFailure.Package(
-                            PackageDependencyEvidenceSourceKind.DirectNuspec,
+                            PackageDependencyEvidenceAcquisitionForm.DirectNuspec,
                             facts.Coordinate,
                             new PackageManifestFailure(
                                 PackageManifestFailureReason.MalformedXml)),
@@ -701,7 +918,7 @@ public sealed class PackageDependencyEvidenceQueryTests
         Assert.Equal(2, outcome.RootSet.RejectedRootCount);
         Assert.Equal(1, outcome.RootSet.FailedRootCount);
         Assert.True(outcome.RootSet.IsTruncated);
-        Assert.Equal(1, outcome.Phases.CompleteDeclarations);
+        Assert.Equal(1, outcome.Phases.Declarations.Complete);
         Assert.True(
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
                 Assert.Single(outcome.Roots).Declaration).IsComplete);
@@ -712,7 +929,7 @@ public sealed class PackageDependencyEvidenceQueryTests
     {
         PackageDependencyEvidenceRoot root = NormalizePackage(
             Facts([Group("", ("A", "[1.0.0]"))]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceGroup group = Assert.Single(
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
                 root.Declaration).Groups);
@@ -735,7 +952,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                         ("", "[2.0.0]"),
                         ("Broken.Range", "not-a-range")),
                 ]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceDeclarationResult.Available declaration =
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
                 root.Declaration);
@@ -781,7 +998,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                     "Source\u202Efailure"));
         var acquisitionFailure =
             new PackageDependencyEvidenceRootFailure.Acquisition(
-                PackageDependencyEvidenceSourceKind.ProjectLocator,
+                PackageDependencyEvidenceAcquisitionForm.ProjectLocator,
                 PackageDependencyEvidenceAcquisitionFailureReason.NotRestored,
                 SourceLabel:
                     new InertString(TextPolicy.Field, "Example.csproj"));
@@ -797,8 +1014,8 @@ public sealed class PackageDependencyEvidenceQueryTests
                 root.Provenance);
 
         Assert.Equal(
-            PackageDependencyEvidenceSourceKind.PackageSourceManifest,
-            provenance.SourceKind);
+            PackageDependencyEvidenceAcquisitionForm.PackageSourceManifest,
+            provenance.AcquisitionForm);
         Assert.Same(source.Source, provenance.Source);
         Assert.Equal(
             PackageDependencyEvidenceRootSetCompletion.Incomplete,
@@ -972,7 +1189,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                         new PackageDependencyEvidenceInput.Package(
                             facts,
                             groups,
-                            PackageDependencyEvidenceSourceKind.DirectNuspec),
+                            PackageDependencyEvidenceAcquisitionForm.DirectNuspec),
                     ])));
     }
 
@@ -999,13 +1216,13 @@ public sealed class PackageDependencyEvidenceQueryTests
                     [
                         PackageDependencyEvidenceQuery.CreatePackageInput(
                             left,
-                            PackageDependencyEvidenceSourceKind.DirectNuspec),
+                            PackageDependencyEvidenceAcquisitionForm.DirectNuspec),
                         PackageDependencyEvidenceQuery.CreatePackageInput(
                             unrelated,
-                            PackageDependencyEvidenceSourceKind.DirectNuspec),
+                            PackageDependencyEvidenceAcquisitionForm.DirectNuspec),
                         PackageDependencyEvidenceQuery.CreatePackageInput(
                             right,
-                            PackageDependencyEvidenceSourceKind.PackageArchive),
+                            PackageDependencyEvidenceAcquisitionForm.PackageArchive),
                     ],
                     isTruncated: true));
 
@@ -1027,7 +1244,7 @@ public sealed class PackageDependencyEvidenceQueryTests
     {
         PackageDependencyEvidenceRoot package = NormalizePackage(
             Facts([Group("net8.0")]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         byte[] assets = Encoding.UTF8.GetBytes(
             """
             {
@@ -1065,7 +1282,7 @@ public sealed class PackageDependencyEvidenceQueryTests
         const string hostileFramework = "net8.0\u202Eevil";
         PackageDependencyEvidenceRoot root = NormalizePackage(
             Facts([Group(hostileFramework, ("A", "[1.0.0]"))]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceGroup group = Assert.Single(
             Assert.IsType<PackageDependencyEvidenceDeclarationResult.Available>(
                 root.Declaration).Groups);
@@ -1103,7 +1320,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                         ".NETCoreApp,Version=v8.0,Platform=windows,PlatformVersion=10.0.19041.0",
                         ("A", "[1.0.0]")),
                 ]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         PackageDependencyEvidenceRoot shortForm = NormalizePackage(
             Facts(
                 [
@@ -1111,7 +1328,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                         "net8.0-windows10.0.19041.0",
                         ("A", "[1.0.0]")),
                 ]),
-            PackageDependencyEvidenceSourceKind.PackageArchive);
+            PackageDependencyEvidenceAcquisitionForm.PackageArchive);
 
         PackageDependencyEvidenceComparison comparison =
             PackageDependencyEvidenceQuery.Compare(longForm, shortForm);
@@ -1132,7 +1349,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                         "net8.0-windows10.0.22621.0",
                         ("A", "[1.0.0]")),
                 ]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         Assert.IsType<PackageDependencyEvidenceComparisonResult.Unequal>(
             PackageDependencyEvidenceQuery.Compare(
                 shortForm,
@@ -1140,7 +1357,7 @@ public sealed class PackageDependencyEvidenceQueryTests
 
         PackageDependencyEvidenceRoot targetWithRuntime = NormalizePackage(
             Facts([Group("net8.0/linux-x64", ("A", "[1.0.0]"))]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         Assert.Equal(
             PackageDependencyFrameworkScopeKind.UnrecognizedFramework,
             Assert.Single(
@@ -1150,7 +1367,7 @@ public sealed class PackageDependencyEvidenceQueryTests
 
         PackageDependencyEvidenceRoot uap = NormalizePackage(
             Facts([Group("UAP,Version=v10.0", ("A", "[1.0.0]"))]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         Assert.Equal(
             "uap10.0",
             Assert.Single(
@@ -1165,7 +1382,7 @@ public sealed class PackageDependencyEvidenceQueryTests
                         ".NETCoreApp,Version=v99.0,Unknown=value",
                         ("A", "[1.0.0]")),
                 ]),
-            PackageDependencyEvidenceSourceKind.DirectNuspec);
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
         Assert.Equal(
             PackageDependencyFrameworkScopeKind.UnrecognizedFramework,
             Assert.Single(
@@ -1176,7 +1393,7 @@ public sealed class PackageDependencyEvidenceQueryTests
 
     private static PackageDependencyEvidenceRoot NormalizePackage(
         PackageManifestFacts facts,
-        PackageDependencyEvidenceSourceKind sourceKind,
+        PackageDependencyEvidenceAcquisitionForm sourceKind,
         string? requestedFramework = null)
     {
         return Assert.Single(
@@ -1198,8 +1415,20 @@ public sealed class PackageDependencyEvidenceQueryTests
                     [
                         PackageDependencyEvidenceQuery.CreateRestoredProjectInput(
                             facts,
-                            PackageDependencyEvidenceSourceKind.ProjectAssets),
+                            PackageDependencyEvidenceAcquisitionForm.ProjectAssets),
                     ])).Roots);
+
+    private static PackageDependencyEvidenceRelationshipResult.Available
+        RestoredRelationships() =>
+        Assert.IsType<PackageDependencyEvidenceRelationshipResult.Available>(
+            NormalizeRestored(
+                Available(
+                    RestoredProjectDependencyFactsQuery.Execute(
+                        File.ReadAllBytes(
+                            FixtureCatalog.RestoredProjectDependencyFacts.AssetPath(
+                                "project.assets.json")),
+                        new RestoredProjectTargetRequest("net11.0"))))
+                .Relationships);
 
     private static PackageManifestFacts Manifest(string dependencies)
     {

--- a/tests/DotnetInspector.Queries.Tests/PackageDependencyTraversalQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/PackageDependencyTraversalQueryTests.cs
@@ -10,7 +10,8 @@ namespace DotnetInspector.Queries.Tests;
 
 /// <summary>
 /// Release gates for the host-neutral Package Dependency Traversal Query
-/// (<c>#5996</c>). Two harnesses are used deliberately:
+/// (<c>#5996</c>), compiled by the Queries test executable. Two harnesses are
+/// used deliberately:
 /// </summary>
 /// <remarks>
 /// <para>
@@ -1681,7 +1682,7 @@ public sealed class PackageDependencyTraversalQueryTests
                                         packageId,
                                         version,
                                         dependenciesXml))).Value,
-                            PackageDependencyEvidenceSourceKind.PackageArchive,
+                            PackageDependencyEvidenceAcquisitionForm.PackageArchive,
                             requestedFramework),
                     ])).Roots);
 


### PR DESCRIPTION
dotnet-inspect builds robust, capable substrate that enables foundational or compelling product experiences while remaining conventionally sound. This slice gives package policy one trustworthy evidence shape instead of making each host or policy reinterpret artifact-specific rows.

## Demo

The same normalized root now distinguishes semantic input, declaration basis, produced relationships, and positive processing evidence:

```text
restored project
  InputKind: RestoredProject
  DeclarationBasis: RestoredProject
  Relationships: Available
  Processing: Available [RestoreResolution]
  root relationship:
    Authorship: ApplicationAuthored
    DeclarationAssociation: restored project declaration-group identity

package manifest
  InputKind: PackageManifest
  DeclarationBasis: PackageManifest
  Relationships: NotApplicable
  Processing: NotApplicable
  declarations:
    Authorship: LibraryDeclared
```

Requested constraints and resolved coordinates remain independent, and project-parent relationships remain unattributed without an owner-issued declaration association.

The CLI and JSON projections intentionally retain their current `Owner`, `SourceKind`, graph, restored-edge, and restored-package presentation names. Product adoption remains #6266 step 7.

## Summary

- evolves `PackageDependencyEvidenceQuery` in place with the agreed `PackageDependencyEvidence*` vocabulary for input kind, acquisition form, declaration basis, authorship, relationships, processing observations/results, and phase counts
- carries exact restored root-to-declaration correspondence from `RestoredProjectDependencyFactsQuery`, so application authorship is never inferred from direct role or display text
- keeps declaration, relationship, and processing completion independent; a selected restored target positively establishes restore resolution even when relationship projection is unavailable
- preserves current CLI and JSON contracts through compatibility projection
- moves `PackageDependencyTraversalQueryTests` into the active Queries test project, restoring 33 previously uncompiled release gates
- updates the owning designs to record the implemented #6266 step-2 vocabulary and remaining provider/consumer work

Advances #6266 step 2. Pruning observations and policy remain in their separately owned slices.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `RestoredProjectDependencyFactsQueryTests`: 138 passed
- `PackageDependencyEvidenceQueryTests`: 37 passed
- `PackageDependencyCandidateQueryTests`: 22 passed
- `PackageDependencyTraversalQueryTests`: 33 passed
- `DependencyEvidenceCommandTests`: 91 passed
- `npx markdownlint-cli docs/design/package-dependency-evidence.md docs/design/restored-project-dependency-facts.md`
