### PR TITLE
Implement model-aware CSharp safety spelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,8 +715,8 @@ jobs:
       - name: Run CSharpText tests
         run: dotnet run --project tests/CSharpText.Tests -c Release
 
-      - name: Run CSharp snapshot preservation tests
-        run: dotnet run --project tests/ILInspector.CSharp.Tests -c Release -- -method '*SnapshotTypeForRendering_*'
+      - name: Run CSharp tests
+        run: dotnet run --project tests/ILInspector.CSharp.Tests -c Release
 
       - name: Run artifact contract tests
         run: dotnet run --project tests/DotnetInspector.Artifacts.Tests -c Release

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,10 +150,11 @@ CSharpText owns textual grammar, while ILInspector.CSharp owns spelling that
 depends on typed models.
 
 [C# memory-safety declaration spelling](design/csharp-memory-safety-spelling.md)
-owns the proposed CSharp policy for consuming independent caller-contract,
-pointer, and declaration-shape facts. Its adoption and production-host gates
-remain pending; Metadata interpretation and Decompiler reconstruction stay
-with their respective owners.
+owns the CSharp policy for consuming independent caller-contract, pointer,
+declaration-shape, and layout facts. The opt-in method/field implementation
+includes explicit-layout source lowering; compatibility remains the default.
+Other declaration forms and production-host adoption remain pending. Metadata
+interpretation and Decompiler reconstruction stay with their respective owners.
 
 ### Evidence and comparison engines
 

--- a/docs/design/csharp-memory-safety-spelling.md
+++ b/docs/design/csharp-memory-safety-spelling.md
@@ -4,8 +4,12 @@
 
 This is the focused declaration contract for
 [#5257](https://github.com/richlander/dotnet-inspect/issues/5257), owned solely
-by `ILInspector.CSharp`. It is a design prerequisite, not a claim that the
-current printer implements model-aware spelling.
+by `ILInspector.CSharp`. The opt-in method/field implementation is tracked by
+[#6105](https://github.com/richlander/dotnet-inspect/issues/6105) and consumes
+the layout facts delivered by
+[#6144](https://github.com/richlander/dotnet-inspect/issues/6144).
+Compatibility remains the default. The remaining declaration forms and
+production-host adoption remain pending.
 
 **Claim:** a rendered declaration preserves the supplied caller contract
 under the selected C# language semantics, independently of structural pointer
@@ -18,7 +22,9 @@ v1/v2 vocabulary and language distinctions. Metadata owns
 and their unavailable states. Decompiler owns reconstructed bodies and the
 primary-constructor fallback under
 [memory-safety rendering modes](memory-safety-modes.md). This document consumes
-those boundaries; it does not redefine their evidence or reconstruction.
+those boundaries, including
+[API layout facts](type-member-api-representation.md#api-layout-facts); it does
+not redefine their evidence or reconstruction.
 
 ## Purpose and design basis
 
@@ -52,6 +58,12 @@ An unmarked binary does not prove that its source used an older language.
 Replay preserves the recognized binary contract; selecting a language does
 not implicitly opt the output into another module rules model. Migration
 simulation is outside this contract.
+
+A composed C# source artifact has one module rules model at compilation time.
+One batch, including its nested types, therefore cannot preserve a mixture of
+legacy and updated input contracts. Model-aware batch printing refuses that
+mixture atomically rather than produce source whose successful compilation
+silently changes one side's caller obligations.
 
 The observable result is no safety modifier, `safe`, `unsafe`, or an explicit
 unavailable result identifying the declaration and missing or incompatible
@@ -102,9 +114,10 @@ The extern decision needs an affirmative declaration-shape fact. An absent
 managed-body RVA is insufficient: abstract, runtime-provided, reference-assembly,
 and reconstructed stub shapes do not all mean the same emitted declaration.
 CSharp does not infer this fact from a displayed attribute or signature.
-The missing Metadata implementation-fact projection is tracked by
-[#5940](https://github.com/richlander/dotnet-inspect/issues/5940); this design
-does not specify that projection's construction.
+The Metadata implementation-fact projection tracked by
+[#5940](https://github.com/richlander/dotnet-inspect/issues/5940) landed in #5972.
+Those facts retain flags and body-RVA presence, not a C# extern decision; this
+design does not specify their construction.
 
 Backing associations are conventions, not recovered source. Unknown or
 ambiguous association evidence is not proof that a property or event has no
@@ -145,6 +158,72 @@ satisfies it.
 
 ## Rendering and adoption
 
+### Method and field slice
+
+`CSharpFormatOptions.MemorySafetyLanguage` and
+`CSharpTypePrintOptions.MemorySafetyLanguage` explicitly select model-aware
+spelling. Their null default retains the existing compatibility view.
+`Legacy` requires a lexical pointer context; `RelaxedPointerSyntax` removes
+that requirement; `UpdatedCallerContracts` additionally supports the v2
+declaration forms. These are language capabilities, not requests to change
+the inspected module's rules. Compilation must select the corresponding
+language and preserve the recognized module model separately.
+
+The first slice supports methods, ordinary constructors, and fields. An
+explicit `CSharpBodyPolicy.Extern`, or `CSharpFormatOptions.IsExtern` for a
+single declaration, selects the no-body extern form. A skeleton, abstract
+member, or reconstructed stub is not automatically extern. Raw MethodDef
+implementation facts remain available to source-shape producers; this policy
+does not substitute an RVA test for their affirmative choice.
+
+An opt-in whole-type batch returns `CSharpTypePrintOutcome.NotRendered` with
+`MemorySafetyFailures` when necessary evidence or a supported declaration
+form is unavailable. The existing self-name failures remain independent;
+neither failure category exposes partial source. String-returning formatter
+entry points report the same refusal through `NotSupportedException`.
+
+Properties, events, accessors, delegates, enums, and primary-constructor
+syntax remain explicitly unavailable in this opt-in slice. A caller can
+select the supported members or supply the product-selected explicit-field
+and ordinary-constructor shape. The printer does not silently drop an
+unsupported selected member. This slice proves safety-modifier spelling and
+caller-contract preservation, not body reconstruction or general layout
+reconstruction.
+
+`safe` is illegal on an ordinary field when its enclosing layout is not
+emitted (CS9388), so the supported updated-rules explicit-layout path emits a
+`StructLayoutAttribute(LayoutKind.Explicit, ...)` on the type and a
+`FieldOffsetAttribute` on every selected instance field. This includes fields
+whose caller contract spells `unsafe`; static fields do not receive an offset.
+Zero is a valid offset. Positive size and packing observations are emitted as
+named arguments; zero retains the attribute defaults. Packing values that C#
+cannot represent are unavailable rather than emitted as invalid source.
+
+The printer admits that source only when the layout MVID and TypeDef token match
+the declaring type, and each selected instance field's MVID, declaring TypeDef
+token, FieldDef token, and usable offset match its declaration. The type and
+member metadata tokens are therefore retained through the rendering snapshot
+alongside the layout facts. Missing or mismatched evidence refuses the complete
+batch before source publication.
+
+These attributes are required semantic spelling, not optional custom-attribute
+display. Suppressing ordinary custom attributes does not suppress them.
+Collision-proof `global::System.Runtime.InteropServices` names keep their
+binding independent of the inspected source's namespace and type names.
+Individual formatter entry points apply the same type or field decision using
+the supplied declaring-type evidence; the whole-type printer is the supported
+compilation-unit proof.
+
+Extended layout still requires a `safe` field decision under the language
+model, but the current evidence does not establish a corresponding C# layout
+attribute form. Model-aware extended-layout output is therefore visibly
+unavailable. Sequential and automatic layouts do not infer offsets or enter
+this narrow replay path. Legacy binaries also remain outside this layout
+lowering path: selecting a newer output-language capability does not change
+their module rules or authorize updated-rules derived attributes.
+
+### Production adoption
+
 The information remains typed through the shared CSharp declaration boundary.
 CSharp owns source-language lowering; Markout remains the presentation
 substrate for views that embed those declarations. Neither CLI nor browser
@@ -160,8 +239,8 @@ declaration path has **three stages**:
 3. #5257 exercises that producer through CLI and browser/Wasm declaration
    surfaces, including their filtered and selected views.
 
-This design is the contract prerequisite within stage 2, not an additional
-host implementation or a completed adoption stage. Implementation must record
+The method/field slice is part of stage 2, not an additional host implementation
+or a completed adoption stage. Implementation must record
 any missing owner-issued declaration-shape input as a focused prerequisite
 rather than derive it from display text or broaden this owner's design.
 Production source composers must also route their declaration portions through
@@ -177,10 +256,24 @@ as described above. No platform or single-host exception is requested.
 
 ## Evidence required before implementation is supported
 
-The behavior in this document is **unverified** until the implementation gates
-land. Existing `ApiMemorySafetyFactsTests` prove the input facts, not these
-spelling decisions. Existing CSharp tests prove current behavior, not this
-proposed adoption.
+The implemented method/field slice is gated by
+`CSharpMemorySafetySpellingTests`, covering declaration decisions, exact
+evidence association, explicit-layout lowering, mixed-rules batch refusal,
+and atomic type outcomes.
+`CSharpMemorySafetySpellingCompileTests` compiles product-produced artifacts
+unchanged, then re-extracts their caller contracts. Its explicit-layout case
+also re-extracts the size, packing, and zero/nonzero field offsets. The compiler
+gate uses the existing Decompiler test executable and its Roslyn reference
+infrastructure; the decision gate uses the CSharp executable. The Dynamic
+fixture census retains the compiler site explicitly.
+
+Ordinary CI runs the complete CSharp test executable and the existing fast
+Decompiler lane. Neither gate establishes the deferred declaration forms,
+primary-constructor fallback, or production-host adoption; those portions of
+this document remain **unverified**.
+
+Existing `ApiMemorySafetyFactsTests` prove the input facts, not the spelling
+decisions.
 
 Use the existing Release CSharp test executable for declaration and whole-type
 outcomes. Compile product-produced artifacts with the selected language and

--- a/docs/design/csharp-memory-safety-spelling.md
+++ b/docs/design/csharp-memory-safety-spelling.md
@@ -209,8 +209,9 @@ an extern extension projected onto an interface receiver. Whole-type printing
 of an enum or delegate remains unavailable independently of a projected
 extension member. A type-unit or whole-type request also retains its actual
 enclosing-type restrictions; it does not relocate an attached extension into
-the defining static class, so an extern extension cannot be emitted inside an
-interface receiver.
+the defining static class. Any attached extension selected through those paths
+is unavailable regardless of receiver kind or body policy; standalone member
+formatting remains the supported projection path.
 
 `safe` is illegal on an ordinary field when its enclosing layout is not
 emitted (CS9388), so the supported updated-rules explicit-layout path emits a

--- a/docs/design/csharp-memory-safety-spelling.md
+++ b/docs/design/csharp-memory-safety-spelling.md
@@ -199,6 +199,19 @@ an ordinary method. This distinction follows the MethodSemantics relationship
 and does not infer accessor shape from a qualified MethodDef name,
 `SpecialName`, or an empty declaration-accessor collection.
 
+An attached extension method is rendered as its defining static declaration,
+not as a declaration of the receiver type that carries the projection. Direct
+member formatting therefore applies the receiver's module rules and exact
+member association but does not apply whole-type enum, delegate, primary-
+constructor, or layout admission to that receiver. The extension declaration's
+own method form still controls ordinary and affirmative extern policy, including
+an extern extension projected onto an interface receiver. Whole-type printing
+of an enum or delegate remains unavailable independently of a projected
+extension member. A type-unit or whole-type request also retains its actual
+enclosing-type restrictions; it does not relocate an attached extension into
+the defining static class, so an extern extension cannot be emitted inside an
+interface receiver.
+
 `safe` is illegal on an ordinary field when its enclosing layout is not
 emitted (CS9388), so the supported updated-rules explicit-layout path emits a
 `StructLayoutAttribute(LayoutKind.Explicit, ...)` on the type and a

--- a/docs/design/csharp-memory-safety-spelling.md
+++ b/docs/design/csharp-memory-safety-spelling.md
@@ -190,6 +190,15 @@ unsupported selected member. This slice proves safety-modifier spelling and
 caller-contract preservation, not body reconstruction or general layout
 reconstruction.
 
+Method-like admission requires the Metadata-owned
+`ApiMember.MethodSemantics` fact. A positive `None` permits the ordinary
+method, constructor, finalizer, extension, or explicit-interface method path.
+Any property or event MethodSemantics role is an unsupported accessor and
+refuses the complete output. Null is unavailable evidence rather than proof of
+an ordinary method. This distinction follows the MethodSemantics relationship
+and does not infer accessor shape from a qualified MethodDef name,
+`SpecialName`, or an empty declaration-accessor collection.
+
 `safe` is illegal on an ordinary field when its enclosing layout is not
 emitted (CS9388), so the supported updated-rules explicit-layout path emits a
 `StructLayoutAttribute(LayoutKind.Explicit, ...)` on the type and a

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -149,6 +149,16 @@ older or declaration-only models that did not retain the relationship, rather
 than a negative metadata result. Only those unknown values retain the prior
 name-based projection fallback; a known negative classification is authoritative.
 
+Full extraction also retains `ApiMember.MethodSemantics` for MethodDefs as a
+typed flag set containing any property-getter, property-setter,
+property-other, event-adder, event-remover, event-raiser, or event-other roles,
+or a positive `None` result. Multiple relationships are retained together;
+enumeration order does not erase an accessor role. Null means that the
+MethodSemantics relationship was not retained or the module association scan
+did not complete successfully. Consumers that must distinguish an ordinary
+method from an accessor use this fact rather than parsing the MethodDef name or
+treating an empty declaration-accessor collection as negative evidence.
+
 ### API memory-safety facts
 
 `ApiMember.MemorySafety` retains two independent facts: the caller contract

--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
@@ -1,0 +1,44 @@
+using System.Runtime.InteropServices;
+
+namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
+
+[StructLayout(LayoutKind.Sequential)]
+public sealed class MemorySafetySpellingFixture
+{
+    public unsafe MemorySafetySpellingFixture()
+    {
+    }
+
+    public static unsafe int PointerFreeUnsafeMethod() => 42;
+
+    public static int PointerNoneMethod(int* value)
+    {
+        unsafe
+        {
+            return *value;
+        }
+    }
+
+    public int* PointerNoneField;
+
+    public unsafe int UnsafeField;
+
+    public int NormalField;
+
+    public static int NormalMethod() => 42;
+
+    [DllImport("__dotnet_inspect_memory_safety_fixture__")]
+    public static safe extern int SafeExtern();
+}
+
+[StructLayout(LayoutKind.Explicit, Pack = 2, Size = 16)]
+public struct MemorySafetyExplicitLayoutFixture
+{
+    [FieldOffset(0)]
+    public safe int SafeInstanceField;
+
+    [FieldOffset(4)]
+    public unsafe int UnsafeInstanceField;
+
+    public static int StaticField;
+}

--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
@@ -53,3 +53,27 @@ public sealed class MemorySafetyExplicitAccessorFixture
 {
     unsafe int IMemorySafetyAccessorContract.Value => 42;
 }
+
+public enum MemorySafetyExtensionEnum
+{
+    Value,
+}
+
+public delegate void MemorySafetyExtensionDelegate();
+
+public interface IMemorySafetyExtensionInterface
+{
+}
+
+public static class MemorySafetyReceiverExtensions
+{
+    public static unsafe int Examine(
+        this MemorySafetyExtensionEnum value) => 42;
+
+    public static unsafe int Examine(
+        this MemorySafetyExtensionDelegate value) => 42;
+
+    [DllImport("__dotnet_inspect_memory_safety_extension_fixture__")]
+    public static safe extern int Examine(
+        this IMemorySafetyExtensionInterface value);
+}

--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
@@ -65,6 +65,14 @@ public interface IMemorySafetyExtensionInterface
 {
 }
 
+public sealed class MemorySafetyExtensionClass
+{
+}
+
+public struct MemorySafetyExtensionStruct
+{
+}
+
 public static class MemorySafetyReceiverExtensions
 {
     public static unsafe int Examine(
@@ -76,4 +84,10 @@ public static class MemorySafetyReceiverExtensions
     [DllImport("__dotnet_inspect_memory_safety_extension_fixture__")]
     public static safe extern int Examine(
         this IMemorySafetyExtensionInterface value);
+
+    public static unsafe int Examine(
+        this MemorySafetyExtensionClass value) => 42;
+
+    public static unsafe int Examine(
+        this MemorySafetyExtensionStruct value) => 42;
 }

--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/MemorySafetySpellingFixtures.cs
@@ -42,3 +42,14 @@ public struct MemorySafetyExplicitLayoutFixture
 
     public static int StaticField;
 }
+
+public interface IMemorySafetyAccessorContract
+{
+    unsafe int Value { get; }
+}
+
+public sealed class MemorySafetyExplicitAccessorFixture
+    : IMemorySafetyAccessorContract
+{
+    unsafe int IMemorySafetyAccessorContract.Value => 42;
+}

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -31,6 +31,8 @@ internal sealed record CSharpDeclarationOptions
     public IReadOnlyCollection<string> AdditionalDeclaredTypeFullNames = [];
     public IReadOnlyCollection<string> AdditionalImportedDeclaredTypeFullNames = [];
     public IReadOnlyCollection<string> AdditionalKnownNamespaces = [];
+    public CSharpMemorySafetyLanguage? MemorySafetyLanguage;
+    public bool IsExtern;
     public CSharpDeclaredTypeSelfNameAdmission.Admitted? DeclaredTypeSelfName { get; init; }
     public string? LegacyDeclaredTypeIdentifier { get; init; }
     public CSharpNamespaceMode NamespaceMode { get; init; } = CSharpNamespaceMode.Omit;
@@ -179,6 +181,7 @@ internal static class CSharpDeclarationWriter
         options ??= new CSharpDeclarationOptions { NamespaceMode = CSharpNamespaceMode.FileScoped };
         var memberList = members?.ToList() ?? type.Members;
         var parameters = primaryConstructorParameters ?? [];
+        CheckMemorySafetyType(type, options, parameters.Count);
         var attributeReferences = CollectAttributeTypeReferences(type.Attributes)
             .Concat(memberList.SelectMany(member => CollectAttributeTypeReferences(
                 member.Attributes,
@@ -281,6 +284,7 @@ internal static class CSharpDeclarationWriter
     {
         options ??= new CSharpDeclarationOptions();
         var parameters = primaryConstructorParameters ?? [];
+        CheckMemorySafetyType(type, options, parameters.Count);
         if (delegateInvoke is not null)
         {
             if (delegateInvoke.SignatureModel is not { } signature)
@@ -1035,10 +1039,18 @@ internal static class CSharpDeclarationWriter
             declaration += " : " + string.Join(", ", bases);
 
         declaration = AppendTypeParameterConstraints(declaration, type.TypeParameters);
-        if (!options.IncludeCustomAttributes || type.Attributes.Count == 0)
+        List<string> attributeLines = [];
+        if (CSharpMemorySafetySpelling.TypeLayoutAttribute(
+                type,
+                options.MemorySafetyLanguage) is { } layoutAttribute)
+        {
+            attributeLines.Add($"[{layoutAttribute}]");
+        }
+        if (options.IncludeCustomAttributes)
+            attributeLines.AddRange(type.Attributes.Select(attribute => $"[{attribute}]"));
+        if (attributeLines.Count == 0)
             return declaration;
-        return string.Join("\n", type.Attributes.Select(attribute => $"[{attribute}]"))
-            + "\n" + declaration;
+        return string.Join("\n", attributeLines) + "\n" + declaration;
     }
 
     static bool NeedsTerminator(string declaration)
@@ -1051,6 +1063,11 @@ internal static class CSharpDeclarationWriter
         IReadOnlyList<string>? methodParameters = null,
         IReadOnlyList<string>? parameterNames = null)
     {
+        var safety = CSharpMemorySafetySpelling.Member(
+            type, member, options.MemorySafetyLanguage, options.IsExtern, options.ForceUnsafe);
+        if (safety.Failure is { } failure)
+            throw new NotSupportedException(failure);
+
         string signature;
         var renderedFromModel = false;
         if (member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType))
@@ -1162,6 +1179,15 @@ internal static class CSharpDeclarationWriter
             signature = EscapeParameterLists(signature);
 
         List<string> attributeLines = [];
+        bool hasLayoutAttribute = false;
+        if (CSharpMemorySafetySpelling.FieldLayoutAttribute(
+                type,
+                member,
+                options.MemorySafetyLanguage) is { } fieldLayoutAttribute)
+        {
+            attributeLines.Add($"[{fieldLayoutAttribute}]");
+            hasLayoutAttribute = true;
+        }
         if (options.IncludeCustomAttributes)
         {
             foreach (var attribute in member.Attributes)
@@ -1178,8 +1204,6 @@ internal static class CSharpDeclarationWriter
         if (member.Name == ".cctor")
         {
             modifiers.Add("static");
-            if (member.IsUnsafe || options.ForceUnsafe)
-                modifiers.Add("unsafe");
         }
         else if (member.IsFinalizer)
         {
@@ -1190,8 +1214,6 @@ internal static class CSharpDeclarationWriter
             // `public`/`virtual` would misrepresent it as a new virtual slot
             // (CS0465) rather than the object-finalizer override it is, so keep
             // the fallback modifier-free too.
-            if (member.IsUnsafe || options.ForceUnsafe)
-                modifiers.Add("unsafe");
         }
         else if (member.Kind != "explicit-interface-implementation")
         {
@@ -1216,19 +1238,20 @@ internal static class CSharpDeclarationWriter
                 else if (!member.IsAbstract && member.IsVirtual && !member.IsStatic)
                     modifiers.Add("virtual");
             }
-            if (member.IsUnsafe || options.ForceUnsafe)
-                modifiers.Add("unsafe");
         }
         else
         {
             // Explicit interface implementations omit the access modifier but must still
             // carry `static` (C# 11 static-abstract interface members implemented explicitly)
-            // and `unsafe`. Order mirrors the .cctor branch: static then unsafe.
+            // and their safety modifier.
             if (member.IsStatic)
                 modifiers.Add("static");
-            if (member.IsUnsafe || options.ForceUnsafe)
-                modifiers.Add("unsafe");
         }
+
+        if (safety.Modifier is { } safetyModifier)
+            modifiers.Add(safetyModifier);
+        if (options.IsExtern)
+            modifiers.Add("extern");
 
         if ((options.ForceAsync || member.IsAsync)
             && !member.IsFinalizer
@@ -1247,7 +1270,9 @@ internal static class CSharpDeclarationWriter
         // the full type printer) each leading attribute goes on its own line, as is
         // idiomatic C#. Single-line/table contexts (which never emit custom
         // attributes) keep obsolete/return attributes inline so the row stays intact.
-        string separator = options.IncludeCustomAttributes ? "\n" : " ";
+        string separator = options.IncludeCustomAttributes || hasLayoutAttribute
+            ? "\n"
+            : " ";
         return string.Join(separator, attributeLines) + separator + declarationLine;
     }
 
@@ -1259,6 +1284,19 @@ internal static class CSharpDeclarationWriter
                 && (!parameter.HasDefault
                     || !string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
             && model.Accessors.All(accessor => accessor.ReturnAttributes.Count == 0);
+
+    static void CheckMemorySafetyType(
+        ApiType type,
+        CSharpDeclarationOptions options,
+        int primaryConstructorParameterCount)
+    {
+        if (options.MemorySafetyLanguage is { } language
+            && CSharpMemorySafetySpelling.TypeFailure(
+                type, language, primaryConstructorParameterCount) is { } failure)
+        {
+            throw new NotSupportedException(failure);
+        }
+    }
 
     static IEnumerable<string> CollectTypeReferences(ApiType type)
     {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -108,7 +108,12 @@ internal static class CSharpDeclarationWriter
             memberReferences.Except(explicitInterfaceReferences).ToHashSet(StringComparer.Ordinal),
             attributeValueReferences,
             synthesizedAttributeReferences);
-        var declaration = RenderMemberDeclarationCore(type, member, options, methodParameters);
+        var declaration = RenderMemberDeclarationCore(
+            type,
+            member,
+            options,
+            methodParameters,
+            isStandaloneMember: true);
         declaration = plan.Apply(declaration);
 
         if (options.TerminateMemberDeclaration && NeedsTerminator(declaration))
@@ -165,7 +170,8 @@ internal static class CSharpDeclarationWriter
             member,
             options,
             methodParameters,
-            parameterNames);
+            parameterNames,
+            isStandaloneMember: true);
         declaration = plan.Apply(declaration);
         return options.TerminateMemberDeclaration && NeedsTerminator(declaration)
             ? declaration + ";"
@@ -1061,10 +1067,16 @@ internal static class CSharpDeclarationWriter
         ApiMember member,
         CSharpDeclarationOptions options,
         IReadOnlyList<string>? methodParameters = null,
-        IReadOnlyList<string>? parameterNames = null)
+        IReadOnlyList<string>? parameterNames = null,
+        bool isStandaloneMember = false)
     {
         var safety = CSharpMemorySafetySpelling.Member(
-            type, member, options.MemorySafetyLanguage, options.IsExtern, options.ForceUnsafe);
+            type,
+            member,
+            options.MemorySafetyLanguage,
+            options.IsExtern,
+            options.ForceUnsafe,
+            isStandaloneMember);
         if (safety.Failure is { } failure)
             throw new NotSupportedException(failure);
 

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -47,6 +47,14 @@ public sealed record CSharpFormatOptions
     public bool TerminateMemberDeclaration { get; init; }
     public bool ForceAsync { get; init; }
     public bool ForceUnsafe { get; init; }
+    /// <summary>
+    /// Opts into model-aware method/field spelling. Null retains the compatibility
+    /// view. Unavailable evidence or unsupported forms throw NotSupportedException;
+    /// use CSharpTypePrinter for an atomic, diagnostic-bearing print outcome.
+    /// </summary>
+    public CSharpMemorySafetyLanguage? MemorySafetyLanguage { get; init; }
+    /// <summary>An affirmative choice to emit an extern declaration, not a body-RVA inference.</summary>
+    public bool IsExtern { get; init; }
     public bool IncludeCustomAttributes { get; init; } = false;
     public bool IncludeSignatureAttributes { get; init; } = true;
     public bool IncludeObsoleteAttribute { get; init; } = true;
@@ -130,10 +138,21 @@ public sealed class CSharpFormatter
             throw new ArgumentOutOfRangeException(nameof(options), options.TypeNamePolicy, "C# type-name policy must be defined.");
         if (!Enum.IsDefined(options.NamespacePolicy))
             throw new ArgumentOutOfRangeException(nameof(options), options.NamespacePolicy, "C# namespace policy must be defined.");
+        if (options.MemorySafetyLanguage is { } language && !Enum.IsDefined(language))
+            throw new ArgumentOutOfRangeException(nameof(options), language, "C# memory-safety language must be defined.");
         var usings = options.Usings?.ToArray()
             ?? throw new ArgumentException("C# formatter usings cannot be null.", nameof(options));
         _declarationOptions = ToDeclarationOptions(options, usings);
     }
+
+    CSharpFormatter(CSharpDeclarationOptions options)
+        => _declarationOptions = options;
+
+    internal CSharpFormatter ForExternDeclaration()
+        => new(_declarationOptions with { IsExtern = true });
+
+    internal bool UsesModelAwareMemorySafety
+        => _declarationOptions.MemorySafetyLanguage is not null;
 
     public string FormatMember(
         ApiType type,
@@ -161,6 +180,11 @@ public sealed class CSharpFormatter
         ArgumentNullException.ThrowIfNull(type);
         ArgumentNullException.ThrowIfNull(member);
         ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        if (_declarationOptions.MemorySafetyLanguage is not null)
+        {
+            throw new NotSupportedException(
+                $"Member '{type.FullName}.{member.Name}.{kind}': model-aware accessor spelling is not supported.");
+        }
 
         var accessor = member.SignatureModel?.Accessors
             .FirstOrDefault(candidate => candidate.Kind == kind);
@@ -789,6 +813,8 @@ public sealed class CSharpFormatter
             TerminateMemberDeclaration = options.TerminateMemberDeclaration,
             ForceAsync = options.ForceAsync,
             ForceUnsafe = options.ForceUnsafe,
+            MemorySafetyLanguage = options.MemorySafetyLanguage,
+            IsExtern = options.IsExtern,
             IncludeCustomAttributes = options.IncludeCustomAttributes,
             IncludeSignatureAttributes = options.IncludeSignatureAttributes,
             IncludeObsoleteAttribute = options.IncludeObsoleteAttribute,

--- a/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
+++ b/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
@@ -100,6 +100,15 @@ internal static class CSharpMemorySafetySpelling
         {
             return Refuse($"model-aware {member.Kind} spelling is not supported.");
         }
+        if (member.Kind is "method" or "extension-method"
+                or "explicit-interface-implementation" or "constructor"
+                or "finalizer")
+        {
+            if (member.MethodSemantics is null)
+                return Refuse("MethodSemantics evidence is unavailable.");
+            if (member.MethodSemantics != ApiMethodSemanticsKind.None)
+                return Refuse("model-aware accessor spelling is not supported.");
+        }
         if (member.SignatureModel is null
             || member.SignatureDecodeStatus == SignatureDecodeStatus.Degraded)
         {

--- a/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
+++ b/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
@@ -105,6 +105,11 @@ internal static class CSharpMemorySafetySpelling
         }
         if (language is not { } selectedLanguage)
             return new(member.IsUnsafe || requiresUnsafeContext ? "unsafe" : null, null);
+        if (member.Kind == "extension-method" && !isStandaloneMember)
+        {
+            return Refuse(
+                "a projected extension can be rendered only as a standalone member of its defining static type.");
+        }
 
         string? typeFailure = isStandaloneMember
                 && member.Kind == "extension-method"

--- a/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
+++ b/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
@@ -36,20 +36,9 @@ internal static class CSharpMemorySafetySpelling
             return $"Type '{type.FullName}': model-aware primary-constructor spelling is not supported; "
                 + "supply the selected explicit fields and ordinary constructor.";
         }
-        if (type.MemorySafety is null)
-            return $"Type '{type.FullName}': module memory-safety facts are unavailable.";
-        if (type.MemorySafety.Rules is not MemorySafetyRulesResult.Available
-            {
-                State: MemorySafetyRulesState.Legacy or MemorySafetyRulesState.Updated
-            } rules)
-        {
-            return $"Type '{type.FullName}': module memory-safety rules are unavailable or unrecognized.";
-        }
-        if (rules.State == MemorySafetyRulesState.Updated
-            && language != CSharpMemorySafetyLanguage.UpdatedCallerContracts)
-        {
-            return $"Type '{type.FullName}': the selected language cannot replay updated caller contracts.";
-        }
+        if (ModuleFailure(type, language) is { } moduleFailure)
+            return moduleFailure;
+        var rules = (MemorySafetyRulesResult.Available)type.MemorySafety!.Rules;
         if (rules.State == MemorySafetyRulesState.Updated
             && type.Layout == ApiTypeLayout.Extended)
         {
@@ -76,14 +65,38 @@ internal static class CSharpMemorySafetySpelling
         return null;
     }
 
+    static string? ModuleFailure(
+        ApiType type,
+        CSharpMemorySafetyLanguage language)
+    {
+        if (type.MemorySafety is null)
+            return $"Type '{type.FullName}': module memory-safety facts are unavailable.";
+        if (type.MemorySafety.Rules is not MemorySafetyRulesResult.Available
+            {
+                State: MemorySafetyRulesState.Legacy or MemorySafetyRulesState.Updated
+            } rules)
+        {
+            return $"Type '{type.FullName}': module memory-safety rules are unavailable or unrecognized.";
+        }
+        if (rules.State == MemorySafetyRulesState.Updated
+            && language != CSharpMemorySafetyLanguage.UpdatedCallerContracts)
+        {
+            return $"Type '{type.FullName}': the selected language cannot replay updated caller contracts.";
+        }
+        return null;
+    }
+
     internal static CSharpMemorySafetyDecision Member(
         ApiType type,
         ApiMember member,
         CSharpMemorySafetyLanguage? language,
         bool isExtern = false,
-        bool requiresUnsafeContext = false)
+        bool requiresUnsafeContext = false,
+        bool isStandaloneMember = false)
     {
-        if (isExtern && (type.Kind == "interface"
+        if (isExtern && ((type.Kind == "interface"
+                && !(isStandaloneMember
+                    && member.Kind == "extension-method"))
             || member.Kind is not ("method" or "extension-method" or "explicit-interface-implementation" or "constructor")
             || member.SignatureModel?.Accessors is { Count: > 0 }
             || member.IsAbstract || member.IsAsync || member.IsFinalizer || member.Name == ".cctor"))
@@ -93,7 +106,11 @@ internal static class CSharpMemorySafetySpelling
         if (language is not { } selectedLanguage)
             return new(member.IsUnsafe || requiresUnsafeContext ? "unsafe" : null, null);
 
-        if (TypeFailure(type, selectedLanguage) is { } typeFailure)
+        string? typeFailure = isStandaloneMember
+                && member.Kind == "extension-method"
+            ? ModuleFailure(type, selectedLanguage)
+            : TypeFailure(type, selectedLanguage);
+        if (typeFailure is not null)
             return Refuse(typeFailure);
         if (member.Kind is not ("method" or "extension-method" or "explicit-interface-implementation" or "constructor" or "finalizer" or "field")
             || member.SignatureModel?.Accessors is { Count: > 0 })

--- a/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
+++ b/src/ILInspector.CSharp/CSharpMemorySafetySpelling.cs
@@ -1,0 +1,243 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp;
+
+/// <summary>
+/// Output-language capabilities, independent of the inspected module's rules.
+/// Selecting a capability does not migrate the module to another rules model.
+/// </summary>
+public enum CSharpMemorySafetyLanguage
+{
+    /// <summary>Pointer declarations require a lexical unsafe context.</summary>
+    Legacy,
+
+    /// <summary>Pointer declarations need no context; updated contracts are unavailable.</summary>
+    RelaxedPointerSyntax,
+
+    /// <summary>Relaxed pointer syntax and updated caller-contract declarations are available.</summary>
+    UpdatedCallerContracts
+}
+
+internal readonly record struct CSharpMemorySafetyDecision(
+    string? Modifier,
+    string? Failure);
+
+internal static class CSharpMemorySafetySpelling
+{
+    internal static string? TypeFailure(
+        ApiType type,
+        CSharpMemorySafetyLanguage language,
+        int primaryConstructorParameterCount = 0)
+    {
+        if (type.Kind is "delegate" or "enum")
+            return $"Type '{type.FullName}': model-aware {type.Kind} spelling is not supported.";
+        if (primaryConstructorParameterCount > 0)
+        {
+            return $"Type '{type.FullName}': model-aware primary-constructor spelling is not supported; "
+                + "supply the selected explicit fields and ordinary constructor.";
+        }
+        if (type.MemorySafety is null)
+            return $"Type '{type.FullName}': module memory-safety facts are unavailable.";
+        if (type.MemorySafety.Rules is not MemorySafetyRulesResult.Available
+            {
+                State: MemorySafetyRulesState.Legacy or MemorySafetyRulesState.Updated
+            } rules)
+        {
+            return $"Type '{type.FullName}': module memory-safety rules are unavailable or unrecognized.";
+        }
+        if (rules.State == MemorySafetyRulesState.Updated
+            && language != CSharpMemorySafetyLanguage.UpdatedCallerContracts)
+        {
+            return $"Type '{type.FullName}': the selected language cannot replay updated caller contracts.";
+        }
+        if (rules.State == MemorySafetyRulesState.Updated
+            && type.Layout == ApiTypeLayout.Extended)
+        {
+            return $"Type '{type.FullName}': extended layout has no supported C# layout-attribute spelling.";
+        }
+        if (rules.State == MemorySafetyRulesState.Updated
+            && type.Layout == ApiTypeLayout.Explicit)
+        {
+            if (type.Kind is not ("class" or "struct"))
+                return $"Type '{type.FullName}': explicit layout is unavailable for C# type kind '{type.Kind}'.";
+            if (type.MetadataToken is not int typeToken)
+                return $"Type '{type.FullName}': the defining TypeDef token is unavailable for explicit-layout spelling.";
+            if (type.LayoutDetails is not { } layout)
+                return $"Type '{type.FullName}': explicit-layout details are unavailable.";
+            if (layout.ModuleVersionId != type.MemorySafety.ModuleVersionId)
+                return $"Type '{type.FullName}': explicit-layout evidence comes from a different module.";
+            if (layout.TypeToken != typeToken)
+                return $"Type '{type.FullName}': explicit-layout evidence identifies a different TypeDef.";
+            if (layout.Size < 0)
+                return $"Type '{type.FullName}': explicit-layout size '{layout.Size}' is not representable in C#.";
+            if (!IsSupportedPackingSize(layout.PackingSize))
+                return $"Type '{type.FullName}': explicit-layout packing size '{layout.PackingSize}' is not representable in C#.";
+        }
+        return null;
+    }
+
+    internal static CSharpMemorySafetyDecision Member(
+        ApiType type,
+        ApiMember member,
+        CSharpMemorySafetyLanguage? language,
+        bool isExtern = false,
+        bool requiresUnsafeContext = false)
+    {
+        if (isExtern && (type.Kind == "interface"
+            || member.Kind is not ("method" or "extension-method" or "explicit-interface-implementation" or "constructor")
+            || member.SignatureModel?.Accessors is { Count: > 0 }
+            || member.IsAbstract || member.IsAsync || member.IsFinalizer || member.Name == ".cctor"))
+        {
+            return Refuse("the selected declaration cannot use the extern form.");
+        }
+        if (language is not { } selectedLanguage)
+            return new(member.IsUnsafe || requiresUnsafeContext ? "unsafe" : null, null);
+
+        if (TypeFailure(type, selectedLanguage) is { } typeFailure)
+            return Refuse(typeFailure);
+        if (member.Kind is not ("method" or "extension-method" or "explicit-interface-implementation" or "constructor" or "finalizer" or "field")
+            || member.SignatureModel?.Accessors is { Count: > 0 })
+        {
+            return Refuse($"model-aware {member.Kind} spelling is not supported.");
+        }
+        if (member.SignatureModel is null
+            || member.SignatureDecodeStatus == SignatureDecodeStatus.Degraded)
+        {
+            return Refuse("a complete structured signature is unavailable.");
+        }
+        if (member.MemorySafety is not { } facts)
+            return Refuse("member memory-safety facts are unavailable.");
+        var rules = (MemorySafetyRulesResult.Available)type.MemorySafety!.Rules;
+        if (facts.ModuleVersionId != type.MemorySafety.ModuleVersionId)
+        {
+            return Refuse("the declaring module's memory-safety evidence does not match the member.");
+        }
+        int? declarationToken = member.Kind == "field"
+            ? member.DeclarationMetadataToken
+            : member.MetadataToken;
+        if (declarationToken is not int memberToken)
+            return Refuse("the defining metadata token is unavailable.");
+        if (facts.CallerContract.Evidence.MemberToken != memberToken)
+            return Refuse("the caller-contract evidence identifies a different declaration.");
+        if (facts.CallerContract.Evidence.RulesState != rules.State)
+            return Refuse("the declaring module's rules state does not match the member.");
+        if (facts.CallerContract is MemorySafetyMemberContractResult.Unavailable unavailable)
+            return Refuse($"caller contract is unavailable: {unavailable.Failure.Detail}");
+
+        if (rules.State == MemorySafetyRulesState.Legacy)
+        {
+            if (facts.CallerContract is not (MemorySafetyMemberContractResult.None or MemorySafetyMemberContractResult.Implicit))
+                return Refuse("the caller contract cannot be represented under legacy module rules.");
+            if (facts.SignaturePointer == MemorySafetyPointerEvidence.Present
+                && facts.CallerContract is MemorySafetyMemberContractResult.None)
+            {
+                return Refuse("an ordinary pointer declaration would introduce an implicit legacy caller contract.");
+            }
+            if (requiresUnsafeContext)
+                return new("unsafe", null);
+            if (selectedLanguage != CSharpMemorySafetyLanguage.Legacy)
+                return new(null, null);
+            return facts.SignaturePointer switch
+            {
+                MemorySafetyPointerEvidence.Present => new("unsafe", null),
+                MemorySafetyPointerEvidence.Absent => new(null, null),
+                _ => Refuse("signature-pointer evidence is unavailable for lexical-context spelling.")
+            };
+        }
+
+        if (member.Kind == "field"
+            && !member.IsStatic
+            && !member.IsConst
+            && type.Layout == ApiTypeLayout.Explicit)
+        {
+            if (type.LayoutDetails is not { } typeLayout)
+                return Refuse("explicit-layout type evidence is unavailable.");
+            if (member.DeclarationMetadataToken is not int fieldToken)
+                return Refuse("the defining FieldDef token is unavailable for explicit-layout spelling.");
+            if (member.FieldLayout is not { } fieldLayout)
+                return Refuse("explicit field-layout evidence is unavailable.");
+            if (fieldLayout.ModuleVersionId != type.MemorySafety.ModuleVersionId)
+                return Refuse("field-layout evidence comes from a different module.");
+            if (fieldLayout.DeclaringTypeToken != typeLayout.TypeToken)
+                return Refuse("field-layout evidence identifies a different declaring TypeDef.");
+            if (fieldLayout.FieldToken != fieldToken)
+                return Refuse("field-layout evidence identifies a different FieldDef.");
+            if (fieldLayout.Offset is not int offset || offset < 0)
+                return Refuse("a usable explicit field offset is unavailable.");
+        }
+
+        if (requiresUnsafeContext)
+        {
+            return Refuse("a member modifier cannot establish an updated-rules body context; "
+                + "the body producer must supply that context.");
+        }
+        if (facts.CallerContract is MemorySafetyMemberContractResult.Explicit)
+        {
+            return member.IsFinalizer || member.Name == ".cctor"
+                ? Refuse("this declaration position cannot carry an updated unsafe contract.")
+                : new("unsafe", null);
+        }
+        if (facts.CallerContract is not MemorySafetyMemberContractResult.None)
+            return Refuse("the caller contract cannot be represented under updated module rules.");
+        if (isExtern)
+            return new("safe", null);
+        if (member.Kind == "field" && !member.IsStatic && !member.IsConst)
+        {
+            if (type.Layout is null)
+                return Refuse("the declaring type's instance-storage layout is unavailable.");
+            if (type.Layout is ApiTypeLayout.Explicit or ApiTypeLayout.Extended)
+                return new("safe", null);
+        }
+        return new(null, null);
+
+        CSharpMemorySafetyDecision Refuse(string reason)
+            => new(null, $"Member '{type.FullName}.{member.Name}': {reason}");
+    }
+
+    internal static string? TypeLayoutAttribute(
+        ApiType type,
+        CSharpMemorySafetyLanguage? language)
+    {
+        if (!UsesUpdatedCallerContracts(type, language)
+            || type.Layout != ApiTypeLayout.Explicit
+            || type.LayoutDetails is not { } layout)
+        {
+            return null;
+        }
+
+        var arguments = new List<string>
+        {
+            "global::System.Runtime.InteropServices.LayoutKind.Explicit"
+        };
+        if (layout.Size > 0)
+            arguments.Add($"Size = {layout.Size}");
+        if (layout.PackingSize > 0)
+            arguments.Add($"Pack = {layout.PackingSize}");
+        return $"global::System.Runtime.InteropServices.StructLayoutAttribute({string.Join(", ", arguments)})";
+    }
+
+    internal static string? FieldLayoutAttribute(
+        ApiType type,
+        ApiMember member,
+        CSharpMemorySafetyLanguage? language)
+        => UsesUpdatedCallerContracts(type, language)
+            && type.Layout == ApiTypeLayout.Explicit
+            && member.Kind == "field"
+            && !member.IsStatic
+            && !member.IsConst
+            && member.FieldLayout?.Offset is int offset
+                ? $"global::System.Runtime.InteropServices.FieldOffsetAttribute({offset})"
+                : null;
+
+    static bool IsSupportedPackingSize(int packingSize)
+        => packingSize is 0 or 1 or 2 or 4 or 8 or 16 or 32 or 64 or 128;
+
+    static bool UsesUpdatedCallerContracts(
+        ApiType type,
+        CSharpMemorySafetyLanguage? language)
+        => language == CSharpMemorySafetyLanguage.UpdatedCallerContracts
+            && type.MemorySafety?.Rules is MemorySafetyRulesResult.Available
+            {
+                State: MemorySafetyRulesState.Updated
+            };
+}

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -7,7 +7,9 @@ public enum CSharpBodyPolicy
 {
     Skeleton,
     Full,
-    Stub
+    Stub,
+    /// <summary>An explicitly selected extern method or instance constructor, with no body.</summary>
+    Extern
 }
 
 public abstract record CSharpMemberBody
@@ -21,6 +23,8 @@ public abstract record CSharpMemberBody
     /// <summary>
     /// True when this body requires an <c>unsafe</c> member context beyond any
     /// unsafe signature already represented by <see cref="ApiMember.IsUnsafe"/>.
+    /// Model-aware updated-rules printing refuses this unsatisfied body-context
+    /// requirement; publishing a caller contract cannot satisfy it.
     /// </summary>
     public bool RequiresUnsafeModifier { get; init; }
 
@@ -257,6 +261,13 @@ public sealed record CSharpTypePrintOptions
     public bool IncludeCustomAttributes { get; init; }
 
     /// <summary>
+    /// Opts into model-aware method/field declaration spelling. Null retains
+    /// the compatibility view. Unsupported forms or necessary unavailable facts
+    /// produce NotRendered, without exposing a partial batch.
+    /// </summary>
+    public CSharpMemorySafetyLanguage? MemorySafetyLanguage { get; init; }
+
+    /// <summary>
     /// Namespaces to emit as <c>using</c> directives in the composed
     /// <see cref="CSharpTypePrintResult.Source"/>. Escaped, de-duplicated, and
     /// ordinal-ordered at composition time. Ignored when <see cref="IncludeUsings"/>
@@ -401,15 +412,21 @@ public abstract record CSharpTypePrintOutcome
     }
 
     /// <summary>
-    /// At least one exact declared-type self-name was unrepresentable. This arm
-    /// exposes no source or partial print result.
+    /// At least one exact declared-type self-name or model-aware memory-safety
+    /// declaration was unrepresentable. This arm exposes no source or partial result.
     /// </summary>
     public sealed record NotRendered : CSharpTypePrintOutcome
     {
         internal NotRendered(
-            ImmutableArray<CSharpDeclaredTypeSelfNameFailure> selfNameFailures)
-            => SelfNameFailures = selfNameFailures;
+            ImmutableArray<CSharpDeclaredTypeSelfNameFailure> selfNameFailures,
+            ImmutableArray<CSharpTypePrintDiagnostic> memorySafetyFailures)
+        {
+            SelfNameFailures = selfNameFailures;
+            MemorySafetyFailures = memorySafetyFailures;
+        }
 
         public ImmutableArray<CSharpDeclaredTypeSelfNameFailure> SelfNameFailures { get; }
+
+        public ImmutableArray<CSharpTypePrintDiagnostic> MemorySafetyFailures { get; }
     }
 }

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -22,6 +22,8 @@ public sealed class CSharpTypePrinter
         options ??= new CSharpTypePrintOptions();
         if (!Enum.IsDefined(options.TypeNamePolicy))
             throw new ArgumentOutOfRangeException(nameof(options), options.TypeNamePolicy, "C# type-name policy must be defined.");
+        if (options.MemorySafetyLanguage is { } language && !Enum.IsDefined(language))
+            throw new ArgumentOutOfRangeException(nameof(options), language, "C# memory-safety language must be defined.");
         var configuredUsings = options.Usings?.ToArray()
             ?? throw new ArgumentException("C# type printer usings cannot be null.", nameof(options));
 
@@ -56,8 +58,12 @@ public sealed class CSharpTypePrinter
         var selfNameFailures = preparedTypes
             .SelectMany(SelfNameFailures)
             .ToImmutableArray();
-        if (selfNameFailures.Length > 0)
-            return new CSharpTypePrintOutcome.NotRendered(selfNameFailures);
+        ImmutableArray<CSharpTypePrintDiagnostic> memorySafetyFailures =
+            options.MemorySafetyLanguage is { } selectedLanguage
+                ? BatchMemorySafetyFailures(preparedTypes, selectedLanguage).ToImmutableArray()
+                : [];
+        if (selfNameFailures.Length > 0 || memorySafetyFailures.Length > 0)
+            return new CSharpTypePrintOutcome.NotRendered(selfNameFailures, memorySafetyFailures);
 
         ValidateDuplicateTypes(preparedTypes, nameof(requests));
 
@@ -468,6 +474,72 @@ public sealed class CSharpTypePrinter
         }
     }
 
+    static IEnumerable<CSharpTypePrintDiagnostic> MemorySafetyFailures(
+        PreparedType prepared,
+        CSharpMemorySafetyLanguage language)
+    {
+        if (CSharpMemorySafetySpelling.TypeFailure(
+            prepared.Type, language, prepared.PrimaryConstructorParameters.Length) is { } typeFailure)
+        {
+            yield return new(prepared.Type.FullName, typeFailure);
+        }
+        else
+        {
+            foreach (var member in prepared.Members)
+            {
+                var decision = CSharpMemorySafetySpelling.Member(
+                    prepared.Type,
+                    member.Member,
+                    language,
+                    isExtern: member.Policy == CSharpBodyPolicy.Extern,
+                    requiresUnsafeContext: member.Body?.RequiresUnsafeModifier == true);
+                if (decision.Failure is { } failure)
+                    yield return new(prepared.Type.FullName, failure);
+            }
+        }
+        foreach (var nested in prepared.NestedTypes)
+        {
+            foreach (var failure in MemorySafetyFailures(nested, language))
+                yield return failure;
+        }
+    }
+
+    static IEnumerable<CSharpTypePrintDiagnostic> BatchMemorySafetyFailures(
+        IReadOnlyList<PreparedType> preparedTypes,
+        CSharpMemorySafetyLanguage language)
+    {
+        foreach (var prepared in preparedTypes)
+        {
+            foreach (var failure in MemorySafetyFailures(prepared, language))
+                yield return failure;
+        }
+
+        MemorySafetyRulesState[] states = preparedTypes
+            .SelectMany(Flatten)
+            .Select(prepared => prepared.Type.MemorySafety?.Rules)
+            .OfType<MemorySafetyRulesResult.Available>()
+            .Select(rules => rules.State)
+            .Where(state => state is MemorySafetyRulesState.Legacy or MemorySafetyRulesState.Updated)
+            .Distinct()
+            .ToArray();
+        if (states.Length > 1)
+        {
+            yield return new CSharpTypePrintDiagnostic(
+                "<batch>",
+                "A single C# source batch cannot preserve both legacy and updated module memory-safety rules.");
+        }
+
+        static IEnumerable<PreparedType> Flatten(PreparedType prepared)
+        {
+            yield return prepared;
+            foreach (var nested in prepared.NestedTypes)
+            {
+                foreach (var descendant in Flatten(nested))
+                    yield return descendant;
+            }
+        }
+    }
+
     static void ValidateDuplicateTypes(
         IReadOnlyList<PreparedType> preparedTypes,
         string parameterName)
@@ -567,7 +639,9 @@ public sealed class CSharpTypePrinter
             prepared.LegacyDeclaredTypeIdentifier);
         var diagnosticPass = DeclarationFormatter(
             prepared.Namespace,
-            options,
+            // This pass collects name diagnostics, not body-policy declarations.
+            // Memory-safety admission above already used each member's actual shape.
+            options with { MemorySafetyLanguage = null },
             contextualUsings,
             inScopeShadowingNames,
             inheritedRootShadowingNames,
@@ -653,7 +727,9 @@ public sealed class CSharpTypePrinter
         string pad = new(' ', indent * 4);
         if (member.Member.Kind == "field")
         {
-            string declaration = formatter.FormatMember(type.Type, member.Member);
+            string declaration = member.Body is not null && formatter.UsesModelAwareMemorySafety
+                ? formatter.FormatMemberWithBody(type.Type, member.Member, member.Body)
+                : formatter.FormatMember(type.Type, member.Member);
             if (member.Body is CSharpFieldInitializer fieldInitializer)
                 return new RenderedFragment($"{PadDeclaration(declaration, pad)} = {fieldInitializer.Source};");
             return new RenderedFragment(PadDeclaration(EnsureTerminated(declaration), pad));
@@ -665,12 +741,14 @@ public sealed class CSharpTypePrinter
         if (IsEvent(member.Member))
             return RenderEvent(type, member, formatter, indent);
 
+        if (member.Policy == CSharpBodyPolicy.Extern)
+            formatter = formatter.ForExternDeclaration();
         string memberDeclaration = member.Body is null
             ? formatter.FormatMember(type.Type, member.Member)
             : formatter.FormatMemberWithBody(type.Type, member.Member, member.Body);
         if (type.Type.Kind == "interface"
             || member.Member.IsAbstract
-            || member.Policy == CSharpBodyPolicy.Skeleton)
+            || member.Policy is CSharpBodyPolicy.Skeleton or CSharpBodyPolicy.Extern)
         {
             return new RenderedFragment(PadDeclaration(EnsureTerminated(memberDeclaration), pad));
         }
@@ -864,6 +942,7 @@ public sealed class CSharpTypePrinter
             LegacyDeclaredTypeIdentifier = legacyDeclaredTypeIdentifier,
             NamespacePolicy = CSharpNamespacePolicy.Omit,
             IncludeCustomAttributes = options.IncludeCustomAttributes,
+            MemorySafetyLanguage = options.MemorySafetyLanguage,
             OmitPropertyAccessors = omitPropertyAccessors,
             TerminateMemberDeclaration = terminateMemberDeclaration
         });
@@ -923,6 +1002,7 @@ public sealed class CSharpTypePrinter
             Name = type.Name,
             MetadataName = type.MetadataName,
             DefinitionName = type.DefinitionName,
+            MetadataToken = type.MetadataToken,
             IntroducedTypeParameterCounts =
                 type.IntroducedTypeParameterCounts?.ToList(),
             Accessibility = type.Accessibility,
@@ -952,6 +1032,8 @@ public sealed class CSharpTypePrinter
         {
             Name = member.Name,
             Kind = member.Kind,
+            MetadataToken = member.MetadataToken,
+            DeclarationMetadataToken = member.DeclarationMetadataToken,
             Attributes = attributes?.ToList()!,
             ReturnType = member.ReturnType,
             Signature = member.Signature,
@@ -1115,6 +1197,15 @@ public sealed class CSharpTypePrinter
         int primaryConstructorParameterCount,
         string parameterName)
     {
+        if (policy.BodyPolicy == CSharpBodyPolicy.Extern)
+        {
+            if (policy.Body is not null)
+                throw new ArgumentException($"Extern member '{member.Name}' cannot carry a body.", parameterName);
+            var decision = CSharpMemorySafetySpelling.Member(type, member, language: null, isExtern: true);
+            if (decision.Failure is { } failure)
+                throw new NotSupportedException(failure);
+            return;
+        }
         if (policy.BodyPolicy == CSharpBodyPolicy.Skeleton && policy.Body is not null)
         {
             throw new ArgumentException(

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -1032,6 +1032,7 @@ public sealed class CSharpTypePrinter
         {
             Name = member.Name,
             Kind = member.Kind,
+            MethodSemantics = member.MethodSemantics,
             MetadataToken = member.MetadataToken,
             DeclarationMetadataToken = member.DeclarationMetadataToken,
             Attributes = attributes?.ToList()!,

--- a/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
@@ -1,0 +1,418 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Fixtures;
+using ILInspector.CSharp;
+using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Validity")]
+public sealed class CSharpMemorySafetySpellingCompileTests
+{
+    const string LegacyFixtureType =
+        "ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures";
+    const string UpdatedFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetySpellingFixture";
+    const string ExplicitLayoutFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExplicitLayoutFixture";
+
+    [Theory]
+    [InlineData(CSharpMemorySafetyLanguage.Legacy, true)]
+    [InlineData(CSharpMemorySafetyLanguage.RelaxedPointerSyntax, false)]
+    public void LegacyBinaryContractsRoundTripUnderBothPointerSyntaxProfiles(
+        CSharpMemorySafetyLanguage language,
+        bool expectsUnsafeModifier)
+    {
+        ApiType original = ExtractType(
+            FixtureCatalog.DecompilerUnsafeLegacy.AssemblyPath(),
+            LegacyFixtureType);
+        AssertRules(original, MemorySafetyRulesState.Legacy);
+        ApiMember pointer = Member(original, "ConsumePointer");
+        ApiMember pointerFree = Member(original, "Risky");
+        CSharpTypePrintResult printed = Print(
+            original,
+            [pointer, pointerFree],
+            CSharpBodyPolicy.Stub,
+            language);
+
+        Assert.Equal(
+            expectsUnsafeModifier,
+            HasWord(MemberLine(printed.Source, pointer.Name), "unsafe"));
+        Assert.False(HasWord(MemberLine(printed.Source, pointerFree.Name), "unsafe"));
+
+        CSharpParseOptions parseOptions = language == CSharpMemorySafetyLanguage.Legacy
+            ? new CSharpParseOptions(LanguageVersion.Latest)
+            : new CSharpParseOptions(LanguageVersion.Preview);
+        using CompiledAssembly compiled = CompileUnchanged(
+            printed.Source,
+            parseOptions,
+            $"MemorySafety{language}");
+        ApiType emitted = ExtractType(compiled.PE, LegacyFixtureType);
+
+        AssertRules(emitted, MemorySafetyRulesState.Legacy);
+        AssertContractPreserved(original, emitted, pointer.Name);
+        AssertContractPreserved(original, emitted, pointerFree.Name);
+    }
+
+    [Fact]
+    public void UpdatedContractsRoundTripForMethodsFieldsAndExplicitExtern()
+    {
+        ApiType original = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            UpdatedFixtureType);
+        AssertRules(original, MemorySafetyRulesState.Updated);
+        Assert.Equal(ApiTypeLayout.Sequential, original.Layout);
+        var originalExternImplementation =
+            Assert.IsType<ApiMethodImplementationFacts>(
+                Member(original, "SafeExtern").MethodImplementation);
+        Assert.True(
+            (originalExternImplementation.Attributes
+                & MethodAttributes.PinvokeImpl) != 0);
+        string[] names =
+        [
+            "PointerFreeUnsafeMethod",
+            "PointerNoneMethod",
+            "PointerNoneField",
+            "UnsafeField",
+            "NormalField",
+            "NormalMethod",
+            "SafeExtern",
+        ];
+        ApiMember[] members = names.Select(name => Member(original, name)).ToArray();
+        CSharpMemberPolicy[] policies = members
+            .Where(member => member.Kind == "method")
+            .Select(member => new CSharpMemberPolicy(
+                member,
+                member.Name == "SafeExtern"
+                    ? CSharpBodyPolicy.Extern
+                    : CSharpBodyPolicy.Stub))
+            .ToArray();
+        CSharpTypePrintResult printed = Print(
+            original,
+            members,
+            CSharpBodyPolicy.Skeleton,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+            policies,
+            includeCustomAttributes: true);
+
+        Assert.True(HasWord(
+            MemberLine(printed.Source, "PointerFreeUnsafeMethod"),
+            "unsafe"));
+        Assert.False(HasWord(
+            MemberLine(printed.Source, "PointerNoneMethod"),
+            "unsafe"));
+        Assert.False(HasWord(
+            MemberLine(printed.Source, "PointerNoneField"),
+            "unsafe"));
+        Assert.True(HasWord(MemberLine(printed.Source, "UnsafeField"), "unsafe"));
+        Assert.False(HasWord(MemberLine(printed.Source, "NormalField"), "safe"));
+        Assert.False(HasWord(MemberLine(printed.Source, "NormalMethod"), "unsafe"));
+        Assert.True(HasWord(MemberLine(printed.Source, "SafeExtern"), "safe"));
+        Assert.True(HasWord(MemberLine(printed.Source, "SafeExtern"), "extern"));
+
+        using CompiledAssembly compiled = CompileUnchanged(
+            printed.Source,
+            UpdatedParseOptions(),
+            "MemorySafetyUpdatedCallerContracts");
+        ApiType emitted = ExtractType(compiled.PE, UpdatedFixtureType);
+
+        AssertRules(emitted, MemorySafetyRulesState.Updated);
+        foreach (string name in names)
+            AssertContractPreserved(original, emitted, name);
+
+        ApiMember emittedExtern = Member(emitted, "SafeExtern");
+        var implementation =
+            Assert.IsType<ApiMethodImplementationFacts>(emittedExtern.MethodImplementation);
+        Assert.False(implementation.HasBodyRva);
+    }
+
+    [Fact]
+    public void ExplicitLayoutFixtureCompilesUnchangedAndPreservesFieldContracts()
+    {
+        ApiType original = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExplicitLayoutFixtureType);
+        ApiMember safe = Member(original, "SafeInstanceField");
+        ApiMember unsafeField = Member(original, "UnsafeInstanceField");
+        ApiMember staticField = Member(original, "StaticField");
+
+        AssertRules(original, MemorySafetyRulesState.Updated);
+        Assert.Equal(ApiTypeLayout.Explicit, original.Layout);
+        Assert.Equal(16, original.LayoutDetails!.Size);
+        Assert.Equal(2, original.LayoutDetails.PackingSize);
+        Assert.Equal(0, safe.FieldLayout!.Offset);
+        Assert.Equal(4, unsafeField.FieldLayout!.Offset);
+        CSharpTypePrintResult printed = Print(
+            original,
+            [safe, unsafeField, staticField],
+            CSharpBodyPolicy.Skeleton,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.True(HasWord(MemberLine(printed.Source, safe.Name), "safe"));
+        Assert.True(HasWord(MemberLine(printed.Source, unsafeField.Name), "unsafe"));
+        Assert.False(HasWord(MemberLine(printed.Source, staticField.Name), "safe"));
+        Assert.False(HasWord(MemberLine(printed.Source, staticField.Name), "unsafe"));
+        Assert.Contains(
+            "[global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Explicit, Size = 16, Pack = 2)]",
+            printed.Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "[global::System.Runtime.InteropServices.FieldOffsetAttribute(0)]\n    public safe int SafeInstanceField;",
+            printed.Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "[global::System.Runtime.InteropServices.FieldOffsetAttribute(4)]\n    public unsafe int UnsafeInstanceField;",
+            printed.Source,
+            StringComparison.Ordinal);
+        string[] lines = printed.Source.Split('\n');
+        int staticLine = Array.FindIndex(
+            lines,
+            line => line.Contains("StaticField", StringComparison.Ordinal));
+        Assert.True(staticLine > 0);
+        Assert.DoesNotContain(
+            "FieldOffsetAttribute",
+            lines[staticLine - 1],
+            StringComparison.Ordinal);
+
+        using CompiledAssembly compiled = CompileUnchanged(
+            printed.Source,
+            UpdatedParseOptions(),
+            "MemorySafetyExplicitLayoutFields");
+        ApiType emitted = ExtractType(compiled.PE, ExplicitLayoutFixtureType);
+
+        AssertRules(emitted, MemorySafetyRulesState.Updated);
+        AssertContractPreserved(original, emitted, safe.Name);
+        AssertContractPreserved(original, emitted, unsafeField.Name);
+        AssertContractPreserved(original, emitted, staticField.Name);
+        Assert.Equal(ApiTypeLayout.Explicit, emitted.Layout);
+        Assert.Equal(16, emitted.LayoutDetails!.Size);
+        Assert.Equal(2, emitted.LayoutDetails.PackingSize);
+        Assert.Equal(0, Member(emitted, safe.Name).FieldLayout!.Offset);
+        Assert.Equal(4, Member(emitted, unsafeField.Name).FieldLayout!.Offset);
+    }
+
+    [Fact]
+    public void MixedLegacyAndUpdatedFixturesAreRejectedAsOneSourceBatch()
+    {
+        ApiType legacy = ExtractType(
+            FixtureCatalog.DecompilerUnsafeLegacy.AssemblyPath(),
+            LegacyFixtureType);
+        ApiType updated = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            UpdatedFixtureType);
+        ApiMember legacyPointer = Member(legacy, "ConsumePointer");
+        ApiMember updatedUnsafe = Member(updated, "PointerFreeUnsafeMethod");
+
+        var outcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().PrintBatch(
+                [
+                    new CSharpTypePrintRequest(
+                        legacy,
+                        CSharpBodyPolicy.Stub,
+                        [legacyPointer]),
+                    new CSharpTypePrintRequest(
+                        updated,
+                        CSharpBodyPolicy.Stub,
+                        [updatedUnsafe]),
+                ],
+                new CSharpTypePrintOptions
+                {
+                    MemorySafetyLanguage =
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                }));
+
+        Assert.Empty(outcome.SelfNameFailures);
+        CSharpTypePrintDiagnostic failure =
+            Assert.Single(outcome.MemorySafetyFailures);
+        Assert.Equal("<batch>", failure.TypeName);
+        Assert.Contains("legacy", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("updated", failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UpdatedUnsafeConstructorRoundTripsAsOrdinaryAndExplicitExtern()
+    {
+        ApiType original = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            UpdatedFixtureType);
+        ApiMember constructor = Member(original, ".ctor");
+
+        CSharpTypePrintResult ordinary = Print(
+            original,
+            [constructor],
+            CSharpBodyPolicy.Stub,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+        CSharpTypePrintResult external = Print(
+            original,
+            [constructor],
+            CSharpBodyPolicy.Skeleton,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+            [new CSharpMemberPolicy(constructor, CSharpBodyPolicy.Extern)]);
+
+        string constructorSignature = $"{original.Name}()";
+        Assert.True(HasWord(
+            MemberLine(ordinary.Source, constructorSignature),
+            "unsafe"));
+        Assert.False(HasWord(
+            MemberLine(ordinary.Source, constructorSignature),
+            "extern"));
+        Assert.True(HasWord(
+            MemberLine(external.Source, constructorSignature),
+            "unsafe"));
+        Assert.True(HasWord(
+            MemberLine(external.Source, constructorSignature),
+            "extern"));
+
+        using CompiledAssembly ordinaryCompiled = CompileUnchanged(
+            ordinary.Source,
+            UpdatedParseOptions(),
+            "MemorySafetyOrdinaryConstructor");
+        using CompiledAssembly externCompiled = CompileUnchanged(
+            external.Source,
+            UpdatedParseOptions(),
+            "MemorySafetyExternConstructor");
+        ApiType ordinaryEmitted = ExtractType(
+            ordinaryCompiled.PE,
+            UpdatedFixtureType);
+        ApiType externEmitted = ExtractType(
+            externCompiled.PE,
+            UpdatedFixtureType);
+
+        AssertRules(ordinaryEmitted, MemorySafetyRulesState.Updated);
+        AssertRules(externEmitted, MemorySafetyRulesState.Updated);
+        AssertContractPreserved(original, ordinaryEmitted, ".ctor");
+        AssertContractPreserved(original, externEmitted, ".ctor");
+        Assert.True(Member(ordinaryEmitted, ".ctor").MethodImplementation!.HasBodyRva);
+        Assert.False(Member(externEmitted, ".ctor").MethodImplementation!.HasBodyRva);
+    }
+
+    static CSharpTypePrintResult Print(
+        ApiType type,
+        IReadOnlyList<ApiMember> members,
+        CSharpBodyPolicy bodyPolicy,
+        CSharpMemorySafetyLanguage language,
+        IReadOnlyList<CSharpMemberPolicy>? policies = null,
+        bool includeCustomAttributes = false)
+    {
+        var outcome = new CSharpTypePrinter().Print(
+            new CSharpTypePrintRequest(
+                type,
+                bodyPolicy,
+                members,
+                policies),
+            new CSharpTypePrintOptions
+            {
+                IncludeCustomAttributes = includeCustomAttributes,
+                MemorySafetyLanguage = language,
+            });
+        return Assert.IsType<CSharpTypePrintOutcome.Printed>(outcome).Result;
+    }
+
+    static ApiType ExtractType(string path, string fullName)
+    {
+        using var pe = new PEReader(File.OpenRead(path));
+        return ExtractType(pe, fullName);
+    }
+
+    static ApiType ExtractType(PEReader pe, string fullName)
+        => Assert.Single(
+            ApiSurfaceExtractor.Extract(pe, includeAll: true).Types,
+            type => type.FullName == fullName);
+
+    static ApiMember Member(ApiType type, string name)
+        => Assert.Single(type.Members, member => member.Name == name);
+
+    static void AssertRules(ApiType type, MemorySafetyRulesState expected)
+    {
+        var rules =
+            Assert.IsType<MemorySafetyRulesResult.Available>(type.MemorySafety!.Rules);
+        Assert.Equal(expected, rules.State);
+    }
+
+    static void AssertContractPreserved(
+        ApiType original,
+        ApiType emitted,
+        string memberName)
+    {
+        ApiMember expected = Member(original, memberName);
+        ApiMember actual = Member(emitted, memberName);
+        ApiMemberMemorySafetyFacts expectedFacts =
+            Assert.IsType<ApiMemberMemorySafetyFacts>(expected.MemorySafety);
+        ApiMemberMemorySafetyFacts actualFacts =
+            Assert.IsType<ApiMemberMemorySafetyFacts>(actual.MemorySafety);
+
+        Assert.Equal(
+            expectedFacts.CallerContract.GetType(),
+            actualFacts.CallerContract.GetType());
+        Assert.Equal(expectedFacts.SignaturePointer, actualFacts.SignaturePointer);
+        Assert.Equal(
+            emitted.MemorySafety!.ModuleVersionId,
+            actualFacts.ModuleVersionId);
+        Assert.Equal(
+            Assert.IsType<MemorySafetyRulesResult.Available>(
+                emitted.MemorySafety.Rules).State,
+            actualFacts.CallerContract.Evidence.RulesState);
+    }
+
+    static string MemberLine(string source, string memberName)
+        => Assert.Single(
+            source.Split('\n'),
+            line => line.Contains(memberName, StringComparison.Ordinal));
+
+    static bool HasWord(string text, string word)
+        => text.Split(
+                [' ', '\t', '\r', '\n', '(', ')', ';', '{', '}', '[', ']', ','],
+                StringSplitOptions.RemoveEmptyEntries)
+            .Contains(word, StringComparer.Ordinal);
+
+    static CSharpParseOptions UpdatedParseOptions()
+        => new CSharpParseOptions(LanguageVersion.Preview)
+            .WithFeatures(
+            [
+                new KeyValuePair<string, string>(
+                    "updated-memory-safety-rules",
+                    "true"),
+            ]);
+
+    static CompiledAssembly CompileUnchanged(
+        string source,
+        CSharpParseOptions parseOptions,
+        string assemblyName)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source, parseOptions)],
+            RoslynTestReferences.TrustedPlatform,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                allowUnsafe: true,
+                optimizationLevel: OptimizationLevel.Release));
+        var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        ImmutableArray<Diagnostic> errors = emit.Diagnostics
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToImmutableArray();
+        Assert.True(
+            emit.Success,
+            $"Product source must compile unchanged.\n{string.Join(Environment.NewLine, errors)}"
+                + $"\n--- source ---\n{source}");
+        stream.Position = 0;
+        return new CompiledAssembly(
+            stream,
+            new PEReader(stream, PEStreamOptions.LeaveOpen));
+    }
+
+    sealed class CompiledAssembly(MemoryStream stream, PEReader pe) : IDisposable
+    {
+        public PEReader PE { get; } = pe;
+
+        public void Dispose()
+        {
+            PE.Dispose();
+            stream.Dispose();
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
@@ -20,6 +20,12 @@ public sealed class CSharpMemorySafetySpellingCompileTests
         "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExplicitLayoutFixture";
     const string ExplicitAccessorFixtureType =
         "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExplicitAccessorFixture";
+    const string ExtensionEnumFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExtensionEnum";
+    const string ExtensionDelegateFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExtensionDelegate";
+    const string ExtensionInterfaceFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.IMemorySafetyExtensionInterface";
 
     [Theory]
     [InlineData(CSharpMemorySafetyLanguage.Legacy, true)]
@@ -268,6 +274,48 @@ public sealed class CSharpMemorySafetySpellingCompileTests
     }
 
     [Fact]
+    public void ProjectedExtensionsUseDeclaringTypeAdmission()
+    {
+        ApiType enumReceiver = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExtensionEnumFixtureType);
+        ApiType delegateReceiver = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExtensionDelegateFixtureType);
+        ApiType interfaceReceiver = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExtensionInterfaceFixtureType);
+        ApiMember enumExtension = ProjectedExtension(enumReceiver);
+        ApiMember delegateExtension = ProjectedExtension(delegateReceiver);
+        ApiMember interfaceExtension = ProjectedExtension(interfaceReceiver);
+
+        Assert.Equal(ApiMethodSemanticsKind.None, enumExtension.MethodSemantics);
+        Assert.Equal(ApiMethodSemanticsKind.None, delegateExtension.MethodSemantics);
+        Assert.Equal(ApiMethodSemanticsKind.None, interfaceExtension.MethodSemantics);
+        var formatter = new CSharpFormatter(new CSharpFormatOptions
+        {
+            MemorySafetyLanguage =
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+        });
+        string enumDeclaration =
+            formatter.FormatMember(enumReceiver, enumExtension);
+        string delegateDeclaration =
+            formatter.FormatMember(delegateReceiver, delegateExtension);
+        string interfaceDeclaration = new CSharpFormatter(
+            new CSharpFormatOptions
+            {
+                IsExtern = true,
+                MemorySafetyLanguage =
+                    CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+            }).FormatMember(interfaceReceiver, interfaceExtension);
+
+        Assert.True(HasWord(enumDeclaration, "unsafe"));
+        Assert.True(HasWord(delegateDeclaration, "unsafe"));
+        Assert.True(HasWord(interfaceDeclaration, "safe"));
+        Assert.True(HasWord(interfaceDeclaration, "extern"));
+    }
+
+    [Fact]
     public void UpdatedUnsafeConstructorRoundTripsAsOrdinaryAndExplicitExtern()
     {
         ApiType original = ExtractType(
@@ -359,6 +407,12 @@ public sealed class CSharpMemorySafetySpellingCompileTests
 
     static ApiMember Member(ApiType type, string name)
         => Assert.Single(type.Members, member => member.Name == name);
+
+    static ApiMember ProjectedExtension(ApiType type)
+        => Assert.Single(
+            type.Members,
+            member => member.Kind == "extension-method"
+                && member.Name == "Examine");
 
     static void AssertRules(ApiType type, MemorySafetyRulesState expected)
     {

--- a/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
@@ -18,6 +18,8 @@ public sealed class CSharpMemorySafetySpellingCompileTests
         "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetySpellingFixture";
     const string ExplicitLayoutFixtureType =
         "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExplicitLayoutFixture";
+    const string ExplicitAccessorFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExplicitAccessorFixture";
 
     [Theory]
     [InlineData(CSharpMemorySafetyLanguage.Legacy, true)]
@@ -230,6 +232,39 @@ public sealed class CSharpMemorySafetySpellingCompileTests
         Assert.Equal("<batch>", failure.TypeName);
         Assert.Contains("legacy", failure.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("updated", failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceAccessorIsAtomicallyUnavailable()
+    {
+        ApiType original = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExplicitAccessorFixtureType);
+        ApiMember accessor = Assert.Single(
+            original.Members,
+            member => member.Kind == "explicit-interface-implementation");
+
+        Assert.Equal(
+            ApiMethodSemanticsKind.PropertyGetter,
+            accessor.MethodSemantics);
+        var outcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(
+                    original,
+                    CSharpBodyPolicy.Stub,
+                    [accessor]),
+                new CSharpTypePrintOptions
+                {
+                    MemorySafetyLanguage =
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                }));
+
+        Assert.Empty(outcome.SelfNameFailures);
+        CSharpTypePrintDiagnostic failure =
+            Assert.Single(outcome.MemorySafetyFailures);
+        Assert.Equal(original.FullName, failure.TypeName);
+        Assert.Contains(accessor.Name, failure.Message, StringComparison.Ordinal);
+        Assert.Contains("accessor", failure.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpMemorySafetySpellingCompileTests.cs
@@ -26,6 +26,12 @@ public sealed class CSharpMemorySafetySpellingCompileTests
         "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExtensionDelegate";
     const string ExtensionInterfaceFixtureType =
         "ILInspector.Decompiler.Fixtures.NewUnsafe.IMemorySafetyExtensionInterface";
+    const string ExtensionClassFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExtensionClass";
+    const string ExtensionStructFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyExtensionStruct";
+    const string ExtensionContainerFixtureType =
+        "ILInspector.Decompiler.Fixtures.NewUnsafe.MemorySafetyReceiverExtensions";
 
     [Theory]
     [InlineData(CSharpMemorySafetyLanguage.Legacy, true)]
@@ -313,6 +319,86 @@ public sealed class CSharpMemorySafetySpellingCompileTests
         Assert.True(HasWord(delegateDeclaration, "unsafe"));
         Assert.True(HasWord(interfaceDeclaration, "safe"));
         Assert.True(HasWord(interfaceDeclaration, "extern"));
+    }
+
+    [Fact]
+    public void ProjectedExtensionsRefuseReceiverTypesAndCompileInDefiningStaticClass()
+    {
+        ApiType classReceiver = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExtensionClassFixtureType);
+        ApiType structReceiver = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExtensionStructFixtureType);
+        ApiType extensionContainer = ExtractType(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+            ExtensionContainerFixtureType);
+        ApiMember classProjection = ProjectedExtension(classReceiver);
+        ApiMember structProjection = ProjectedExtension(structReceiver);
+
+        foreach ((ApiType receiver, ApiMember projection) in
+            new[] { (classReceiver, classProjection), (structReceiver, structProjection) })
+        {
+            var outcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+                new CSharpTypePrinter().Print(
+                    new CSharpTypePrintRequest(
+                        receiver,
+                        CSharpBodyPolicy.Stub,
+                        [projection]),
+                    new CSharpTypePrintOptions
+                    {
+                        MemorySafetyLanguage =
+                            CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                    }));
+
+            CSharpTypePrintDiagnostic failure =
+                Assert.Single(outcome.MemorySafetyFailures);
+            Assert.Contains("projected extension", failure.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("standalone", failure.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        HashSet<int> declarationTokens =
+        [
+            Assert.IsType<int>(classProjection.MetadataToken),
+            Assert.IsType<int>(structProjection.MetadataToken),
+        ];
+        ApiMember[] declarations = extensionContainer.Members
+            .Where(member => member.MetadataToken is int token
+                && declarationTokens.Contains(token))
+            .ToArray();
+        Assert.Equal(2, declarations.Length);
+        Assert.All(declarations, declaration =>
+        {
+            Assert.Equal("method", declaration.Kind);
+            Assert.True(declaration.IsExtension);
+        });
+
+        var printed = Assert.IsType<CSharpTypePrintOutcome.Printed>(
+            new CSharpTypePrinter().PrintBatch(
+                [
+                    new CSharpTypePrintRequest(
+                        classReceiver,
+                        CSharpBodyPolicy.Skeleton,
+                        []),
+                    new CSharpTypePrintRequest(
+                        structReceiver,
+                        CSharpBodyPolicy.Skeleton,
+                        []),
+                    new CSharpTypePrintRequest(
+                        extensionContainer,
+                        CSharpBodyPolicy.Stub,
+                        declarations),
+                ],
+                new CSharpTypePrintOptions
+                {
+                    MemorySafetyLanguage =
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                })).Result;
+
+        using CompiledAssembly _ = CompileUnchanged(
+            printed.Source,
+            UpdatedParseOptions(),
+            "MemorySafetyProjectedExtensionsInDefiningStaticClass");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -29,6 +29,7 @@ public sealed class DynamicCompilationSiteInventoryTests
             ["CatchEntryFoldingTests.cs"] = (1, "Product-output validity: compiles synthesized try/catch source per case."),
             ["CharElementStorePrinterTests.cs"] = (1, "Product-output validity: compiles printer-produced char-element-store source."),
             ["CoerceChokePointTests.cs"] = (1, "Product-output validity: compiles synthesized coercion source per case."),
+            ["CSharpMemorySafetySpellingCompileTests.cs"] = (1, "Product-output validity: compiles CSharp-produced memory-safety declarations unchanged and re-extracts their contracts."),
             ["CSharpPrinterReceiverTests.cs"] = (1, "Product-output validity: compiles printer receiver-spelling output."),
             ["CSharpPrinterSemanticSpacingTests.cs"] = (1, "Product-output validity: compiles printer-produced nested-function labels and structured-comment lambda bodies."),
             ["DataflowFactsTests.cs"] = (1, "Product-output validity: compiles synthesized dataflow source per case."),
@@ -145,9 +146,11 @@ public sealed class DynamicCompilationSiteInventoryTests
     //     retained-snapshot reference contracts.
     //   #6120 adds CompileReferencePlatformPolicyTests.cs (1 site): binds against
     //     the same retained platform images that Metadata resolves.
-    //   Combined: 46 files, 60 sites.
-    const int ExpectedDynamicFiles = 46;
-    const int ExpectedDynamicSites = 60;
+    //   #6105 adds CSharpMemorySafetySpellingCompileTests.cs (1 site): compiles
+    //     CSharp-produced declarations unchanged and re-extracts their contracts.
+    //   Combined: 47 files, 61 sites.
+    const int ExpectedDynamicFiles = 47;
+    const int ExpectedDynamicSites = 61;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/src/ILInspector.Metadata/ApiMemberAccessors.cs
+++ b/src/ILInspector.Metadata/ApiMemberAccessors.cs
@@ -139,6 +139,14 @@ public static class ApiMemberAccessors
             Kind = isExplicitImplementation
                 ? "explicit-interface-implementation"
                 : "method",
+            MethodSemantics = accessorKind switch
+            {
+                "get" => ApiMethodSemanticsKind.PropertyGetter,
+                "set" or "init" => ApiMethodSemanticsKind.PropertySetter,
+                "add" => ApiMethodSemanticsKind.EventAdder,
+                "remove" => ApiMethodSemanticsKind.EventRemover,
+                _ => null,
+            },
             MetadataToken = token,
             DeclaringType = declaringType,
             ReturnType = returnType,

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -670,6 +670,20 @@ public class ApiParameter
         : $"{Modifier} {EffectiveCanonicalType}";
 }
 
+[Flags]
+[JsonConverter(typeof(JsonStringEnumConverter<ApiMethodSemanticsKind>))]
+public enum ApiMethodSemanticsKind
+{
+    None = 0,
+    PropertyGetter = 1 << 0,
+    PropertySetter = 1 << 1,
+    PropertyOther = 1 << 2,
+    EventAdder = 1 << 3,
+    EventRemover = 1 << 4,
+    EventRaiser = 1 << 5,
+    EventOther = 1 << 6,
+}
+
 public class ApiAccessor
 {
     public string Kind { get; set; } = "";
@@ -1003,6 +1017,15 @@ public class ApiMember
     public string Name { get; set; } = "";
     public string Kind { get; set; } = "";  // method, property, field, event, constructor, operator, explicit-interface-implementation, extension-method
     public List<string> Attributes { get; set; } = [];
+
+    /// <summary>
+    /// The property or event MethodSemantics role for this MethodDef.
+    /// <see cref="ApiMethodSemanticsKind.None"/> is a positive full-extraction
+    /// result; null means the relationship was not retained or could not be
+    /// trusted.
+    /// </summary>
+    [JsonIgnore]
+    public ApiMethodSemanticsKind? MethodSemantics { get; set; }
 
     /// <summary>Raw field-layout observation; null means unavailable or not a field.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -958,6 +958,10 @@ public static class ApiSurfaceExtractor
             // property or event rows. Raiser and Other semantic methods have no
             // ApiMember token slots, so they stay methods.
             var accessorMethods = GetSemanticAccessorMethods(reader, typeDef);
+            MemorySafetyMetadataIndex memorySafety = GetMemorySafetyIndex();
+            bool accessorAssociationsAvailable =
+                memorySafety.Rules is MemorySafetyRulesResult.Available
+                && memorySafety.AssociationFailure is null;
             var runtimeJsExportWrapperCandidateMethods =
                 new Dictionary<string, List<int>>(
                     StringComparer.Ordinal);
@@ -1011,7 +1015,10 @@ public static class ApiSurfaceExtractor
                 // hide the public contract. Public MethodImpl accessors — static
                 // abstract implementations, covariant overrides, VB Implements —
                 // stay on that public row. ApiSurfaceEmitSetTests is the gate.
-                if (accessorMethods.Contains(methodHandle)
+                if (accessorMethods.TryGetValue(
+                        methodHandle,
+                        out ApiMethodSemanticsKind methodSemantics)
+                    && IsCSharpAccessor(methodSemantics)
                     && !(isExplicitInterfaceImplementation
                         && methodAccess == MethodAttributes.Private))
                 {
@@ -1124,6 +1131,11 @@ public static class ApiSurfaceExtractor
                         _ when isExplicitInterfaceImplementation => "explicit-interface-implementation",
                         _ => "method"
                     },
+                    MethodSemantics = accessorAssociationsAvailable
+                        ? accessorMethods.GetValueOrDefault(
+                            methodHandle,
+                            ApiMethodSemanticsKind.None)
+                        : null,
                     IsStatic = modifiers.IsStatic,
                     IsVirtual = modifiers.IsVirtual,
                     IsAbstract = modifiers.IsAbstract,
@@ -1949,7 +1961,10 @@ public static class ApiSurfaceExtractor
                 continue;
 
             string methodName = reader.GetString(method.Name);
-            if ((accessorMethods.Contains(methodHandle)
+            if ((accessorMethods.TryGetValue(
+                        methodHandle,
+                        out ApiMethodSemanticsKind methodSemantics)
+                    && IsCSharpAccessor(methodSemantics)
                     && !(isExplicitImplementation
                         && methodAccess == MethodAttributes.Private))
                 || methodName.StartsWith('<'))
@@ -2431,7 +2446,7 @@ public static class ApiSurfaceExtractor
     }
 
     /// <summary>
-    /// Property getter/setter and event adder/remover bodies from
+    /// Property and event semantic methods from
     /// <c>MethodSemantics</c>. Ordinary accessors are represented by their
     /// property or event row; raiser and Other semantic methods have no
     /// <see cref="ApiMember"/> token slots, so they stay methods.
@@ -2443,35 +2458,55 @@ public static class ApiSurfaceExtractor
     /// because its property or event row does not represent the public contract.
     /// A public MethodImpl accessor is represented by that public row.
     /// </remarks>
-    private static HashSet<MethodDefinitionHandle> GetSemanticAccessorMethods(
+    private static Dictionary<MethodDefinitionHandle, ApiMethodSemanticsKind>
+        GetSemanticAccessorMethods(
         MetadataReader reader,
         TypeDefinition typeDef)
     {
-        HashSet<MethodDefinitionHandle> accessors = [];
+        Dictionary<MethodDefinitionHandle, ApiMethodSemanticsKind> accessors = [];
         foreach (PropertyDefinitionHandle propertyHandle in typeDef.GetProperties())
         {
             PropertyAccessors propertyAccessors =
                 reader.GetPropertyDefinition(propertyHandle).GetAccessors();
-            Add(propertyAccessors.Getter);
-            Add(propertyAccessors.Setter);
+            Add(propertyAccessors.Getter, ApiMethodSemanticsKind.PropertyGetter);
+            Add(propertyAccessors.Setter, ApiMethodSemanticsKind.PropertySetter);
+            foreach (MethodDefinitionHandle other in propertyAccessors.Others)
+                Add(other, ApiMethodSemanticsKind.PropertyOther);
         }
 
         foreach (EventDefinitionHandle eventHandle in typeDef.GetEvents())
         {
             EventAccessors eventAccessors =
                 reader.GetEventDefinition(eventHandle).GetAccessors();
-            Add(eventAccessors.Adder);
-            Add(eventAccessors.Remover);
+            Add(eventAccessors.Adder, ApiMethodSemanticsKind.EventAdder);
+            Add(eventAccessors.Remover, ApiMethodSemanticsKind.EventRemover);
+            Add(eventAccessors.Raiser, ApiMethodSemanticsKind.EventRaiser);
+            foreach (MethodDefinitionHandle other in eventAccessors.Others)
+                Add(other, ApiMethodSemanticsKind.EventOther);
         }
 
         return accessors;
 
-        void Add(MethodDefinitionHandle accessor)
+        void Add(
+            MethodDefinitionHandle accessor,
+            ApiMethodSemanticsKind semantics)
         {
-            if (!accessor.IsNil)
-                accessors.Add(accessor);
+            if (accessor.IsNil)
+                return;
+
+            accessors.TryGetValue(
+                accessor,
+                out ApiMethodSemanticsKind existing);
+            accessors[accessor] = existing | semantics;
         }
     }
+
+    static bool IsCSharpAccessor(ApiMethodSemanticsKind semantics)
+        => (semantics
+            & (ApiMethodSemanticsKind.PropertyGetter
+                | ApiMethodSemanticsKind.PropertySetter
+                | ApiMethodSemanticsKind.EventAdder
+                | ApiMethodSemanticsKind.EventRemover)) != 0;
 
     private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
         MetadataReader reader, TypeDefinition typeDef)
@@ -2995,6 +3030,7 @@ public static class ApiSurfaceExtractor
                     Signature = extension.Signature,
                     SignatureModel = extension.SignatureModel,
                     SignatureDecodeStatus = extension.SignatureDecodeStatus,
+                    MethodSemantics = extension.MethodSemantics,
                     MetadataToken = extension.MetadataToken,
                     IsStatic = extension.IsStatic,
                     IsVirtual = extension.IsVirtual,

--- a/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
+++ b/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
@@ -1130,6 +1130,139 @@ public sealed class CSharpMemorySafetySpellingTests
     }
 
     [Theory]
+    [InlineData("enum", ApiTypeLayout.Auto)]
+    [InlineData("delegate", ApiTypeLayout.Auto)]
+    [InlineData("struct", ApiTypeLayout.Extended)]
+    public void ProjectedExtensionsUseModuleRatherThanReceiverTypeAdmission(
+        string receiverKind,
+        ApiTypeLayout layout)
+    {
+        ApiType receiver = Type(
+            MemorySafetyRulesState.Updated,
+            layout: layout,
+            kind: receiverKind);
+        ApiMember extension = Method(
+            "Examine",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "extension-method");
+        extension.IsExtension = true;
+        extension.Signature =
+            $"int Examine({receiver.FullName} value)";
+        extension.SignatureModel!.Parameters =
+        [
+            new ApiParameter
+            {
+                Modifier = "this",
+                Type = receiver.FullName,
+                Name = "value",
+            },
+        ];
+
+        string declaration = Format(
+            receiver,
+            extension,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.True(HasWord(declaration, "unsafe"));
+        Assert.Contains("Examine", declaration, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProjectedExternExtensionUsesDeclarationRatherThanInterfaceReceiver()
+    {
+        ApiType receiver = Type(
+            MemorySafetyRulesState.Updated,
+            kind: "interface");
+        ApiMember extension = Method(
+            "Examine",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "extension-method");
+        extension.IsExtension = true;
+        extension.Signature =
+            $"int Examine({receiver.FullName} value)";
+        extension.SignatureModel!.Parameters =
+        [
+            new ApiParameter
+            {
+                Modifier = "this",
+                Type = receiver.FullName,
+                Name = "value",
+            },
+        ];
+
+        string declaration = Format(
+            receiver,
+            extension,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+            isExtern: true);
+
+        Assert.True(HasWord(declaration, "safe"));
+        Assert.True(HasWord(declaration, "extern"));
+    }
+
+    [Fact]
+    public void WholeTypeExternExtensionRetainsInterfaceReceiverRestriction()
+    {
+        ApiType receiver = Type(
+            MemorySafetyRulesState.Updated,
+            kind: "interface");
+        ApiMember extension = Method(
+            "Examine",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "extension-method");
+        extension.IsExtension = true;
+        extension.Signature =
+            $"int Examine({receiver.FullName} value)";
+        extension.SignatureModel!.Parameters =
+        [
+            new ApiParameter
+            {
+                Modifier = "this",
+                Type = receiver.FullName,
+                Name = "value",
+            },
+        ];
+        receiver.Members = [extension];
+
+        NotSupportedException exception =
+            Assert.Throws<NotSupportedException>(
+                () => new CSharpTypePrinter().Print(
+                    new CSharpTypePrintRequest(
+                        receiver,
+                        members: [extension],
+                        memberPolicyOverrides:
+                        [
+                            new CSharpMemberPolicy(
+                                extension,
+                                CSharpBodyPolicy.Extern),
+                        ]),
+                    Options(
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        Assert.Contains("extern", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cannot", exception.Message, StringComparison.OrdinalIgnoreCase);
+        NotSupportedException unitException =
+            Assert.Throws<NotSupportedException>(
+                () => new CSharpFormatter(new CSharpFormatOptions
+                {
+                    IsExtern = true,
+                    MemorySafetyLanguage =
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                }).FormatTypeUnit(
+                    receiver,
+                    [extension]));
+
+        Assert.Contains("extern", unitException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cannot", unitException.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
     [InlineData(ApiMethodSemanticsKind.PropertyGetter)]
     [InlineData(ApiMethodSemanticsKind.PropertySetter)]
     [InlineData(ApiMethodSemanticsKind.PropertyOther)]

--- a/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
+++ b/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
@@ -1263,6 +1263,69 @@ public sealed class CSharpMemorySafetySpellingTests
     }
 
     [Theory]
+    [InlineData("class")]
+    [InlineData("struct")]
+    public void WholeTypeProjectedExtensionsAreUnavailable(
+        string receiverKind)
+    {
+        ApiType receiver = Type(
+            MemorySafetyRulesState.Updated,
+            kind: receiverKind);
+        ApiMember extension = Method(
+            "Examine",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "extension-method");
+        extension.IsExtension = true;
+        extension.Signature =
+            $"int Examine({receiver.FullName} value)";
+        extension.SignatureModel!.Parameters =
+        [
+            new ApiParameter
+            {
+                Modifier = "this",
+                Type = receiver.FullName,
+                Name = "value",
+            },
+        ];
+        receiver.Members = [extension];
+
+        string standalone = Format(
+            receiver,
+            extension,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+        Assert.True(HasWord(standalone, "unsafe"));
+
+        var outcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(
+                    receiver,
+                    CSharpBodyPolicy.Stub,
+                    [extension]),
+                Options(
+                    CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        CSharpTypePrintDiagnostic failure =
+            Assert.Single(outcome.MemorySafetyFailures);
+        Assert.Contains("projected extension", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("standalone", failure.Message, StringComparison.OrdinalIgnoreCase);
+
+        NotSupportedException unitException =
+            Assert.Throws<NotSupportedException>(
+                () => new CSharpFormatter(new CSharpFormatOptions
+                {
+                    MemorySafetyLanguage =
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                }).FormatTypeUnit(
+                    receiver,
+                    [extension]));
+
+        Assert.Contains("projected extension", unitException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("standalone", unitException.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
     [InlineData(ApiMethodSemanticsKind.PropertyGetter)]
     [InlineData(ApiMethodSemanticsKind.PropertySetter)]
     [InlineData(ApiMethodSemanticsKind.PropertyOther)]

--- a/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
+++ b/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
@@ -1129,6 +1129,57 @@ public sealed class CSharpMemorySafetySpellingTests
         Assert.Contains(name, declaration, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(ApiMethodSemanticsKind.PropertyGetter)]
+    [InlineData(ApiMethodSemanticsKind.PropertySetter)]
+    [InlineData(ApiMethodSemanticsKind.PropertyOther)]
+    [InlineData(ApiMethodSemanticsKind.EventAdder)]
+    [InlineData(ApiMethodSemanticsKind.EventRemover)]
+    [InlineData(ApiMethodSemanticsKind.EventRaiser)]
+    [InlineData(ApiMethodSemanticsKind.EventOther)]
+    public void MethodSemanticsAccessorsAreUnavailable(
+        ApiMethodSemanticsKind semantics)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "IContract.Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "explicit-interface-implementation");
+        member.MethodSemantics = semantics;
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                member,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("accessor", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("supported", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MissingMethodSemanticsEvidenceIsUnavailable()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        member.MethodSemantics = null;
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                member,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("MethodSemantics", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("unavailable", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void ConstructorsPreserveOnlySupportedUpdatedContracts()
     {
@@ -1491,6 +1542,7 @@ public sealed class CSharpMemorySafetySpellingTests
         {
             Name = name,
             Kind = kind,
+            MethodSemantics = ApiMethodSemanticsKind.None,
             MetadataToken = token,
             IsStatic = kind != "constructor" && kind != "finalizer"
                 && kind != "explicit-interface-implementation",

--- a/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
+++ b/tests/ILInspector.CSharp.Tests/CSharpMemorySafetySpellingTests.cs
@@ -1,0 +1,1608 @@
+using System.Text.RegularExpressions;
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp.Tests;
+
+public sealed class CSharpMemorySafetySpellingTests
+{
+    static readonly Guid ModuleId = Guid.Parse("b6dbdca1-2db5-4777-a021-7aa862120af8");
+    static readonly Guid OtherModuleId = Guid.Parse("a091c075-78a5-4b57-bf95-c28f72d28f64");
+    const int TypeToken = 0x02000001;
+
+    [Theory]
+    [InlineData(
+        MemorySafetyRulesState.Updated,
+        ContractKind.Explicit,
+        MemorySafetyPointerEvidence.Absent,
+        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+        true)]
+    [InlineData(
+        MemorySafetyRulesState.Updated,
+        ContractKind.None,
+        MemorySafetyPointerEvidence.Present,
+        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+        false)]
+    [InlineData(
+        MemorySafetyRulesState.Legacy,
+        ContractKind.Implicit,
+        MemorySafetyPointerEvidence.Present,
+        CSharpMemorySafetyLanguage.Legacy,
+        true)]
+    [InlineData(
+        MemorySafetyRulesState.Legacy,
+        ContractKind.Implicit,
+        MemorySafetyPointerEvidence.Present,
+        CSharpMemorySafetyLanguage.RelaxedPointerSyntax,
+        false)]
+    [InlineData(
+        MemorySafetyRulesState.Legacy,
+        ContractKind.None,
+        MemorySafetyPointerEvidence.Absent,
+        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+        false)]
+    public void MethodModifierMatrixSeparatesBinaryRulesFromLanguageCapability(
+        MemorySafetyRulesState rules,
+        ContractKind contract,
+        MemorySafetyPointerEvidence pointer,
+        CSharpMemorySafetyLanguage language,
+        bool expectedUnsafe)
+    {
+        ApiType type = Type(rules);
+        ApiMember member = Method("Run", rules, contract, pointer);
+
+        string declaration = Format(type, member, language);
+
+        Assert.Equal(expectedUnsafe, HasWord(declaration, "unsafe"));
+        Assert.False(HasWord(declaration, "safe"));
+    }
+
+    [Fact]
+    public void CompatibilityModeRetainsLegacyIsUnsafeOutput()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Run",
+            Kind = "method",
+            IsStatic = true,
+            IsUnsafe = true,
+            SignatureModel = new ApiSignature
+            {
+                MemberName = "Run",
+                ReturnType = "int",
+            },
+        };
+
+        string declaration = new CSharpFormatter().FormatMember(type, member);
+
+        Assert.True(HasWord(declaration, "unsafe"));
+    }
+
+    [Fact]
+    public void UpdatedNoneIgnoresCompatibilityIsUnsafe()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        member.IsUnsafe = true;
+
+        string declaration = Format(
+            type,
+            member,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.False(HasWord(declaration, "unsafe"));
+    }
+
+    [Theory]
+    [InlineData(CSharpMemorySafetyLanguage.Legacy)]
+    [InlineData(CSharpMemorySafetyLanguage.RelaxedPointerSyntax)]
+    public void UpdatedContractsRequireUpdatedCallerContractSyntax(
+        CSharpMemorySafetyLanguage language)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(type, member, language));
+
+        Assert.Contains("updated caller contracts", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(ApiTypeLayout.Explicit, true)]
+    [InlineData(ApiTypeLayout.Auto, false)]
+    [InlineData(ApiTypeLayout.Sequential, false)]
+    public void UpdatedNoneInstanceFieldsSpellSafeOnlyForRequiredLayouts(
+        ApiTypeLayout layout,
+        bool expectedSafe)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated, layout: layout);
+        ApiMember field = Field(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+
+        string declaration = Format(
+            type,
+            field,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.Equal(expectedSafe, HasWord(declaration, "safe"));
+        Assert.False(HasWord(declaration, "unsafe"));
+        Assert.Equal(
+            layout == ApiTypeLayout.Explicit,
+            declaration.Contains(
+                "[global::System.Runtime.InteropServices.FieldOffsetAttribute(0)]",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ExtendedLayoutIsVisibleUnavailable()
+    {
+        ApiType type = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Extended);
+        ApiMember field = Field(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                field,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("extended layout", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("supported", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LegacyExplicitLayoutDoesNotEnterUpdatedLayoutReplay()
+    {
+        ApiType type = Type(
+            MemorySafetyRulesState.Legacy,
+            layout: ApiTypeLayout.Explicit);
+        type.LayoutDetails = null;
+        ApiMember field = Field(
+            "Value",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        field.FieldLayout = null;
+        type.Members = [field];
+
+        CSharpTypePrintResult printed = Printed(new CSharpTypePrinter().Print(
+            new CSharpTypePrintRequest(type),
+            Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        Assert.DoesNotContain("StructLayout", printed.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("FieldOffset", printed.Source, StringComparison.Ordinal);
+        Assert.Contains("public int Value;", printed.Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExplicitLayoutPrinterEmitsTypeAndEveryInstanceFieldOffset()
+    {
+        ApiType type = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Explicit);
+        ApiMember safeField = Field(
+            "SafeValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            offset: 0);
+        ApiMember unsafeField = Field(
+            "UnsafeValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            offset: 4);
+        ApiMember staticField = Field(
+            "StaticValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            isStatic: true);
+        type.Attributes = ["Samples.TypeMarker"];
+        safeField.Attributes = ["Samples.FieldMarker"];
+        type.Members = [safeField, unsafeField, staticField];
+
+        CSharpTypePrintResult printed = Printed(new CSharpTypePrinter().Print(
+            new CSharpTypePrintRequest(type),
+            Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts) with
+            {
+                IncludeCustomAttributes = true,
+            }));
+
+        Assert.Contains(
+            "[global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Explicit, Size = 32, Pack = 2)]\n[Samples.TypeMarker]",
+            printed.Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "[global::System.Runtime.InteropServices.FieldOffsetAttribute(0)]\n    [Samples.FieldMarker]\n    public safe int SafeValue;",
+            printed.Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "[global::System.Runtime.InteropServices.FieldOffsetAttribute(4)]\n    public unsafe int UnsafeValue;",
+            printed.Source,
+            StringComparison.Ordinal);
+        Assert.Contains("public static int StaticValue;", printed.Source, StringComparison.Ordinal);
+        string[] lines = printed.Source.Split('\n');
+        int staticLine = Array.FindIndex(
+            lines,
+            line => line.Contains("StaticValue", StringComparison.Ordinal));
+        Assert.True(staticLine > 0);
+        Assert.DoesNotContain(
+            "FieldOffsetAttribute",
+            lines[staticLine - 1],
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("missing", "field-layout")]
+    [InlineData("module", "module")]
+    [InlineData("type", "TypeDef")]
+    [InlineData("field", "FieldDef")]
+    [InlineData("offset", "offset")]
+    public void ExplicitFieldLayoutEvidenceMustBeUsableAndAssociated(
+        string defect,
+        string expectedText)
+    {
+        ApiType type = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Explicit);
+        ApiMember field = Field(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        ApiFieldLayoutFacts valid = field.FieldLayout!;
+        field.FieldLayout = defect switch
+        {
+            "missing" => null,
+            "module" => valid with { ModuleVersionId = OtherModuleId },
+            "type" => valid with { DeclaringTypeToken = TypeToken + 1 },
+            "field" => valid with { FieldToken = valid.FieldToken + 1 },
+            "offset" => valid with { Offset = null },
+            _ => throw new ArgumentOutOfRangeException(nameof(defect)),
+        };
+        type.Members = [field];
+
+        var outcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(type),
+                Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        CSharpTypePrintDiagnostic failure = Assert.Single(outcome.MemorySafetyFailures);
+        Assert.Equal(type.FullName, failure.TypeName);
+        Assert.Contains("Value", failure.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedText, failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("missing", "details")]
+    [InlineData("module", "module")]
+    [InlineData("token", "TypeDef")]
+    [InlineData("size", "size")]
+    [InlineData("pack", "packing")]
+    public void ExplicitTypeLayoutEvidenceMustBeRepresentableAndAssociated(
+        string defect,
+        string expectedText)
+    {
+        ApiType type = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Explicit);
+        ApiTypeLayoutFacts valid = type.LayoutDetails!;
+        type.LayoutDetails = defect switch
+        {
+            "missing" => null,
+            "module" => valid with { ModuleVersionId = OtherModuleId },
+            "token" => valid with { TypeToken = TypeToken + 1 },
+            "size" => valid with { Size = -1 },
+            "pack" => valid with { PackingSize = 3 },
+            _ => throw new ArgumentOutOfRangeException(nameof(defect)),
+        };
+        ApiMember field = Field(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        type.Members = [field];
+
+        var outcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(type),
+                Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        CSharpTypePrintDiagnostic failure = Assert.Single(outcome.MemorySafetyFailures);
+        Assert.Equal(type.FullName, failure.TypeName);
+        Assert.Contains(expectedText, failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UpdatedFieldNeighborsDoNotBorrowInstanceStorageRules()
+    {
+        ApiType explicitType = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Explicit);
+        ApiMember staticField = Field(
+            "StaticValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            isStatic: true);
+        ApiMember unsafeField = Field(
+            "UnsafeValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Unavailable);
+        ApiMember ordinaryField = Field(
+            "OrdinaryValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        ApiType sequentialType = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Sequential);
+
+        string staticDeclaration = Format(
+            explicitType,
+            staticField,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+        string unsafeDeclaration = Format(
+            Type(MemorySafetyRulesState.Updated, layout: null),
+            unsafeField,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+        string ordinaryDeclaration = Format(
+            sequentialType,
+            ordinaryField,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.False(HasWord(staticDeclaration, "safe"));
+        Assert.False(HasWord(staticDeclaration, "unsafe"));
+        Assert.True(HasWord(unsafeDeclaration, "unsafe"));
+        Assert.False(HasWord(unsafeDeclaration, "safe"));
+        Assert.False(HasWord(ordinaryDeclaration, "safe"));
+        Assert.False(HasWord(ordinaryDeclaration, "unsafe"));
+    }
+
+    [Fact]
+    public void MissingLayoutIsRequiredOnlyForUpdatedNoneInstanceField()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated, layout: null);
+        ApiMember none = Field(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        ApiMember explicitContract = Field(
+            "UnsafeValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent);
+        ApiMember staticField = Field(
+            "StaticValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            isStatic: true);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                none,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("Value", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("layout", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.True(HasWord(
+            Format(
+                type,
+                explicitContract,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts),
+            "unsafe"));
+        Assert.False(HasWord(
+            Format(
+                type,
+                staticField,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts),
+            "safe"));
+    }
+
+    [Fact]
+    public void ExplicitExternAndOrdinaryStubShapesRemainDistinct()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember safeExtern = Method(
+            "Native",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        safeExtern.HasMethodBody = false;
+        ApiMember unsafeExtern = Method(
+            "RiskyNative",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent);
+        unsafeExtern.HasMethodBody = false;
+
+        string safeDeclaration = Format(
+            type,
+            safeExtern,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+            isExtern: true);
+        string unsafeDeclaration = Format(
+            type,
+            unsafeExtern,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+            isExtern: true);
+        string ordinaryDeclaration = Format(
+            type,
+            safeExtern,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.True(HasWord(safeDeclaration, "extern"));
+        Assert.True(HasWord(safeDeclaration, "safe"));
+        Assert.False(HasWord(safeDeclaration, "unsafe"));
+        Assert.True(HasWord(unsafeDeclaration, "extern"));
+        Assert.True(HasWord(unsafeDeclaration, "unsafe"));
+        Assert.False(HasWord(unsafeDeclaration, "safe"));
+        Assert.False(HasWord(ordinaryDeclaration, "extern"));
+        Assert.False(HasWord(ordinaryDeclaration, "safe"));
+    }
+
+    [Fact]
+    public void TypePrinterExternPolicyDoesNotInferExternFromMissingRva()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "Native",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        member.HasMethodBody = false;
+        member.MethodImplementation = new ApiMethodImplementationFacts(
+            ModuleId,
+            member.MetadataToken!.Value,
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Static,
+            System.Reflection.MethodImplAttributes.IL,
+            HasBodyRva: false);
+        type.Members = [member];
+        var options = new CSharpTypePrintOptions
+        {
+            MemorySafetyLanguage = CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+        };
+
+        CSharpTypePrintResult external = Printed(new CSharpTypePrinter().Print(
+            new CSharpTypePrintRequest(
+                type,
+                memberPolicyOverrides:
+                [
+                    new CSharpMemberPolicy(member, CSharpBodyPolicy.Extern),
+                ]),
+            options));
+        CSharpTypePrintResult stub = Printed(new CSharpTypePrinter().Print(
+            new CSharpTypePrintRequest(
+                type,
+                memberPolicyOverrides:
+                [
+                    new CSharpMemberPolicy(member, CSharpBodyPolicy.Stub),
+                ]),
+            options));
+
+        Assert.True(HasWord(external.Source, "extern"));
+        Assert.True(HasWord(external.Source, "safe"));
+        Assert.False(HasWord(stub.Source, "extern"));
+        Assert.False(HasWord(stub.Source, "safe"));
+    }
+
+    [Theory]
+    [InlineData("field", "class", false)]
+    [InlineData("property", "class", false)]
+    [InlineData("event", "class", false)]
+    [InlineData("method", "class", true)]
+    [InlineData("method", "interface", false)]
+    [InlineData("static-constructor", "class", false)]
+    [InlineData("finalizer", "class", false)]
+    public void ExternPolicyRejectsUnsupportedDeclarationShapes(
+        string memberKind,
+        string typeKind,
+        bool isAbstract)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated, kind: typeKind);
+        ApiMember member = memberKind == "field"
+            ? Field(
+                "Value",
+                MemorySafetyRulesState.Updated,
+                ContractKind.None,
+                MemorySafetyPointerEvidence.Absent)
+            : Method(
+                memberKind == "static-constructor" ? ".cctor" :
+                memberKind == "finalizer" ? "Finalize" : "Run",
+                MemorySafetyRulesState.Updated,
+                ContractKind.None,
+                MemorySafetyPointerEvidence.Absent,
+                kind: memberKind == "static-constructor"
+                    ? "constructor"
+                    : memberKind);
+        member.IsStatic = memberKind == "static-constructor" || member.IsStatic;
+        member.IsAbstract = isAbstract;
+        member.IsFinalizer = memberKind == "finalizer";
+        type.Members = [member];
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(
+                    type,
+                    memberPolicyOverrides:
+                    [
+                        new CSharpMemberPolicy(member, CSharpBodyPolicy.Extern),
+                    ]),
+                new CSharpTypePrintOptions
+                {
+                    MemorySafetyLanguage =
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                }));
+
+        Assert.Contains(member.Name, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExternPolicyAcceptsAnOrdinaryInstanceConstructor()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember constructor = Method(
+            ".ctor",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "constructor");
+        type.Members = [constructor];
+
+        CSharpTypePrintResult printed = Printed(new CSharpTypePrinter().Print(
+            new CSharpTypePrintRequest(
+                type,
+                memberPolicyOverrides:
+                [
+                    new CSharpMemberPolicy(
+                        constructor,
+                        CSharpBodyPolicy.Extern),
+                ]),
+            Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        Assert.True(HasWord(printed.Source, "extern"));
+        Assert.True(HasWord(printed.Source, "safe"));
+    }
+
+    [Fact]
+    public void ExternPolicyRejectsAnAttachedBody()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "Native",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        type.Members = [member];
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(
+                    type,
+                    memberPolicyOverrides:
+                    [
+                        new CSharpMemberPolicy(
+                            member,
+                            CSharpBodyPolicy.Extern,
+                            new CSharpBlockBody("return 0;")),
+                    ]),
+                new CSharpTypePrintOptions
+                {
+                    MemorySafetyLanguage =
+                        CSharpMemorySafetyLanguage.UpdatedCallerContracts,
+                }));
+
+        Assert.Contains("cannot carry a body", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(CSharpMemorySafetyLanguage.Legacy)]
+    [InlineData(CSharpMemorySafetyLanguage.RelaxedPointerSyntax)]
+    [InlineData(CSharpMemorySafetyLanguage.UpdatedCallerContracts)]
+    public void LegacyBodyRequirementsUseAMemberModifier(
+        CSharpMemorySafetyLanguage language)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Legacy);
+        ApiMember method = Method(
+            "Run",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Unavailable);
+        ApiMember field = Field(
+            "Value",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Unavailable);
+        var formatter = Formatter(language);
+
+        string methodDeclaration = formatter.FormatMemberWithBody(
+            type,
+            method,
+            new CSharpBlockBody("return 0;")
+            {
+                RequiresUnsafeModifier = true,
+            });
+        string fieldDeclaration = formatter.FormatMemberWithBody(
+            type,
+            field,
+            new CSharpFieldInitializer("0")
+            {
+                RequiresUnsafeModifier = true,
+            });
+
+        Assert.True(HasWord(methodDeclaration, "unsafe"));
+        Assert.True(HasWord(fieldDeclaration, "unsafe"));
+    }
+
+    [Fact]
+    public void TypePrinterUsesBodyRequirementBeforeDiagnosingUnavailablePointerEvidence()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Legacy);
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Unavailable);
+        type.Members = [member];
+        var body = new CSharpBlockBody("return 0;")
+        {
+            RequiresUnsafeModifier = true,
+        };
+
+        CSharpTypePrintResult printed = Printed(new CSharpTypePrinter().Print(
+            new CSharpTypePrintRequest(
+                type,
+                memberPolicyOverrides:
+                [
+                    new CSharpMemberPolicy(
+                        member,
+                        CSharpBodyPolicy.Full,
+                        body),
+                ]),
+            Options(CSharpMemorySafetyLanguage.Legacy)));
+
+        Assert.True(HasWord(printed.Source, "unsafe"));
+    }
+
+    [Theory]
+    [InlineData(CSharpMemorySafetyLanguage.Legacy)]
+    [InlineData(CSharpMemorySafetyLanguage.RelaxedPointerSyntax)]
+    [InlineData(CSharpMemorySafetyLanguage.UpdatedCallerContracts)]
+    public void LegacyForceUnsafeSuppliesContextWithoutPointerEvidence(
+        CSharpMemorySafetyLanguage language)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Legacy);
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Unavailable);
+        var formatter = new CSharpFormatter(new CSharpFormatOptions
+        {
+            ForceUnsafe = true,
+            MemorySafetyLanguage = language,
+        });
+
+        string declaration = formatter.FormatMember(type, member);
+
+        Assert.True(HasWord(declaration, "unsafe"));
+    }
+
+    [Theory]
+    [InlineData(ContractKind.None)]
+    [InlineData(ContractKind.Explicit)]
+    public void UpdatedBodyRequirementsAreUnavailableEvenWithAContract(
+        ContractKind contract)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Updated,
+            contract,
+            MemorySafetyPointerEvidence.Absent);
+        var body = new CSharpBlockBody("return 0;")
+        {
+            RequiresUnsafeModifier = true,
+        };
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Formatter(CSharpMemorySafetyLanguage.UpdatedCallerContracts)
+                .FormatMemberWithBody(type, member, body));
+
+        Assert.Contains("Run", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("body", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UpdatedFieldInitializerBodyRequirementIsUnavailable()
+    {
+        ApiType type = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Sequential);
+        ApiMember field = Field(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        var initializer = new CSharpFieldInitializer("0")
+        {
+            RequiresUnsafeModifier = true,
+        };
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Formatter(CSharpMemorySafetyLanguage.UpdatedCallerContracts)
+                .FormatMemberWithBody(type, field, initializer));
+
+        Assert.Contains("Value", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("body", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WholeTypeFieldInitializerUsesFinalSafetyShapeAtomically()
+    {
+        ApiType legacyType = Type(
+            MemorySafetyRulesState.Legacy,
+            layout: ApiTypeLayout.Sequential);
+        ApiMember legacyField = Field(
+            "LegacyValue",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Unavailable);
+        legacyType.Members = [legacyField];
+        var legacyInitializer = new CSharpFieldInitializer("0")
+        {
+            RequiresUnsafeModifier = true,
+        };
+        var legacyRequest = new CSharpTypePrintRequest(
+            legacyType,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    legacyField,
+                    CSharpBodyPolicy.Full,
+                    legacyInitializer),
+            ]);
+
+        CSharpTypePrintResult legacy = Printed(new CSharpTypePrinter().Print(
+            legacyRequest,
+            Options(CSharpMemorySafetyLanguage.Legacy)));
+
+        Assert.True(HasWord(legacy.Source, "unsafe"));
+
+        ApiType updatedType = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Sequential);
+        ApiMember updatedField = Field(
+            "UpdatedValue",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        updatedType.Members = [updatedField];
+        var updatedRequest = new CSharpTypePrintRequest(
+            updatedType,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    updatedField,
+                    CSharpBodyPolicy.Full,
+                    new CSharpFieldInitializer("0")
+                    {
+                        RequiresUnsafeModifier = true,
+                    }),
+            ]);
+
+        var updated = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().Print(
+                updatedRequest,
+                Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        Assert.Empty(updated.SelfNameFailures);
+        CSharpTypePrintDiagnostic failure =
+            Assert.Single(updated.MemorySafetyFailures);
+        Assert.Equal(updatedType.FullName, failure.TypeName);
+        Assert.Contains("UpdatedValue", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("body", failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(MemorySafetyRulesState.Unsupported)]
+    [InlineData(MemorySafetyRulesState.Malformed)]
+    [InlineData(MemorySafetyRulesState.Conflicting)]
+    public void UnrecognizedRulesAreUnavailable(MemorySafetyRulesState rules)
+    {
+        ApiType type = Type(rules);
+        ApiMember member = Method(
+            "Run",
+            rules,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                member,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("rules", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UnavailableRuleAcquisitionIsUnavailable()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        type.MemorySafety = new ApiModuleMemorySafetyFacts(
+            ModuleId,
+            new MemorySafetyRulesResult.Unavailable(
+                new MemorySafetyMetadataFailure(
+                    MemorySafetyMetadataFailureKind.Malformed,
+                    "Synthetic unavailable rules."),
+                []));
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                member,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("rules", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MissingOrUnavailableFactsRemainVisible()
+    {
+        ApiType missingRules = Type(MemorySafetyRulesState.Updated);
+        missingRules.MemorySafety = null;
+        ApiMember member = Method(
+            "Run",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember missingMemberFacts = Method(
+            "Missing",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        missingMemberFacts.MemorySafety = null;
+        ApiMember unavailableContract = Method(
+            "Unavailable",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Unavailable,
+            MemorySafetyPointerEvidence.Absent);
+
+        Assert.Contains(
+            "memory-safety facts",
+            Assert.Throws<NotSupportedException>(() => Format(
+                missingRules,
+                member,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts)).Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "Missing",
+            Assert.Throws<NotSupportedException>(() => Format(
+                type,
+                missingMemberFacts,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts)).Message,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Unavailable",
+            Assert.Throws<NotSupportedException>(() => Format(
+                type,
+                unavailableContract,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts)).Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PointerEvidenceIsRequiredOnlyWhenItChangesTheModifier()
+    {
+        ApiType legacy = Type(MemorySafetyRulesState.Legacy);
+        ApiMember unavailablePointer = Method(
+            "Pointer",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.Implicit,
+            MemorySafetyPointerEvidence.Unavailable,
+            parameterType: "int*");
+        ApiType updated = Type(MemorySafetyRulesState.Updated);
+        ApiMember explicitContract = Method(
+            "Risky",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Unavailable);
+
+        Assert.Throws<NotSupportedException>(() => Format(
+            legacy,
+            unavailablePointer,
+            CSharpMemorySafetyLanguage.Legacy));
+        Assert.False(HasWord(
+            Format(
+                legacy,
+                unavailablePointer,
+                CSharpMemorySafetyLanguage.RelaxedPointerSyntax),
+            "unsafe"));
+        Assert.True(HasWord(
+            Format(
+                updated,
+                explicitContract,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts),
+            "unsafe"));
+    }
+
+    [Theory]
+    [InlineData(CSharpMemorySafetyLanguage.Legacy)]
+    [InlineData(CSharpMemorySafetyLanguage.RelaxedPointerSyntax)]
+    [InlineData(CSharpMemorySafetyLanguage.UpdatedCallerContracts)]
+    public void LegacyNonePointerFieldCannotAcquireAnImplicitContract(
+        CSharpMemorySafetyLanguage language)
+    {
+        ApiType type = Type(
+            MemorySafetyRulesState.Legacy,
+            layout: ApiTypeLayout.Sequential);
+        ApiMember field = Field(
+            "Buffer",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Present,
+            fixedBuffer: MemorySafetyFixedBufferEvidence.Present);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(type, field, language));
+
+        Assert.Contains("Buffer", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("implicit", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ModelAwareReplayRejectsDegradedOrUnstructuredSignatures()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember degraded = Method(
+            "Degraded",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        degraded.SignatureDecodeStatus = SignatureDecodeStatus.Degraded;
+        ApiMember unstructured = Method(
+            "Unstructured",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        unstructured.Signature = "int Unstructured()";
+        unstructured.SignatureModel = null;
+
+        NotSupportedException degradedException = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                degraded,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+        NotSupportedException unstructuredException = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                unstructured,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("Degraded", degradedException.Message, StringComparison.Ordinal);
+        Assert.Contains("signature", degradedException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Unstructured", unstructuredException.Message, StringComparison.Ordinal);
+        Assert.Contains("signature", unstructuredException.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DefiningEvidenceMustMatchModuleAndRulesState()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember wrongModule = Method(
+            "WrongModule",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            moduleId: OtherModuleId);
+        ApiMember wrongRules = Method(
+            "WrongRules",
+            MemorySafetyRulesState.Legacy,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        ApiMember wrongToken = Method(
+            "WrongToken",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        var wrongTokenContract =
+            Assert.IsType<MemorySafetyMemberContractResult.None>(
+                wrongToken.MemorySafety!.CallerContract);
+        wrongToken.MemorySafety = wrongToken.MemorySafety with
+        {
+            CallerContract = new MemorySafetyMemberContractResult.None(
+                wrongTokenContract.Evidence with
+                {
+                    MemberToken = wrongTokenContract.Evidence.MemberToken + 1,
+                }),
+        };
+        ApiType explicitType = Type(
+            MemorySafetyRulesState.Updated,
+            layout: ApiTypeLayout.Explicit);
+        ApiMember projectedField = Field(
+            "ProjectedField",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            moduleId: OtherModuleId);
+
+        NotSupportedException moduleException = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                wrongModule,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+        NotSupportedException rulesException = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                wrongRules,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+        NotSupportedException tokenException = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                wrongToken,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+        NotSupportedException layoutException = Assert.Throws<NotSupportedException>(
+            () => Format(
+                explicitType,
+                projectedField,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("WrongModule", moduleException.Message, StringComparison.Ordinal);
+        Assert.Contains("module", moduleException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WrongRules", rulesException.Message, StringComparison.Ordinal);
+        Assert.Contains("rules", rulesException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WrongToken", tokenException.Message, StringComparison.Ordinal);
+        Assert.Contains("declaration", tokenException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ProjectedField", layoutException.Message, StringComparison.Ordinal);
+        Assert.Contains("module", layoutException.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("extension-method", "Extend")]
+    [InlineData("explicit-interface-implementation", "IWorker.Run")]
+    public void MethodLikeFormsPreserveExplicitUpdatedContracts(
+        string kind,
+        string name)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            name,
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            kind: kind);
+        // These Metadata projections retain declaration details in Signature
+        // that the shared writer does not yet lower from ApiSignature.
+        member.Signature = kind == "extension-method"
+            ? $"int {name}(Widget value)"
+            : $"int {name}()";
+        if (kind == "extension-method")
+        {
+            member.IsExtension = true;
+            member.SignatureModel!.Parameters =
+            [
+                new ApiParameter
+                {
+                    Modifier = "this",
+                    Type = "Widget",
+                    Name = "value",
+                },
+            ];
+        }
+
+        string declaration = Format(
+            type,
+            member,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.True(HasWord(declaration, "unsafe"));
+        Assert.Contains(name, declaration, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConstructorsPreserveOnlySupportedUpdatedContracts()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember constructor = Method(
+            ".ctor",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "constructor");
+        ApiMember staticConstructor = Method(
+            ".cctor",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "constructor");
+        staticConstructor.IsStatic = true;
+        ApiMember finalizer = Method(
+            "Finalize",
+            MemorySafetyRulesState.Updated,
+            ContractKind.Explicit,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "finalizer");
+        finalizer.IsFinalizer = true;
+        ApiMember safeStaticConstructor = Method(
+            ".cctor",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "constructor");
+        safeStaticConstructor.IsStatic = true;
+        ApiMember safeFinalizer = Method(
+            "Finalize",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "finalizer");
+        safeFinalizer.IsFinalizer = true;
+
+        Assert.True(HasWord(
+            Format(
+                type,
+                constructor,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts),
+            "unsafe"));
+        Assert.Throws<NotSupportedException>(() => Format(
+            type,
+            staticConstructor,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+        Assert.Throws<NotSupportedException>(() => Format(
+            type,
+            finalizer,
+            CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+        Assert.False(HasWord(
+            Format(
+                type,
+                safeStaticConstructor,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts),
+            "unsafe"));
+        Assert.False(HasWord(
+            Format(
+                type,
+                safeFinalizer,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts),
+            "unsafe"));
+    }
+
+    [Theory]
+    [InlineData("property")]
+    [InlineData("event")]
+    public void UnsupportedMemberFormsAreUnavailable(string kind)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember member = Method(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: kind);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => Format(
+                type,
+                member,
+                CSharpMemorySafetyLanguage.UpdatedCallerContracts));
+
+        Assert.Contains("Value", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(kind, exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("delegate")]
+    [InlineData("enum")]
+    public void UnsupportedTypeFormsProduceAtomicFailure(string kind)
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated, kind: kind);
+        if (kind == "delegate")
+        {
+            ApiMember invoke = Method(
+                "Invoke",
+                MemorySafetyRulesState.Updated,
+                ContractKind.None,
+                MemorySafetyPointerEvidence.Absent);
+            invoke.IsStatic = false;
+            type.Members =
+            [
+                invoke,
+            ];
+        }
+
+        var outcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(type),
+                Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts)));
+
+        Assert.Empty(outcome.SelfNameFailures);
+        CSharpTypePrintDiagnostic failure = Assert.Single(outcome.MemorySafetyFailures);
+        Assert.Equal(type.FullName, failure.TypeName);
+        Assert.Contains(kind, failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PrimaryConstructorSyntaxIsUnavailableInOptInMode()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        var formatter = Formatter(CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => formatter.FormatTypeDeclaration(
+                type,
+                [new ApiParameter { Type = "int", Name = "value" }]));
+
+        Assert.Contains("primary", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DirectEntryPointsSurfaceModelAwareRefusals()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember missing = Method(
+            "Missing",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        missing.MemorySafety = null;
+        ApiMember property = Method(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "property");
+        var formatter = Formatter(CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        Assert.Throws<NotSupportedException>(() => formatter.FormatMember(type, missing));
+        Assert.Throws<NotSupportedException>(() => formatter.FormatMemberUnit(type, missing));
+        Assert.Throws<NotSupportedException>(() => formatter.FormatMemberWithBody(
+            type,
+            missing,
+            new CSharpBlockBody("return 0;")));
+        Assert.Throws<NotSupportedException>(
+            () => formatter.FormatAccessorHead(type, property, "get"));
+        Assert.Throws<NotSupportedException>(() => formatter.FormatTypeUnit(type, [property]));
+        type.MemorySafety = null;
+        Assert.Throws<NotSupportedException>(() => formatter.FormatTypeDeclaration(type));
+    }
+
+    [Fact]
+    public void SelectedMembersCanExcludeUnsupportedFormsWithoutDroppingSelectedFailures()
+    {
+        ApiType type = Type(MemorySafetyRulesState.Updated);
+        ApiMember method = Method(
+            "Run",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent);
+        ApiMember property = Method(
+            "Value",
+            MemorySafetyRulesState.Updated,
+            ContractKind.None,
+            MemorySafetyPointerEvidence.Absent,
+            kind: "property");
+        type.Members = [method, property];
+        var printer = new CSharpTypePrinter();
+        CSharpTypePrintOptions options =
+            Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        CSharpTypePrintResult selected = Printed(printer.Print(
+            new CSharpTypePrintRequest(type, members: [method]),
+            options));
+        var selectedFailure = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            printer.Print(
+                new CSharpTypePrintRequest(type, members: [method, property]),
+                options));
+
+        Assert.Contains("Run", selected.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Value", selected.Source, StringComparison.Ordinal);
+        CSharpTypePrintDiagnostic failure =
+            Assert.Single(selectedFailure.MemorySafetyFailures);
+        Assert.Equal(type.FullName, failure.TypeName);
+        Assert.Contains("Value", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NestedAndBatchFailuresAreAtomicBeforeSourcePublication()
+    {
+        ApiType valid = Type(MemorySafetyRulesState.Updated, name: "Valid");
+        valid.Members =
+        [
+            Method(
+                "Run",
+                MemorySafetyRulesState.Updated,
+                ContractKind.None,
+                MemorySafetyPointerEvidence.Absent),
+        ];
+        ApiType nested = Type(MemorySafetyRulesState.Updated, name: "Outer.Inner");
+        nested.Members =
+        [
+            Method(
+                "Value",
+                MemorySafetyRulesState.Updated,
+                ContractKind.None,
+                MemorySafetyPointerEvidence.Absent,
+                kind: "property"),
+        ];
+        ApiType outer = Type(MemorySafetyRulesState.Updated, name: "Outer");
+        var printer = new CSharpTypePrinter();
+        CSharpTypePrintOptions options =
+            Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        var nestedOutcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            printer.Print(
+                new CSharpTypePrintRequest(
+                    outer,
+                    nestedTypes: [new CSharpTypePrintRequest(nested)]),
+                options));
+        var batchOutcome = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            printer.PrintBatch(
+                [
+                    new CSharpTypePrintRequest(valid),
+                    new CSharpTypePrintRequest(
+                        outer,
+                        nestedTypes: [new CSharpTypePrintRequest(nested)]),
+                ],
+                options));
+
+        Assert.Empty(nestedOutcome.SelfNameFailures);
+        Assert.Equal(nested.FullName, Assert.Single(nestedOutcome.MemorySafetyFailures).TypeName);
+        Assert.Empty(batchOutcome.SelfNameFailures);
+        Assert.Equal(nested.FullName, Assert.Single(batchOutcome.MemorySafetyFailures).TypeName);
+    }
+
+    [Fact]
+    public void MixedLegacyAndUpdatedRulesAreAtomicBeforeSourcePublication()
+    {
+        ApiType legacy = Type(MemorySafetyRulesState.Legacy, name: "Legacy");
+        legacy.Members =
+        [
+            Method(
+                "ConsumePointer",
+                MemorySafetyRulesState.Legacy,
+                ContractKind.Implicit,
+                MemorySafetyPointerEvidence.Present,
+                parameterType: "int*"),
+        ];
+        ApiType updated = Type(MemorySafetyRulesState.Updated, name: "Updated");
+        updated.Members =
+        [
+            Method(
+                "PointerFreeUnsafe",
+                MemorySafetyRulesState.Updated,
+                ContractKind.Explicit,
+                MemorySafetyPointerEvidence.Absent),
+        ];
+        CSharpTypePrintOptions options =
+            Options(CSharpMemorySafetyLanguage.UpdatedCallerContracts);
+
+        var batch = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().PrintBatch(
+                [
+                    new CSharpTypePrintRequest(legacy),
+                    new CSharpTypePrintRequest(updated),
+                ],
+                options));
+        var nested = Assert.IsType<CSharpTypePrintOutcome.NotRendered>(
+            new CSharpTypePrinter().Print(
+                new CSharpTypePrintRequest(
+                    legacy,
+                    nestedTypes: [new CSharpTypePrintRequest(updated)]),
+                options));
+
+        Assert.Empty(batch.SelfNameFailures);
+        CSharpTypePrintDiagnostic batchFailure =
+            Assert.Single(batch.MemorySafetyFailures);
+        Assert.Equal("<batch>", batchFailure.TypeName);
+        Assert.Contains("legacy", batchFailure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("updated", batchFailure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(nested.SelfNameFailures);
+        Assert.Equal(
+            "<batch>",
+            Assert.Single(nested.MemorySafetyFailures).TypeName);
+    }
+
+    static CSharpFormatter Formatter(CSharpMemorySafetyLanguage language)
+        => new(new CSharpFormatOptions
+        {
+            MemorySafetyLanguage = language,
+        });
+
+    static string Format(
+        ApiType type,
+        ApiMember member,
+        CSharpMemorySafetyLanguage language,
+        bool isExtern = false)
+        => new CSharpFormatter(new CSharpFormatOptions
+        {
+            MemorySafetyLanguage = language,
+            IsExtern = isExtern,
+        }).FormatMember(type, member);
+
+    static CSharpTypePrintOptions Options(CSharpMemorySafetyLanguage language)
+        => new()
+        {
+            MemorySafetyLanguage = language,
+        };
+
+    static CSharpTypePrintResult Printed(CSharpTypePrintOutcome outcome)
+        => Assert.IsType<CSharpTypePrintOutcome.Printed>(outcome).Result;
+
+    static ApiType Type(
+        MemorySafetyRulesState rules,
+        ApiTypeLayout? layout = ApiTypeLayout.Auto,
+        string kind = "class",
+        string name = "Widget")
+        => new()
+        {
+            Namespace = "Samples",
+            Name = name,
+            Kind = kind,
+            MetadataToken = TypeToken,
+            Layout = layout,
+            LayoutDetails = layout == ApiTypeLayout.Explicit
+                ? new ApiTypeLayoutFacts(ModuleId, TypeToken, Size: 32, PackingSize: 2)
+                : null,
+            MemorySafety = new ApiModuleMemorySafetyFacts(
+                ModuleId,
+                new MemorySafetyRulesResult.Available(rules, [])),
+        };
+
+    static ApiMember Method(
+        string name,
+        MemorySafetyRulesState rules,
+        ContractKind contract,
+        MemorySafetyPointerEvidence pointer,
+        string kind = "method",
+        string? parameterType = null,
+        Guid? moduleId = null)
+    {
+        int token = Token(name, 0x06000000);
+        return new ApiMember
+        {
+            Name = name,
+            Kind = kind,
+            MetadataToken = token,
+            IsStatic = kind != "constructor" && kind != "finalizer"
+                && kind != "explicit-interface-implementation",
+            SignatureModel = new ApiSignature
+            {
+                MemberName = name,
+                ReturnType = kind == "constructor" || kind == "finalizer"
+                    ? "void"
+                    : "int",
+                Parameters = parameterType is null
+                    ? []
+                    : [new ApiParameter { Type = parameterType, Name = "value" }],
+            },
+            MemorySafety = Facts(
+                token,
+                rules,
+                contract,
+                pointer,
+                moduleId ?? ModuleId),
+        };
+    }
+
+    static ApiMember Field(
+        string name,
+        MemorySafetyRulesState rules,
+        ContractKind contract,
+        MemorySafetyPointerEvidence pointer,
+        bool isStatic = false,
+        MemorySafetyFixedBufferEvidence fixedBuffer =
+            MemorySafetyFixedBufferEvidence.Absent,
+        Guid? moduleId = null,
+        int? offset = 0)
+    {
+        int token = Token(name, 0x04000000);
+        return new ApiMember
+        {
+            Name = name,
+            Kind = "field",
+            DeclarationMetadataToken = token,
+            IsStatic = isStatic,
+            ReturnType = pointer == MemorySafetyPointerEvidence.Present ? "int*" : "int",
+            SignatureModel = new ApiSignature
+            {
+                MemberName = name,
+                ReturnType = pointer == MemorySafetyPointerEvidence.Present ? "int*" : "int",
+            },
+            MemorySafety = Facts(
+                token,
+                rules,
+                contract,
+                pointer,
+                moduleId ?? ModuleId,
+                fixedBuffer),
+            FieldLayout = new ApiFieldLayoutFacts(
+                moduleId ?? ModuleId,
+                TypeToken,
+                token,
+                isStatic ? null : offset),
+        };
+    }
+
+    static ApiMemberMemorySafetyFacts Facts(
+        int token,
+        MemorySafetyRulesState rules,
+        ContractKind contract,
+        MemorySafetyPointerEvidence pointer,
+        Guid moduleId,
+        MemorySafetyFixedBufferEvidence fixedBuffer =
+            MemorySafetyFixedBufferEvidence.Absent)
+    {
+        var evidence = new MemorySafetyMemberContractEvidence(
+            token,
+            rules,
+            pointer,
+            fixedBuffer,
+            RequiresUnsafeAttributeEvidence.None,
+            RequiresUnsafeAttributeEvidence.None,
+            AssociatedMemberToken: null);
+        MemorySafetyMemberContractResult callerContract = contract switch
+        {
+            ContractKind.None => new MemorySafetyMemberContractResult.None(evidence),
+            ContractKind.Implicit => new MemorySafetyMemberContractResult.Implicit(evidence),
+            ContractKind.Explicit => new MemorySafetyMemberContractResult.Explicit(evidence),
+            ContractKind.Unavailable => new MemorySafetyMemberContractResult.Unavailable(
+                evidence,
+                new MemorySafetyMemberContractFailure(
+                    MemorySafetyMemberContractFailureKind.MetadataUnavailable,
+                    "Synthetic unavailable contract.")),
+            _ => throw new ArgumentOutOfRangeException(nameof(contract)),
+        };
+        return new ApiMemberMemorySafetyFacts(moduleId, callerContract, pointer);
+    }
+
+    static bool HasWord(string text, string word)
+        => Regex.IsMatch(
+            text,
+            $@"\b{Regex.Escape(word)}\b",
+            RegexOptions.CultureInvariant);
+
+    static int Token(string name, int table)
+    {
+        int row = 1;
+        foreach (char character in name)
+            row = ((row * 31) + character) & 0x00ffffff;
+        return table | Math.Max(row, 1);
+    }
+
+    public enum ContractKind
+    {
+        None,
+        Implicit,
+        Explicit,
+        Unavailable,
+    }
+}

--- a/tests/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/tests/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -406,7 +406,10 @@ public sealed class CSharpTypePrinterTests
         AssertNotRendered(_outcomePrinter.PrintBatch(refusalThenDuplicate.Reverse()));
 
         Assert.Equal(
-            [nameof(CSharpTypePrintOutcome.NotRendered.SelfNameFailures)],
+            [
+                nameof(CSharpTypePrintOutcome.NotRendered.SelfNameFailures),
+                nameof(CSharpTypePrintOutcome.NotRendered.MemorySafetyFailures)
+            ],
             typeof(CSharpTypePrintOutcome.NotRendered)
                 .GetProperties()
                 .Where(property =>
@@ -4547,6 +4550,7 @@ public sealed class CSharpTypePrinterTests
         {
             Name = "Value",
             Kind = "field",
+            DeclarationMetadataToken = fieldFacts.FieldToken,
             ReturnType = "int",
             FieldLayout = fieldFacts,
         };
@@ -4555,6 +4559,7 @@ public sealed class CSharpTypePrinterTests
             Namespace = "Samples",
             Name = "LayoutCarrier",
             Kind = "struct",
+            MetadataToken = typeFacts.TypeToken,
             Layout = ApiTypeLayout.Explicit,
             LayoutDetails = typeFacts,
             Members = [field],
@@ -4563,7 +4568,11 @@ public sealed class CSharpTypePrinterTests
         ApiType snapshot = CSharpTypePrinter.SnapshotTypeForRendering(type, type.Members);
 
         Assert.Same(typeFacts, snapshot.LayoutDetails);
+        Assert.Equal(typeFacts.TypeToken, snapshot.MetadataToken);
         Assert.Same(fieldFacts, Assert.Single(snapshot.Members).FieldLayout);
+        Assert.Equal(
+            fieldFacts.FieldToken,
+            Assert.Single(snapshot.Members).DeclarationMetadataToken);
         Assert.Equal(
             """
             namespace Samples;

--- a/tests/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/tests/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -4540,6 +4540,30 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void SnapshotTypeForRendering_CarriesMethodSemanticsEvidence()
+    {
+        var accessor = new ApiMember
+        {
+            Name = "IValue.get_Value",
+            Kind = "explicit-interface-implementation",
+            MethodSemantics = ApiMethodSemanticsKind.PropertyGetter,
+        };
+        var type = new ApiType
+        {
+            Name = "Example",
+            Kind = "class",
+            Members = [accessor],
+        };
+
+        ApiType snapshot =
+            CSharpTypePrinter.SnapshotTypeForRendering(type, type.Members);
+
+        Assert.Equal(
+            ApiMethodSemanticsKind.PropertyGetter,
+            Assert.Single(snapshot.Members).MethodSemantics);
+    }
+
+    [Fact]
     public void SnapshotTypeForRendering_CarriesLayoutFactsWithoutEmittingLayoutSyntax()
     {
         Guid moduleVersionId = Guid.NewGuid();

--- a/tests/ILInspector.Metadata.Tests/ApiMethodImplementationFactsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMethodImplementationFactsTests.cs
@@ -86,6 +86,8 @@ public sealed class ApiMethodImplementationFactsTests
         Assert.NotNull(original.MethodImplementation);
         Assert.Same(original.MethodImplementation, projected.MethodImplementation);
         Assert.Equal(original.HasMethodBody, projected.HasMethodBody);
+        Assert.Equal(ApiMethodSemanticsKind.None, original.MethodSemantics);
+        Assert.Equal(original.MethodSemantics, projected.MethodSemantics);
     }
 
     [Theory]

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceEmitSetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceEmitSetTests.cs
@@ -50,6 +50,11 @@ public sealed class ApiSurfaceEmitSetTests
             type.Members,
             member => member.Kind == "method"
                 && member.Name == nameof(EmitSetFixture.remove_Standalone));
+        Assert.All(
+            type.Members.Where(member => member.Kind == "method"),
+            member => Assert.Equal(
+                ApiMethodSemanticsKind.None,
+                member.MethodSemantics));
     }
 
     [Fact]
@@ -102,6 +107,15 @@ public sealed class ApiSurfaceEmitSetTests
                 && member.Name.EndsWith(
                     $".remove_{nameof(IEmitSetContract.Changed)}",
                     StringComparison.Ordinal));
+        Assert.Equal(
+            ApiMethodSemanticsKind.PropertyGetter,
+            propertyAccessor.MethodSemantics);
+        Assert.Contains(
+            type.Members,
+            member => member.MethodSemantics == ApiMethodSemanticsKind.EventAdder);
+        Assert.Contains(
+            type.Members,
+            member => member.MethodSemantics == ApiMethodSemanticsKind.EventRemover);
 
         Assert.DoesNotContain(
             type.Members,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3100,8 +3100,16 @@ public static class CompileBackSourceComposer
             });
         if (printOutcome is CSharpTypePrintOutcome.NotRendered notRendered)
         {
+            var refusals = new List<string>();
+            if (!notRendered.SelfNameFailures.IsEmpty)
+                refusals.Add($"{notRendered.SelfNameFailures.Length} exact declared-type self-name(s)");
+            if (!notRendered.MemorySafetyFailures.IsEmpty)
+                refusals.Add($"{notRendered.MemorySafetyFailures.Length} memory-safety declaration(s)");
             throw new NotSupportedException(
-                $"C# type printing refused {notRendered.SelfNameFailures.Length} exact declared-type self-name(s).");
+                $"C# type printing refused {string.Join(" and ", refusals)}."
+                + (notRendered.MemorySafetyFailures.IsEmpty
+                    ? ""
+                    : " " + string.Join(" ", notRendered.MemorySafetyFailures.Select(failure => failure.Message))));
         }
         var rendered = ((CSharpTypePrintOutcome.Printed)printOutcome).Result;
         var enrichedPlan = plan with


### PR DESCRIPTION
Build robust, capable declaration infrastructure that is conventionally sound
and enables compelling source experiences across the eventual CLI and
browser/Wasm adoption path.

Closes #6105

## Demo

The unchanged-source compiler oracle previously received a `safe` field without
the explicit layout that makes that declaration legal:

```csharp
public struct MemorySafetyExplicitLayoutFixture
{
    public safe int SafeInstanceField;
    public unsafe int UnsafeInstanceField;
    public static int StaticField;
}
```

That source fails with CS9388. The opt-in CSharp producer now emits the complete
supported declaration context from Metadata-owned layout facts:

```csharp
[global::System.Runtime.InteropServices.StructLayoutAttribute(
    global::System.Runtime.InteropServices.LayoutKind.Explicit,
    Size = 16,
    Pack = 2)]
public struct MemorySafetyExplicitLayoutFixture
{
    [global::System.Runtime.InteropServices.FieldOffsetAttribute(0)]
    public safe int SafeInstanceField;

    [global::System.Runtime.InteropServices.FieldOffsetAttribute(4)]
    public unsafe int UnsafeInstanceField;

    public static int StaticField;
}
```

The product source compiles unchanged and re-extracts the original updated
caller contracts, layout kind, size, packing, and zero/nonzero offsets. A
mixed legacy/updated batch instead returns atomic unavailability because one
C# compilation unit cannot preserve both module rules models.

A compiler-produced private explicit-interface getter is another neighboring
case: Metadata retains its typed `MethodSemantics` role, and the opt-in producer
returns atomic unavailability instead of publishing method syntax that fails
with CS0683 and CS0535.

Attached extensions are rendered as their defining static declarations during
standalone member formatting. Enum, delegate, extended-layout, and interface
receivers contribute module identity without being mistaken for the enclosing
declaration. Type-unit and whole-type paths atomically refuse every attached
extension, including ordinary class and struct receivers, rather than
relocating it into an enclosing type where the unchanged source fails with
CS1106.

## What "model-aware" means

Here, **model-aware** means that CSharp spells a declaration from the typed
semantic evidence retained from the inspected assembly, rather than from the
legacy `IsUnsafe` Boolean, rendered text, or pointer-syntax heuristics.

For each opt-in declaration, the producer consumes the recognized module rules
model, caller-contract and signature-pointer facts, `MethodSemantics`,
implementation/body policy, type and field layout, and exact module/type/member
identity. It emits `safe`, `unsafe`, or no modifier only when those facts prove
the result; otherwise it returns visible unavailability. It does **not** mean
AI-based inference or source reconstruction.

The existing compatibility renderer remains the default for callers and older
surfaces that do not carry all of those typed facts.

## Summary

- Add explicit opt-in typed-evidence language modes for legacy lexical pointer
  context, relaxed pointer syntax, and updated caller contracts while
  preserving the existing compatibility default.
- Derive method, constructor, field, and affirmative extern `safe`/`unsafe`
  spelling from typed module, member, pointer, body-policy, and layout evidence.
- Validate module and declaration identity before consuming caller-contract or
  layout facts; retain the required TypeDef, MethodDef, and FieldDef tokens
  through rendering snapshots.
- Preserve typed property/event `MethodSemantics` roles through extraction,
  extension/accessor projection, and rendering snapshots so deferred accessors
  cannot enter the supported ordinary-method path.
- Separate standalone projected-extension admission from whole-type admission,
  preserving enum/delegate/interface receiver projections without weakening
  actual receiver type-unit restrictions.
- Emit collision-proof explicit-layout attributes, including every selected
  instance field offset, while leaving static fields unannotated and refusing
  extended or unrepresentable layout evidence.
- Return atomic `CSharpTypePrintOutcome.NotRendered` diagnostics for unsupported
  declarations, missing evidence, mixed rules models, or body requirements that
  cannot be represented without changing the caller contract.
- Route the compile-back prototype through the same opt-in policy and run the
  complete CSharp suite in ordinary CI.

## Compatibility and scope

Compatibility rendering remains the default and continues to use the existing
surface. This slice does not enable CLI or browser/Wasm hosts, reconstruct body
contexts, choose primary-constructor storage, or support property, accessor,
event, delegate, enum, or primary-constructor typed-evidence spelling.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --nologo`
  - succeeded with 0 errors and 3 existing `SYSLIB1227` warnings in JS-export
    union fixtures
- `dotnet run --project tests/ILInspector.CSharp.Tests -c Release`
  - 626 passed
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
  - 3,029 passed, 3 environment-gated cases skipped
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class '*CSharpMemorySafetySpellingCompileTests' -class '*DynamicCompilationSiteInventoryTests'`
  - 13 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- 'Speed=Slow'`
  - 6,282 passed
- `npx markdownlint-cli docs/architecture.md docs/design/csharp-memory-safety-spelling.md docs/design/type-member-api-representation.md`
- `git diff --check origin/main...HEAD`
