### PR TITLE
Add bounded NuGet Catalog acquisition

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |
 | [Member Body Substrate](design/member-body-substrate.md) | One base for skeleton/full/merged/diff body rendering: `ApiType` shape, `MemberAnchor` address, one scope, and `MemberBody`'s scalar (whole-body) and vector (offset-keyed) shapes. |
 | [NuGet API Selection](design/nuget.md) | Scenario-to-API decisions, endpoint roles, first/last-result performance evidence, and current versus proposed adoption. |
+| [NuGet Catalog Acquisition](design/nuget-catalog-acquisition.md) | Bounded incremental acquisition of advertised Catalog event windows with source identity, horizon, completion, and typed failure. |
 | [NuGet Gallery Discovery](design/nuget-gallery-discovery.md) | Proposed NuGetFetch termless/type-filtered Gallery search, source orders, search-facet discovery, and bounded row-source delegation, with CLI/browser adoption tracked separately. |
 | [Package Query Input Selection](design/package-query-input-selection.md) | Exact-ID, explicit-prefix, and explicit Gallery input selection for shared Query and its hosts. |
 | [Package Query Inspection Evidence](design/package-query-inspection-evidence.md) | Inspection-produced item counts and bounded previews, distinct from query-wide context. |

--- a/docs/design/nuget-catalog-acquisition.md
+++ b/docs/design/nuget-catalog-acquisition.md
@@ -28,7 +28,7 @@ This owner defines:
 - discovery and selection of advertised `Catalog/3.0.0` resources;
 - explicit interval validation and bounded index/page acquisition;
 - typed Catalog event, progress, horizon, completion, and failure evidence;
-- chronological page and event processing; and
+- deterministic page delivery and per-page chronological event processing; and
 - the exact point at which a bounded interval may be called covered.
 
 It does not define ecosystem membership, package-ID prefix filtering, security
@@ -128,10 +128,10 @@ Acquisition performs these steps:
    the first maximum later than the effective upper bound. A page timestamp is
    its maximum, not its minimum, so each tied crossing page can still contain
    in-window events.
-5. Parse each selected page atomically, sort its items by commit timestamp and
-   stable leaf-URL tie-breaker, and publish only items whose timestamps are
-   greater than the lower bound and less than or equal to the effective upper
-   bound.
+5. Deliver pages in sorted descriptor order. Parse each selected page
+   atomically, sort its items by commit timestamp and stable leaf-URL
+   tie-breaker, and publish only items whose timestamps are greater than the
+   lower bound and less than or equal to the effective upper bound.
 
 The index `commitTimeStamp` is the observed horizon for this attempt. The
 effective upper bound is the earlier of that horizon and the requested end. If
@@ -144,6 +144,17 @@ deliberately extends that algorithm through every descriptor tied at the
 crossing maximum: the wire contract makes index order undefined and exposes no
 page minimum that would prove another tied page contains no in-window event.
 The ordinary acquisition bounds remain the stopping authority.
+
+Page descriptors with equal maxima have no source-issued relative order, and
+one commit can span pages, so their event ranges can overlap. Their
+advertised-URL tie-breaker makes page delivery deterministic, but event
+timestamps can move backward between those tied page outcomes. Distinct page
+maxima remain chronological. Acquisition does not buffer an arbitrary tied
+group or reject it as malformed: both choices would undermine bounded
+page-atomic streaming or omit valid source evidence. A consumer that requires
+global chronological or newest-first order sorts each tied group or the
+bounded typed result after acquisition; the ecosystem report query owns that
+presentation-independent ordering.
 
 The active page can grow after the index was fetched. Events later than the
 captured index horizon are excluded even if the subsequent page response
@@ -201,10 +212,13 @@ release, relist, metadata change, or vulnerability update. Repeated events for
 one coordinate are not deduplicated.
 
 Catalog commits are strictly ordered by timestamp, but item order within one
-commit is undefined. The stable leaf-URL tie-breaker gives deterministic
-delivery without claiming causality. This capability does not persist or
-promise a resumable cursor. In particular, an intermediate page is not proof
-that every item sharing its last commit timestamp has been processed.
+commit is undefined. Page descriptors are delivered by maximum timestamp and
+advertised URL; events within each page are delivered by commit timestamp and
+leaf URL. These tie-breakers give deterministic delivery without claiming
+causality or global timestamp order across equal-maximum pages. This capability
+does not persist or promise a resumable cursor. In particular, an intermediate
+page is not proof that every item sharing its last commit timestamp has been
+processed.
 
 ## Failure and admission
 
@@ -239,6 +253,8 @@ The focused Release suite must gate:
   cancellation;
 - repeated coordinates, deterministic same-commit delivery, and distinct
   Details/Delete evidence;
+- equal-maximum page delivery without omitted evidence or a global event-order
+  claim;
 - source identity, normalized advertised URLs, credential scope, malformed
   URLs, duplicate properties, and per-response/aggregate body limits; and
 - original coordinate spelling beside normalized package identity; and

--- a/docs/design/nuget-catalog-acquisition.md
+++ b/docs/design/nuget-catalog-acquisition.md
@@ -1,0 +1,246 @@
+# NuGet Catalog acquisition
+
+## Status and authority
+
+Focused source-capability design for
+[#6294](https://github.com/richlander/dotnet-inspect/issues/6294), implementing
+step 2 of the eight-step
+[ecosystem change-report tracker](https://github.com/richlander/dotnet-inspect/issues/6124).
+
+**NuGet Catalog acquisition in `NuGetFetch` is the sole normative owner.**
+Its claim is:
+
+> One authorized NuGet V3 source can incrementally acquire a bounded Catalog
+> interval while preserving source-issued event identity, the observed Catalog
+> horizon, explicit completion, and typed failure. It never promotes a partial
+> read into complete coverage.
+
+The named consumer is the shared ecosystem change-report query, followed by
+CLI and browser/Wasm adoption in steps 4, 6, and 7 of #6124. This capability
+adds no host surface. It retires no existing source path, so no migration or
+retirement plan applies. Rendering is not applicable: the output is typed
+source evidence, and shared Presentation remains a later Markout owner.
+
+## Scope and consumed contracts
+
+This owner defines:
+
+- discovery and selection of advertised `Catalog/3.0.0` resources;
+- explicit interval validation and bounded index/page acquisition;
+- typed Catalog event, progress, horizon, completion, and failure evidence;
+- chronological page and event processing; and
+- the exact point at which a bounded interval may be called covered.
+
+It does not define ecosystem membership, package-ID prefix filtering, security
+evidence, report predicates or row limits, current package inventory, saved
+cursors, caching, leaf enrichment, query event-stream semantics, command
+grammar, browser placement, or rendering.
+
+| Owner | Boundary consumed here |
+| --- | --- |
+| [NuGetFetch source-result identity](browser-package-sources.md#nugetfetch-typed-source-result-identity) | Caller-authorized source association, factory-issued provenance, contained failures, and custom-client validation. |
+| [NuGetFetch operation deadlines](browser-package-sources.md#timeout-ownership) | One monotonic operation ceiling, nested request deadlines, caller cancellation, and source-safe timeout identity. |
+| [NuGet API selection](nuget.md#scenario-selection) | Catalog is the time-indexed source for exhaustive recent activity; Search and Registration retain their distinct scenarios. |
+| [Untrusted-data threat model](untrusted-data-threat-model.md#feed-discovered-package-resources-use-a-guarded-destination-policy) | Guarded advertised destinations, source-relative credentials, bounded response bodies, duplicate-property rejection, and visible malformed metadata. |
+| [Ecosystem change report](ecosystem-change-report.md) | Future consumer of source-issued events and coverage; report scope, selection, security meaning, and presentation remain above this owner. |
+
+The implementation inherits the existing platform contract and transport
+mechanisms. Desktop and browser transports retain their existing destination
+policies; in particular, browser/Wasm does not gain cross-origin feed authority
+through this capability.
+
+## Request and resource bounds
+
+`NuGetCatalogRequest` names one explicit UTC interval
+`(FromExclusive, ThroughInclusive]`. The end must be later than the start, and
+the interval may not exceed 42 days. The source owner does not resolve a
+default reference time: the report query owns the rolling six-week default and
+passes its resolved bounds here.
+
+The request contains no package scope, prefix, prerelease choice, security
+selector, semantic row count, or presentation option. Every in-window Catalog
+event is source evidence for later consumers. Repeated coordinates remain
+repeated events.
+
+Catalog-specific `NuGetFetchOptions` bound one operation independently of the
+existing per-response metadata limit:
+
+| Bound | Default | Meaning |
+| --- | ---: | --- |
+| Catalog pages | 512 | Maximum page documents acquired after the index |
+| HTTP attempts | 1,024 | Service-index, Catalog-index, page, and retry attempts |
+| Aggregate decoded metadata | 512 MiB | Bytes read across every admitted Catalog document and retry attempt |
+
+The existing 16 MiB per-response ceiling, request deadline, metadata-body
+deadline, and 120-second default operation deadline still apply. A response
+that exceeds its own ceiling, malformed JSON, and transport failure remain
+typed source failures.
+Reaching an operation-wide Catalog bound between complete documents is an
+explicit partial completion, not an empty success or an assertion that the
+window was exhausted after the Catalog horizon has been captured. A bound
+reached before that point is a typed source failure because no coverage
+evidence exists to attach to a partial completion. If an aggregate byte bound
+is crossed while reading a document, that incomplete document is rejected and
+no events from it are published.
+
+The defaults are grounded in the preserved 42-day experiment, which consumed
+210 pages, 212 requests, and about 184 MiB of decoded metadata. They bound the
+approved scenario without turning those observations into provider promises.
+
+## Discovery and advertised authority
+
+The client reads the selected source's service index and discovers
+`Catalog/3.0.0`; it never substitutes the nuget.org Catalog for another source.
+The resource type may use the service-index string-or-array shape. Usable
+equivalent endpoints are retained in service-index order under a small fixed
+cap, matching existing V3 resource discovery. An unusable supported resource
+is a visible invalid response when no usable equivalent remains; a source that
+does not advertise Catalog returns `Unsupported`.
+
+Every Catalog index, page, and retained leaf URL is taken from an advertised
+document and normalized through the existing source request projection. URLs
+are not synthesized from page numbers, timestamps, package IDs, or versions.
+Credentials follow the existing same-origin rule, and the configured transport
+enforces desktop and browser destination policy for every request.
+
+Equivalent Catalog endpoints may fail over only before an endpoint publishes
+an acquired page. One interval never combines pages from independent Catalog
+roots, because their horizons and event identity need not describe one log.
+
+## Bounded interval traversal
+
+The [NuGet Catalog resource specification][catalog-spec] is normative for wire
+semantics. The
+[`NuGet.Protocol.Catalog` bounded-range implementation][catalog-bounds] is
+supporting analogous evidence for its documented “upper range plus one page”
+algorithm; it is not an imported implementation.
+
+Acquisition performs these steps:
+
+1. Fetch the service index and one selected Catalog index under the operation
+   budgets.
+2. Validate the index horizon and page descriptors, then sort page descriptors
+   by `commitTimeStamp` and a stable advertised-URL tie-breaker. Index array
+   position has no ordering meaning.
+3. Select pages whose maximum commit timestamp is later than the exclusive
+   lower bound.
+4. Continue through the first selected page whose maximum commit timestamp is
+   later than the effective upper bound. A page timestamp is its maximum, not
+   its minimum, so this crossing page can still contain in-window events.
+5. Parse each selected page atomically, sort its items by commit timestamp and
+   stable leaf-URL tie-breaker, and publish only items whose timestamps are
+   greater than the lower bound and less than or equal to the effective upper
+   bound.
+
+The index `commitTimeStamp` is the observed horizon for this attempt. The
+effective upper bound is the earlier of that horizon and the requested end. If
+the source horizon trails the requested end, acquisition may still publish the
+covered prefix, but terminal completion is `SourceHorizonReached`, not
+`WindowExhausted`.
+
+The active page can grow after the index was fetched. Events later than the
+captured index horizon are excluded even if the subsequent page response
+contains them. This binds every emitted event and terminal coverage claim to
+one observed horizon without claiming a stable filesystem-like snapshot.
+The index horizon must match its latest page descriptor; an inconsistent root
+cannot establish coverage. A page response older than its descriptor is
+retried as a stale active-page observation and fails visibly if it remains
+stale.
+
+Top-level and page `count` values are not used to invent events or coverage.
+The acquired arrays are authoritative for that response. No page-size
+assumption is made: a single commit can produce a page much larger than a
+provider's nominal target.
+
+## Typed incremental result
+
+`INuGetCatalogPackageSourceClient` is a capability implemented by the V3
+source client. It exposes a backpressured `IAsyncEnumerable` of factory-issued
+`PackageSourceOperationResult<NuGetCatalogPage>`. The general package-source
+interface remains unchanged; consumers opt into Catalog only when the source
+implements this capability.
+
+Each successful page value retains:
+
+- the exact source-result identity and request;
+- immutable typed events from one acquired page;
+- the captured Catalog horizon;
+- cumulative pages, HTTP attempts, decoded bytes, and in-window event count;
+- and an optional terminal `NuGetCatalogCompletion`.
+
+The last successful value carries exactly one terminal completion:
+
+| Completion | Meaning |
+| --- | --- |
+| `WindowExhausted` | The source horizon covers the requested end and every selected page was admitted. |
+| `SourceHorizonReached` | Every page through the captured horizon was admitted, but that horizon predates the requested end. |
+| `PageLimitReached` | The configured page bound stopped acquisition before coverage was established. |
+| `RequestLimitReached` | The configured attempt bound stopped acquisition before coverage was established. |
+| `DecodedByteLimitReached` | The aggregate decoded-byte bound stopped acquisition before another complete document could be admitted. |
+
+An empty interval still produces one terminal value. A typed source failure
+ends the sequence after any already-published pages; caller cancellation
+propagates as cancellation. No internally created deadline or network resource
+remains live while the consumer processes a yielded page. A caller-owned
+`NuGetOperationContext` retains its caller-defined lifetime across the stream.
+Catalog acquisition inherits the operation-context owner's token-identity
+rules rather than defining a second cancellation contract.
+
+`NuGetCatalogEvent` retains the source package ID and version, their normalized
+package coordinate, advertised leaf URL, Catalog commit ID, commit timestamp,
+and a closed Details/Delete kind.
+Both kinds are activity observations. Details is not renamed to publish,
+release, relist, metadata change, or vulnerability update. Repeated events for
+one coordinate are not deduplicated.
+
+Catalog commits are strictly ordered by timestamp, but item order within one
+commit is undefined. The stable leaf-URL tie-breaker gives deterministic
+delivery without claiming causality. This capability does not persist or
+promise a resumable cursor. In particular, an intermediate page is not proof
+that every item sharing its last commit timestamp has been processed.
+
+## Failure and admission
+
+Service indexes, Catalog indexes, and pages are untrusted JSON. Required
+members, timestamp values, package coordinates, supported event kinds, and
+advertised URLs are validated before a page is published. Duplicate object
+properties are rejected at every depth so two readers cannot bind different
+values. Unknown optional properties are ignored.
+
+A page is admitted atomically. Malformed or over-bound metadata never produces
+some events from that page. Previously yielded pages remain observable, while
+the terminal source result remains failed rather than being rewritten as
+`WindowExhausted`.
+
+Only `nuget:PackageDetails` and `nuget:PackageDelete` page items are supported.
+Their page observations do not require leaf acquisition. The leaf URL is
+retained as source-issued identity and possible future enrichment authority;
+this slice does not fetch or interpret leaf documents.
+
+## Evidence and non-claims
+
+The focused Release suite must gate:
+
+- explicit request bounds and the absence of implicit filtering;
+- advertised resource discovery and no hard-coded Catalog fallback;
+- unordered index/page arrays and the crossing-page upper boundary;
+- exclusive lower and inclusive upper timestamps;
+- captured-horizon filtering when the active page grows;
+- inconsistent index horizons and retry of stale active-page responses;
+- `WindowExhausted` versus `SourceHorizonReached` and each acquisition bound;
+- backpressure, page-atomic publication, partial failure, and caller
+  cancellation;
+- repeated coordinates, deterministic same-commit delivery, and distinct
+  Details/Delete evidence;
+- source identity, normalized advertised URLs, credential scope, malformed
+  URLs, duplicate properties, and per-response/aggregate body limits; and
+- original coordinate spelling beside normalized package identity; and
+- no leaf request for page-event acquisition.
+
+The six-week live experiment remains performance evidence, not a normal CI
+dependency. This slice makes no report latency, security completeness,
+ecosystem membership, inventory, cache, cursor, CLI, or browser presentation
+claim.
+
+[catalog-spec]: https://learn.microsoft.com/nuget/api/catalog-resource
+[catalog-bounds]: https://github.com/NuGet/NuGetGallery/blob/main/src/NuGet.Protocol.Catalog/Models/ModelExtensions.cs

--- a/docs/design/nuget-catalog-acquisition.md
+++ b/docs/design/nuget-catalog-acquisition.md
@@ -68,7 +68,7 @@ existing per-response metadata limit:
 | Bound | Default | Meaning |
 | --- | ---: | --- |
 | Catalog pages | 512 | Maximum page documents acquired after the index |
-| HTTP attempts | 1,024 | Service-index, Catalog-index, page, and retry attempts |
+| HTTP attempts | 1,024 | Actual sends across service-index, Catalog-index, page, redirect, authentication, and retry traffic |
 | Aggregate decoded metadata | 512 MiB | Bytes read across every admitted Catalog document and retry attempt |
 
 The existing 16 MiB per-response ceiling, request deadline, metadata-body
@@ -124,9 +124,10 @@ Acquisition performs these steps:
    position has no ordering meaning.
 3. Select pages whose maximum commit timestamp is later than the exclusive
    lower bound.
-4. Continue through the first selected page whose maximum commit timestamp is
-   later than the effective upper bound. A page timestamp is its maximum, not
-   its minimum, so this crossing page can still contain in-window events.
+4. Continue through every selected page whose maximum commit timestamp equals
+   the first maximum later than the effective upper bound. A page timestamp is
+   its maximum, not its minimum, so each tied crossing page can still contain
+   in-window events.
 5. Parse each selected page atomically, sort its items by commit timestamp and
    stable leaf-URL tie-breaker, and publish only items whose timestamps are
    greater than the lower bound and less than or equal to the effective upper
@@ -137,6 +138,12 @@ effective upper bound is the earlier of that horizon and the requested end. If
 the source horizon trails the requested end, acquisition may still publish the
 covered prefix, but terminal completion is `SourceHorizonReached`, not
 `WindowExhausted`.
+
+The analogous NuGet implementation stops after one crossing page. This owner
+deliberately extends that algorithm through every descriptor tied at the
+crossing maximum: the wire contract makes index order undefined and exposes no
+page minimum that would prove another tied page contains no in-window event.
+The ordinary acquisition bounds remain the stopping authority.
 
 The active page can grow after the index was fetched. Events later than the
 captured index horizon are excluded even if the subsequent page response

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -514,6 +514,11 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
   decision guidance and evidence, including API combinations and first/last
   requested-result costs. This is not a new runtime selector; source, query,
   and host contracts remain with their focused owners.
+- [NuGet Catalog acquisition](design/nuget-catalog-acquisition.md): bounded,
+  incremental `NuGetFetch` acquisition of advertised Catalog event windows,
+  preserving source identity, observed horizon, completion, and typed failure.
+  Ecosystem scope, security meaning, report selection, cursors, leaf
+  enrichment, and host adoption remain with their focused owners.
 - [NuGet Gallery discovery](design/nuget-gallery-discovery.md): proposed
   NuGetFetch-owned termless/type-filtered discovery, source ordering,
   search-selector catalog, typed metadata observations, and Gallery-specific

--- a/src/NuGetFetch/NuGetCatalogAcquisition.cs
+++ b/src/NuGetFetch/NuGetCatalogAcquisition.cs
@@ -602,9 +602,8 @@ internal sealed class NuGetCatalogAcquisition
             NuGetOperationDeadline operation,
             CancellationToken cancellationToken)
     {
-        using JsonDocument document = await JsonDocument.ParseAsync(
+        using JsonDocument document = await ParseDocumentAsync(
             json,
-            DocumentOptions,
             cancellationToken).ConfigureAwait(false);
         JsonElement root = RequiredObject(
             document.RootElement,
@@ -679,9 +678,8 @@ internal sealed class NuGetCatalogAcquisition
             NuGetOperationDeadline operation,
             CancellationToken cancellationToken)
     {
-        using JsonDocument document = await JsonDocument.ParseAsync(
+        using JsonDocument document = await ParseDocumentAsync(
             json,
-            DocumentOptions,
             cancellationToken).ConfigureAwait(false);
         JsonElement root = RequiredObject(
             document.RootElement,
@@ -784,9 +782,8 @@ internal sealed class NuGetCatalogAcquisition
             NuGetOperationDeadline operation,
             CancellationToken cancellationToken)
     {
-        using JsonDocument document = await JsonDocument.ParseAsync(
+        using JsonDocument document = await ParseDocumentAsync(
             json,
-            DocumentOptions,
             cancellationToken).ConfigureAwait(false);
         JsonElement root = RequiredObject(
             document.RootElement,
@@ -1027,6 +1024,25 @@ internal sealed class NuGetCatalogAcquisition
         {
             throw Invalid(
                 $"The {document} contained invalid UTF-16 text.",
+                exception);
+        }
+    }
+
+    private static async ValueTask<JsonDocument> ParseDocumentAsync(
+        Stream json,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await JsonDocument.ParseAsync(
+                json,
+                DocumentOptions,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException exception)
+        {
+            throw Invalid(
+                "NuGet Catalog metadata contained invalid UTF-16 text.",
                 exception);
         }
     }

--- a/src/NuGetFetch/NuGetCatalogAcquisition.cs
+++ b/src/NuGetFetch/NuGetCatalogAcquisition.cs
@@ -485,6 +485,12 @@ internal sealed class NuGetCatalogAcquisition
         for (int retry = 0; ; retry++)
         {
             operation.ThrowIfExpired();
+            if (!_budget.CanReadDecodedByte)
+            {
+                return NuGetCatalogDocumentResult<T>.Limited(
+                    NuGetCatalogCompletion.DecodedByteLimitReached);
+            }
+
             if (!_budget.TryBeginRequest())
             {
                 return NuGetCatalogDocumentResult<T>.Limited(
@@ -530,6 +536,18 @@ internal sealed class NuGetCatalogAcquisition
                 when (retry < NuGetHttpRetry.MaximumRetries
                     && NuGetHttpRetry.IsTransient(exception))
             {
+                if (!_budget.CanStartRequest)
+                {
+                    return NuGetCatalogDocumentResult<T>.Limited(
+                        NuGetCatalogCompletion.RequestLimitReached);
+                }
+
+                if (!_budget.CanReadDecodedByte)
+                {
+                    return NuGetCatalogDocumentResult<T>.Limited(
+                        NuGetCatalogCompletion.DecodedByteLimitReached);
+                }
+
                 await NuGetHttpRetry.DelayAsync(operation, retry)
                     .ConfigureAwait(false);
             }
@@ -621,7 +639,10 @@ internal sealed class NuGetCatalogAcquisition
                 if (!validTypeShape
                     || Optional(resource, "@id") is not
                         { ValueKind: JsonValueKind.String } id
-                    || id.GetString() is not { } declared
+                    || ReadText(
+                        id,
+                        "service index Catalog resource")
+                        is not { } declared
                     || !TryNormalizeAdvertisedUrl(
                         declared,
                         out string normalized))
@@ -896,7 +917,9 @@ internal sealed class NuGetCatalogAcquisition
         hasCatalogType = false;
         if (type.ValueKind == JsonValueKind.String)
         {
-            hasCatalogType = type.GetString()?.Equals(
+            hasCatalogType = ReadText(
+                type,
+                "service index resource type")?.Equals(
                 "Catalog/3.0.0",
                 StringComparison.OrdinalIgnoreCase) == true;
             return true;
@@ -909,7 +932,10 @@ internal sealed class NuGetCatalogAcquisition
         foreach (JsonElement item in type.EnumerateArray())
         {
             if (item.ValueKind != JsonValueKind.String
-                || item.GetString() is not { } value)
+                || ReadText(
+                    item,
+                    "service index resource type")
+                    is not { } value)
             {
                 valid = false;
                 continue;
@@ -972,14 +998,37 @@ internal sealed class NuGetCatalogAcquisition
         string document)
     {
         JsonElement value = Optional(parent, name);
-        if (value.ValueKind != JsonValueKind.String
-            || string.IsNullOrWhiteSpace(value.GetString()))
+        if (value.ValueKind != JsonValueKind.String)
         {
             throw Invalid(
                 $"The {document} must contain nonempty '{name}' text.");
         }
 
-        return value.GetString()!;
+        string? text = ReadText(value, document);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw Invalid(
+                $"The {document} must contain nonempty '{name}' text.");
+        }
+
+        return text;
+    }
+
+    private static string? ReadText(
+        JsonElement value,
+        string document)
+    {
+        try
+        {
+            return value.GetString();
+        }
+        catch (InvalidOperationException exception)
+            when (value.ValueKind == JsonValueKind.String)
+        {
+            throw Invalid(
+                $"The {document} contained invalid UTF-16 text.",
+                exception);
+        }
     }
 
     private static string RequiredUrl(

--- a/src/NuGetFetch/NuGetCatalogAcquisition.cs
+++ b/src/NuGetFetch/NuGetCatalogAcquisition.cs
@@ -310,14 +310,23 @@ internal sealed class NuGetCatalogAcquisition
             : _request.ThroughInclusive;
         var selected =
             ImmutableArray.CreateBuilder<NuGetCatalogPageDescriptor>();
+        DateTimeOffset? crossingTimestamp = null;
         foreach (NuGetCatalogPageDescriptor page in index.Pages)
         {
             if (page.CommitTimestamp <= _request.FromExclusive)
                 continue;
+            if (crossingTimestamp is { } crossing
+                && page.CommitTimestamp != crossing)
+            {
+                break;
+            }
 
             selected.Add(page);
-            if (page.CommitTimestamp > upper)
-                break;
+            if (crossingTimestamp is null
+                && page.CommitTimestamp > upper)
+            {
+                crossingTimestamp = page.CommitTimestamp;
+            }
         }
 
         return selected.ToImmutable();
@@ -493,7 +502,7 @@ internal sealed class NuGetCatalogAcquisition
                     NuGetCatalogCompletion.DecodedByteLimitReached);
             }
 
-            if (!_budget.TryBeginRequest())
+            if (!_budget.CanStartRequest)
             {
                 return NuGetCatalogDocumentResult<T>.Limited(
                     NuGetCatalogCompletion.RequestLimitReached);
@@ -507,6 +516,9 @@ internal sealed class NuGetCatalogAcquisition
                         using HttpRequestMessage request =
                             NuGetHttpRequest
                                 .CreateGetPreservingPathAndQuery(url);
+                        request.Options.Set(
+                            NuGetCatalogAttemptHandler.BudgetOption,
+                            _budget);
                         NuGetSourceRequest.ApplyCredential(
                             request,
                             credential);
@@ -533,6 +545,11 @@ internal sealed class NuGetCatalogAcquisition
             {
                 return NuGetCatalogDocumentResult<T>.Limited(
                     NuGetCatalogCompletion.DecodedByteLimitReached);
+            }
+            catch (NuGetCatalogRequestLimitExceededException)
+            {
+                return NuGetCatalogDocumentResult<T>.Limited(
+                    NuGetCatalogCompletion.RequestLimitReached);
             }
             catch (Exception exception)
                 when (retry < NuGetHttpRetry.MaximumRetries
@@ -1349,6 +1366,29 @@ internal sealed class NuGetCatalogBudget
             int offset,
             int count) =>
             throw new NotSupportedException();
+    }
+}
+
+internal sealed class NuGetCatalogAttemptHandler(
+    HttpMessageHandler innerHandler)
+    : DelegatingHandler(innerHandler)
+{
+    internal static HttpRequestOptionsKey<NuGetCatalogBudget> BudgetOption
+    { get; } = new("NuGetFetch.CatalogAttemptBudget");
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Options.TryGetValue(
+                BudgetOption,
+                out NuGetCatalogBudget? budget)
+            && !budget.TryBeginRequest())
+        {
+            throw new NuGetCatalogRequestLimitExceededException();
+        }
+
+        return base.SendAsync(request, cancellationToken);
     }
 }
 

--- a/src/NuGetFetch/NuGetCatalogAcquisition.cs
+++ b/src/NuGetFetch/NuGetCatalogAcquisition.cs
@@ -1,0 +1,1259 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace NuGetFetch;
+
+internal sealed partial class NuGetV3PackageSourceClient
+{
+    public async IAsyncEnumerable<PackageSourceOperationResult<NuGetCatalogPage>>
+        AcquireCatalogAsync(
+            NuGetCatalogRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default,
+            NuGetOperationContext? operationContext = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken = operationContext?.ResolveInvocationToken(
+            cancellationToken) ?? cancellationToken;
+        var acquisition = new NuGetCatalogAcquisition(
+            _results,
+            _client,
+            _endpoint,
+            _credential,
+            _options,
+            _clientTimeout,
+            request,
+            cancellationToken,
+            operationContext);
+
+        IReadOnlyList<string>? endpoints = null;
+        Exception? failure = null;
+        try
+        {
+            endpoints = await acquisition.DiscoverCatalogEndpointsAsync()
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+            when (acquisition.TryCaptureFailure(exception, out _))
+        {
+            failure = exception;
+        }
+
+        if (failure is not null)
+        {
+            yield return acquisition.Failed(failure);
+            yield break;
+        }
+
+        if (endpoints!.Count == 0)
+        {
+            yield return _results.FailedCatalog(
+                PackageSourceFailureKind.Unsupported);
+            yield break;
+        }
+
+        Exception? lastEndpointFailure = null;
+        foreach (string endpoint in endpoints)
+        {
+            NuGetCatalogIndex? index = null;
+            failure = null;
+            try
+            {
+                NuGetCatalogDocumentResult<NuGetCatalogIndex> indexRead =
+                    await acquisition.ReadCatalogIndexAsync(endpoint)
+                        .ConfigureAwait(false);
+                if (indexRead.Completion is not null)
+                {
+                    throw new NuGetCatalogResourceLimitExceededException(
+                        "A Catalog acquisition bound was reached before the Catalog horizon was captured.");
+                }
+
+                index = indexRead.Value!;
+            }
+            catch (Exception exception)
+                when (acquisition.TryCaptureFailure(exception, out _))
+            {
+                failure = exception;
+            }
+
+            if (failure is not null)
+            {
+                if (acquisition.CanFailOver(failure))
+                {
+                    lastEndpointFailure = failure;
+                    continue;
+                }
+
+                yield return acquisition.Failed(failure);
+                yield break;
+            }
+
+            ImmutableArray<NuGetCatalogPageDescriptor> pages =
+                acquisition.SelectPages(index!);
+            if (pages.IsEmpty)
+            {
+                yield return await acquisition.CreateTerminalAsync(
+                    index!.Horizon,
+                    acquisition.CoverageCompletion(index.Horizon))
+                    .ConfigureAwait(false);
+                yield break;
+            }
+
+            NuGetCatalogDocumentResult<ImmutableArray<NuGetCatalogEvent>>
+                firstRead = default;
+            failure = null;
+            try
+            {
+                firstRead = await acquisition.ReadPageAsync(
+                    index!.Horizon,
+                    pages[0]).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+                when (acquisition.TryCaptureFailure(exception, out _))
+            {
+                failure = exception;
+            }
+
+            if (failure is not null)
+            {
+                if (acquisition.CanFailOver(failure))
+                {
+                    lastEndpointFailure = failure;
+                    continue;
+                }
+
+                yield return acquisition.Failed(failure);
+                yield break;
+            }
+
+            if (firstRead.Completion is { } firstLimit)
+            {
+                yield return await acquisition.CreateTerminalAsync(
+                    index!.Horizon,
+                    firstLimit).ConfigureAwait(false);
+                yield break;
+            }
+
+            PackageSourceOperationResult<NuGetCatalogPage> first =
+                await acquisition.AdmitPageAsync(
+                    index!.Horizon,
+                    pages,
+                    pageIndex: 0,
+                    firstRead.Value!).ConfigureAwait(false);
+            yield return first;
+            if (first.Failure is not null
+                || first.Value!.Completion is not null)
+                yield break;
+
+            for (int pageIndex = 1; pageIndex < pages.Length; pageIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                NuGetCatalogDocumentResult<ImmutableArray<NuGetCatalogEvent>>
+                    pageRead = default;
+                failure = null;
+                try
+                {
+                    pageRead = await acquisition.ReadPageAsync(
+                        index.Horizon,
+                        pages[pageIndex]).ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                    when (acquisition.TryCaptureFailure(exception, out _))
+                {
+                    failure = exception;
+                }
+
+                if (failure is not null)
+                {
+                    yield return acquisition.Failed(failure);
+                    yield break;
+                }
+
+                if (pageRead.Completion is { } limit)
+                {
+                    yield return await acquisition.CreateTerminalAsync(
+                        index.Horizon,
+                        limit).ConfigureAwait(false);
+                    yield break;
+                }
+
+                PackageSourceOperationResult<NuGetCatalogPage> outcome =
+                    await acquisition.AdmitPageAsync(
+                        index.Horizon,
+                        pages,
+                        pageIndex,
+                        pageRead.Value!).ConfigureAwait(false);
+                yield return outcome;
+                if (outcome.Failure is not null
+                    || outcome.Value!.Completion is not null)
+                    yield break;
+            }
+
+            yield break;
+        }
+
+        yield return acquisition.Failed(
+            lastEndpointFailure
+            ?? new NuGetSourceResponseException(
+                "The package source did not provide a usable Catalog endpoint."));
+    }
+}
+
+internal sealed class NuGetCatalogAcquisition
+{
+    private const int MaxEquivalentCatalogEndpoints = 4;
+    private const int TraversalCheckpointInterval = 128;
+
+    private static JsonDocumentOptions DocumentOptions =>
+        new()
+        {
+            AllowDuplicateProperties = false,
+            MaxDepth = 64,
+        };
+
+    private readonly PackageSourceResultFactory _results;
+    private readonly HttpClient _client;
+    private readonly string _serviceIndexUrl;
+    private readonly PackageSourceCredential? _credential;
+    private readonly NuGetFetchOptions _options;
+    private readonly TimeSpan _clientTimeout;
+    private readonly NuGetCatalogRequest _request;
+    private readonly CancellationToken _cancellationToken;
+    private readonly NuGetOperationContext? _operationContext;
+    private readonly NuGetCatalogBudget _budget;
+    private TimeSpan _remaining;
+    private NuGetCatalogEvent? _lastEvent;
+
+    internal NuGetCatalogAcquisition(
+        PackageSourceResultFactory results,
+        HttpClient client,
+        Uri serviceIndex,
+        PackageSourceCredential? credential,
+        NuGetFetchOptions options,
+        TimeSpan clientTimeout,
+        NuGetCatalogRequest request,
+        CancellationToken cancellationToken,
+        NuGetOperationContext? operationContext)
+    {
+        _results = results;
+        _client = client;
+        _serviceIndexUrl = NuGetSourceRequest.EndpointUrl(serviceIndex);
+        _credential = credential;
+        _options = options;
+        _clientTimeout = clientTimeout;
+        _request = request;
+        _cancellationToken = cancellationToken;
+        _operationContext = operationContext;
+        _budget = new NuGetCatalogBudget(options);
+        _remaining = options.OperationTimeout;
+    }
+
+    internal async Task<IReadOnlyList<string>>
+        DiscoverCatalogEndpointsAsync()
+    {
+        NuGetCatalogDocumentResult<IReadOnlyList<string>> result =
+            await ReadDocumentAsync(
+                _serviceIndexUrl,
+                _credential,
+                ReadServiceIndexAsync).ConfigureAwait(false);
+        if (result.Completion is not null)
+        {
+            throw new NuGetCatalogResourceLimitExceededException(
+                "A Catalog acquisition bound was reached while reading the service index.");
+        }
+
+        return result.Value!;
+    }
+
+    internal Task<NuGetCatalogDocumentResult<NuGetCatalogIndex>>
+        ReadCatalogIndexAsync(string endpoint) =>
+        ReadDocumentAsync(
+            endpoint,
+            NuGetSourceRequest.CredentialForEndpoint(
+                _serviceIndexUrl,
+                endpoint,
+                _credential),
+            (json, operation, cancellationToken) =>
+                ReadCatalogIndexCoreAsync(
+                    json,
+                    operation,
+                    cancellationToken));
+
+    internal Task<
+        NuGetCatalogDocumentResult<ImmutableArray<NuGetCatalogEvent>>>
+        ReadPageAsync(
+            DateTimeOffset capturedHorizon,
+            NuGetCatalogPageDescriptor page) =>
+        ReadDocumentAsync(
+            page.Url,
+            NuGetSourceRequest.CredentialForEndpoint(
+                _serviceIndexUrl,
+                page.Url,
+                _credential),
+            (json, operation, cancellationToken) =>
+                ReadPageCoreAsync(
+                    json,
+                    capturedHorizon,
+                    page,
+                    operation,
+                    cancellationToken));
+
+    internal ImmutableArray<NuGetCatalogPageDescriptor> SelectPages(
+        NuGetCatalogIndex index)
+    {
+        DateTimeOffset upper = index.Horizon < _request.ThroughInclusive
+            ? index.Horizon
+            : _request.ThroughInclusive;
+        var selected =
+            ImmutableArray.CreateBuilder<NuGetCatalogPageDescriptor>();
+        foreach (NuGetCatalogPageDescriptor page in index.Pages)
+        {
+            if (page.CommitTimestamp <= _request.FromExclusive)
+                continue;
+
+            selected.Add(page);
+            if (page.CommitTimestamp > upper)
+                break;
+        }
+
+        return selected.ToImmutable();
+    }
+
+    internal NuGetCatalogCompletion CoverageCompletion(
+        DateTimeOffset horizon) =>
+        horizon >= _request.ThroughInclusive
+            ? NuGetCatalogCompletion.WindowExhausted
+            : NuGetCatalogCompletion.SourceHorizonReached;
+
+    internal bool TryCaptureFailure(
+        Exception exception,
+        out PackageSourceFailureKind kind) =>
+        PackageSourceOperation.TryClassify(
+            exception,
+            allowNotFound: false,
+            out kind);
+
+    internal bool CanFailOver(Exception exception)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (!TryCaptureFailure(exception, out PackageSourceFailureKind kind)
+            || kind == PackageSourceFailureKind.AuthenticationRequired
+            || exception is NuGetOperationTimeoutException
+            || !_budget.CanStartRequest
+            || !_budget.CanReadDecodedByte)
+        {
+            return false;
+        }
+
+        return kind is PackageSourceFailureKind.Timeout
+            or PackageSourceFailureKind.InvalidResponse
+            or PackageSourceFailureKind.ResponseRejected
+            or PackageSourceFailureKind.Transport;
+    }
+
+    internal PackageSourceOperationResult<NuGetCatalogPage> Failed(
+        Exception exception)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        if (!TryCaptureFailure(exception, out PackageSourceFailureKind kind))
+            throw exception;
+        return _results.FailedCatalog(kind);
+    }
+
+    internal async Task<PackageSourceOperationResult<NuGetCatalogPage>>
+        CreateTerminalAsync(
+            DateTimeOffset horizon,
+            NuGetCatalogCompletion completion)
+    {
+        try
+        {
+            return await CreatePageAsync(
+                horizon,
+                [],
+                completion).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+            when (TryCaptureFailure(exception, out _))
+        {
+            return Failed(exception);
+        }
+    }
+
+    internal async Task<PackageSourceOperationResult<NuGetCatalogPage>>
+        AdmitPageAsync(
+            DateTimeOffset horizon,
+            ImmutableArray<NuGetCatalogPageDescriptor> selectedPages,
+            int pageIndex,
+            ImmutableArray<NuGetCatalogEvent> events)
+    {
+        try
+        {
+            ValidatePageOrder(events);
+            _budget.AdmitPage(events.Length);
+            NuGetCatalogCompletion? completion =
+                pageIndex == selectedPages.Length - 1
+                    ? CoverageCompletion(horizon)
+                    : _budget.PagesAcquired >= _options.MaxCatalogPages
+                        ? NuGetCatalogCompletion.PageLimitReached
+                        : !_budget.CanStartRequest
+                            ? NuGetCatalogCompletion.RequestLimitReached
+                            : !_budget.CanReadDecodedByte
+                                ? NuGetCatalogCompletion.DecodedByteLimitReached
+                                : null;
+            return await CreatePageAsync(
+                horizon,
+                events,
+                completion).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+            when (TryCaptureFailure(exception, out _))
+        {
+            return Failed(exception);
+        }
+    }
+
+    private async Task<PackageSourceOperationResult<NuGetCatalogPage>>
+        CreatePageAsync(
+            DateTimeOffset horizon,
+            ImmutableArray<NuGetCatalogEvent> events,
+            NuGetCatalogCompletion? completion)
+    {
+        return await RunStepAsync(
+            operation =>
+            {
+                NuGetCatalogPage page = _results.CatalogPage(
+                    _request,
+                    events,
+                    horizon,
+                    _budget.PagesAcquired,
+                    _budget.HttpAttempts,
+                    _budget.DecodedBytes,
+                    _budget.InWindowEventCount,
+                    completion,
+                    operation);
+                return Task.FromResult(
+                    _results.SucceededCatalog(page, operation));
+            }).ConfigureAwait(false);
+    }
+
+    private void ValidatePageOrder(
+        ImmutableArray<NuGetCatalogEvent> events)
+    {
+        if (events.IsEmpty)
+            return;
+
+        NuGetCatalogEvent first = events[0];
+        if (_lastEvent is not null
+            && _lastEvent.CommitTimestamp > first.CommitTimestamp)
+        {
+            throw new NuGetSourceResponseException(
+                "Catalog pages did not produce chronological event order.");
+        }
+
+        _lastEvent = events[^1];
+    }
+
+    private async Task<NuGetCatalogDocumentResult<T>> ReadDocumentAsync<T>(
+        string url,
+        PackageSourceCredential? credential,
+        Func<
+            Stream,
+            NuGetOperationDeadline,
+            CancellationToken,
+            ValueTask<T>> deserialize)
+        =>
+        await RunStepAsync(
+            operation => ReadDocumentWithRetryAsync(
+                url,
+                credential,
+                deserialize,
+                operation)).ConfigureAwait(false);
+
+    private async Task<NuGetCatalogDocumentResult<T>>
+        ReadDocumentWithRetryAsync<T>(
+            string url,
+            PackageSourceCredential? credential,
+            Func<
+                Stream,
+                NuGetOperationDeadline,
+                CancellationToken,
+                ValueTask<T>> deserialize,
+            NuGetOperationDeadline operation)
+    {
+        for (int retry = 0; ; retry++)
+        {
+            operation.ThrowIfExpired();
+            if (!_budget.TryBeginRequest())
+            {
+                return NuGetCatalogDocumentResult<T>.Limited(
+                    NuGetCatalogCompletion.RequestLimitReached);
+            }
+
+            try
+            {
+                T value = await operation.RunRequestAsync(
+                    async requestToken =>
+                    {
+                        using HttpRequestMessage request =
+                            NuGetHttpRequest
+                                .CreateGetPreservingPathAndQuery(url);
+                        NuGetSourceRequest.ApplyCredential(
+                            request,
+                            credential);
+                        using HttpResponseMessage response =
+                            await _client.SendAsync(
+                                request,
+                                HttpCompletionOption.ResponseHeadersRead,
+                                requestToken).ConfigureAwait(false);
+                        response.EnsureSuccessStatusCode();
+                        return await NuGetMetadataReader.ReadResponseAsync(
+                            response,
+                            (stream, cancellationToken) =>
+                                deserialize(
+                                    _budget.LimitDecodedBytes(stream),
+                                    operation,
+                                    cancellationToken),
+                            _options,
+                            operation.RequestTimeout,
+                            requestToken).ConfigureAwait(false);
+                    }).ConfigureAwait(false);
+                return NuGetCatalogDocumentResult<T>.Succeeded(value);
+            }
+            catch (NuGetCatalogDecodedByteLimitExceededException)
+            {
+                return NuGetCatalogDocumentResult<T>.Limited(
+                    NuGetCatalogCompletion.DecodedByteLimitReached);
+            }
+            catch (Exception exception)
+                when (retry < NuGetHttpRetry.MaximumRetries
+                    && NuGetHttpRetry.IsTransient(exception))
+            {
+                await NuGetHttpRetry.DelayAsync(operation, retry)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task<T> RunStepAsync<T>(
+        Func<NuGetOperationDeadline, Task<T>> action)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+        long started = Stopwatch.GetTimestamp();
+        try
+        {
+            using NuGetOperationDeadline operation = CreateOperation();
+            return await action(operation).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (_operationContext is null)
+                _remaining -= Stopwatch.GetElapsedTime(started);
+        }
+    }
+
+    private NuGetOperationDeadline CreateOperation()
+    {
+        if (_operationContext is not null)
+        {
+            return _operationContext.CreateDeadline(
+                _clientTimeout,
+                _cancellationToken,
+                _results.Source);
+        }
+
+        if (_remaining <= TimeSpan.Zero)
+        {
+            throw new NuGetOperationTimeoutException(
+                _options.OperationTimeout,
+                new OperationCanceledException(
+                    "NuGet Catalog operation deadline expired."));
+        }
+
+        return new NuGetOperationDeadline(
+            _options with { OperationTimeout = _remaining },
+            _clientTimeout,
+            _cancellationToken,
+            _results.Source);
+    }
+
+    private static async ValueTask<IReadOnlyList<string>>
+        ReadServiceIndexAsync(
+            Stream json,
+            NuGetOperationDeadline operation,
+            CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await JsonDocument.ParseAsync(
+            json,
+            DocumentOptions,
+            cancellationToken).ConfigureAwait(false);
+        JsonElement root = RequiredObject(
+            document.RootElement,
+            "The package source service index must be an object.");
+        _ = RequiredText(root, "version", "service index");
+        JsonElement resources = RequiredArray(
+            root,
+            "resources",
+            "service index");
+
+        var endpoints = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        bool malformedSupportedResource = false;
+        int observed = 0;
+        foreach (JsonElement resource in resources.EnumerateArray())
+        {
+            if (resource.ValueKind != JsonValueKind.Object)
+            {
+                observed++;
+                await CheckTraversalAsync(
+                    observed,
+                    operation,
+                    cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            bool validTypeShape = TryHasCatalogType(
+                Optional(resource, "@type"),
+                out bool hasCatalogType);
+            if (hasCatalogType)
+            {
+                if (!validTypeShape
+                    || Optional(resource, "@id") is not
+                        { ValueKind: JsonValueKind.String } id
+                    || id.GetString() is not { } declared
+                    || !TryNormalizeAdvertisedUrl(
+                        declared,
+                        out string normalized))
+                {
+                    malformedSupportedResource = true;
+                }
+                else if (seen.Add(normalized)
+                    && endpoints.Count < MaxEquivalentCatalogEndpoints)
+                {
+                    endpoints.Add(normalized);
+                }
+            }
+
+            observed++;
+            await CheckTraversalAsync(
+                observed,
+                operation,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        if (endpoints.Count == 0 && malformedSupportedResource)
+        {
+            throw new NuGetSourceResponseException(
+                "The package source service index advertised an unusable Catalog endpoint.");
+        }
+
+        operation.ThrowIfExpired();
+        return endpoints;
+    }
+
+    private async ValueTask<NuGetCatalogIndex>
+        ReadCatalogIndexCoreAsync(
+            Stream json,
+            NuGetOperationDeadline operation,
+            CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await JsonDocument.ParseAsync(
+            json,
+            DocumentOptions,
+            cancellationToken).ConfigureAwait(false);
+        JsonElement root = RequiredObject(
+            document.RootElement,
+            "The Catalog index must be an object.");
+        _ = RequiredText(root, "commitId", "Catalog index");
+        DateTimeOffset horizon = RequiredTimestamp(
+            root,
+            "commitTimeStamp",
+            "Catalog index");
+        _ = RequiredNonNegativeInteger(root, "count", "Catalog index");
+        JsonElement items = RequiredArray(root, "items", "Catalog index");
+        var pages =
+            ImmutableArray.CreateBuilder<NuGetCatalogPageDescriptor>(
+                items.GetArrayLength());
+        var urls = new HashSet<string>(StringComparer.Ordinal);
+        int observed = 0;
+        foreach (JsonElement item in items.EnumerateArray())
+        {
+            JsonElement page = RequiredObject(
+                item,
+                "A Catalog index page descriptor must be an object.");
+            string url = RequiredUrl(
+                page,
+                "@id",
+                "Catalog index page descriptor");
+            string commitId = RequiredText(
+                page,
+                "commitId",
+                "Catalog index page descriptor");
+            DateTimeOffset commitTimestamp = RequiredTimestamp(
+                page,
+                "commitTimeStamp",
+                "Catalog index page descriptor");
+            _ = RequiredNonNegativeInteger(
+                page,
+                "count",
+                "Catalog index page descriptor");
+            if (commitTimestamp > horizon)
+            {
+                throw Invalid(
+                    "A Catalog page descriptor exceeded the captured Catalog horizon.");
+            }
+
+            if (!urls.Add(url))
+            {
+                throw Invalid(
+                    "The Catalog index repeated a page URL.");
+            }
+
+            pages.Add(
+                new NuGetCatalogPageDescriptor(
+                    url,
+                    commitId,
+                    commitTimestamp));
+            observed++;
+            await CheckTraversalAsync(
+                observed,
+                operation,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        NuGetCatalogPageDescriptor[] sorted = pages.ToArray();
+        Array.Sort(
+            sorted,
+            static (left, right) =>
+            {
+                int timestamp = left.CommitTimestamp.CompareTo(
+                    right.CommitTimestamp);
+                return timestamp != 0
+                    ? timestamp
+                    : StringComparer.Ordinal.Compare(
+                        left.Url,
+                        right.Url);
+            });
+        if (sorted.Length == 0)
+        {
+            if (horizon != DateTimeOffset.MinValue)
+            {
+                throw Invalid(
+                    "An empty Catalog index advertised a nonempty horizon.");
+            }
+        }
+        else if (sorted[^1].CommitTimestamp != horizon)
+        {
+            throw Invalid(
+                "The Catalog index horizon did not match its latest page descriptor.");
+        }
+
+        operation.ThrowIfExpired();
+        return new NuGetCatalogIndex(
+            horizon,
+            ImmutableArray.CreateRange(sorted));
+    }
+
+    private async ValueTask<ImmutableArray<NuGetCatalogEvent>>
+        ReadPageCoreAsync(
+            Stream json,
+            DateTimeOffset capturedHorizon,
+            NuGetCatalogPageDescriptor descriptor,
+            NuGetOperationDeadline operation,
+            CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await JsonDocument.ParseAsync(
+            json,
+            DocumentOptions,
+            cancellationToken).ConfigureAwait(false);
+        JsonElement root = RequiredObject(
+            document.RootElement,
+            "A Catalog page must be an object.");
+        _ = RequiredText(root, "commitId", "Catalog page");
+        DateTimeOffset pageHorizon = RequiredTimestamp(
+            root,
+            "commitTimeStamp",
+            "Catalog page");
+        if (pageHorizon < descriptor.CommitTimestamp)
+        {
+            throw new NuGetCatalogStalePageException(
+                "A Catalog page preceded its advertised page horizon.");
+        }
+
+        _ = RequiredNonNegativeInteger(root, "count", "Catalog page");
+        _ = RequiredUrl(root, "parent", "Catalog page");
+
+        JsonElement items = RequiredArray(root, "items", "Catalog page");
+        var allEvents =
+            ImmutableArray.CreateBuilder<NuGetCatalogEvent>(
+                items.GetArrayLength());
+        var urls = new HashSet<string>(StringComparer.Ordinal);
+        int observed = 0;
+        foreach (JsonElement value in items.EnumerateArray())
+        {
+            JsonElement item = RequiredObject(
+                value,
+                "A Catalog page item must be an object.");
+            string leafUrl = RequiredUrl(
+                item,
+                "@id",
+                "Catalog page item");
+            if (!urls.Add(leafUrl))
+                throw Invalid("A Catalog page repeated a leaf URL.");
+
+            NuGetCatalogEventKind kind = RequiredEventKind(item);
+            string commitId = RequiredText(
+                item,
+                "commitId",
+                "Catalog page item");
+            DateTimeOffset commitTimestamp = RequiredTimestamp(
+                item,
+                "commitTimeStamp",
+                "Catalog page item");
+            if (commitTimestamp > pageHorizon)
+            {
+                throw Invalid(
+                    "A Catalog page item exceeded its page horizon.");
+            }
+
+            string packageId = RequiredText(
+                item,
+                "nuget:id",
+                "Catalog page item");
+            string version = RequiredText(
+                item,
+                "nuget:version",
+                "Catalog page item");
+            PackageSourceCoordinate coordinate;
+            try
+            {
+                coordinate = PackageSourceCoordinate.Create(
+                    packageId,
+                    version);
+            }
+            catch (ArgumentException exception)
+            {
+                throw Invalid(
+                    "A Catalog page item contained an invalid package coordinate.",
+                    exception);
+            }
+
+            allEvents.Add(
+                _results.CatalogEvent(
+                    coordinate,
+                    packageId,
+                    version,
+                    leafUrl,
+                    commitId,
+                    commitTimestamp,
+                    kind));
+            observed++;
+            await CheckTraversalAsync(
+                observed,
+                operation,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        NuGetCatalogEvent[] sorted = allEvents.ToArray();
+        Array.Sort(sorted, CompareEvents);
+        DateTimeOffset upper =
+            _request.ThroughInclusive < capturedHorizon
+                ? _request.ThroughInclusive
+                : capturedHorizon;
+        var selected = ImmutableArray.CreateBuilder<NuGetCatalogEvent>();
+        foreach (NuGetCatalogEvent item in sorted)
+        {
+            operation.ThrowIfExpired();
+            if (item.CommitTimestamp > _request.FromExclusive
+                && item.CommitTimestamp <= upper)
+            {
+                selected.Add(item);
+            }
+        }
+
+        operation.ThrowIfExpired();
+        return selected.ToImmutable();
+    }
+
+    private static int CompareEvents(
+        NuGetCatalogEvent left,
+        NuGetCatalogEvent right)
+    {
+        int timestamp = left.CommitTimestamp.CompareTo(
+            right.CommitTimestamp);
+        return timestamp != 0
+            ? timestamp
+            : StringComparer.Ordinal.Compare(
+                left.LeafUrl,
+                right.LeafUrl);
+    }
+
+    private static bool TryHasCatalogType(
+        JsonElement type,
+        out bool hasCatalogType)
+    {
+        hasCatalogType = false;
+        if (type.ValueKind == JsonValueKind.String)
+        {
+            hasCatalogType = type.GetString()?.Equals(
+                "Catalog/3.0.0",
+                StringComparison.OrdinalIgnoreCase) == true;
+            return true;
+        }
+
+        if (type.ValueKind != JsonValueKind.Array)
+            return false;
+
+        bool valid = true;
+        foreach (JsonElement item in type.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String
+                || item.GetString() is not { } value)
+            {
+                valid = false;
+                continue;
+            }
+
+            if (value.Equals(
+                "Catalog/3.0.0",
+                StringComparison.OrdinalIgnoreCase))
+            {
+                hasCatalogType = true;
+            }
+        }
+
+        return valid;
+    }
+
+    private static NuGetCatalogEventKind RequiredEventKind(
+        JsonElement item)
+    {
+        string kind = RequiredText(
+            item,
+            "@type",
+            "Catalog page item");
+        return kind switch
+        {
+            "nuget:PackageDetails" =>
+                NuGetCatalogEventKind.Details,
+            "nuget:PackageDelete" =>
+                NuGetCatalogEventKind.Delete,
+            _ => throw Invalid(
+                "A Catalog page item had an unsupported event kind."),
+        };
+    }
+
+    private static JsonElement RequiredObject(
+        JsonElement value,
+        string message) =>
+        value.ValueKind == JsonValueKind.Object
+            ? value
+            : throw Invalid(message);
+
+    private static JsonElement RequiredArray(
+        JsonElement parent,
+        string name,
+        string document)
+    {
+        JsonElement value = Optional(parent, name);
+        if (value.ValueKind != JsonValueKind.Array)
+        {
+            throw Invalid(
+                $"The {document} must contain an '{name}' array.");
+        }
+
+        return value;
+    }
+
+    private static string RequiredText(
+        JsonElement parent,
+        string name,
+        string document)
+    {
+        JsonElement value = Optional(parent, name);
+        if (value.ValueKind != JsonValueKind.String
+            || string.IsNullOrWhiteSpace(value.GetString()))
+        {
+            throw Invalid(
+                $"The {document} must contain nonempty '{name}' text.");
+        }
+
+        return value.GetString()!;
+    }
+
+    private static string RequiredUrl(
+        JsonElement parent,
+        string name,
+        string document)
+    {
+        string declared = RequiredText(parent, name, document);
+        if (!TryNormalizeAdvertisedUrl(
+                declared,
+                out string normalized))
+        {
+            throw Invalid(
+                $"The {document} contained an unusable '{name}' URL.");
+        }
+
+        return normalized;
+    }
+
+    private static bool TryNormalizeAdvertisedUrl(
+        string declared,
+        out string normalized)
+    {
+        normalized = "";
+        if (!NuGetSourceRequest.TryEndpointUrl(
+                declared,
+                out string endpoint)
+            || !NuGetHttpRequest.TryCreatePreservingPathAndQuery(
+                endpoint,
+                out Uri? parsed)
+            || parsed is null
+            || parsed.UserInfo.Length > 0)
+        {
+            return false;
+        }
+
+        normalized = endpoint;
+        return true;
+    }
+
+    private static DateTimeOffset RequiredTimestamp(
+        JsonElement parent,
+        string name,
+        string document)
+    {
+        string text = RequiredText(parent, name, document);
+        if (!DateTimeOffset.TryParse(
+                text,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out DateTimeOffset value)
+            || value.Offset != TimeSpan.Zero
+            || text.AsSpan().Trim().Length != text.Length
+            || !HasExplicitUtcSuffix(text))
+        {
+            throw Invalid(
+                $"The {document} contained an invalid UTC '{name}' timestamp.");
+        }
+
+        return value.ToUniversalTime();
+    }
+
+    private static bool HasExplicitUtcSuffix(string value) =>
+        value.EndsWith("Z", StringComparison.OrdinalIgnoreCase)
+        || value.EndsWith("+00:00", StringComparison.Ordinal);
+
+    private static long RequiredNonNegativeInteger(
+        JsonElement parent,
+        string name,
+        string document)
+    {
+        JsonElement value = Optional(parent, name);
+        if (value.ValueKind != JsonValueKind.Number
+            || !value.TryGetInt64(out long count)
+            || count < 0)
+        {
+            throw Invalid(
+                $"The {document} contained an invalid '{name}' count.");
+        }
+
+        return count;
+    }
+
+    private static JsonElement Optional(
+        JsonElement parent,
+        string name) =>
+        parent.ValueKind == JsonValueKind.Object
+            && parent.TryGetProperty(name, out JsonElement value)
+                ? value
+                : default;
+
+    private static async ValueTask CheckTraversalAsync(
+        int observed,
+        NuGetOperationDeadline operation,
+        CancellationToken cancellationToken)
+    {
+        if (observed % TraversalCheckpointInterval != 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            operation.ThrowIfExpired();
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        operation.ThrowIfExpired();
+        if (OperatingSystem.IsBrowser())
+            await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+        operation.ThrowIfExpired();
+    }
+
+    private static JsonException Invalid(
+        string message,
+        Exception? innerException = null) =>
+        new(message, innerException);
+}
+
+internal sealed record NuGetCatalogIndex(
+    DateTimeOffset Horizon,
+    ImmutableArray<NuGetCatalogPageDescriptor> Pages);
+
+internal sealed record NuGetCatalogPageDescriptor(
+    string Url,
+    string CommitId,
+    DateTimeOffset CommitTimestamp);
+
+internal readonly record struct NuGetCatalogDocumentResult<T>(
+    T Value,
+    NuGetCatalogCompletion? Completion)
+{
+    internal static NuGetCatalogDocumentResult<T> Succeeded(T value) =>
+        new(value, Completion: null);
+
+    internal static NuGetCatalogDocumentResult<T> Limited(
+        NuGetCatalogCompletion completion) =>
+        new(Value: default!, completion);
+}
+
+internal sealed class NuGetCatalogBudget
+{
+    private readonly int _maximumRequests;
+    private readonly long _maximumDecodedBytes;
+
+    internal NuGetCatalogBudget(NuGetFetchOptions options)
+    {
+        _maximumRequests = options.MaxCatalogHttpAttempts;
+        _maximumDecodedBytes = options.MaxCatalogDecodedBytes;
+    }
+
+    internal int PagesAcquired { get; private set; }
+    internal int HttpAttempts { get; private set; }
+    internal long DecodedBytes { get; private set; }
+    internal long InWindowEventCount { get; private set; }
+    internal bool CanStartRequest => HttpAttempts < _maximumRequests;
+    internal bool CanReadDecodedByte =>
+        DecodedBytes < _maximumDecodedBytes;
+
+    internal bool TryBeginRequest()
+    {
+        if (!CanStartRequest)
+            return false;
+        HttpAttempts++;
+        return true;
+    }
+
+    internal Stream LimitDecodedBytes(Stream stream) =>
+        new NuGetCatalogDecodedByteStream(stream, this);
+
+    internal void AdmitPage(int eventCount)
+    {
+        PagesAcquired++;
+        InWindowEventCount += eventCount;
+    }
+
+    private sealed class NuGetCatalogDecodedByteStream(
+        Stream inner,
+        NuGetCatalogBudget budget) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (buffer.IsEmpty)
+                return 0;
+
+            int read = inner.Read(Limit(buffer));
+            AccountFor(read);
+            return read;
+        }
+
+        public override int ReadByte()
+        {
+            int value = inner.ReadByte();
+            AccountFor(value < 0 ? 0 : 1);
+            return value;
+        }
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken) =>
+            ReadAsync(
+                buffer.AsMemory(offset, count),
+                cancellationToken).AsTask();
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (buffer.IsEmpty)
+                return 0;
+
+            int read = await inner.ReadAsync(
+                Limit(buffer),
+                cancellationToken).ConfigureAwait(false);
+            AccountFor(read);
+            return read;
+        }
+
+        private Span<byte> Limit(Span<byte> buffer)
+        {
+            long remaining =
+                budget._maximumDecodedBytes - budget.DecodedBytes;
+            int allowed = remaining > 0
+                ? (int)Math.Min(buffer.Length, remaining)
+                : 1;
+            return buffer[..allowed];
+        }
+
+        private Memory<byte> Limit(Memory<byte> buffer)
+        {
+            long remaining =
+                budget._maximumDecodedBytes - budget.DecodedBytes;
+            int allowed = remaining > 0
+                ? (int)Math.Min(buffer.Length, remaining)
+                : 1;
+            return buffer[..allowed];
+        }
+
+        private void AccountFor(int read)
+        {
+            if (read == 0)
+                return;
+
+            if (budget.DecodedBytes >= budget._maximumDecodedBytes)
+                throw new NuGetCatalogDecodedByteLimitExceededException();
+            budget.DecodedBytes += read;
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+        public override void Write(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
+    }
+}
+
+internal sealed class NuGetCatalogDecodedByteLimitExceededException()
+    : IOException(
+        "NuGet Catalog metadata exceeded the aggregate decoded-byte limit.");

--- a/src/NuGetFetch/NuGetCatalogAcquisition.cs
+++ b/src/NuGetFetch/NuGetCatalogAcquisition.cs
@@ -226,7 +226,6 @@ internal sealed class NuGetCatalogAcquisition
     private readonly NuGetOperationContext? _operationContext;
     private readonly NuGetCatalogBudget _budget;
     private TimeSpan _remaining;
-    private NuGetCatalogEvent? _lastEvent;
 
     internal NuGetCatalogAcquisition(
         PackageSourceResultFactory results,
@@ -401,7 +400,6 @@ internal sealed class NuGetCatalogAcquisition
     {
         try
         {
-            ValidatePageOrder(events);
             _budget.AdmitPage(events.Length);
             NuGetCatalogCompletion? completion =
                 pageIndex == selectedPages.Length - 1
@@ -447,23 +445,6 @@ internal sealed class NuGetCatalogAcquisition
                 return Task.FromResult(
                     _results.SucceededCatalog(page, operation));
             }).ConfigureAwait(false);
-    }
-
-    private void ValidatePageOrder(
-        ImmutableArray<NuGetCatalogEvent> events)
-    {
-        if (events.IsEmpty)
-            return;
-
-        NuGetCatalogEvent first = events[0];
-        if (_lastEvent is not null
-            && _lastEvent.CommitTimestamp > first.CommitTimestamp)
-        {
-            throw new NuGetSourceResponseException(
-                "Catalog pages did not produce chronological event order.");
-        }
-
-        _lastEvent = events[^1];
     }
 
     private async Task<NuGetCatalogDocumentResult<T>> ReadDocumentAsync<T>(

--- a/src/NuGetFetch/NuGetCatalogAcquisition.cs
+++ b/src/NuGetFetch/NuGetCatalogAcquisition.cs
@@ -205,6 +205,8 @@ internal sealed class NuGetCatalogAcquisition
 {
     private const int MaxEquivalentCatalogEndpoints = 4;
     private const int TraversalCheckpointInterval = 128;
+    private const string UtcTimestampFormat =
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK";
 
     private static JsonDocumentOptions DocumentOptions =>
         new()
@@ -1091,14 +1093,14 @@ internal sealed class NuGetCatalogAcquisition
         string document)
     {
         string text = RequiredText(parent, name, document);
-        if (!DateTimeOffset.TryParse(
+        if (!HasCompleteUtcTimestampShape(text)
+            || !DateTimeOffset.TryParseExact(
                 text,
+                UtcTimestampFormat,
                 CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
+                DateTimeStyles.AssumeUniversal,
                 out DateTimeOffset value)
-            || value.Offset != TimeSpan.Zero
-            || text.AsSpan().Trim().Length != text.Length
-            || !HasExplicitUtcSuffix(text))
+            || value.Offset != TimeSpan.Zero)
         {
             throw Invalid(
                 $"The {document} contained an invalid UTC '{name}' timestamp.");
@@ -1107,9 +1109,40 @@ internal sealed class NuGetCatalogAcquisition
         return value.ToUniversalTime();
     }
 
-    private static bool HasExplicitUtcSuffix(string value) =>
-        value.EndsWith("Z", StringComparison.OrdinalIgnoreCase)
-        || value.EndsWith("+00:00", StringComparison.Ordinal);
+    private static bool HasCompleteUtcTimestampShape(string value)
+    {
+        int suffixStart;
+        if (value.EndsWith("Z", StringComparison.Ordinal))
+        {
+            suffixStart = value.Length - 1;
+        }
+        else if (value.EndsWith("+00:00", StringComparison.Ordinal))
+        {
+            suffixStart = value.Length - 6;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (suffixStart == 19)
+            return true;
+        if (suffixStart < 21
+            || suffixStart > 27
+            || value.Length <= 19
+            || value[19] != '.')
+        {
+            return false;
+        }
+
+        for (int index = 20; index < suffixStart; index++)
+        {
+            if (!char.IsAsciiDigit(value[index]))
+                return false;
+        }
+
+        return true;
+    }
 
     private static long RequiredNonNegativeInteger(
         JsonElement parent,

--- a/src/NuGetFetch/NuGetCatalogResult.cs
+++ b/src/NuGetFetch/NuGetCatalogResult.cs
@@ -1,0 +1,290 @@
+using System.Collections.Immutable;
+
+namespace NuGetFetch;
+
+/// <summary>
+/// One explicit UTC NuGet Catalog interval, exclusive at the start and
+/// inclusive at the end.
+/// </summary>
+public sealed record NuGetCatalogRequest
+{
+    /// <summary>The largest interval accepted by Catalog acquisition.</summary>
+    public static TimeSpan MaximumInterval { get; } =
+        TimeSpan.FromDays(42);
+
+    public NuGetCatalogRequest(
+        DateTimeOffset fromExclusive,
+        DateTimeOffset throughInclusive)
+    {
+        if (fromExclusive.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                "The Catalog lower bound must be UTC.",
+                nameof(fromExclusive));
+        }
+
+        if (throughInclusive.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                "The Catalog upper bound must be UTC.",
+                nameof(throughInclusive));
+        }
+
+        if (throughInclusive <= fromExclusive)
+        {
+            throw new ArgumentException(
+                "The Catalog upper bound must be later than the lower bound.",
+                nameof(throughInclusive));
+        }
+
+        if (throughInclusive - fromExclusive > MaximumInterval)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(throughInclusive),
+                throughInclusive,
+                $"A Catalog interval cannot exceed {MaximumInterval}.");
+        }
+
+        FromExclusive = fromExclusive;
+        ThroughInclusive = throughInclusive;
+    }
+
+    /// <summary>Gets the exclusive UTC lower bound.</summary>
+    public DateTimeOffset FromExclusive { get; }
+
+    /// <summary>Gets the inclusive UTC upper bound.</summary>
+    public DateTimeOffset ThroughInclusive { get; }
+}
+
+/// <summary>The closed source-issued kind of one Catalog event.</summary>
+public enum NuGetCatalogEventKind
+{
+    /// <summary>A <c>nuget:PackageDetails</c> activity observation.</summary>
+    Details,
+
+    /// <summary>A <c>nuget:PackageDelete</c> activity observation.</summary>
+    Delete,
+}
+
+/// <summary>Why a bounded Catalog acquisition completed.</summary>
+public enum NuGetCatalogCompletion
+{
+    /// <summary>The source horizon covers the request and all selected pages were admitted.</summary>
+    WindowExhausted,
+
+    /// <summary>All pages through the captured horizon were admitted, but the horizon trails the request.</summary>
+    SourceHorizonReached,
+
+    /// <summary>The configured Catalog page bound stopped acquisition.</summary>
+    PageLimitReached,
+
+    /// <summary>The configured Catalog HTTP-attempt bound stopped acquisition.</summary>
+    RequestLimitReached,
+
+    /// <summary>The configured aggregate decoded-byte bound stopped acquisition.</summary>
+    DecodedByteLimitReached,
+}
+
+/// <summary>The optional NuGet V3 Catalog capability of a package source.</summary>
+public interface INuGetCatalogPackageSourceClient : IPackageSourceClient
+{
+    /// <summary>
+    /// Acquires backpressured page outcomes for one explicit Catalog interval.
+    /// </summary>
+    IAsyncEnumerable<PackageSourceOperationResult<NuGetCatalogPage>>
+        AcquireCatalogAsync(
+            NuGetCatalogRequest request,
+            CancellationToken cancellationToken = default,
+            NuGetOperationContext? operationContext = null);
+}
+
+/// <summary>One validated activity observation from a Catalog page.</summary>
+public sealed class NuGetCatalogEvent
+{
+    private readonly object _issuer;
+
+    internal NuGetCatalogEvent(
+        object ownerCapability,
+        object issuer,
+        PackageSourceCoordinate coordinate,
+        string packageId,
+        string version,
+        string leafUrl,
+        string commitId,
+        DateTimeOffset commitTimestamp,
+        NuGetCatalogEventKind kind)
+    {
+        PackageSourceClientFactory.RequireOwnerCapability(ownerCapability);
+        ArgumentNullException.ThrowIfNull(issuer);
+        ArgumentNullException.ThrowIfNull(coordinate);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        ArgumentException.ThrowIfNullOrWhiteSpace(leafUrl);
+        ArgumentException.ThrowIfNullOrWhiteSpace(commitId);
+        if (commitTimestamp.Offset != TimeSpan.Zero)
+            throw new ArgumentException("A Catalog event timestamp must be UTC.", nameof(commitTimestamp));
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
+
+        _issuer = issuer;
+        Coordinate = coordinate;
+        PackageId = packageId;
+        Version = version;
+        LeafUrl = leafUrl;
+        CommitId = commitId;
+        CommitTimestamp = commitTimestamp;
+        Kind = kind;
+    }
+
+    public PackageSourceCoordinate Coordinate { get; }
+    public string PackageId { get; }
+    public string Version { get; }
+    public string LeafUrl { get; }
+    public string CommitId { get; }
+    public DateTimeOffset CommitTimestamp { get; }
+    public NuGetCatalogEventKind Kind { get; }
+
+    internal bool HasIssuer(object issuer) =>
+        ReferenceEquals(_issuer, issuer);
+}
+
+/// <summary>
+/// One immutable Catalog page outcome with cumulative acquisition progress.
+/// The terminal marker for an empty interval or a crossed acquisition bound
+/// has an empty <see cref="Events"/> collection.
+/// </summary>
+public sealed class NuGetCatalogPage
+{
+    private readonly object _issuer;
+
+    internal NuGetCatalogPage(
+        object ownerCapability,
+        object issuer,
+        PackageSourceResultIdentity source,
+        NuGetCatalogRequest request,
+        ImmutableArray<NuGetCatalogEvent> events,
+        DateTimeOffset capturedHorizon,
+        int pagesAcquired,
+        int httpAttempts,
+        long decodedBytes,
+        long inWindowEventCount,
+        NuGetCatalogCompletion? completion)
+    {
+        PackageSourceClientFactory.RequireOwnerCapability(ownerCapability);
+        ArgumentNullException.ThrowIfNull(issuer);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(request);
+        if (events.IsDefault)
+            throw new ArgumentException("Catalog events must be initialized.", nameof(events));
+        if (capturedHorizon.Offset != TimeSpan.Zero)
+            throw new ArgumentException("The Catalog horizon must be UTC.", nameof(capturedHorizon));
+        ArgumentOutOfRangeException.ThrowIfNegative(pagesAcquired);
+        ArgumentOutOfRangeException.ThrowIfNegative(httpAttempts);
+        ArgumentOutOfRangeException.ThrowIfNegative(decodedBytes);
+        ArgumentOutOfRangeException.ThrowIfNegative(inWindowEventCount);
+        if (inWindowEventCount < events.Length)
+            throw new ArgumentOutOfRangeException(nameof(inWindowEventCount));
+        if (completion is { } terminal && !Enum.IsDefined(terminal))
+            throw new ArgumentOutOfRangeException(nameof(completion), completion, null);
+
+        _issuer = issuer;
+        Source = source;
+        Request = request;
+        Events = events;
+        CapturedHorizon = capturedHorizon;
+        PagesAcquired = pagesAcquired;
+        HttpAttempts = httpAttempts;
+        DecodedBytes = decodedBytes;
+        InWindowEventCount = inWindowEventCount;
+        Completion = completion;
+    }
+
+    public PackageSourceResultIdentity Source { get; }
+    public NuGetCatalogRequest Request { get; }
+    public ImmutableArray<NuGetCatalogEvent> Events { get; }
+    public DateTimeOffset CapturedHorizon { get; }
+    public int PagesAcquired { get; }
+    public int HttpAttempts { get; }
+    public long DecodedBytes { get; }
+    public long InWindowEventCount { get; }
+    public NuGetCatalogCompletion? Completion { get; }
+
+    internal bool HasIssuer(object issuer) =>
+        ReferenceEquals(_issuer, issuer);
+}
+
+public sealed partial class PackageSourceResultFactory
+{
+    internal NuGetCatalogEvent CatalogEvent(
+        PackageSourceCoordinate coordinate,
+        string packageId,
+        string version,
+        string leafUrl,
+        string commitId,
+        DateTimeOffset commitTimestamp,
+        NuGetCatalogEventKind kind) =>
+        new(
+            _ownerCapability,
+            _issuer,
+            coordinate,
+            packageId,
+            version,
+            leafUrl,
+            commitId,
+            commitTimestamp,
+            kind);
+
+    internal NuGetCatalogPage CatalogPage(
+        NuGetCatalogRequest request,
+        ImmutableArray<NuGetCatalogEvent> events,
+        DateTimeOffset capturedHorizon,
+        int pagesAcquired,
+        int httpAttempts,
+        long decodedBytes,
+        long inWindowEventCount,
+        NuGetCatalogCompletion? completion,
+        NuGetOperationDeadline operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        operation.ThrowIfExpired();
+        foreach (NuGetCatalogEvent item in events)
+        {
+            operation.ThrowIfExpired();
+            if (item is null || !item.HasIssuer(_issuer))
+                throw ContractViolation();
+        }
+
+        var value = new NuGetCatalogPage(
+            _ownerCapability,
+            _issuer,
+            Source,
+            request,
+            events,
+            capturedHorizon,
+            pagesAcquired,
+            httpAttempts,
+            decodedBytes,
+            inWindowEventCount,
+            completion);
+        operation.ThrowIfExpired();
+        return value;
+    }
+
+    internal PackageSourceOperationResult<NuGetCatalogPage>
+        SucceededCatalog(
+            NuGetCatalogPage value,
+            NuGetOperationDeadline operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        operation.ThrowIfExpired();
+        RequireSourceAndIssuer(value.Source, value.HasIssuer(_issuer));
+        return Succeeded(value);
+    }
+
+    internal PackageSourceOperationResult<NuGetCatalogPage>
+        FailedCatalog(PackageSourceFailureKind kind) =>
+        Failed<NuGetCatalogPage>(
+            PackageSourceCapabilities.Catalog,
+            coordinate: null,
+            ValidateFailureKind(kind, allowNotFound: false));
+}

--- a/src/NuGetFetch/NuGetFetchOptions.cs
+++ b/src/NuGetFetch/NuGetFetchOptions.cs
@@ -31,6 +31,22 @@ public sealed record NuGetFetchOptions
         64 * 1024 * 1024;
 
     /// <summary>
+    /// Default maximum number of Catalog page documents acquired after the index.
+    /// </summary>
+    public const int DefaultMaxCatalogPages = 512;
+
+    /// <summary>
+    /// Default maximum HTTP attempts across one Catalog acquisition.
+    /// </summary>
+    public const int DefaultMaxCatalogHttpAttempts = 1024;
+
+    /// <summary>
+    /// Default maximum decoded metadata bytes across one Catalog acquisition.
+    /// </summary>
+    public const long DefaultMaxCatalogDecodedBytes =
+        512L * 1024 * 1024;
+
+    /// <summary>
     /// Default deadline for one HTTP request, including response-body consumption.
     /// </summary>
     public static TimeSpan DefaultRequestTimeout { get; } =
@@ -73,6 +89,26 @@ public sealed record NuGetFetchOptions
     /// </summary>
     public long MaxRegistrationPageBatchBytes { get; init; } =
         DefaultMaxRegistrationPageBatchBytes;
+
+    /// <summary>
+    /// Gets the maximum Catalog page documents acquired after the index.
+    /// </summary>
+    public int MaxCatalogPages { get; init; } =
+        DefaultMaxCatalogPages;
+
+    /// <summary>
+    /// Gets the maximum HTTP attempts across service-index, Catalog-index,
+    /// page, and retry requests in one Catalog acquisition.
+    /// </summary>
+    public int MaxCatalogHttpAttempts { get; init; } =
+        DefaultMaxCatalogHttpAttempts;
+
+    /// <summary>
+    /// Gets the maximum decoded metadata bytes across every Catalog document
+    /// and retry attempt in one Catalog acquisition.
+    /// </summary>
+    public long MaxCatalogDecodedBytes { get; init; } =
+        DefaultMaxCatalogDecodedBytes;
 
     /// <summary>
     /// Gets the deadline for one HTTP request, including response-body consumption.
@@ -126,6 +162,12 @@ public sealed record NuGetFetchOptions
             options.MaxRegistrationMetadataBytes);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
             options.MaxRegistrationPageBatchBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            options.MaxCatalogPages);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            options.MaxCatalogHttpAttempts);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            options.MaxCatalogDecodedBytes);
         ValidateTimeout(options.RequestTimeout, nameof(RequestTimeout));
         ValidateTimeout(options.OperationTimeout, nameof(OperationTimeout));
         if (options.MetadataBodyTimeout != Timeout.InfiniteTimeSpan)

--- a/src/NuGetFetch/NuGetHttpRetry.cs
+++ b/src/NuGetFetch/NuGetHttpRetry.cs
@@ -64,6 +64,7 @@ internal static class NuGetHttpRetry
             and not NuGetRedirectLimitExceededException
             and not NuGetRegistrationResourceLimitExceededException
             and not NuGetCatalogResourceLimitExceededException
+            and not NuGetCatalogRequestLimitExceededException
             and not NuGetCatalogDecodedByteLimitExceededException
         || exception is NuGetCatalogStalePageException
         || exception is HttpRequestException request

--- a/src/NuGetFetch/NuGetHttpRetry.cs
+++ b/src/NuGetFetch/NuGetHttpRetry.cs
@@ -4,7 +4,7 @@ namespace NuGetFetch;
 
 internal static class NuGetHttpRetry
 {
-    private const int MaximumRetries = 3;
+    internal const int MaximumRetries = 3;
 
     public static async Task<T> RunRequestAsync<T>(
         NuGetOperationDeadline operation,
@@ -50,19 +50,22 @@ internal static class NuGetHttpRetry
         }
     }
 
-    private static Task DelayAsync(
+    internal static Task DelayAsync(
         NuGetOperationDeadline operation,
         int retry) =>
         operation.DelayAsync(
             TimeSpan.FromMilliseconds(100 * (1 << retry)));
 
-    private static bool IsTransient(Exception exception) =>
+    internal static bool IsTransient(Exception exception) =>
         exception is NuGetRequestTimeoutException
             or NuGetMetadataBodyTimeoutException
         || exception is IOException
             and not NuGetMetadataResponseTooLargeException
             and not NuGetRedirectLimitExceededException
             and not NuGetRegistrationResourceLimitExceededException
+            and not NuGetCatalogResourceLimitExceededException
+            and not NuGetCatalogDecodedByteLimitExceededException
+        || exception is NuGetCatalogStalePageException
         || exception is HttpRequestException request
             && (request.StatusCode is null
                 || request.StatusCode is

--- a/src/NuGetFetch/NuGetMetadataExceptions.cs
+++ b/src/NuGetFetch/NuGetMetadataExceptions.cs
@@ -36,6 +36,12 @@ internal sealed class NuGetRedirectLimitExceededException()
 internal sealed class NuGetRegistrationResourceLimitExceededException(
     string message) : IOException(message);
 
+internal sealed class NuGetCatalogResourceLimitExceededException(
+    string message) : IOException(message);
+
+internal sealed class NuGetCatalogStalePageException(
+    string message) : InvalidOperationException(message);
+
 /// <summary>
 /// Thrown when a NuGet metadata response body does not complete within its configured
 /// body-phase timeout.

--- a/src/NuGetFetch/NuGetMetadataExceptions.cs
+++ b/src/NuGetFetch/NuGetMetadataExceptions.cs
@@ -39,6 +39,10 @@ internal sealed class NuGetRegistrationResourceLimitExceededException(
 internal sealed class NuGetCatalogResourceLimitExceededException(
     string message) : IOException(message);
 
+internal sealed class NuGetCatalogRequestLimitExceededException()
+    : IOException(
+        "NuGet Catalog traffic exceeded the aggregate HTTP-attempt limit.");
+
 internal sealed class NuGetCatalogStalePageException(
     string message) : InvalidOperationException(message);
 

--- a/src/NuGetFetch/NuGetOperationDeadline.cs
+++ b/src/NuGetFetch/NuGetOperationDeadline.cs
@@ -362,6 +362,7 @@ internal sealed class NuGetOperationDeadline : IDisposable
             and not NuGetRedirectLimitExceededException
             and not NuGetRegistrationResourceLimitExceededException
             and not NuGetCatalogResourceLimitExceededException
+            and not NuGetCatalogRequestLimitExceededException
             and not NuGetCatalogDecodedByteLimitExceededException
             or NuGetCatalogStalePageException
             or HttpRequestException

--- a/src/NuGetFetch/NuGetOperationDeadline.cs
+++ b/src/NuGetFetch/NuGetOperationDeadline.cs
@@ -361,6 +361,9 @@ internal sealed class NuGetOperationDeadline : IDisposable
             and not NuGetMetadataResponseTooLargeException
             and not NuGetRedirectLimitExceededException
             and not NuGetRegistrationResourceLimitExceededException
+            and not NuGetCatalogResourceLimitExceededException
+            and not NuGetCatalogDecodedByteLimitExceededException
+            or NuGetCatalogStalePageException
             or HttpRequestException
             or ObjectDisposedException;
 

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -51,6 +51,9 @@ public enum PackageSourceCapabilities
 
     /// <summary>Exact bounded package-manifest acquisition.</summary>
     Manifest = 1 << 4,
+
+    /// <summary>Bounded NuGet V3 Catalog acquisition.</summary>
+    Catalog = 1 << 5,
 }
 
 /// <summary>
@@ -713,6 +716,13 @@ public static partial class PackageSourceClientFactory
                 throw new InvalidOperationException(
                     "The custom package source client did not expose the bound source identity.");
             }
+
+            if (client.Capabilities.HasFlag(
+                    PackageSourceCapabilities.Catalog))
+            {
+                throw new InvalidOperationException(
+                    "Custom package source clients cannot advertise the Catalog capability.");
+            }
         }
         catch (Exception validationFailure)
         {
@@ -1230,7 +1240,8 @@ internal sealed class CustomPackageSourceClientAdapter
     }
 }
 
-internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
+internal sealed partial class NuGetV3PackageSourceClient
+    : INuGetCatalogPackageSourceClient
 {
     private readonly PackageSourceResultFactory _results;
     private readonly Uri _endpoint;
@@ -1262,7 +1273,8 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
         PackageSourceCapabilities.Search
         | PackageSourceCapabilities.VersionEnumeration
         | PackageSourceCapabilities.Manifest
-        | PackageSourceCapabilities.PackagePayload;
+        | PackageSourceCapabilities.PackagePayload
+        | PackageSourceCapabilities.Catalog;
 
     public async Task<PackageSourceOperationResult<PackageSearchResult>> SearchAsync(
         string query,

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -760,6 +760,7 @@ public static partial class PackageSourceClientFactory
 
         HttpMessageHandler handler = transport
             ?? CreateV3TransportHandler(source, isBrowser);
+        handler = new NuGetCatalogAttemptHandler(handler);
         if (authenticationContext is not null)
         {
             handler = authenticationContext.Bind(handler);

--- a/src/NuGetFetch/PackageSourceResults.cs
+++ b/src/NuGetFetch/PackageSourceResults.cs
@@ -670,6 +670,7 @@ public sealed class PackageSourceOperationResult<T>
         PackageSourceClientFactory.RequireOwnerCapability(ownerCapability);
         if (typeof(T) != typeof(PackageSearchResult)
             && typeof(T) != typeof(NuGetGalleryDiscoveryResult)
+            && typeof(T) != typeof(NuGetCatalogPage)
             && typeof(T) != typeof(PackageVersionResult)
             && typeof(T) != typeof(PackageSourceManifest)
             && typeof(T) != typeof(PackageSourcePayload))
@@ -1526,7 +1527,7 @@ internal static class PackageSourceOperation
         }
     }
 
-    private static bool TryClassify(
+    internal static bool TryClassify(
         Exception exception,
         bool allowNotFound,
         out PackageSourceFailureKind kind)
@@ -1543,11 +1544,14 @@ internal static class PackageSourceOperation
                 PackageSourceFailureKind.ResponseRejected,
             NuGetRedirectLimitExceededException
                 or NuGetRegistrationResourceLimitExceededException
+                or NuGetCatalogResourceLimitExceededException
+                or NuGetCatalogDecodedByteLimitExceededException
                 or LocalPackageSourceLimitExceededException =>
                 PackageSourceFailureKind.ResponseRejected,
             NuGetSourceCapabilityUnavailableException =>
                 PackageSourceFailureKind.Unsupported,
             NuGetSourceResponseException
+                or NuGetCatalogStalePageException
                 or System.Text.Json.JsonException
                 or InvalidDataException =>
                 PackageSourceFailureKind.InvalidResponse,
@@ -1586,10 +1590,13 @@ internal static class PackageSourceOperation
             or NuGetMetadataResponseTooLargeException
             or NuGetRedirectLimitExceededException
             or NuGetRegistrationResourceLimitExceededException
+            or NuGetCatalogResourceLimitExceededException
+            or NuGetCatalogDecodedByteLimitExceededException
             or LocalPackageSourceLimitExceededException
             or LocalPackageSourceNotFoundException
             or NuGetSourceCapabilityUnavailableException
             or NuGetSourceResponseException
+            or NuGetCatalogStalePageException
             or System.Text.Json.JsonException
             or InvalidDataException
             or HttpRequestException

--- a/src/NuGetFetch/PackageSourceResults.cs
+++ b/src/NuGetFetch/PackageSourceResults.cs
@@ -1545,6 +1545,7 @@ internal static class PackageSourceOperation
             NuGetRedirectLimitExceededException
                 or NuGetRegistrationResourceLimitExceededException
                 or NuGetCatalogResourceLimitExceededException
+                or NuGetCatalogRequestLimitExceededException
                 or NuGetCatalogDecodedByteLimitExceededException
                 or LocalPackageSourceLimitExceededException =>
                 PackageSourceFailureKind.ResponseRejected,
@@ -1591,6 +1592,7 @@ internal static class PackageSourceOperation
             or NuGetRedirectLimitExceededException
             or NuGetRegistrationResourceLimitExceededException
             or NuGetCatalogResourceLimitExceededException
+            or NuGetCatalogRequestLimitExceededException
             or NuGetCatalogDecodedByteLimitExceededException
             or LocalPackageSourceLimitExceededException
             or LocalPackageSourceNotFoundException

--- a/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
+++ b/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
@@ -737,6 +737,78 @@ public sealed class NuGetCatalogAcquisitionTests
     }
 
     [Fact]
+    public async Task ExhaustedDecodedBudgetStopsBeforeTheFirstPage()
+    {
+        string service = ServiceDocument(
+            $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""");
+        string index = IndexDocument(
+            Day1,
+            Page(Page1, Day1));
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(service),
+            [Catalog] = Json(index),
+            [Page1] = new RouteResponse(
+                HttpStatusCode.ServiceUnavailable,
+                ""),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxCatalogDecodedBytes =
+                        Utf8Length(service) + Utf8Length(index),
+                });
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))));
+
+        Assert.Equal(
+            NuGetCatalogCompletion.DecodedByteLimitReached,
+            terminal.Completion);
+        Assert.Equal([ServiceIndex, Catalog], handler.Requested);
+    }
+
+    [Fact]
+    public async Task ExhaustedAttemptBudgetSkipsRetryDelay()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day1, Page(Page1, Day1))),
+            [Page1] = new RouteResponse(
+                HttpStatusCode.ServiceUnavailable,
+                ""),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxCatalogHttpAttempts = 3,
+                    OperationTimeout = TimeSpan.FromMilliseconds(50),
+                });
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))));
+
+        Assert.Equal(
+            NuGetCatalogCompletion.RequestLimitReached,
+            terminal.Completion);
+        Assert.Equal([ServiceIndex, Catalog, Page1], handler.Requested);
+    }
+
+    [Fact]
     public async Task AggregateByteCrossingRejectsTheWholeActivePage()
     {
         string service = ServiceDocument(
@@ -838,6 +910,27 @@ public sealed class NuGetCatalogAcquisitionTests
                     new NuGetCatalogRequest(Day0, Day1))).Failure);
 
         Assert.Equal(PackageSourceFailureKind.ResponseRejected, failure.Kind);
+    }
+
+    [Fact]
+    public async Task MalformedUtf16TextRemainsATypedFailure()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                """{"version":"\uD800","resources":[]}"""),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+        Assert.Equal([ServiceIndex], handler.Requested);
         Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
     }
 

--- a/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
+++ b/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
@@ -931,6 +931,59 @@ public sealed class NuGetCatalogAcquisitionTests
 
         Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
         Assert.Equal([ServiceIndex], handler.Requested);
+    }
+
+    [Theory]
+    [InlineData(MalformedCatalogDocument.ServiceIndex)]
+    [InlineData(MalformedCatalogDocument.CatalogIndex)]
+    [InlineData(MalformedCatalogDocument.CatalogPage)]
+    public async Task MalformedUtf16PropertyNameRemainsATypedFailure(
+        MalformedCatalogDocument document)
+    {
+        string service = document == MalformedCatalogDocument.ServiceIndex
+            ? """{"version":"3.0.0","resources":[],"\uD800":true}"""
+            : ServiceDocument(
+                $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""");
+        string index = document == MalformedCatalogDocument.CatalogIndex
+            ? $$"""
+                {"commitId":"index","commitTimeStamp":"{{Stamp(Day1)}}",
+                "count":1,"items":[{{Page(Page1, Day1)}}],"\uD800":true}
+                """
+            : IndexDocument(Day1, Page(Page1, Day1));
+        string page = document == MalformedCatalogDocument.CatalogPage
+            ? $$"""
+                {"commitId":"page","commitTimeStamp":"{{Stamp(Day1)}}",
+                "count":0,"parent":"{{Catalog}}","items":[],"\uD800":true}
+                """
+            : PageDocument(Catalog, Day1);
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(service),
+            [Catalog] = Json(index),
+            [Page1] = Json(page),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+        Assert.Equal(
+            document switch
+            {
+                MalformedCatalogDocument.ServiceIndex =>
+                    [ServiceIndex],
+                MalformedCatalogDocument.CatalogIndex =>
+                    [ServiceIndex, Catalog],
+                MalformedCatalogDocument.CatalogPage =>
+                    [ServiceIndex, Catalog, Page1],
+                _ => throw new ArgumentOutOfRangeException(nameof(document)),
+            },
+            handler.Requested);
         Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
     }
 
@@ -1669,6 +1722,13 @@ public sealed class NuGetCatalogAcquisitionTests
         Index,
         Page,
         PageItem,
+    }
+
+    public enum MalformedCatalogDocument
+    {
+        ServiceIndex,
+        CatalogIndex,
+        CatalogPage,
     }
 
     private sealed record RouteResponse(

--- a/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
+++ b/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
@@ -301,6 +301,90 @@ public sealed class NuGetCatalogAcquisitionTests
             handler.Requested);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task EqualMaximumPagesDoNotInferOrderFromAdvertisedUrls(
+        bool laterOnlyPageFirst)
+    {
+        string existingPage = PageDocument(
+            Catalog,
+            Day3,
+            Item(
+                "https://feed.example/leaf/earlier.json",
+                "Earlier",
+                "1.0.0",
+                Day2,
+                "nuget:PackageDetails"),
+            Item(
+                "https://feed.example/leaf/existing.json",
+                "Existing",
+                "1.0.0",
+                Day3,
+                "nuget:PackageDetails"));
+        string laterOnlyPage = PageDocument(
+            Catalog,
+            Day3,
+            Item(
+                "https://feed.example/leaf/later.json",
+                "Later",
+                "1.0.0",
+                Day3,
+                "nuget:PackageDetails"));
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day3,
+                    Page(Page1, Day3),
+                    Page(Page2, Day3))),
+            [Page1] = Json(
+                laterOnlyPageFirst ? laterOnlyPage : existingPage),
+            [Page2] = Json(
+                laterOnlyPageFirst ? existingPage : laterOnlyPage),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                new NuGetCatalogRequest(Day0, Day3));
+
+        Assert.Equal(2, outcomes.Count);
+        NuGetCatalogPage first = Succeeded(outcomes[0]);
+        NuGetCatalogPage second = Succeeded(outcomes[1]);
+        Assert.Equal(
+            laterOnlyPageFirst
+                ? ["Later"]
+                : ["Earlier", "Existing"],
+            first.Events.Select(item => item.PackageId));
+        Assert.Equal(
+            laterOnlyPageFirst
+                ? ["Earlier", "Existing"]
+                : ["Later"],
+            second.Events.Select(item => item.PackageId));
+        if (laterOnlyPageFirst)
+        {
+            Assert.True(
+                first.Events[^1].CommitTimestamp
+                > second.Events[0].CommitTimestamp);
+        }
+
+        NuGetCatalogPage terminal = Succeeded(outcomes[^1]);
+        Assert.Equal(2, terminal.PagesAcquired);
+        Assert.Equal(3, terminal.InWindowEventCount);
+        Assert.Equal(
+            NuGetCatalogCompletion.WindowExhausted,
+            terminal.Completion);
+        Assert.Equal(
+            [ServiceIndex, Catalog, Page1, Page2],
+            handler.Requested);
+    }
+
     [Fact]
     public async Task CapturedHorizonFiltersAPageThatGrowsAfterTheIndex()
     {

--- a/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
+++ b/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
@@ -223,6 +223,84 @@ public sealed class NuGetCatalogAcquisitionTests
             url => url.Contains("/leaf/", StringComparison.Ordinal));
     }
 
+    [Theory]
+    [InlineData(1, NuGetCatalogCompletion.PageLimitReached)]
+    [InlineData(2, NuGetCatalogCompletion.WindowExhausted)]
+    public async Task TiedCrossingPagesStopOnlyAtCoverageOrAVisibleLimit(
+        int maximumPages,
+        NuGetCatalogCompletion expectedCompletion)
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day3,
+                    Page(Page1, Day3),
+                    Page(Page2, Day3))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day3,
+                    Item(
+                        "https://feed.example/leaf/after-first.json",
+                        "After.First",
+                        "1.0.0",
+                        Day3,
+                        "nuget:PackageDetails"))),
+            [Page2] = Json(
+                PageDocument(
+                    Catalog,
+                    Day3,
+                    Item(
+                        "https://feed.example/leaf/in-window.json",
+                        "In.Window",
+                        "1.0.0",
+                        Day2,
+                        "nuget:PackageDetails"),
+                    Item(
+                        "https://feed.example/leaf/after-second.json",
+                        "After.Second",
+                        "1.0.0",
+                        Day3,
+                        "nuget:PackageDetails"))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxCatalogPages = maximumPages,
+                });
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                new NuGetCatalogRequest(Day0, Day2));
+
+        Assert.Equal(maximumPages, outcomes.Count);
+        NuGetCatalogPage terminal = Succeeded(outcomes[^1]);
+        Assert.Equal(expectedCompletion, terminal.Completion);
+        if (maximumPages == 1)
+        {
+            Assert.Empty(terminal.Events);
+        }
+        else
+        {
+            Assert.Equal(
+                "in.window",
+                Assert.Single(terminal.Events).Coordinate.PackageId);
+        }
+
+        Assert.Equal(
+            maximumPages == 1
+                ? [ServiceIndex, Catalog, Page1]
+                : [ServiceIndex, Catalog, Page1, Page2],
+            handler.Requested);
+    }
+
     [Fact]
     public async Task CapturedHorizonFiltersAPageThatGrowsAfterTheIndex()
     {
@@ -734,6 +812,69 @@ public sealed class NuGetCatalogAcquisitionTests
         Assert.Equal(
             [ServiceIndex, Catalog, Page1, Page1],
             handler.Requested);
+    }
+
+    [Theory]
+    [InlineData(3, NuGetCatalogCompletion.RequestLimitReached)]
+    [InlineData(4, NuGetCatalogCompletion.WindowExhausted)]
+    public async Task RedirectHopsConsumeCatalogWideAttemptBudget(
+        int maximumAttempts,
+        NuGetCatalogCompletion expectedCompletion)
+    {
+        string page = PageDocument(
+            Catalog,
+            Day1,
+            Item(
+                "https://feed.example/leaf/redirected.json",
+                "Redirected",
+                "1.0.0",
+                Day1,
+                "nuget:PackageDetails"));
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day1, Page(Page1, Day1))),
+            [Page2] = Json(page),
+        };
+        handler.Set(
+            Page1,
+            (request, _) =>
+            {
+                var response =
+                    new HttpResponseMessage(HttpStatusCode.Redirect)
+                    {
+                        RequestMessage = request,
+                    };
+                response.Headers.Location = new Uri(Page2);
+                return Task.FromResult(response);
+            });
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxCatalogHttpAttempts = maximumAttempts,
+                });
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))));
+
+        Assert.Equal(expectedCompletion, terminal.Completion);
+        Assert.Equal(maximumAttempts, terminal.HttpAttempts);
+        Assert.Equal(
+            maximumAttempts == 3
+                ? [ServiceIndex, Catalog, Page1]
+                : [ServiceIndex, Catalog, Page1, Page2],
+            handler.Requested);
+        Assert.Equal(
+            maximumAttempts == 3 ? 0 : 1,
+            terminal.Events.Length);
     }
 
     [Fact]

--- a/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
+++ b/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
@@ -1340,6 +1340,40 @@ public sealed class NuGetCatalogAcquisitionTests
             handler.Requested);
     }
 
+    [Theory]
+    [InlineData("12:00:00Z")]
+    [InlineData("2026-01-02 00:00:00Z")]
+    [InlineData("2026-01-02T00:00:00.Z")]
+    [InlineData("2026-01-02T00:00:00z")]
+    [InlineData("2026-01-02T00:00:00-00:00")]
+    [InlineData("2026-01-02T00:00:00.12345678Z")]
+    public async Task IncompleteOrNoncanonicalTimestampRemainsTypedFailure(
+        string timestamp)
+    {
+        string index = $$"""
+            {"commitId":"index","commitTimeStamp":"{{timestamp}}",
+            "count":0,"items":[]}
+            """;
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(index),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+        Assert.Equal([ServiceIndex, Catalog], handler.Requested);
+    }
+
     [Fact]
     public async Task CallerOwnedContextRemainsUsableAfterStreamCompletion()
     {

--- a/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
+++ b/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
@@ -1,0 +1,1662 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+
+namespace NuGetFetch.Tests;
+
+public sealed class NuGetCatalogAcquisitionTests
+{
+    private const string ServiceIndex =
+        "https://feed.example/v3/index.json";
+    private const string Catalog =
+        "https://feed.example/v3/catalog/index.json";
+    private const string AlternateCatalog =
+        "https://feed.example/v3/catalog-alt/index.json";
+    private const string Page1 =
+        "https://feed.example/v3/catalog/page1.json";
+    private const string Page2 =
+        "https://feed.example/v3/catalog/page2.json";
+    private const string Page3 =
+        "https://feed.example/v3/catalog/page3.json";
+
+    private static readonly DateTimeOffset Day0 = Utc(2026, 1, 1);
+    private static readonly DateTimeOffset Day1 = Utc(2026, 1, 2);
+    private static readonly DateTimeOffset Day2 = Utc(2026, 1, 3);
+    private static readonly DateTimeOffset Day3 = Utc(2026, 1, 4);
+    private static readonly DateTimeOffset Day4 = Utc(2026, 1, 5);
+
+    [Fact]
+    public void RequestAndOptionsExposeOnlyCatalogAcquisitionBounds()
+    {
+        var maximum = new NuGetCatalogRequest(
+            Day0,
+            Day0 + NuGetCatalogRequest.MaximumInterval);
+
+        Assert.Equal(Day0, maximum.FromExclusive);
+        Assert.Equal(
+            Day0 + TimeSpan.FromDays(42),
+            maximum.ThroughInclusive);
+        Assert.Equal(
+            ["FromExclusive", "ThroughInclusive"],
+            typeof(NuGetCatalogRequest)
+                .GetProperties()
+                .Where(property => property.GetMethod?.IsStatic == false)
+                .Select(property => property.Name)
+                .Order(StringComparer.Ordinal));
+
+        Assert.Throws<ArgumentException>(
+            () => new NuGetCatalogRequest(
+                Day0.ToOffset(TimeSpan.FromHours(1)),
+                Day1));
+        Assert.Throws<ArgumentException>(
+            () => new NuGetCatalogRequest(
+                Day0,
+                Day1.ToOffset(TimeSpan.FromHours(-1))));
+        Assert.Throws<ArgumentException>(
+            () => new NuGetCatalogRequest(Day0, Day0));
+        Assert.Throws<ArgumentException>(
+            () => new NuGetCatalogRequest(Day1, Day0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new NuGetCatalogRequest(
+                Day0,
+                Day0 + TimeSpan.FromDays(42) + TimeSpan.FromTicks(1)));
+
+        var options = new NuGetFetchOptions();
+        Assert.Equal(512, options.MaxCatalogPages);
+        Assert.Equal(1024, options.MaxCatalogHttpAttempts);
+        Assert.Equal(512L * 1024 * 1024, options.MaxCatalogDecodedBytes);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => NuGetFetchOptions.Validate(
+                options with { MaxCatalogPages = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => NuGetFetchOptions.Validate(
+                options with { MaxCatalogHttpAttempts = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => NuGetFetchOptions.Validate(
+                options with { MaxCatalogDecodedBytes = 0 }));
+
+        foreach (Type type in new[]
+        {
+            typeof(NuGetCatalogEvent),
+            typeof(NuGetCatalogPage),
+            typeof(PackageSourceOperationResult<NuGetCatalogPage>),
+        })
+        {
+            ConstructorInfo constructor = Assert.Single(
+                type.GetConstructors(
+                    BindingFlags.Instance
+                    | BindingFlags.Public
+                    | BindingFlags.NonPublic));
+            Assert.False(constructor.IsPublic);
+            Assert.Equal(
+                typeof(object),
+                constructor.GetParameters()[0].ParameterType);
+        }
+    }
+
+    [Fact]
+    public async Task AdvertisedCatalogUsesSortedPlusOnePagesAndExactWindow()
+    {
+        string before = "https://feed.example/v3/catalog/before.json";
+        string after = "https://feed.example/v3/catalog/after.json";
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":["Other","Catalog/3.0.0"]}""")),
+            [Catalog] = Json(
+                IndexDocumentWithCount(
+                    Day4,
+                    999,
+                    Page(after, Day4),
+                    Page(Page2, Day3),
+                    Page(before, Day0),
+                    Page(Page1, Day1))),
+            [Page1] = Json(
+                PageDocumentWithCount(
+                    Catalog,
+                    Day1,
+                    5000,
+                    Item(
+                        "https://feed.example/leaf/z.json",
+                        "Repeat.Package",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"),
+                    Item(
+                        "https://feed.example/leaf/exclusive.json",
+                        "Excluded",
+                        "1.0.0",
+                        Day0,
+                        "nuget:PackageDetails"),
+                    Item(
+                        "https://feed.example/leaf/a.json",
+                        "Alpha",
+                        "2.0.0",
+                        Day0 + TimeSpan.FromHours(12),
+                        "nuget:PackageDetails"))),
+            [Page2] = Json(
+                PageDocument(
+                    Catalog,
+                    Day3,
+                    Item(
+                        "https://feed.example/leaf/after.json",
+                        "Excluded",
+                        "2.0.0",
+                        Day3,
+                        "nuget:PackageDetails"),
+                    Item(
+                        "https://feed.example/leaf/tie-z.json",
+                        "Repeat.Package",
+                        "1.0.0",
+                        Day1 + TimeSpan.FromHours(12),
+                        "nuget:PackageDetails"),
+                    Item(
+                        "https://feed.example/leaf/inclusive.json",
+                        "Deleted.Package",
+                        "3.0.0",
+                        Day2,
+                        "nuget:PackageDelete"),
+                    Item(
+                        "https://feed.example/leaf/tie-a.json",
+                        "Repeat.Package",
+                        "1.0.0",
+                        Day1 + TimeSpan.FromHours(12),
+                        "nuget:PackageDetails"))),
+        };
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler, association: association);
+        var request = new NuGetCatalogRequest(Day0, Day2);
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(source, request);
+
+        Assert.Equal(2, outcomes.Count);
+        NuGetCatalogPage first = Succeeded(outcomes[0]);
+        NuGetCatalogPage terminal = Succeeded(outcomes[1]);
+        Assert.Same(source.Source, first.Source);
+        Assert.Same(association, first.Source.Association);
+        Assert.Same(request, first.Request);
+        Assert.Equal(Day4, first.CapturedHorizon);
+        Assert.Equal(1, first.PagesAcquired);
+        Assert.Equal(3, first.HttpAttempts);
+        Assert.Equal(2, first.InWindowEventCount);
+        Assert.Null(first.Completion);
+        Assert.Equal(
+            ["alpha", "repeat.package"],
+            first.Events.Select(item => item.Coordinate.PackageId));
+        Assert.Equal("Alpha", first.Events[0].PackageId);
+        Assert.Equal("2.0.0", first.Events[0].Version);
+
+        Assert.Equal(
+            [
+                "https://feed.example/leaf/tie-a.json",
+                "https://feed.example/leaf/tie-z.json",
+                "https://feed.example/leaf/inclusive.json",
+            ],
+            terminal.Events.Select(item => item.LeafUrl));
+        Assert.Equal(
+            [
+                NuGetCatalogEventKind.Details,
+                NuGetCatalogEventKind.Details,
+                NuGetCatalogEventKind.Delete,
+            ],
+            terminal.Events.Select(item => item.Kind));
+        Assert.Equal(2, terminal.PagesAcquired);
+        Assert.Equal(4, terminal.HttpAttempts);
+        Assert.Equal(5, terminal.InWindowEventCount);
+        Assert.Equal(
+            NuGetCatalogCompletion.WindowExhausted,
+            terminal.Completion);
+        Assert.True(terminal.DecodedBytes > first.DecodedBytes);
+        Assert.Equal(
+            [ServiceIndex, Catalog, Page1, Page2],
+            handler.Requested);
+        Assert.DoesNotContain(before, handler.Requested);
+        Assert.DoesNotContain(after, handler.Requested);
+        Assert.DoesNotContain(
+            handler.Requested,
+            url => url.Contains("/leaf/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CapturedHorizonFiltersAPageThatGrowsAfterTheIndex()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day3,
+                Item(
+                    "https://feed.example/leaf/covered.json",
+                    "Covered",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails"),
+                Item(
+                    "https://feed.example/leaf/grew.json",
+                    "Too.New",
+                    "1.0.0",
+                    Day2,
+                    "nuget:PackageDetails")));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day2))));
+
+        Assert.Equal(Day1, terminal.CapturedHorizon);
+        Assert.Equal(
+            NuGetCatalogCompletion.SourceHorizonReached,
+            terminal.Completion);
+        Assert.Equal(
+            "covered",
+            Assert.Single(terminal.Events).Coordinate.PackageId);
+    }
+
+    [Fact]
+    public async Task InconsistentIndexHorizonCannotClaimWindowCoverage()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day2, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    "https://feed.example/leaf/older.json",
+                    "Older",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day2))).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+        Assert.Equal([ServiceIndex, Catalog], handler.Requested);
+    }
+
+    [Fact]
+    public async Task StaleActivePageIsRetriedBeforePublication()
+    {
+        string stale = PageDocument(
+            Catalog,
+            Day0,
+            Item(
+                "https://feed.example/leaf/stale.json",
+                "Stale",
+                "1.0.0",
+                Day0,
+                "nuget:PackageDetails"));
+        string current = PageDocument(
+            Catalog,
+            Day1,
+            Item(
+                "https://feed.example/leaf/current.json",
+                "Current",
+                "1.0.0",
+                Day1,
+                "nuget:PackageDetails"));
+        int attempts = 0;
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day1, Page(Page1, Day1))),
+        };
+        handler.Set(
+            Page1,
+            (request, _) => Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        ++attempts == 1 ? stale : current,
+                        Encoding.UTF8,
+                        "application/json"),
+                    RequestMessage = request,
+                }));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))));
+
+        Assert.Equal(2, attempts);
+        Assert.Equal(
+            "current",
+            Assert.Single(terminal.Events).Coordinate.PackageId);
+        Assert.Equal(
+            NuGetCatalogCompletion.WindowExhausted,
+            terminal.Completion);
+    }
+
+    [Fact]
+    public async Task PersistentlyStaleActivePageFailsAfterStandardRetries()
+    {
+        int attempts = 0;
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day1, Page(Page1, Day1))),
+        };
+        handler.Set(
+            Page1,
+            (request, _) =>
+            {
+                attempts++;
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            PageDocument(
+                                Catalog,
+                                Day0,
+                                Item(
+                                    "https://feed.example/leaf/stale.json",
+                                    "Stale",
+                                    "1.0.0",
+                                    Day0,
+                                    "nuget:PackageDetails")),
+                            Encoding.UTF8,
+                            "application/json"),
+                        RequestMessage = request,
+                    });
+            });
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(NuGetHttpRetry.MaximumRetries + 1, attempts);
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+    }
+
+    [Fact]
+    public async Task EqualTimestampPagesUseAdvertisedUrlTieBreaker()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day1,
+                    Page(Page2, Day1),
+                    Page(Page1, Day1))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/z.json",
+                        "First.Page",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+            [Page2] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/a.json",
+                        "Second.Page",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                new NuGetCatalogRequest(Day0, Day1));
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.Equal(
+            "first.page",
+            Assert.Single(Succeeded(outcomes[0]).Events).Coordinate.PackageId);
+        Assert.Equal(
+            "second.page",
+            Assert.Single(Succeeded(outcomes[1]).Events).Coordinate.PackageId);
+        Assert.Equal(
+            [ServiceIndex, Catalog, Page1, Page2],
+            handler.Requested);
+    }
+
+    [Fact]
+    public async Task EmptyCoveredPrefixStillProducesOneTerminalValue()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day0, Page(Page1, Day0))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day2))));
+
+        Assert.Empty(terminal.Events);
+        Assert.Equal(0, terminal.PagesAcquired);
+        Assert.Equal(2, terminal.HttpAttempts);
+        Assert.Equal(0, terminal.InWindowEventCount);
+        Assert.Equal(
+            NuGetCatalogCompletion.SourceHorizonReached,
+            terminal.Completion);
+        Assert.Equal([ServiceIndex, Catalog], handler.Requested);
+    }
+
+    [Theory]
+    [InlineData(false, PackageSourceFailureKind.Unsupported)]
+    [InlineData(true, PackageSourceFailureKind.InvalidResponse)]
+    public async Task CatalogDiscoveryHasNoHardCodedFallback(
+        bool malformedSupportedResource,
+        PackageSourceFailureKind expected)
+    {
+        string resources = malformedSupportedResource
+            ? """{"@id":"not a URL","@type":"Catalog/3.0.0"}"""
+            : """{"@id":"https://feed.example/search","@type":"SearchQueryService"}""";
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(ServiceDocument(resources)),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(expected, failure.Kind);
+        Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
+        Assert.Same(source.Source, failure.Source);
+        Assert.Equal([ServiceIndex], handler.Requested);
+        Assert.DoesNotContain(
+            handler.Requested,
+            url => url.Contains("nuget.org", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task EquivalentCatalogFailsOverOnlyBeforePagePublication()
+    {
+        string alternatePage =
+            "https://feed.example/v3/catalog-alt/page.json";
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"},"""
+                    + $$"""{"@id":"{{AlternateCatalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day1, Page(Page1, Day1))),
+            [Page1] = Json("""{}"""),
+            [AlternateCatalog] = Json(
+                IndexDocument(Day1, Page(alternatePage, Day1))),
+            [alternatePage] = Json(
+                PageDocument(
+                    AlternateCatalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/alternate.json",
+                        "Alternate",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))));
+
+        Assert.Equal("alternate", Assert.Single(terminal.Events).Coordinate.PackageId);
+        Assert.Equal(5, terminal.HttpAttempts);
+        Assert.Equal(
+            [
+                ServiceIndex,
+                Catalog,
+                Page1,
+                AlternateCatalog,
+                alternatePage,
+            ],
+            handler.Requested);
+    }
+
+    [Fact]
+    public async Task FailureAfterPublishedPageDoesNotMixCatalogRoots()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"},"""
+                    + $$"""{"@id":"{{AlternateCatalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day2,
+                    Page(Page1, Day1),
+                    Page(Page2, Day2))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/first.json",
+                        "First",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+            [Page2] = Json("""{"commitId":"broken"}"""),
+            [AlternateCatalog] = Json(
+                IndexDocument(Day2, Page(Page3, Day2))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                new NuGetCatalogRequest(Day0, Day2));
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.Equal("first", Assert.Single(Succeeded(outcomes[0]).Events).Coordinate.PackageId);
+        Assert.Equal(
+            PackageSourceFailureKind.InvalidResponse,
+            outcomes[1].Failure!.Kind);
+        Assert.DoesNotContain(AlternateCatalog, handler.Requested);
+    }
+
+    [Theory]
+    [InlineData(CatalogLimit.Page)]
+    [InlineData(CatalogLimit.Request)]
+    [InlineData(CatalogLimit.DecodedBytes)]
+    public async Task AcquisitionBoundsAreTypedPartialCompletion(
+        CatalogLimit limit)
+    {
+        string service = ServiceDocument(
+            $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""");
+        string index = IndexDocument(
+            Day2,
+            Page(Page1, Day1),
+            Page(Page2, Day2));
+        string firstPage = PageDocument(
+            Catalog,
+            Day1,
+            Item(
+                "https://feed.example/leaf/first.json",
+                "First",
+                "1.0.0",
+                Day1,
+                "nuget:PackageDetails"));
+        string secondPage = PageDocument(
+            Catalog,
+            Day2,
+            Item(
+                "https://feed.example/leaf/second.json",
+                "Second",
+                "1.0.0",
+                Day2,
+                "nuget:PackageDetails"));
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(service),
+            [Catalog] = Json(index),
+            [Page1] = Json(firstPage),
+            [Page2] = Json(secondPage),
+        };
+        long bytesThroughFirst =
+            Utf8Length(service) + Utf8Length(index) + Utf8Length(firstPage);
+        var options = new NuGetFetchOptions
+        {
+            MaxCatalogPages =
+                limit == CatalogLimit.Page ? 1 : 512,
+            MaxCatalogHttpAttempts =
+                limit == CatalogLimit.Request ? 3 : 1024,
+            MaxCatalogDecodedBytes =
+                limit == CatalogLimit.DecodedBytes
+                    ? bytesThroughFirst
+                    : NuGetFetchOptions.DefaultMaxCatalogDecodedBytes,
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler, options);
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day2))));
+
+        Assert.Equal("first", Assert.Single(terminal.Events).Coordinate.PackageId);
+        Assert.Equal(1, terminal.PagesAcquired);
+        Assert.Equal(1, terminal.InWindowEventCount);
+        Assert.Equal(
+            limit switch
+            {
+                CatalogLimit.Page =>
+                    NuGetCatalogCompletion.PageLimitReached,
+                CatalogLimit.Request =>
+                    NuGetCatalogCompletion.RequestLimitReached,
+                CatalogLimit.DecodedBytes =>
+                    NuGetCatalogCompletion.DecodedByteLimitReached,
+                _ => throw new ArgumentOutOfRangeException(nameof(limit)),
+            },
+            terminal.Completion);
+        Assert.DoesNotContain(Page2, handler.Requested);
+    }
+
+    [Fact]
+    public async Task RetriesConsumeCatalogWideAttemptBudget()
+    {
+        string page = PageDocument(
+            Catalog,
+            Day1,
+            Item(
+                "https://feed.example/leaf/retried.json",
+                "Retried",
+                "1.0.0",
+                Day1,
+                "nuget:PackageDetails"));
+        int attempts = 0;
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day1, Page(Page1, Day1))),
+        };
+        handler.Set(
+            Page1,
+            (request, _) => Task.FromResult(
+                ++attempts == 1
+                    ? new HttpResponseMessage(
+                        HttpStatusCode.ServiceUnavailable)
+                    {
+                        RequestMessage = request,
+                    }
+                    : new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            page,
+                            Encoding.UTF8,
+                            "application/json"),
+                        RequestMessage = request,
+                    }));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))));
+
+        Assert.Equal(2, attempts);
+        Assert.Equal(4, terminal.HttpAttempts);
+        Assert.Equal(
+            [ServiceIndex, Catalog, Page1, Page1],
+            handler.Requested);
+    }
+
+    [Fact]
+    public async Task AggregateByteCrossingRejectsTheWholeActivePage()
+    {
+        string service = ServiceDocument(
+            $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""");
+        string index = IndexDocument(
+            Day2,
+            Page(Page1, Day1),
+            Page(Page2, Day2));
+        string firstPage = PageDocument(
+            Catalog,
+            Day1,
+            Item(
+                "https://feed.example/leaf/first.json",
+                "First",
+                "1.0.0",
+                Day1,
+                "nuget:PackageDetails"));
+        string secondPage = PageDocumentWithPadding(
+            Catalog,
+            Day2,
+            Item(
+                "https://feed.example/leaf/not-published.json",
+                "Not.Published",
+                "1.0.0",
+                Day2,
+                "nuget:PackageDetails"),
+            padding: new string('x', 256));
+        long maximum =
+            Utf8Length(service)
+            + Utf8Length(index)
+            + Utf8Length(firstPage)
+            + Utf8Length(secondPage) / 2;
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(service),
+            [Catalog] = Json(index),
+            [Page1] = Json(firstPage),
+            [Page2] = Json(secondPage),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxCatalogDecodedBytes = maximum,
+                });
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                new NuGetCatalogRequest(Day0, Day2));
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.Equal(
+            "first",
+            Assert.Single(Succeeded(outcomes[0]).Events).Coordinate.PackageId);
+        NuGetCatalogPage terminal = Succeeded(outcomes[1]);
+        Assert.Empty(terminal.Events);
+        Assert.Equal(1, terminal.PagesAcquired);
+        Assert.Equal(1, terminal.InWindowEventCount);
+        Assert.Equal(maximum, terminal.DecodedBytes);
+        Assert.Equal(
+            NuGetCatalogCompletion.DecodedByteLimitReached,
+            terminal.Completion);
+        Assert.Contains(Page2, handler.Requested);
+    }
+
+    [Fact]
+    public async Task PerResponseLimitAndMalformedPageRemainTypedFailures()
+    {
+        string page = PageDocumentWithPadding(
+            Catalog,
+            Day1,
+            Item(
+                "https://feed.example/leaf/large.json",
+                "Large",
+                "1.0.0",
+                Day1,
+                "nuget:PackageDetails"),
+            padding: new string('x', 4096));
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            page);
+        int setupMaximum = checked((int)Math.Max(
+            Utf8Length(handler.Body(ServiceIndex)),
+            Utf8Length(handler.Body(Catalog))));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxMetadataResponseBytes = setupMaximum,
+                });
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.ResponseRejected, failure.Kind);
+        Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
+    }
+
+    [Fact]
+    public async Task MalformedLaterPagePublishesNoEventsFromThatPage()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day2,
+                    Page(Page1, Day1),
+                    Page(Page2, Day2))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/first.json",
+                        "First",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+            [Page2] = Json(
+                PageDocument(
+                    Catalog,
+                    Day2,
+                    Item(
+                        "https://feed.example/leaf/valid.json",
+                        "Would.Be.Partial",
+                        "1.0.0",
+                        Day2,
+                        "nuget:PackageDetails"),
+                    Item(
+                        "https://feed.example/leaf/invalid.json",
+                        "../invalid",
+                        "1.0.0",
+                        Day2,
+                        "nuget:PackageDetails"))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                new NuGetCatalogRequest(Day0, Day2));
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.Equal("first", Assert.Single(Succeeded(outcomes[0]).Events).Coordinate.PackageId);
+        Assert.Null(outcomes[1].Value);
+        Assert.Equal(
+            PackageSourceFailureKind.InvalidResponse,
+            outcomes[1].Failure!.Kind);
+    }
+
+    [Theory]
+    [InlineData(DuplicateLocation.Service)]
+    [InlineData(DuplicateLocation.Index)]
+    [InlineData(DuplicateLocation.Page)]
+    [InlineData(DuplicateLocation.PageItem)]
+    public async Task DuplicatePropertiesAreRejectedAtEveryDepth(
+        DuplicateLocation location)
+    {
+        string resource =
+            $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""";
+        string service = location == DuplicateLocation.Service
+            ? "{\"version\":\"3.0.0\",\"resources\":["
+                + resource
+                + "],\"ignored\":{\"x\":1,\"x\":2}}"
+            : ServiceDocument(resource);
+        string index = location == DuplicateLocation.Index
+            ? "{\"commitId\":\"index\",\"commitTimeStamp\":\""
+                + Stamp(Day1)
+                + "\",\"count\":1,\"items\":["
+                + Page(Page1, Day1)
+                + "],\"ignored\":{\"x\":1,\"x\":2}}"
+            : IndexDocument(Day1, Page(Page1, Day1));
+        string item = Item(
+            "https://feed.example/leaf/one.json",
+            "One",
+            "1.0.0",
+            Day1,
+            "nuget:PackageDetails",
+            location == DuplicateLocation.PageItem
+                ? ""","ignored":{"x":1,"x":2}"""
+                : "");
+        string page = location == DuplicateLocation.Page
+            ? "{\"commitId\":\"page\",\"commitTimeStamp\":\""
+                + Stamp(Day1)
+                + "\",\"count\":1,\"parent\":\""
+                + Catalog
+                + "\",\"items\":["
+                + item
+                + "],\"ignored\":{\"x\":1,\"x\":2}}"
+            : PageDocument(Catalog, Day1, item);
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(service),
+            [Catalog] = Json(index),
+            [Page1] = Json(page),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+    }
+
+    [Theory]
+    [InlineData("file:///catalog/page.json", false)]
+    [InlineData("https://user:secret@feed.example/leaf.json", true)]
+    public async Task MalformedAdvertisedUrlsRejectTheContainingDocument(
+        string malformed,
+        bool leaf)
+    {
+        string pageUrl = leaf ? Page1 : malformed;
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(Day1, Page(pageUrl, Day1))),
+        };
+        if (leaf)
+        {
+            handler[Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        malformed,
+                        "Package",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails")));
+        }
+
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+    }
+
+    [Fact]
+    public async Task CredentialsStayOnSourceOriginAndLeafUrlIsNormalized()
+    {
+        const string CrossOriginPage =
+            "https://cdn.example/catalog/page.json?sig=%2f";
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day1,
+                    Page(CrossOriginPage, Day1))),
+            [CrossOriginPage] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://bücher.example/leaf/naïve.json",
+                        "Package",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+        };
+        var credential = new PackageSourceCredential("user", "secret");
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler, credential: credential);
+
+        NuGetCatalogPage terminal = Succeeded(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))));
+
+        Assert.Equal("user:secret", handler.DecodedAuthFor(ServiceIndex));
+        Assert.Equal("user:secret", handler.DecodedAuthFor(Catalog));
+        Assert.Null(handler.AuthFor(CrossOriginPage));
+        Assert.Equal(
+            "https://xn--bcher-kva.example/leaf/na%C3%AFve.json",
+            Assert.Single(terminal.Events).LeafUrl);
+        Assert.DoesNotContain(
+            handler.Requested,
+            url => url.Contains("xn--bcher-kva", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PageAcquisitionIsBackpressured()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day2,
+                    Page(Page1, Day1),
+                    Page(Page2, Day2))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/first.json",
+                        "First",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+            [Page2] = Json(
+                PageDocument(
+                    Catalog,
+                    Day2,
+                    Item(
+                        "https://feed.example/leaf/second.json",
+                        "Second",
+                        "1.0.0",
+                        Day2,
+                        "nuget:PackageDetails"))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        await using IAsyncEnumerator<
+            PackageSourceOperationResult<NuGetCatalogPage>> enumerator =
+            source.AcquireCatalogAsync(
+                    new NuGetCatalogRequest(Day0, Day2),
+                    TestContext.Current.CancellationToken)
+                .GetAsyncEnumerator(
+                    TestContext.Current.CancellationToken);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal([ServiceIndex, Catalog, Page1], handler.Requested);
+        await Task.Delay(
+            TimeSpan.FromMilliseconds(20),
+            TestContext.Current.CancellationToken);
+        Assert.Equal([ServiceIndex, Catalog, Page1], handler.Requested);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal([ServiceIndex, Catalog, Page1, Page2], handler.Requested);
+        Assert.Equal(
+            NuGetCatalogCompletion.WindowExhausted,
+            enumerator.Current.Value!.Completion);
+        Assert.False(await enumerator.MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task ConsumerTimeDoesNotSpendTheInternalOperationDeadline()
+    {
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day2,
+                    Page(Page1, Day1),
+                    Page(Page2, Day2))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/first.json",
+                        "First",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+            [Page2] = Json(
+                PageDocument(
+                    Catalog,
+                    Day2,
+                    Item(
+                        "https://feed.example/leaf/second.json",
+                        "Second",
+                        "1.0.0",
+                        Day2,
+                        "nuget:PackageDetails"))),
+        };
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    OperationTimeout = TimeSpan.FromSeconds(1),
+                });
+        await using IAsyncEnumerator<
+            PackageSourceOperationResult<NuGetCatalogPage>> enumerator =
+            source.AcquireCatalogAsync(
+                    new NuGetCatalogRequest(Day0, Day2),
+                    TestContext.Current.CancellationToken)
+                .GetAsyncEnumerator(
+                    TestContext.Current.CancellationToken);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        await Task.Delay(
+            TimeSpan.FromMilliseconds(1100),
+            TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(
+            NuGetCatalogCompletion.WindowExhausted,
+            enumerator.Current.Value!.Completion);
+    }
+
+    [Fact]
+    public async Task CallerOwnedContextRetainsItsWallClockDeadline()
+    {
+        var handler = TwoPageHandler();
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        using var operation = new NuGetOperationContext(
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+        await using IAsyncEnumerator<
+            PackageSourceOperationResult<NuGetCatalogPage>> enumerator =
+            source.AcquireCatalogAsync(
+                    new NuGetCatalogRequest(Day0, Day2),
+                    TestContext.Current.CancellationToken,
+                    operation)
+                .GetAsyncEnumerator(
+                    TestContext.Current.CancellationToken);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        await Task.Delay(
+            TimeSpan.FromMilliseconds(1100),
+            TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(
+            PackageSourceFailureKind.Timeout,
+            enumerator.Current.Failure!.Kind);
+        Assert.Throws<NuGetOperationTimeoutException>(
+            operation.ThrowIfExpired);
+        Assert.Equal(
+            [ServiceIndex, Catalog, Page1],
+            handler.Requested);
+    }
+
+    [Fact]
+    public async Task CallerOwnedContextRemainsUsableAfterStreamCompletion()
+    {
+        var handler = TwoPageHandler();
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        using var operation = new NuGetOperationContext(
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromSeconds(30),
+            TestContext.Current.CancellationToken);
+
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                new NuGetCatalogRequest(Day0, Day2),
+                operationContext: operation);
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.Equal(
+            NuGetCatalogCompletion.WindowExhausted,
+            Succeeded(outcomes[^1]).Completion);
+        operation.ThrowIfExpired();
+    }
+
+    [Fact]
+    public async Task CallerCancellationPropagatesAfterPublishedPages()
+    {
+        var secondRequested =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new RouteHandler
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day2,
+                    Page(Page1, Day1),
+                    Page(Page2, Day2))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/first.json",
+                        "First",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+        };
+        handler.Set(
+            Page2,
+            async (_, cancellationToken) =>
+            {
+                secondRequested.TrySetResult();
+                await Task.Delay(
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+                throw new InvalidOperationException("Unreachable.");
+            });
+        using var cancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        await using IAsyncEnumerator<
+            PackageSourceOperationResult<NuGetCatalogPage>> enumerator =
+            source.AcquireCatalogAsync(
+                    new NuGetCatalogRequest(Day0, Day2),
+                    cancellation.Token)
+                .GetAsyncEnumerator(
+                    TestContext.Current.CancellationToken);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        ValueTask<bool> next = enumerator.MoveNextAsync();
+        await secondRequested.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => next.AsTask());
+    }
+
+    [Fact]
+    public async Task CallerCancellationWinsARacingSourceFailure()
+    {
+        var handler = TwoPageHandler();
+        using var cancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+        handler.Set(
+            Page2,
+            (request, _) =>
+            {
+                cancellation.Cancel();
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                    {
+                        RequestMessage = request,
+                    });
+            });
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        await using IAsyncEnumerator<
+            PackageSourceOperationResult<NuGetCatalogPage>> enumerator =
+            source.AcquireCatalogAsync(
+                    new NuGetCatalogRequest(Day0, Day2),
+                    cancellation.Token)
+                .GetAsyncEnumerator(cancellation.Token);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => enumerator.MoveNextAsync().AsTask());
+    }
+
+    [Fact]
+    public async Task OperationDeadlineIsATypedTerminalFailure()
+    {
+        var handler = new RouteHandler();
+        handler.Set(
+            ServiceIndex,
+            async (_, cancellationToken) =>
+            {
+                await Task.Delay(
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+                throw new InvalidOperationException("Unreachable.");
+            });
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    RequestTimeout = TimeSpan.FromMilliseconds(20),
+                    OperationTimeout = TimeSpan.FromMilliseconds(80),
+                });
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.Timeout, failure.Kind);
+        Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
+    }
+
+    [Fact]
+    public async Task UnsupportedEventKindRejectsThePage()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    "https://feed.example/leaf/unknown.json",
+                    "Unknown",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackagePublish")));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            Assert.Single(
+                await ReadAllAsync(
+                    source,
+                    new NuGetCatalogRequest(Day0, Day1))).Failure);
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+    }
+
+    private static INuGetCatalogPackageSourceClient CreateSource(
+        RouteHandler handler,
+        NuGetFetchOptions? options = null,
+        PackageSourceAssociation? association = null,
+        PackageSourceCredential? credential = null)
+    {
+        IPackageSourceClient source = PackageSourceClientFactory.Create(
+            PackageSourceDescriptor.NuGetV3(
+                "feed",
+                "Feed",
+                new Uri(ServiceIndex)),
+            association ?? PackageSourceAssociation.Create(),
+            handler,
+            options,
+            credential);
+        Assert.True(
+            source.Capabilities.HasFlag(PackageSourceCapabilities.Catalog));
+        return Assert.IsAssignableFrom<INuGetCatalogPackageSourceClient>(
+            source);
+    }
+
+    private static async Task<
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>>>
+        ReadAllAsync(
+            INuGetCatalogPackageSourceClient source,
+            NuGetCatalogRequest request,
+            NuGetOperationContext? operationContext = null)
+    {
+        var outcomes =
+            new List<PackageSourceOperationResult<NuGetCatalogPage>>();
+        await foreach (
+            PackageSourceOperationResult<NuGetCatalogPage> outcome
+            in source.AcquireCatalogAsync(
+                request,
+                TestContext.Current.CancellationToken,
+                operationContext))
+        {
+            outcomes.Add(outcome);
+        }
+
+        return outcomes;
+    }
+
+    private static NuGetCatalogPage Succeeded(
+        PackageSourceOperationResult<NuGetCatalogPage> outcome)
+    {
+        Assert.Null(outcome.Failure);
+        return Assert.IsType<NuGetCatalogPage>(outcome.Value);
+    }
+
+    private static RouteHandler StandardHandler(
+        string index,
+        string page) =>
+        new()
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(index),
+            [Page1] = Json(page),
+        };
+
+    private static RouteHandler TwoPageHandler() =>
+        new()
+        {
+            [ServiceIndex] = Json(
+                ServiceDocument(
+                    $$"""{"@id":"{{Catalog}}","@type":"Catalog/3.0.0"}""")),
+            [Catalog] = Json(
+                IndexDocument(
+                    Day2,
+                    Page(Page1, Day1),
+                    Page(Page2, Day2))),
+            [Page1] = Json(
+                PageDocument(
+                    Catalog,
+                    Day1,
+                    Item(
+                        "https://feed.example/leaf/first.json",
+                        "First",
+                        "1.0.0",
+                        Day1,
+                        "nuget:PackageDetails"))),
+            [Page2] = Json(
+                PageDocument(
+                    Catalog,
+                    Day2,
+                    Item(
+                        "https://feed.example/leaf/second.json",
+                        "Second",
+                        "1.0.0",
+                        Day2,
+                        "nuget:PackageDetails"))),
+        };
+
+    private static string ServiceDocument(string resources) =>
+        $$"""{"version":"3.0.0","resources":[{{resources}}]}""";
+
+    private static string IndexDocument(
+        DateTimeOffset horizon,
+        params string[] pages) =>
+        IndexDocument(horizon, pages, pages.Length);
+
+    private static string IndexDocumentWithCount(
+        DateTimeOffset horizon,
+        int count,
+        params string[] pages) =>
+        IndexDocument(horizon, pages, count);
+
+    private static string IndexDocument(
+        DateTimeOffset horizon,
+        string[] pages,
+        int count) =>
+        $$"""
+        {"commitId":"index","commitTimeStamp":"{{Stamp(horizon)}}",
+        "count":{{count}},"items":[{{string.Join(',', pages)}}]}
+        """;
+
+    private static string Page(
+        string url,
+        DateTimeOffset horizon) =>
+        $$"""
+        {"@id":"{{url}}","commitId":"page",
+        "commitTimeStamp":"{{Stamp(horizon)}}","count":999}
+        """;
+
+    private static string PageDocument(
+        string parent,
+        DateTimeOffset horizon,
+        params string[] items) =>
+        PageDocument(parent, horizon, items, count: items.Length);
+
+    private static string PageDocumentWithCount(
+        string parent,
+        DateTimeOffset horizon,
+        int count,
+        params string[] items) =>
+        PageDocument(parent, horizon, items, count);
+
+    private static string PageDocumentWithPadding(
+        string parent,
+        DateTimeOffset horizon,
+        string item,
+        string padding) =>
+        PageDocument(
+            parent,
+            horizon,
+            [item],
+            count: 1,
+            padding);
+
+    private static string PageDocument(
+        string parent,
+        DateTimeOffset horizon,
+        string[] items,
+        int count,
+        string? padding = null)
+    {
+        string paddingProperty = padding is null
+            ? ""
+            : ",\"padding\":\"" + padding + "\"";
+        return $$"""
+            {"commitId":"page","commitTimeStamp":"{{Stamp(horizon)}}",
+            "count":{{count}},"parent":"{{parent}}","items":[{{string.Join(',', items)}}]
+            {{paddingProperty}}}
+            """;
+    }
+
+    private static string Item(
+        string leafUrl,
+        string packageId,
+        string version,
+        DateTimeOffset timestamp,
+        string kind,
+        string suffix = "") =>
+        $$"""
+        {"@id":"{{leafUrl}}","@type":"{{kind}}","commitId":"commit",
+        "commitTimeStamp":"{{Stamp(timestamp)}}","nuget:id":"{{packageId}}",
+        "nuget:version":"{{version}}"{{suffix}}}
+        """;
+
+    private static string Stamp(DateTimeOffset value) =>
+        value.ToString("O", CultureInfo.InvariantCulture);
+
+    private static DateTimeOffset Utc(
+        int year,
+        int month,
+        int day) =>
+        new(year, month, day, 0, 0, 0, TimeSpan.Zero);
+
+    private static long Utf8Length(string value) =>
+        Encoding.UTF8.GetByteCount(value);
+
+    private static RouteResponse Json(string body) =>
+        new(HttpStatusCode.OK, body);
+
+    public enum CatalogLimit
+    {
+        Page,
+        Request,
+        DecodedBytes,
+    }
+
+    public enum DuplicateLocation
+    {
+        Service,
+        Index,
+        Page,
+        PageItem,
+    }
+
+    private sealed record RouteResponse(
+        HttpStatusCode StatusCode,
+        string Body);
+
+    private sealed class RouteHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<
+            string,
+            Func<
+                HttpRequestMessage,
+                CancellationToken,
+                Task<HttpResponseMessage>>> _routes =
+            new(StringComparer.Ordinal);
+        private readonly Dictionary<string, string> _bodies =
+            new(StringComparer.Ordinal);
+        private readonly List<
+            (string Url, AuthenticationHeaderValue? Authorization)> _requests =
+            [];
+
+        public RouteResponse this[string url]
+        {
+            set
+            {
+                _bodies[url] = value.Body;
+                Set(
+                    url,
+                    (request, _) => Task.FromResult(
+                        new HttpResponseMessage(value.StatusCode)
+                        {
+                            Content = new StringContent(
+                                value.Body,
+                                Encoding.UTF8,
+                                "application/json"),
+                            RequestMessage = request,
+                        }));
+            }
+        }
+
+        public IReadOnlyList<string> Requested =>
+            _requests.Select(item => item.Url).ToArray();
+
+        public string Body(string url) => _bodies[url];
+
+        public AuthenticationHeaderValue? AuthFor(string url) =>
+            _requests.FirstOrDefault(
+                item => item.Url.Equals(
+                    url,
+                    StringComparison.Ordinal)).Authorization;
+
+        public string? DecodedAuthFor(string url)
+        {
+            AuthenticationHeaderValue? authorization = AuthFor(url);
+            return authorization?.Parameter is { } parameter
+                ? Encoding.UTF8.GetString(
+                    Convert.FromBase64String(parameter))
+                : null;
+        }
+
+        public void Set(
+            string url,
+            Func<
+                HttpRequestMessage,
+                CancellationToken,
+                Task<HttpResponseMessage>> response) =>
+            _routes[url] = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.AbsoluteUri;
+            _requests.Add((url, request.Headers.Authorization));
+            return _routes.TryGetValue(url, out var response)
+                ? response(request, cancellationToken)
+                : Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.NotFound)
+                    {
+                        RequestMessage = request,
+                    });
+        }
+    }
+}

--- a/tests/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/tests/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -226,7 +226,8 @@ public sealed class PackageSourceClientTests
             PackageSourceCapabilities.Search
                 | PackageSourceCapabilities.VersionEnumeration
                 | PackageSourceCapabilities.Manifest
-                | PackageSourceCapabilities.PackagePayload,
+                | PackageSourceCapabilities.PackagePayload
+                | PackageSourceCapabilities.Catalog,
             runtime.Capabilities);
         PackageVersionResult versions = Succeeded(
             await runtime.GetVersionsAsync(
@@ -286,6 +287,28 @@ public sealed class PackageSourceClientTests
                 "user:token",
             ],
             handler.Authentication.Select(DecodeBasic));
+    }
+
+    [Fact]
+    public void CustomClientCannotAdvertiseAnUnforwardedCatalogCapability()
+    {
+        var descriptor = PackageSourceDescriptor.NuGetV3(
+            "custom",
+            "Custom",
+            new Uri(ServiceIndex));
+
+        InvalidOperationException error =
+            Assert.Throws<InvalidOperationException>(
+                () => NuGetFetch.PackageSourceClientFactory.CreateCustom(
+                    descriptor,
+                    PackageSourceAssociation.Create(),
+                    factory => new FactoryOnlyPackageSourceClient(
+                        factory.Source,
+                        PackageSourceCapabilities.Catalog)));
+
+        Assert.Contains(
+            "cannot advertise the Catalog capability",
+            error.Message);
     }
 
     [Fact]
@@ -5548,12 +5571,14 @@ public sealed class PackageSourceClientTests
     }
 
     private sealed class FactoryOnlyPackageSourceClient(
-        PackageSourceResultIdentity source)
+        PackageSourceResultIdentity source,
+        PackageSourceCapabilities capabilities =
+            PackageSourceCapabilities.None)
         : IPackageSourceClient
     {
         public PackageSourceResultIdentity Source { get; } = source;
-        public PackageSourceCapabilities Capabilities =>
-            PackageSourceCapabilities.None;
+        public PackageSourceCapabilities Capabilities { get; } =
+            capabilities;
 
         public Task<PackageSourceOperationResult<PackageSearchResult>>
             SearchAsync(

--- a/tests/NuGetFetch.Tests/PackageSourceCustomClientTests.cs
+++ b/tests/NuGetFetch.Tests/PackageSourceCustomClientTests.cs
@@ -382,7 +382,7 @@ public sealed class PackageSourceCustomClientTests
 
         Assert.Equal(inner.CapabilityValue, adapter.Capabilities);
         Assert.Equal(inner.CapabilityValue, adapter.Capabilities);
-        Assert.Equal(2, inner.CapabilityReads);
+        Assert.Equal(3, inner.CapabilityReads);
         Assert.Same(factory.Source, adapter.Source);
         Assert.Equal(1, inner.SourceReads);
 


### PR DESCRIPTION
Builds a robust, foundational source capability for the ecosystem-change
experience: an authorized NuGet V3 source can now stream a bounded Catalog
interval without turning partial acquisition into a complete-coverage claim.

## Demo

A 15-minute live nuget.org request through the new public capability:

```csharp
var request = new NuGetCatalogRequest(
    DateTimeOffset.UtcNow.AddMinutes(-15),
    DateTimeOffset.UtcNow);

await foreach (var outcome in catalog.AcquireCatalogAsync(request))
{
    NuGetCatalogPage page = outcome.Value!;
    Console.WriteLine(
        $"page={page.PagesAcquired} events={page.Events.Length} "
        + $"attempts={page.HttpAttempts} completion={page.Completion}");
}
```

```text
page=1 events=201 attempts=3 completion=SourceHorizonReached
```

The result retains original and normalized coordinates, typed Details/Delete
activity, the captured source horizon, cumulative resource use, and explicit
completion.

## What changed

- discovers source-advertised `Catalog/3.0.0` endpoints and applies the
  existing source identity, credential, destination, deadline, and typed
  failure contracts;
- implements unordered index/page handling, strengthened tied crossing-page
  traversal, `(from, through]` filtering, captured-horizon filtering, and stale
  active-page retry;
- preserves valid evidence across equal-maximum pages without inferring global
  chronological order from advertised URL order;
- streams page-atomic outcomes under page, HTTP-attempt, per-response, and
  aggregate decoded-byte bounds;
- counts every actual HTTP send, including redirects and authentication
  exchanges, against the aggregate attempt bound;
- adds a focused source-owner design and 52 offline contract tests.

This slice deliberately does not define ecosystem filtering, security
classification, leaf enrichment, caching, cursor persistence, report-query
semantics, commands, rendering, or browser placement. Those remain later
owner-scoped steps in #6124.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `NuGetCatalogAcquisitionTests`: 52 passed
- full `NuGetFetch.Tests`: 1,069 passed, 11 skipped; the known 44 local
  `PluginProtocolTests` failures remain because spawned apphosts resolve the
  central runtime that lacks the selected SDK runtime
- live nuget.org 15-minute acquisition shown above
- `markdownlint` for all changed Markdown
- `git diff --check`

Closes #6294.
