### PR TITLE
Add restored package pruning evidence

### DIFF
--- a/docs/design/package-dependency-evidence.md
+++ b/docs/design/package-dependency-evidence.md
@@ -13,8 +13,9 @@ package-prefix admission, and failure core is implemented under #5533 as
 input-kind, declaration-basis, authorship, produced-relationship, positive
 processing, and independent phase-count vocabulary for package-manifest and
 restored-project inputs. Authored-project and runtime-dependency providers,
-typed pruning observations, policy composition, and host adoption remain
-staged work. Optional owner observations remain dependent on #5315.
+policy composition, and host adoption remain staged work. Restored-project
+inputs now consume typed pruning-processing evidence from their artifact
+owner. Optional owner observations remain dependent on #5315.
 
 ## Owner
 
@@ -73,7 +74,8 @@ steps are:
 2. Add input kind, declaration basis, authorship, normalized produced
    relationships, processing evidence, and independent phase counts to the
    immutable result (implemented by the current query).
-3. Add typed pruning-processing evidence to restored-project facts.
+3. Add typed pruning-processing evidence to restored-project facts
+   (implemented by the current query).
 4. Add a typed authored-project declaration provider.
 5. Add a typed runtime-dependency provider for `.deps.json`.
 6. Adopt the shape in package-pruning policy.
@@ -593,7 +595,7 @@ initial semantic vocabulary is:
 
 | Semantic | Positive evidence |
 | --- | --- |
-| Restore resolution | A selected restored target graph |
+| Restore resolution | A selected restored target |
 | Package-pruning evaluation | The restored target's typed `packagesToPrune` evidence |
 | Runtime dependency projection | A typed runtime target graph |
 
@@ -612,6 +614,14 @@ Prunable and processed are independent. Declaration authorship and the
 consuming policy determine whether an edge may receive a transformation or
 exemption; processing observations state which semantics already ran. This
 owner therefore defines no `IsPruned` or `IsPrunable` bit.
+
+The restored-project provider associates its pruning evidence with the exact
+selected declaration-group identity. A valid empty `packagesToPrune` object is
+positive evidence. An absent member remains unavailable, while malformed,
+ambiguous, or over-limit evidence becomes a typed provider failure. The
+normalized result preserves restore resolution independently: provider failure
+makes processing available but incomplete, with the owner-issued failure
+retained and no pruning observation manufactured.
 
 Processing retains the same closed state as the other phases:
 
@@ -1050,7 +1060,9 @@ and current larger-shape properties are gated in Release by
 `PackageDependencyEvidenceQueryTests`. The current larger-shape gates are:
 
 - `Execute_CurrentInputKindsAndDeclarationBasesAreExplicit`;
-- `Execute_RestoredGraphProvidesPositiveRestoreResolutionObservation`;
+- `PackageInput_AssetsPruningObservationRequiresTypedPackagesToPruneEvidence`;
+- `PackageInput_AssetsWithoutPruneEvidenceRemainProcessingUnknown`;
+- `PackageInput_InvalidPruneEvidencePreservesRestoreAsIncompleteProcessing`;
 - `Execute_PreservesSelectedRestoredTargetWhenGraphIsUnavailable`;
 - `PackageInput_InputKindAndBasisRequireMatchingIdentityAndProvenance`;
 - `PackageInput_RequestedConstraintAndResolvedCoordinateRemainIndependent`;
@@ -1060,13 +1072,10 @@ and current larger-shape properties are gated in Release by
 - `PackageInput_NotApplicableIsNotUnavailableOrCompleteEmpty`.
 
 Owner-enrichment behavior remains `unverified` until #5315 supplies its typed
-input and focused gates. The remaining authored-project, pruning-processing,
-runtime-dependency, and cross-host properties remain `unverified` until these
-Release gates land:
+input and focused gates. The remaining authored-project, runtime-dependency,
+and cross-host properties remain `unverified` until these Release gates land:
 
 - `PackageInput_AuthoredSyntaxAndEvaluatedBasisRemainDistinct`;
-- `PackageInput_AssetsPruningObservationRequiresTypedPackagesToPruneEvidence`;
-- `PackageInput_AssetsWithoutPruneEvidenceRemainProcessingUnknown`;
 - `PackageInput_DepsAbsenceNeverBecomesPruningEvidence`;
 - `PackageInput_CliAndBrowserConsumeTheSameTypedSnapshot`.
 

--- a/docs/design/restored-project-dependency-facts.md
+++ b/docs/design/restored-project-dependency-facts.md
@@ -5,7 +5,8 @@ declared-dependency and restored-graph evidence without transferring filesystem,
 restore, presentation, or normalized cross-input ownership into the query
 layer.
 
-**Status:** implementation contract for #5314.
+**Status:** implementation contract for #5314, evolved with pruning-processing
+evidence under #6266.
 
 ## Owner
 
@@ -15,11 +16,12 @@ The **Restored Project Dependency Facts Query** in
 - bounded parsing of exact caller-supplied `project.assets.json` UTF-8 bytes;
 - deterministic target-framework and optional runtime-identifier selection;
 - immutable project-authored package declaration groups;
+- typed evidence that package-pruning evaluation ran for the selected target;
 - exact resolved package coordinates and package-resolving graph edges;
 - content-scoped identities for the selection, root, declaration groups, graph
   nodes, and graph edges;
-- independent declaration and graph capability, provenance, completion, and
-  failure evidence; and
+- independent declaration, pruning-processing, and graph capability,
+  provenance, completion, and failure evidence; and
 - construction-time containment of artifact-authored display text.
 
 The query does not accept a path, read a file, evaluate MSBuild, initiate
@@ -94,8 +96,8 @@ deterministic identity tie-breaker.
 Because matching collapses case, two target pivots may share one canonical
 target identity. That is detected before selection: the ambiguity fails the
 graph and selects no target rather than letting JSON property order decide
-which pivot wins. Detection is a graph-phase concern and leaves the declaration
-phase untouched.
+which pivot wins. Detection prevents target-associated pruning and graph
+projection while leaving the declaration phase untouched.
 
 An absent `targets` capability or an unsatisfied request is graph
 **unavailable**, not a complete-empty graph. A selected target whose own shape
@@ -108,15 +110,15 @@ input provenance. That digest is not semantic identity: harmless JSON property
 reordering changes it.
 
 The selection identity instead combines the selected target identity with a
-deterministic digest over the query's canonical declaration and selected-graph
-facts. That digest is computed from an unambiguous typed encoding in which
-every field is length-prefixed and every collection is preceded by its element
-count, so no artifact-authored string can be split or joined across field
-boundaries to forge a digest collision. No local path, project display name,
-request spelling, JSON property position, raw byte order, or rendered text
-participates. A default request and an explicit request that select the same
-target therefore share semantic selection identity while retaining distinct
-selection provenance.
+deterministic digest over the query's canonical declaration,
+pruning-processing, and selected-graph facts. That digest is computed from an
+unambiguous typed encoding in which every field is length-prefixed and every
+collection is preceded by its element count, so no artifact-authored string
+can be split or joined across field boundaries to forge a digest collision.
+No local path, project display name, request spelling, JSON property position,
+raw byte order, or rendered text participates. A default request and an
+explicit request that select the same target therefore share semantic
+selection identity while retaining distinct selection provenance.
 
 Every public identity string is one of two safe forms, and no artifact-authored
 text is ever emitted verbatim as identity:
@@ -243,7 +245,47 @@ Completion is explicit typed state rather than an inference from an empty
 failure collection, and an available phase cannot represent the invalid
 combinations of complete-with-failures or incomplete-without-failures.
 
-Declaration completion does not depend on graph availability or success.
+Declaration completion does not depend on pruning-processing or graph
+availability or success.
+
+## Package-pruning processing evidence
+
+The selected target is correlated with its uniquely corresponding
+`project.frameworks` group through the same schema-aware rule used for root
+constraints: schema version 3 uses canonical NuGet framework identity and
+schema version 4 uses the target alias. For a runtime-specific selected target,
+the evidence remains associated with its framework group because
+`packagesToPrune` is framework-scoped in the assets schema.
+
+A present `packagesToPrune` member is valid only when it is a JSON object whose
+property names are valid bounded package IDs and whose values are valid bounded
+NuGet version ranges. A valid empty object is positive evidence: it proves the
+typed processing capability is present even though it contains no pruning
+rules.
+
+The public evidence is deliberately smaller than the artifact map. It carries
+the exact selected declaration-group identity and establishes only that
+package-pruning evaluation ran for that restored target. It does not duplicate
+the platform package inventory, identify an exemption, or prove that any edge
+was removed. Valid rule-map contents beyond their validity do not participate
+in semantic selection identity because the query issues no rule rows. Exact
+source bytes remain available through content provenance.
+
+The pruning-processing phase is one of:
+
+- **Available** — a valid `packagesToPrune` object, including an empty object,
+  is associated with the selected target;
+- **Unavailable** — no target was selected, no uniquely corresponding
+  framework group is available, or the selected group has no
+  `packagesToPrune` member; or
+- **Failed** — association is ambiguous, the member is not an object, an entry
+  has an invalid package ID or version range, or the independent pruning-rule
+  bound is exceeded.
+
+Unavailable evidence means **not evidenced**, never that pruning did not run.
+Present invalid evidence remains a typed failure rather than becoming absence.
+Pruning availability or failure does not upgrade or downgrade declaration or
+graph completion.
 
 ## Restored graph projection
 
@@ -343,7 +385,8 @@ cross-input comparison owner.
 
 Malformed or duplicate-bearing JSON, unsupported document shape, unsupported
 schema version, and configured whole-document limits are query failures.
-Declaration- and graph-local failures remain on their owning phase.
+Declaration-, pruning-processing-, and graph-local failures remain on their
+owning phase.
 
 Failure messages are derived only from closed reason values and optional
 numeric counts. They never quote package IDs, framework names, version text,
@@ -367,6 +410,7 @@ The query enforces fixed limits for:
 - authored framework groups;
 - authored package declarations;
 - authored project-reference declarations;
+- selected-group package-pruning rules;
 - selected-target nodes; and
 - reachable graph edges.
 
@@ -376,8 +420,9 @@ package chain.
 
 Exceeding a whole-document bound fails the query. Exceeding a declaration or
 graph collection bound leaves that phase incomplete when already-projected
-evidence remains usable; identity-ambiguity and fundamentally invalid section
-shape fail the phase.
+evidence remains usable. Exceeding the package-pruning rule bound fails only
+that independently projected evidence. Identity ambiguity and fundamentally
+invalid section shape fail their associated phase.
 
 The limits run in the Release test suite. A caller cannot opt out through a
 larger requested value.
@@ -404,6 +449,13 @@ The contract is gated by:
 - duplicate canonical target identity failing the graph regardless of JSON
   order while leaving the declaration phase usable;
 - authored groups retaining requested ranges and valid empty groups;
+- real SDK-produced `packagesToPrune` content yielding selected-group typed
+  pruning evidence, with a valid empty object remaining positive;
+- absent, non-object, invalid-entry, ambiguous-association, and configured-limit
+  pruning states remaining distinct and independent from declaration and graph
+  completion;
+- schema version 3 pruning evidence correlating a short declaration pivot with
+  its long selected target;
 - absent versus non-object `dependencies` at both declaration groups and
   reachable graph nodes;
 - unclassified dependency targets being invalid rather than assumed packages;
@@ -451,6 +503,8 @@ This owner does not:
 - locate `.csproj`, directory, or assets paths;
 - report project-not-found or assets-not-restored locator failures;
 - evaluate project files, choose MSBuild properties, restore, or build;
+- define package-pruning policy, direct-reference exemptions, platform-package
+  subsumption, or which graph edges pruning removed;
 - resolve package files under a global-packages directory;
 - normalize package and nuspec declarations into common evidence;
 - acquire package-owner metadata;

--- a/src/DotnetInspector.Queries/PackageDependencyEvidenceQuery.cs
+++ b/src/DotnetInspector.Queries/PackageDependencyEvidenceQuery.cs
@@ -611,6 +611,10 @@ public abstract record PackageDependencyEvidenceProcessingFailure
     public sealed record Association(
         PackageDependencyEvidenceProcessingObservation Observation) :
         PackageDependencyEvidenceProcessingFailure;
+
+    public sealed record RestoredProjectPackagePruning(
+        RestoredProjectPackagePruningFailure Failure) :
+        PackageDependencyEvidenceProcessingFailure;
 }
 
 /// <summary>The positive processing-evidence state for one normalized root.</summary>
@@ -1524,16 +1528,46 @@ public static class PackageDependencyEvidenceQuery
         };
 
     private static PackageDependencyEvidenceProcessingResult
-        ProjectRestoredProcessing(RestoredProjectDependencyFacts facts) =>
-        facts.SelectedTarget is not null
-            ? new PackageDependencyEvidenceProcessingResult.Available(
-                [
-                    PackageDependencyEvidenceProcessingObservation
-                        .RestoreResolution,
-                ],
-                [],
-                PackageDependencyEvidencePhaseCompletion.Complete)
-            : new PackageDependencyEvidenceProcessingResult.Unavailable();
+        ProjectRestoredProcessing(RestoredProjectDependencyFacts facts)
+    {
+        if (facts.SelectedTarget is null)
+            return new PackageDependencyEvidenceProcessingResult.Unavailable();
+
+        return facts.PackagePruning switch
+        {
+            RestoredProjectPackagePruningResult.Available =>
+                new PackageDependencyEvidenceProcessingResult.Available(
+                    [
+                        PackageDependencyEvidenceProcessingObservation
+                            .RestoreResolution,
+                        PackageDependencyEvidenceProcessingObservation
+                            .PackagePruningEvaluation,
+                    ],
+                    [],
+                    PackageDependencyEvidencePhaseCompletion.Complete),
+            RestoredProjectPackagePruningResult.Unavailable =>
+                new PackageDependencyEvidenceProcessingResult.Available(
+                    [
+                        PackageDependencyEvidenceProcessingObservation
+                            .RestoreResolution,
+                    ],
+                    [],
+                    PackageDependencyEvidencePhaseCompletion.Complete),
+            RestoredProjectPackagePruningResult.Failed failed =>
+                new PackageDependencyEvidenceProcessingResult.Available(
+                    [
+                        PackageDependencyEvidenceProcessingObservation
+                            .RestoreResolution,
+                    ],
+                    [
+                        new PackageDependencyEvidenceProcessingFailure
+                            .RestoredProjectPackagePruning(failed.Failure),
+                    ],
+                    PackageDependencyEvidencePhaseCompletion.Incomplete),
+            _ => throw new InvalidOperationException(
+                $"Unknown restored-project package-pruning result: {facts.PackagePruning.GetType().FullName}"),
+        };
+    }
 
     private static PackageDependencyFrameworkScopeIdentity
         CreatePackageFrameworkScope(

--- a/src/DotnetInspector.Queries/RestoredProjectDependencyFactsQuery.cs
+++ b/src/DotnetInspector.Queries/RestoredProjectDependencyFactsQuery.cs
@@ -394,6 +394,75 @@ public abstract record RestoredProjectDeclarationResult
     public sealed record Failed(RestoredProjectDeclarationFailure Failure) : RestoredProjectDeclarationResult;
 }
 
+/// <summary>
+/// Positive evidence that the selected declaration group carries a valid
+/// <c>packagesToPrune</c> map.
+/// </summary>
+public sealed record RestoredProjectPackagePruningEvidence(
+    RestoredProjectDeclarationGroupIdentity DeclarationGroup);
+
+/// <summary>Why selected-group package-pruning evidence could not be projected.</summary>
+public enum RestoredProjectPackagePruningFailureReason
+{
+    /// <summary>More than one declaration group corresponds to the selected target.</summary>
+    AmbiguousDeclarationGroupAssociation,
+
+    /// <summary>The selected group's <c>packagesToPrune</c> member is not an object.</summary>
+    InvalidShape,
+
+    /// <summary>One or more pruning rules has an invalid package identity or version range.</summary>
+    InvalidRule,
+
+    /// <summary>The pruning-rule collection exceeds its configured bound.</summary>
+    ConfiguredLimitExceeded,
+}
+
+/// <summary>A content-free package-pruning evidence failure.</summary>
+public sealed record RestoredProjectPackagePruningFailure(
+    RestoredProjectPackagePruningFailureReason Reason,
+    int Count = 1)
+{
+    public int Count { get; } = Count >= 1
+        ? Count
+        : throw new ArgumentOutOfRangeException(
+            nameof(Count),
+            Count,
+            "A failure count must be at least one.");
+
+    public string Message => Reason switch
+    {
+        RestoredProjectPackagePruningFailureReason
+            .AmbiguousDeclarationGroupAssociation =>
+                "More than one project.frameworks group corresponds to the selected target.",
+        RestoredProjectPackagePruningFailureReason.InvalidShape =>
+            "The selected declaration group's packagesToPrune member has an invalid shape.",
+        RestoredProjectPackagePruningFailureReason.InvalidRule =>
+            "A packagesToPrune entry has an invalid package identity or version range.",
+        RestoredProjectPackagePruningFailureReason.ConfiguredLimitExceeded =>
+            "The packagesToPrune collection exceeds a configured resource limit.",
+        _ => "Package-pruning evidence could not be projected.",
+    };
+}
+
+/// <summary>The closed outcome of projecting selected-group package-pruning evidence.</summary>
+public abstract record RestoredProjectPackagePruningResult
+{
+    private RestoredProjectPackagePruningResult()
+    {
+    }
+
+    /// <summary>A valid <c>packagesToPrune</c> map was associated with the selected target.</summary>
+    public sealed record Available(RestoredProjectPackagePruningEvidence Evidence) :
+        RestoredProjectPackagePruningResult;
+
+    /// <summary>No selected-group <c>packagesToPrune</c> evidence is available.</summary>
+    public sealed record Unavailable : RestoredProjectPackagePruningResult;
+
+    /// <summary>Present pruning evidence could not be associated or validated soundly.</summary>
+    public sealed record Failed(RestoredProjectPackagePruningFailure Failure) :
+        RestoredProjectPackagePruningResult;
+}
+
 /// <summary>One resolved package node reached from the root, with its aggregate direct/transitive role.</summary>
 public sealed record RestoredProjectPackageNode(
     RestoredProjectPackageNodeIdentity Identity,
@@ -546,6 +615,7 @@ public sealed record RestoredProjectDependencyFacts(
     RestoredProjectSelectedTarget? SelectedTarget,
     RestoredProjectRootIdentity Root,
     RestoredProjectDeclarationResult Declaration,
+    RestoredProjectPackagePruningResult PackagePruning,
     RestoredProjectGraphResult Graph);
 
 /// <summary>Why the whole document could not be admitted.</summary>
@@ -611,6 +681,7 @@ public static class RestoredProjectDependencyFactsQuery
     public const int MaxDeclarationGroups = 256;
     public const int MaxDeclaredPackages = 4096;
     public const int MaxDeclaredProjectReferences = 4096;
+    public const int MaxPackagePruningRules = 4096;
     public const int MaxGraphNodes = 8192;
     public const int MaxGraphEdges = 16384;
 
@@ -685,13 +756,21 @@ public static class RestoredProjectDependencyFactsQuery
                     : $"{selectedTarget.FrameworkIdentity}/{selectedTarget.RuntimeIdentifierIdentity}";
 
             RestoredProjectDeclarationResult declaration = ProjectDeclaration(root);
+            RestoredProjectPackagePruningResult packagePruning =
+                ambiguousTargetIdentity
+                    ? new RestoredProjectPackagePruningResult.Unavailable()
+                    : ProjectPackagePruning(root, schemaVersion, selectedCandidate);
 
             RestoredProjectGraphResult graph = ambiguousTargetIdentity
                 ? new RestoredProjectGraphResult.Failed(
                     new RestoredProjectGraphFailure(RestoredProjectGraphFailureReason.AmbiguousTargetIdentity))
                 : ProjectGraph(root, schemaVersion, selectedCandidate, targetsElement, targetsPresent);
 
-            string factsDigest = ComputeFactsDigest(targetIdentityText, declaration, graph);
+            string factsDigest = ComputeFactsDigest(
+                targetIdentityText,
+                declaration,
+                packagePruning,
+                graph);
             var selectionIdentity = new RestoredProjectSelectionIdentity(targetIdentityText, factsDigest);
             var rootIdentity = new RestoredProjectRootIdentity(selectionIdentity);
 
@@ -702,6 +781,7 @@ public static class RestoredProjectDependencyFactsQuery
                     selectedTarget,
                     rootIdentity,
                     RescopeDeclaration(declaration, selectionIdentity),
+                    RescopePackagePruning(packagePruning, selectionIdentity),
                     RescopeGraph(graph, rootIdentity)));
         }
     }
@@ -1245,6 +1325,97 @@ public static class RestoredProjectDependencyFactsQuery
     static Dictionary<string, List<RootConstraint>> EmptyRootConstraints =>
         new(StringComparer.Ordinal);
 
+    static RestoredProjectPackagePruningResult ProjectPackagePruning(
+        JsonElement root,
+        int schemaVersion,
+        TargetCandidate? selectedCandidate)
+    {
+        if (selectedCandidate is not { } candidate)
+            return new RestoredProjectPackagePruningResult.Unavailable();
+
+        RootCorrelationOutcome correlation = CorrelateFrameworkGroup(
+            root,
+            schemaVersion,
+            candidate,
+            out JsonProperty matchedProperty);
+        if (correlation == RootCorrelationOutcome.Unavailable)
+            return new RestoredProjectPackagePruningResult.Unavailable();
+        if (correlation == RootCorrelationOutcome.Ambiguous)
+        {
+            return new RestoredProjectPackagePruningResult.Failed(
+                new RestoredProjectPackagePruningFailure(
+                    RestoredProjectPackagePruningFailureReason
+                        .AmbiguousDeclarationGroupAssociation));
+        }
+        if (correlation == RootCorrelationOutcome.InvalidShape)
+        {
+            return new RestoredProjectPackagePruningResult.Failed(
+                new RestoredProjectPackagePruningFailure(
+                    RestoredProjectPackagePruningFailureReason.InvalidShape));
+        }
+
+        JsonElement group = matchedProperty.Value;
+        if (!group.TryGetProperty("packagesToPrune", out JsonElement packagesToPrune))
+            return new RestoredProjectPackagePruningResult.Unavailable();
+        if (packagesToPrune.ValueKind != JsonValueKind.Object)
+        {
+            return new RestoredProjectPackagePruningResult.Failed(
+                new RestoredProjectPackagePruningFailure(
+                    RestoredProjectPackagePruningFailureReason.InvalidShape));
+        }
+
+        int scanned = 0;
+        int invalid = 0;
+        foreach (JsonProperty rule in EnumeratePropertiesInCanonicalOrder(packagesToPrune))
+        {
+            if (++scanned > MaxPackagePruningRules)
+            {
+                return new RestoredProjectPackagePruningResult.Failed(
+                    new RestoredProjectPackagePruningFailure(
+                        RestoredProjectPackagePruningFailureReason.ConfiguredLimitExceeded));
+            }
+
+            string rawPackageId = rule.Name;
+            if (rawPackageId.Length == 0
+                || rawPackageId.Length > MaxScalarCharacters
+                || !PackageCoordinateResolver.IsCanonicalPackageId(rawPackageId)
+                || rule.Value.ValueKind != JsonValueKind.String)
+            {
+                invalid++;
+                continue;
+            }
+
+            string? rawVersionRange = rule.Value.GetString();
+            if (rawVersionRange is not { Length: > 0 }
+                || rawVersionRange.Length > MaxScalarCharacters
+                || !VersionRange.TryParse(rawVersionRange, out _))
+            {
+                invalid++;
+            }
+        }
+
+        if (invalid > 0)
+        {
+            return new RestoredProjectPackagePruningResult.Failed(
+                new RestoredProjectPackagePruningFailure(
+                    RestoredProjectPackagePruningFailureReason.InvalidRule,
+                    invalid));
+        }
+
+        string rawPivot = matchedProperty.Name;
+        bool recognized = NuGetTargetFrameworkIdentity.TryNormalize(
+            rawPivot,
+            out string normalizedTfm);
+        string pivotIdentity = DeclarationPivotIdentity(
+            rawPivot,
+            recognized,
+            normalizedTfm);
+
+        return new RestoredProjectPackagePruningResult.Available(
+            new RestoredProjectPackagePruningEvidence(
+                new RestoredProjectDeclarationGroupIdentity(default!, pivotIdentity)));
+    }
+
     /// <summary>
     /// Finds the single <c>project.frameworks</c> group corresponding to the selected target and
     /// reads its authored package constraints. Distinct constraints for one canonical id are all
@@ -1255,37 +1426,15 @@ public static class RestoredProjectDependencyFactsQuery
         int schemaVersion,
         TargetCandidate candidate)
     {
-        if (!root.TryGetProperty("project", out JsonElement project)
-            || project.ValueKind != JsonValueKind.Object
-            || !project.TryGetProperty("frameworks", out JsonElement frameworks)
-            || frameworks.ValueKind != JsonValueKind.Object)
-        {
-            return new RootConstraintCorrelation(RootCorrelationOutcome.Unavailable, EmptyRootConstraints);
-        }
-
-        JsonProperty? matched = null;
-        foreach (JsonProperty pivot in EnumeratePropertiesInCanonicalOrder(frameworks))
-        {
-            if (pivot.Name.Length == 0
-                || pivot.Name.Length > MaxScalarCharacters
-                || !CorrelatesWithPivot(pivot.Name, schemaVersion, candidate))
-            {
-                continue;
-            }
-
-            if (matched is not null)
-                return new RootConstraintCorrelation(RootCorrelationOutcome.Ambiguous, EmptyRootConstraints);
-
-            matched = pivot;
-        }
-
-        if (matched is not { } matchedProperty)
-            return new RootConstraintCorrelation(RootCorrelationOutcome.Unavailable, EmptyRootConstraints);
+        RootCorrelationOutcome correlation = CorrelateFrameworkGroup(
+            root,
+            schemaVersion,
+            candidate,
+            out JsonProperty matchedProperty);
+        if (correlation != RootCorrelationOutcome.Correlated)
+            return new RootConstraintCorrelation(correlation, EmptyRootConstraints);
 
         JsonElement group = matchedProperty.Value;
-        if (group.ValueKind != JsonValueKind.Object)
-            return new RootConstraintCorrelation(RootCorrelationOutcome.InvalidShape, EmptyRootConstraints);
-
         string rawPivot = matchedProperty.Name;
         bool recognized = NuGetTargetFrameworkIdentity.TryNormalize(
             rawPivot,
@@ -1355,6 +1504,46 @@ public static class RestoredProjectDependencyFactsQuery
             constraints,
             declarationGroupPivotIdentity,
             limitExceeded);
+    }
+
+    static RootCorrelationOutcome CorrelateFrameworkGroup(
+        JsonElement root,
+        int schemaVersion,
+        TargetCandidate candidate,
+        out JsonProperty matchedProperty)
+    {
+        matchedProperty = default;
+        if (!root.TryGetProperty("project", out JsonElement project)
+            || project.ValueKind != JsonValueKind.Object
+            || !project.TryGetProperty("frameworks", out JsonElement frameworks)
+            || frameworks.ValueKind != JsonValueKind.Object)
+        {
+            return RootCorrelationOutcome.Unavailable;
+        }
+
+        JsonProperty? matched = null;
+        foreach (JsonProperty pivot in EnumeratePropertiesInCanonicalOrder(frameworks))
+        {
+            if (pivot.Name.Length == 0
+                || pivot.Name.Length > MaxScalarCharacters
+                || !CorrelatesWithPivot(pivot.Name, schemaVersion, candidate))
+            {
+                continue;
+            }
+
+            if (matched is not null)
+                return RootCorrelationOutcome.Ambiguous;
+
+            matched = pivot;
+        }
+
+        if (matched is not { } correlated)
+            return RootCorrelationOutcome.Unavailable;
+        if (correlated.Value.ValueKind != JsonValueKind.Object)
+            return RootCorrelationOutcome.InvalidShape;
+
+        matchedProperty = correlated;
+        return RootCorrelationOutcome.Correlated;
     }
 
     /// <summary>
@@ -1882,6 +2071,21 @@ public static class RestoredProjectDependencyFactsQuery
             _ => declaration,
         };
 
+    static RestoredProjectPackagePruningResult RescopePackagePruning(
+        RestoredProjectPackagePruningResult packagePruning,
+        RestoredProjectSelectionIdentity selection) =>
+        packagePruning switch
+        {
+            RestoredProjectPackagePruningResult.Available available =>
+                new RestoredProjectPackagePruningResult.Available(
+                    new RestoredProjectPackagePruningEvidence(
+                        available.Evidence.DeclarationGroup with
+                        {
+                            Selection = selection,
+                        })),
+            _ => packagePruning,
+        };
+
     static RestoredProjectGraphResult RescopeGraph(
         RestoredProjectGraphResult graph,
         RestoredProjectRootIdentity root)
@@ -1935,12 +2139,14 @@ public static class RestoredProjectDependencyFactsQuery
     static string ComputeFactsDigest(
         string targetIdentity,
         RestoredProjectDeclarationResult declaration,
+        RestoredProjectPackagePruningResult packagePruning,
         RestoredProjectGraphResult graph)
     {
         var text = new StringBuilder();
-        Field(text, "rpdf/1");
+        Field(text, "rpdf/2");
         Field(text, targetIdentity);
         AppendDeclaration(text, declaration);
+        AppendPackagePruning(text, packagePruning);
         AppendGraph(text, graph);
         return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(text.ToString())));
     }
@@ -1988,6 +2194,30 @@ public static class RestoredProjectDependencyFactsQuery
                 Count(text, (int)failed.Failure.Reason);
                 Count(text, failed.Failure.Count);
                 break;
+        }
+    }
+
+    static void AppendPackagePruning(
+        StringBuilder text,
+        RestoredProjectPackagePruningResult packagePruning)
+    {
+        switch (packagePruning)
+        {
+            case RestoredProjectPackagePruningResult.Available available:
+                Field(text, "package-pruning.available");
+                Field(text, available.Evidence.DeclarationGroup.PivotIdentity);
+                break;
+            case RestoredProjectPackagePruningResult.Unavailable:
+                Field(text, "package-pruning.unavailable");
+                break;
+            case RestoredProjectPackagePruningResult.Failed failed:
+                Field(text, "package-pruning.failed");
+                Count(text, (int)failed.Failure.Reason);
+                Count(text, failed.Failure.Count);
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown package-pruning result: {packagePruning.GetType().FullName}");
         }
     }
 

--- a/tests/DotnetInspector.Queries.Tests/PackageDependencyEvidenceQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/PackageDependencyEvidenceQueryTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Text;
+using System.Text.Json.Nodes;
 using DotnetInspector.Fixtures;
 using InertText;
 using NuGetFetch;
@@ -173,7 +174,7 @@ public sealed class PackageDependencyEvidenceQueryTests
     }
 
     [Fact]
-    public void Execute_RestoredGraphProvidesPositiveRestoreResolutionObservation()
+    public void PackageInput_AssetsPruningObservationRequiresTypedPackagesToPruneEvidence()
     {
         PackageDependencyEvidenceRoot restored = NormalizeRestored(
             Available(
@@ -188,8 +189,67 @@ public sealed class PackageDependencyEvidenceQueryTests
                 restored.Processing);
         Assert.True(processing.IsComplete);
         Assert.Equal(
+            [
+                PackageDependencyEvidenceProcessingObservation.RestoreResolution,
+                PackageDependencyEvidenceProcessingObservation
+                    .PackagePruningEvaluation,
+            ],
+            processing.Observations);
+    }
+
+    [Fact]
+    public void PackageInput_AssetsWithoutPruneEvidenceRemainProcessingUnknown()
+    {
+        byte[] assetsBytes = MutateRestoredAssets(
+            root => root["project"]!["frameworks"]!["net11.0"]!
+                .AsObject()
+                .Remove("packagesToPrune"));
+        PackageDependencyEvidenceRoot restored = NormalizeRestored(
+            Available(
+                RestoredProjectDependencyFactsQuery.Execute(
+                    assetsBytes,
+                    new RestoredProjectTargetRequest("net11.0"))));
+
+        var processing =
+            Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
+                restored.Processing);
+        Assert.True(processing.IsComplete);
+        Assert.Equal(
             [PackageDependencyEvidenceProcessingObservation.RestoreResolution],
             processing.Observations);
+        Assert.DoesNotContain(
+            PackageDependencyEvidenceProcessingObservation
+                .PackagePruningEvaluation,
+            processing.Observations);
+    }
+
+    [Fact]
+    public void PackageInput_InvalidPruneEvidencePreservesRestoreAsIncompleteProcessing()
+    {
+        byte[] assetsBytes = MutateRestoredAssets(
+            root => root["project"]!["frameworks"]!["net11.0"]!
+                .AsObject()["packagesToPrune"] = "invalid");
+        PackageDependencyEvidenceRoot restored = NormalizeRestored(
+            Available(
+                RestoredProjectDependencyFactsQuery.Execute(
+                    assetsBytes,
+                    new RestoredProjectTargetRequest("net11.0"))));
+
+        var processing =
+            Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
+                restored.Processing);
+        var failure = Assert.IsType<
+            PackageDependencyEvidenceProcessingFailure
+                .RestoredProjectPackagePruning>(
+            Assert.Single(processing.Failures));
+
+        Assert.False(processing.IsComplete);
+        Assert.Equal(
+            [PackageDependencyEvidenceProcessingObservation.RestoreResolution],
+            processing.Observations);
+        Assert.Equal(
+            RestoredProjectPackagePruningFailureReason.InvalidShape,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -768,7 +828,11 @@ public sealed class PackageDependencyEvidenceQueryTests
             Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
                 root.Processing);
         Assert.Equal(
-            [PackageDependencyEvidenceProcessingObservation.RestoreResolution],
+            [
+                PackageDependencyEvidenceProcessingObservation.RestoreResolution,
+                PackageDependencyEvidenceProcessingObservation
+                    .PackagePruningEvaluation,
+            ],
             processing.Observations);
     }
 
@@ -1490,6 +1554,16 @@ public sealed class PackageDependencyEvidenceQueryTests
     private static RestoredProjectDependencyFacts Available(
         RestoredProjectDependencyFactsResult result) =>
         Assert.IsType<RestoredProjectDependencyFactsResult.Available>(result).Value;
+
+    private static byte[] MutateRestoredAssets(Action<JsonNode> mutate)
+    {
+        JsonNode root = JsonNode.Parse(
+            File.ReadAllBytes(
+                FixtureCatalog.RestoredProjectDependencyFacts.AssetPath(
+                    "project.assets.json")))!;
+        mutate(root);
+        return Encoding.UTF8.GetBytes(root.ToJsonString());
+    }
 
     private static void AssertDeclarationIncomplete(
         PackageDependencyEvidenceComparisonResult result)

--- a/tests/DotnetInspector.Queries.Tests/RestoredProjectDependencyFactsQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/RestoredProjectDependencyFactsQueryTests.cs
@@ -178,6 +178,15 @@ public sealed class RestoredProjectDependencyFactsQueryTests
         RestoredProjectGraphResult.Available graph = Assert.IsType<RestoredProjectGraphResult.Available>(facts.Graph);
         Assert.True(graph.IsComplete);
         Assert.Contains(graph.Packages, p => p.Identity.Coordinate.PackageId == "nuget.packaging");
+        RestoredProjectPackagePruningResult.Available packagePruning =
+            Assert.IsType<RestoredProjectPackagePruningResult.Available>(
+                facts.PackagePruning);
+        Assert.Equal(
+            facts.SelectionIdentity,
+            packagePruning.Evidence.DeclarationGroup.Selection);
+        Assert.Equal(
+            "net11.0",
+            packagePruning.Evidence.DeclarationGroup.PivotIdentity);
     }
 
     [Fact]
@@ -561,6 +570,235 @@ public sealed class RestoredProjectDependencyFactsQueryTests
         Assert.Equal(RestoredProjectDependencyRole.Direct, foo.Role);
         RestoredProjectPackageNode bar = Assert.Single(graph.Packages, p => p.Identity.Coordinate.PackageId == "bar");
         Assert.Equal(RestoredProjectDependencyRole.Transitive, bar.Role);
+    }
+
+    // ---- Selected-group package-pruning processing evidence --------------
+
+    [Fact]
+    public void Execute_SelectedFrameworkPackagesToPruneProvidesTypedEvidence()
+    {
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                ReadCopiedAssetsBytes(),
+                new RestoredProjectTargetRequest("net11.0")));
+
+        RestoredProjectPackagePruningResult.Available available =
+            Assert.IsType<RestoredProjectPackagePruningResult.Available>(
+                facts.PackagePruning);
+        Assert.Equal(
+            facts.SelectionIdentity,
+            available.Evidence.DeclarationGroup.Selection);
+        Assert.Equal(
+            "net11.0",
+            available.Evidence.DeclarationGroup.PivotIdentity);
+        Assert.Contains(
+            Assert.IsType<RestoredProjectDeclarationResult.Available>(
+                facts.Declaration).Groups,
+            group => group.Identity == available.Evidence.DeclarationGroup);
+    }
+
+    [Fact]
+    public void Execute_ValidEmptyPackagesToPruneIsPositiveEvidence()
+    {
+        byte[] bytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] =
+                new JsonObject());
+
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                bytes,
+                new RestoredProjectTargetRequest("net11.0")));
+
+        Assert.IsType<RestoredProjectPackagePruningResult.Available>(
+            facts.PackagePruning);
+    }
+
+    [Fact]
+    public void Execute_AbsentPackagesToPruneRemainsUnavailable()
+    {
+        byte[] bytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root).Remove("packagesToPrune"));
+
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                bytes,
+                new RestoredProjectTargetRequest("net11.0")));
+
+        Assert.IsType<RestoredProjectPackagePruningResult.Unavailable>(
+            facts.PackagePruning);
+    }
+
+    [Fact]
+    public void Execute_PackagePruningIdentityTracksEvidenceStateNotRuleInventory()
+    {
+        byte[] emptyBytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] =
+                new JsonObject());
+        byte[] otherValidBytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] =
+                new JsonObject { ["Other.Package"] = "(,9.0.0]" });
+        byte[] absentBytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root).Remove("packagesToPrune"));
+        byte[] failedBytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] = "invalid");
+
+        RestoredProjectTargetRequest request = new("net11.0");
+        RestoredProjectDependencyFacts empty = Available(
+            RestoredProjectDependencyFactsQuery.Execute(emptyBytes, request));
+        RestoredProjectDependencyFacts otherValid = Available(
+            RestoredProjectDependencyFactsQuery.Execute(otherValidBytes, request));
+        RestoredProjectDependencyFacts absent = Available(
+            RestoredProjectDependencyFactsQuery.Execute(absentBytes, request));
+        RestoredProjectDependencyFacts failed = Available(
+            RestoredProjectDependencyFactsQuery.Execute(failedBytes, request));
+
+        Assert.Equal(empty.SelectionIdentity, otherValid.SelectionIdentity);
+        Assert.NotEqual(empty.ContentProvenance, otherValid.ContentProvenance);
+        Assert.NotEqual(empty.SelectionIdentity, absent.SelectionIdentity);
+        Assert.NotEqual(absent.SelectionIdentity, failed.SelectionIdentity);
+    }
+
+    [Fact]
+    public void Execute_InvalidPackagesToPruneShapeFailsIndependently()
+    {
+        byte[] bytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] = "invalid");
+
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                bytes,
+                new RestoredProjectTargetRequest("net11.0")));
+
+        RestoredProjectPackagePruningResult.Failed failed =
+            Assert.IsType<RestoredProjectPackagePruningResult.Failed>(
+                facts.PackagePruning);
+        Assert.Equal(
+            RestoredProjectPackagePruningFailureReason.InvalidShape,
+            failed.Failure.Reason);
+        Assert.True(
+            Assert.IsType<RestoredProjectDeclarationResult.Available>(
+                facts.Declaration).IsComplete);
+        Assert.True(
+            Assert.IsType<RestoredProjectGraphResult.Available>(
+                facts.Graph).IsComplete);
+    }
+
+    [Fact]
+    public void Execute_InvalidPackagesToPruneRulesFailWithDeterministicCount()
+    {
+        byte[] bytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] =
+                new JsonObject
+                {
+                    [""] = "(,1.0.0]",
+                    ["Bad.Range"] = "not-a-range",
+                    ["Bad.Shape"] = 42,
+                });
+
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                bytes,
+                new RestoredProjectTargetRequest("net11.0")));
+        RestoredProjectDependencyFacts reordered = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                WithReversedPropertyOrder(bytes),
+                new RestoredProjectTargetRequest("net11.0")));
+
+        RestoredProjectPackagePruningResult.Failed failed =
+            Assert.IsType<RestoredProjectPackagePruningResult.Failed>(
+                facts.PackagePruning);
+        Assert.Equal(
+            RestoredProjectPackagePruningFailureReason.InvalidRule,
+            failed.Failure.Reason);
+        Assert.Equal(3, failed.Failure.Count);
+        Assert.Equal(Describe(facts), Describe(reordered));
+        Assert.Equal(facts.SelectionIdentity, reordered.SelectionIdentity);
+    }
+
+    [Fact]
+    public void Execute_PackagesToPruneRuleLimitFailsVisibly()
+    {
+        var rules = new JsonObject();
+        for (int index = 0;
+            index <= RestoredProjectDependencyFactsQuery.MaxPackagePruningRules;
+            index++)
+        {
+            rules.Add($"Package.{index}", "(,1.0.0]");
+        }
+
+        byte[] bytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] = rules);
+
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                bytes,
+                new RestoredProjectTargetRequest("net11.0")));
+        RestoredProjectPackagePruningResult.Failed failed =
+            Assert.IsType<RestoredProjectPackagePruningResult.Failed>(
+                facts.PackagePruning);
+
+        Assert.Equal(
+            RestoredProjectPackagePruningFailureReason.ConfiguredLimitExceeded,
+            failed.Failure.Reason);
+        Assert.Equal(1, failed.Failure.Count);
+    }
+
+    [Fact]
+    public void Execute_AmbiguousFrameworkGroupAssociationFailsPruningEvidence()
+    {
+        byte[] bytes = WithReplacedNode(
+            ReadCopiedAssetsBytes(),
+            root =>
+            {
+                JsonObject frameworks =
+                    root["project"]!["frameworks"]!.AsObject();
+                frameworks.Add(
+                    "NET11.0",
+                    frameworks["net11.0"]!.DeepClone());
+            });
+
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                bytes,
+                new RestoredProjectTargetRequest("net11.0")));
+        RestoredProjectPackagePruningResult.Failed failed =
+            Assert.IsType<RestoredProjectPackagePruningResult.Failed>(
+                facts.PackagePruning);
+
+        Assert.Equal(
+            RestoredProjectPackagePruningFailureReason
+                .AmbiguousDeclarationGroupAssociation,
+            failed.Failure.Reason);
+    }
+
+    [Fact]
+    public void Execute_SchemaVersion3CorrelatesPruningEvidenceToShortFrameworkGroup()
+    {
+        byte[] bytes = WithReplacedNode(
+            SchemaVersion3Document(),
+            root => SelectedFrameworkGroup(root)["packagesToPrune"] =
+                new JsonObject { ["Framework.Package"] = "(,1.0.0]" });
+
+        RestoredProjectDependencyFacts facts = Available(
+            RestoredProjectDependencyFactsQuery.Execute(
+                bytes,
+                new RestoredProjectTargetRequest("net11.0")));
+        RestoredProjectPackagePruningResult.Available available =
+            Assert.IsType<RestoredProjectPackagePruningResult.Available>(
+                facts.PackagePruning);
+
+        Assert.Equal(
+            "net11.0",
+            available.Evidence.DeclarationGroup.PivotIdentity);
     }
 
     // ---- Groups, ranges, and valid empty groups --------------------------
@@ -2246,10 +2484,22 @@ public sealed class RestoredProjectDependencyFactsQueryTests
         foreach (RestoredProjectGraphFailureReason reason in Enum.GetValues<RestoredProjectGraphFailureReason>())
             Assert.False(string.IsNullOrWhiteSpace(new RestoredProjectGraphFailure(reason).Message));
 
+        foreach (RestoredProjectPackagePruningFailureReason reason
+            in Enum.GetValues<RestoredProjectPackagePruningFailureReason>())
+        {
+            Assert.False(
+                string.IsNullOrWhiteSpace(
+                    new RestoredProjectPackagePruningFailure(reason).Message));
+        }
+
         Assert.Throws<ArgumentOutOfRangeException>(() =>
             new RestoredProjectDeclarationFailure(RestoredProjectDeclarationFailureReason.InvalidGroupShape, 0));
         Assert.Throws<ArgumentOutOfRangeException>(() =>
             new RestoredProjectGraphFailure(RestoredProjectGraphFailureReason.UnresolvedDependency, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RestoredProjectPackagePruningFailure(
+                RestoredProjectPackagePruningFailureReason.InvalidRule,
+                0));
     }
 
     [Fact]
@@ -2280,6 +2530,13 @@ public sealed class RestoredProjectDependencyFactsQueryTests
         RestoredProjectDeclarationResult.Available declaration =
             Assert.IsType<RestoredProjectDeclarationResult.Available>(facts.Declaration);
         Assert.All(declaration.Groups, g => Assert.Equal(selection, g.Identity.Selection));
+
+        RestoredProjectPackagePruningResult.Available packagePruning =
+            Assert.IsType<RestoredProjectPackagePruningResult.Available>(
+                facts.PackagePruning);
+        Assert.Equal(
+            selection,
+            packagePruning.Evidence.DeclarationGroup.Selection);
 
         RestoredProjectGraphResult.Available graph = Assert.IsType<RestoredProjectGraphResult.Available>(facts.Graph);
         Assert.NotEmpty(graph.Edges);
@@ -2373,6 +2630,23 @@ public sealed class RestoredProjectDependencyFactsQueryTests
                 break;
         }
 
+        switch (facts.PackagePruning)
+        {
+            case RestoredProjectPackagePruningResult.Available available:
+                lines.Add(
+                    $"package-pruning=available "
+                    + available.Evidence.DeclarationGroup.PivotIdentity);
+                break;
+            case RestoredProjectPackagePruningResult.Unavailable:
+                lines.Add("package-pruning=unavailable");
+                break;
+            case RestoredProjectPackagePruningResult.Failed failed:
+                lines.Add(
+                    $"package-pruning=failed {failed.Failure.Reason} "
+                    + $"x{failed.Failure.Count}");
+                break;
+        }
+
         return lines.ToImmutable();
     }
 
@@ -2423,6 +2697,12 @@ public sealed class RestoredProjectDependencyFactsQueryTests
                     yield return package.CanonicalVersionConstraint;
                 }
             }
+        }
+
+        if (facts.PackagePruning
+            is RestoredProjectPackagePruningResult.Available packagePruning)
+        {
+            yield return packagePruning.Evidence.DeclarationGroup.PivotIdentity;
         }
 
         if (facts.Graph is RestoredProjectGraphResult.Available graph)
@@ -2541,6 +2821,9 @@ public sealed class RestoredProjectDependencyFactsQueryTests
         mutate(root);
         return Encoding.UTF8.GetBytes(root.ToJsonString());
     }
+
+    static JsonObject SelectedFrameworkGroup(JsonNode root) =>
+        root["project"]!["frameworks"]!["net11.0"]!.AsObject();
 
     static byte[] WithReversedPropertyOrder(byte[] assetsBytes)
     {


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational
capabilities or compelling user experiences and are conventionally sound,
delightfully new, or both. This slice gives restored package inputs truthful
processing evidence without importing package-pruning policy into artifact
parsing.

## Summary

- add an owner-issued `RestoredProjectPackagePruningResult` associated with the
  exact selected declaration-group identity;
- validate the selected framework group's optional `packagesToPrune` map as
  available, unavailable, or failed evidence, including explicit malformed,
  ambiguous, and bounded states;
- project `PackagePruningEvaluation` into normalized package evidence only from
  valid typed provider evidence;
- preserve `RestoreResolution` independently when pruning evidence is absent or
  invalid; and
- keep rule interpretation, exemptions, subsumption, and removed-edge
  conclusions in the separately owned pruning-policy work.

## Demo

The SDK-produced `net11.0` fixture contains a valid
`project.frameworks.net11.0.packagesToPrune` object. Its normalized processing
evidence changes from restore-only:

```text
Complete
  RestoreResolution
```

to:

```text
Complete
  RestoreResolution
  PackagePruningEvaluation
```

A neighboring assets input with no `packagesToPrune` member remains:

```text
Complete
  RestoreResolution
```

A present non-object member preserves the usable restore observation and makes
only the processing phase incomplete:

```text
Incomplete
  RestoreResolution
  RestoredProjectPackagePruning: InvalidShape
```

No state claims that a particular dependency edge was removed.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release --no-build -- --filter-class '*RestoredProjectDependencyFactsQueryTests' '*PackageDependencyEvidenceQueryTests' '*PackageDependencyCandidateQueryTests' '*PackageDependencyTraversalQueryTests'`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- --filter-class '*DependencyEvidenceCommandTests'`
- `npx markdownlint-cli docs/design/restored-project-dependency-facts.md docs/design/package-dependency-evidence.md`
- `git diff --check origin/main...HEAD`

Part of #6266.
