### PR TITLE
Rename SourceFetcher to SourceFetch

### DIFF
--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -247,7 +247,7 @@ projection. The resulting declaration must remain sliceable with identical
 boundaries; otherwise the slicer refuses the result rather than include a
 sibling from an inactive branch.
 
-`SourceFetcher` delegates reusable verified bytes to an
+`SourceFetch` delegates reusable verified bytes to an
 `ISourceContentStore`. Its compatibility constructor retains the desktop
 `CoreCache`; content-only hosts supply `InMemorySourceContentStore`, so source
 acquisition has no ambient filesystem requirement.

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1460,7 +1460,7 @@ Browser-Wasm cannot perform the DNS-level checks that
 `ISourceFetchPolicy` that authorizes a narrow set of HTTPS source hosts before
 dispatch, omits credentials, and configures Fetch to reject redirects. A
 destination outside that set is a PDB-source acquisition limitation and may
-fall back to decompilation; it is never probed. The shared `SourceFetcher`
+fall back to decompilation; it is never probed. The shared `SourceFetch`
 applies that host policy before its memory or content-store caches and before
 creating the request. `PdbSourceAcquisitionTests.FetchSourceBytes_PolicyRejectsDestinationBeforeDispatch`
 and

--- a/prototypes/inspect-web/engine.SourceExports/SourceExports.cs
+++ b/prototypes/inspect-web/engine.SourceExports/SourceExports.cs
@@ -306,7 +306,7 @@ public static partial class SourceExports
             BrowserPackageWorkspace.NetworkClient,
             new InMemoryPdbStore(maxRetainedBytes: 24 * MiB),
             BrowserPackageWorkspace.PackageSourceAuthorization,
-            new SourceFetcher(
+            new SourceFetch(
                 BrowserPackageWorkspace.NetworkClient,
                 sourceStore,
                 BrowserSourceFetchPolicy.Instance))

--- a/prototypes/inspect-web/engine.Tests/BrowserSourceComparisonOperationTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserSourceComparisonOperationTests.cs
@@ -593,7 +593,7 @@ public sealed class BrowserSourceComparisonOperationTests(ITestOutputHelper outp
                 _symbolClient,
                 new InMemoryPdbStore(),
                 new UniformPackageSourceAuthorization([PackageSource.NuGetOrg]),
-                new SourceFetcher(
+                new SourceFetch(
                     _sourceClient,
                     new InMemorySourceContentStore(),
                     BrowserSourceFetchPolicy.Instance));

--- a/src/DotnetInspector.Core/HttpClientFactory.cs
+++ b/src/DotnetInspector.Core/HttpClientFactory.cs
@@ -147,7 +147,7 @@ public static class HttpClientFactory
     /// <summary>
     /// Test-only: substitutes the transport used by untrusted-source fetches so acquisition
     /// paths (including failure) can be exercised without network access. This replaces only
-    /// the transport; callers still run the real <c>SourceFetcher</c>, so scheme restriction,
+    /// the transport; callers still run the real <c>SourceFetch</c>, so scheme restriction,
     /// caching, and status handling stay under test. Pass null to restore the real client.
     /// </summary>
     internal static void SetUntrustedFetchForTesting(HttpClient? client) => _untrustedFetchOverride = client;

--- a/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
@@ -23,7 +23,7 @@ public sealed class AssemblyContextSourceQueryContext
         HttpClient symbolClient,
         IPdbStore pdbStore,
         IPackageSourceAuthorization packageSourceAuthorization,
-        SourceFetcher sourceFetcher)
+        SourceFetch sourceFetcher)
     {
         SymbolClient =
             symbolClient
@@ -35,7 +35,7 @@ public sealed class AssemblyContextSourceQueryContext
             packageSourceAuthorization
             ?? throw new ArgumentNullException(
                 nameof(packageSourceAuthorization));
-        SourceFetcher =
+        SourceFetch =
             sourceFetcher
             ?? throw new ArgumentNullException(nameof(sourceFetcher));
     }
@@ -46,7 +46,7 @@ public sealed class AssemblyContextSourceQueryContext
     {
         get;
     }
-    public SourceFetcher SourceFetcher { get; }
+    public SourceFetch SourceFetch { get; }
     public ISourceLinkIndexCache? SourceLinkCache { get; init; }
     public IReadOnlyList<string>? RepositoryPaths { get; init; }
     public NuGetSourceOptions? NuGetSourceOptions { get; init; }
@@ -833,7 +833,7 @@ public static class AssemblyContextSourceQuery
                             request.MetadataToken,
                             request.Member.MemberName,
                             findingSubject,
-                            context.SourceFetcher,
+                            context.SourceFetch,
                             context.RepositoryPaths,
                             cancellationToken,
                             allowLocalSource:
@@ -939,7 +939,7 @@ public static class AssemblyContextSourceQuery
                             source,
                             request.Type,
                             findingSubject,
-                            context.SourceFetcher,
+                            context.SourceFetch,
                             context.RepositoryPaths,
                             cancellationToken,
                             allowLocalSource:

--- a/src/DotnetInspector.Services.Tests/LocalRepoSourceAcquisitionIntegrationTests.cs
+++ b/src/DotnetInspector.Services.Tests/LocalRepoSourceAcquisitionIntegrationTests.cs
@@ -24,7 +24,7 @@ public class LocalRepoSourceAcquisitionIntegrationTests
         using SourceLinkService source = SourceLinkService.Open(targetType.Assembly.Location);
         var outage = new NetworkOutageHandler();
         using var client = new HttpClient(outage);
-        var fetcher = new SourceFetcher(client, new InMemorySourceContentStore());
+        var fetcher = new SourceFetch(client, new InMemorySourceContentStore());
         var subject = new FindingSubject("local-repo-source", targetType.FullName!);
 
         PdbMemberSourceInspection member =

--- a/src/DotnetInspector.Services.Tests/PdbSourceAcquisitionTests.cs
+++ b/src/DotnetInspector.Services.Tests/PdbSourceAcquisitionTests.cs
@@ -32,7 +32,7 @@ public class PdbSourceAcquisitionTests
     {
         using SourceLinkService source = OpenSourceNeedingPdb();
         using var client = new HttpClient(new QueueHandler());
-        var fetcher = new SourceFetcher(
+        var fetcher = new SourceFetch(
             client,
             new InMemorySourceContentStore());
         var type = Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
@@ -81,7 +81,7 @@ public class PdbSourceAcquisitionTests
             writable: false));
         Assert.True(source.Context.WindowsPdbDetected);
         using var client = new HttpClient(new QueueHandler());
-        var fetcher = new SourceFetcher(
+        var fetcher = new SourceFetch(
             client,
             new InMemorySourceContentStore());
         var type = Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
@@ -365,7 +365,7 @@ public class PdbSourceAcquisitionTests
         byte[] actual = Encoding.UTF8.GetBytes(Source.ReplaceLineEndings("\r\n"));
         var handler = new QueueHandler(actual);
         using var client = new HttpClient(handler);
-        var fetcher = new SourceFetcher(
+        var fetcher = new SourceFetch(
             client,
             new InMemorySourceContentStore());
 
@@ -434,7 +434,7 @@ public class PdbSourceAcquisitionTests
         try
         {
             var cancellationToken = TestContext.Current.CancellationToken;
-            var fetcher = new SourceFetcher(client);
+            var fetcher = new SourceFetch(client);
             var repaired = await fetcher.FetchVerifiedSourceBytesAsync(
                 Url,
                 bytes => bytes.Span.SequenceEqual(expected),
@@ -443,7 +443,7 @@ public class PdbSourceAcquisitionTests
             Assert.Equal(expected, repaired);
             Assert.Equal(1, handler.RequestCount);
 
-            var cached = await new SourceFetcher(client).FetchVerifiedSourceBytesAsync(
+            var cached = await new SourceFetch(client).FetchVerifiedSourceBytesAsync(
                 Url,
                 bytes => bytes.Span.SequenceEqual(expected),
                 cancellationToken);
@@ -471,7 +471,7 @@ public class PdbSourceAcquisitionTests
             content,
             "https://spsprodeus27.vssps.visualstudio.com/_signin?realm=dev.azure.com");
         using var client = new HttpClient(handler);
-        var fetcher = new SourceFetcher(client);
+        var fetcher = new SourceFetch(client);
         const string Url =
             "https://dev.azure.com/org/project/_apis/git/repositories/repo/items"
             + "?api-version=7.1&versionType=commit"
@@ -501,7 +501,7 @@ public class PdbSourceAcquisitionTests
         var handler = new QueueHandler(Encoding.UTF8.GetBytes(Source));
         using var client = new HttpClient(handler);
         var policy = new RejectingSourceFetchPolicy();
-        var fetcher = new SourceFetcher(
+        var fetcher = new SourceFetch(
             client,
             new InMemorySourceContentStore(),
             policy);
@@ -536,7 +536,7 @@ public class PdbSourceAcquisitionTests
 
         try
         {
-            var fetcher = new SourceFetcher(client);
+            var fetcher = new SourceFetch(client);
             byte[]? result = await fetcher.FetchVerifiedSourceBytesAsync(
                 Url,
                 bytes => bytes.Span.SequenceEqual(expected),

--- a/src/DotnetInspector.Services/PdbSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/PdbSourceAcquisition.cs
@@ -113,7 +113,7 @@ public static class PdbSourceAcquisition
         SourceLinkService source,
         MetadataTypeDefinitionName type,
         FindingSubject subject,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         IReadOnlyList<string>? repositoryPaths = null,
         CancellationToken cancellationToken = default,
         bool allowLocalSource = true)
@@ -287,7 +287,7 @@ public static class PdbSourceAcquisition
         int metadataToken,
         string methodName,
         FindingSubject subject,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         IReadOnlyList<string>? repositoryPaths = null,
         CancellationToken cancellationToken = default,
         bool allowLocalSource = true)
@@ -527,7 +527,7 @@ public static class PdbSourceAcquisition
     }
 
     public static async Task<VerifiedSourceTextResult> FetchVerifiedSourceTextAsync(
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         string url,
         string? checksumAlgorithm,
         byte[]? checksum,
@@ -585,7 +585,7 @@ public static class PdbSourceAcquisition
     }
 
     public static async Task<VerifiedSourceTextResult> AcquireVerifiedSourceTextAsync(
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         string? localPath,
         string url,
         string? checksumAlgorithm,

--- a/src/DotnetInspector.Services/SourceFetch.cs
+++ b/src/DotnetInspector.Services/SourceFetch.cs
@@ -25,7 +25,7 @@ internal readonly record struct SourceFetchBytesResult(
 /// The compatibility constructor uses the process-wide disk cache; content-only
 /// hosts can supply <see cref="InMemorySourceContentStore"/>.
 /// </summary>
-public class SourceFetcher
+public class SourceFetch
 {
     private readonly ConcurrentDictionary<string, byte[]> _byteMemoryCache = new();
     private readonly HttpClient _httpClient;
@@ -34,12 +34,12 @@ public class SourceFetcher
     private const string ByteCacheCategory = "source-bytes-v2";
     internal const long MaxSourceDownloadSize = 16_000_000;
 
-    public SourceFetcher(HttpClient httpClient)
+    public SourceFetch(HttpClient httpClient)
         : this(httpClient, CoreCacheSourceContentStore.Instance)
     {
     }
 
-    public SourceFetcher(
+    public SourceFetch(
         HttpClient httpClient,
         ISourceContentStore contentStore,
         ISourceFetchPolicy? fetchPolicy = null)

--- a/src/DotnetInspector.Services/SourceIntegrityService.cs
+++ b/src/DotnetInspector.Services/SourceIntegrityService.cs
@@ -111,7 +111,7 @@ public static class SourceIntegrityService
                                 log: null,
                                 cancellationToken: ct,
                                 trafficKind: NetworkTrafficKind.SourceIntegrity,
-                                maxDownloadSize: SourceFetcher.MaxSourceDownloadSize)
+                                maxDownloadSize: SourceFetch.MaxSourceDownloadSize)
                                 .ConfigureAwait(false);
                         if (fetch.Status
                             == HttpRetryHelper.HttpBodyFetchStatus.ResponseRejected)

--- a/src/ILInspector.Decompiler.Tests/AuthoredBuildContextTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredBuildContextTests.cs
@@ -23,7 +23,7 @@ public sealed class AuthoredBuildContextTests
         using var http = new HttpClient(new NoNetworkHandler());
         var results = await AuthoredRebuildFidelity.EvaluateAssembliesAsync(
             [FixtureCatalog.DecompilerAuthoredRebuild.AssemblyPath()],
-            1, http, new SourceFetcher(http));
+            1, http, new SourceFetch(http));
         var result = Assert.Single(results);
 
         Assert.True(result.ChecksumVerification == SourceChecksumVerification.Exact, result.Detail);

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -570,7 +570,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             ReturnToSenderSourceProbeResult result = Assert.Single(results);
             SourceAcquisitionOutcome expected = expectedFailure
@@ -605,7 +605,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             ReturnToSenderSourceProbeResult result = Assert.Single(results);
             Assert.Equal(
@@ -640,7 +640,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient),
+                    new SourceFetch(httpClient),
                     pdbStore: new PermissionDeniedPdbStore());
 
             ReturnToSenderSourceProbeResult result = Assert.Single(results);
@@ -674,7 +674,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             AuthoredRebuildFidelityResult result = Assert.Single(results);
             Assert.Equal(
@@ -707,7 +707,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             AuthoredRebuildFidelityResult result = Assert.Single(results);
             Assert.Equal(
@@ -744,7 +744,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             ReturnToSenderSourceProbeResult result = Assert.Single(results);
             Assert.Equal(
@@ -813,7 +813,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             ReturnToSenderSourceProbeResult result = Assert.Single(results);
             Assert.Equal(
@@ -829,7 +829,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
             AuthoredRebuildFidelityResult authored = Assert.Single(fidelity);
             Assert.Equal(
                 AuthoredRebuildOutcome.SourceFailed,
@@ -861,7 +861,7 @@ public sealed class AuthoredRebuildFidelityTests
                 [assemblyPath],
                 cap: 1,
                 httpClient,
-                new SourceFetcher(httpClient));
+                new SourceFetch(httpClient));
 
         ReturnToSenderSourceProbeResult result = Assert.Single(results);
         Assert.Equal(
@@ -893,7 +893,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [assemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
         ReturnToSenderSourceProbeResult result = Assert.Single(results);
         Assert.Equal(
@@ -925,7 +925,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [assemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
         ReturnToSenderSourceProbeResult result = Assert.Single(results);
         Assert.Equal(
@@ -957,7 +957,7 @@ public sealed class AuthoredRebuildFidelityTests
                         [assemblyPath],
                         cap: 1,
                         httpClient,
-                        new SourceFetcher(httpClient));
+                        new SourceFetch(httpClient));
 
         ReturnToSenderSourceProbeResult result = Assert.Single(results);
         Assert.Equal(
@@ -996,7 +996,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 2,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             Assert.Equal(2, results.Count);
             Assert.All(
@@ -1039,7 +1039,7 @@ public sealed class AuthoredRebuildFidelityTests
                     [fixture.AssemblyPath],
                     cap: 1,
                     httpClient,
-                    new SourceFetcher(httpClient));
+                    new SourceFetch(httpClient));
 
             ReturnToSenderSourceProbeResult result = Assert.Single(results);
             Assert.True(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -15471,7 +15471,7 @@ public partial class CommandExecutionTests
 
     /// <summary>
     /// A failed acquisition of the selected row must stay visible rather than degrade into
-    /// success-shaped output. Only the transport is substituted, so the real SourceFetcher
+    /// success-shaped output. Only the transport is substituted, so the real SourceFetch
     /// still applies scheme restriction, caching, and status handling.
     /// </summary>
     [Fact]

--- a/src/dotnet-inspect.Tests/SelectedSourceDiffTests.cs
+++ b/src/dotnet-inspect.Tests/SelectedSourceDiffTests.cs
@@ -236,7 +236,7 @@ public sealed class SelectedSourceDiffTests
             client,
             new InMemoryPdbStore(),
             new UniformPackageSourceAuthorization([NuGetFetch.PackageSource.NuGetOrg]),
-            new SourceFetcher(client, new InMemorySourceContentStore()));
+            new SourceFetch(client, new InMemorySourceContentStore()));
         var surface = AssemblySetSurfaceBuilder.Build([beforePath])!;
         var type = Assert.Single(surface.Types, type => type.FullName == "SourceDiffFixture.Counter");
         var member = Assert.Single(type.Members, member => member.Name == "Value");

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -2301,7 +2301,7 @@ public class ApiCommand
             }
             else if (methodInfo.SourceUrl != null)
             {
-                var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+                var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
                 var fetch = await PdbSourceAcquisition.FetchVerifiedSourceTextAsync(
                     fetcher,
                     methodInfo.SourceUrl,
@@ -3307,7 +3307,7 @@ public class ApiCommand
 
         var rawUrl = GitHubUrlResolver.ConvertBlobToRawUrl(selectedRow.Url!);
         var selectedSource = materialized.Single(row => row.Row == selectedRow.Row);
-        var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
         var fetch = await PdbSourceAcquisition.AcquireVerifiedSourceTextAsync(
             fetcher,
             selectedSource.FilePath,

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1189,7 +1189,7 @@ public class DiffCommand
                 httpClient,
                 FileSystemPdbStore.CreateDefault(),
                 new SourcePolicyPackageSourceAuthorization(options.SourceOptions),
-                new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch))
+                new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch))
             {
                 AllowAdjacentPdbReads = true,
                 AllowLocalSourceReads = true,
@@ -1348,7 +1348,7 @@ public class DiffCommand
     {
         var results = new Dictionary<string, FindingInspection<string>>(StringComparer.Ordinal);
         var indexingFailures = ImmutableArray.CreateBuilder<string>();
-        var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
         var (packageName, packageVersion) = DiffPackageIdentity(options, oldSide);
 
         foreach (string path in paths)

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -2249,7 +2249,7 @@ public class LibraryCommand
         }
 
         var rawUrl = StripUrlFragment(GitHubUrlResolver.ConvertBlobToRawUrl(result.Url));
-        var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
         var fetch = await PdbSourceAcquisition.FetchVerifiedSourceTextAsync(
             fetcher,
             rawUrl,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -685,7 +685,7 @@ public static class MemberCommand
                         FileSystemPdbStore.CreateDefault(),
                         new SourcePolicyPackageSourceAuthorization(
                             effectiveOptions.SourceOptions),
-                        new SourceFetcher(
+                        new SourceFetch(
                             DotnetInspector.Core.HttpClientFactory
                                 .SharedUntrustedFetch))
                     {

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -313,7 +313,7 @@ internal static class SourceEnricher
 
         logger.Log($"Phase 1: Resolved {typeSourceInfo.Count} types, {allSourcesToFetch.Count} unique source documents ({stopwatch.ElapsedMilliseconds}ms)");
 
-        var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
         var fetchList = allSourcesToFetch
             .OrderBy(entry => entry.Key, StringComparer.Ordinal)
             .Select(entry => entry.Value)
@@ -835,7 +835,7 @@ internal static class SourceEnricher
             return;
         }
 
-        var fetcher = new SourceFetcher(
+        var fetcher = new SourceFetch(
             DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
         var parser = new DocCommentParser();
         List<(string Url, string FilePath, string? Algorithm, byte[]? Checksum)> sourceFilesToFetch =

--- a/tests/DotnetInspector.Queries.Tests/AssemblyContextSourceQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/AssemblyContextSourceQueryTests.cs
@@ -3722,7 +3722,7 @@ public sealed partial class AssemblyContextSourceQueryTests
                     ?? new InMemoryPdbStore(),
                 new UniformPackageSourceAuthorization(
                     [NuGetFetch.PackageSource.NuGetOrg]),
-                new SourceFetcher(
+                new SourceFetch(
                     _sourceClient,
                     sourceContentStore
                         ?? new InMemorySourceContentStore()))

--- a/tools/DecompilerHarness/AuthoredCorpusDrift.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusDrift.cs
@@ -83,7 +83,7 @@ static class AuthoredCorpusDrift
 
         HttpClientFactory.Initialize(new HttpClientFactoryOptions());
         using var httpClient = HttpClientFactory.CreateClient();
-        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(HttpClientFactory.SharedUntrustedFetch);
 
         var results = new List<RowResult>();
         var matchedGroups = new HashSet<string>(StringComparer.Ordinal);
@@ -133,7 +133,7 @@ static class AuthoredCorpusDrift
     static async Task<RowResult> EvaluateRowAsync(
         SourceLinkService source,
         AuthoredSourceHarvest.CorpusRecord record,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         IReadOnlyList<string>? repositoryPaths)
     {
         var subject = new FindingSubject(

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -64,7 +64,7 @@ static class AuthoredRebuildFidelity
     {
         HttpClientFactory.Initialize(new HttpClientFactoryOptions());
         using var httpClient = HttpClientFactory.CreateClient();
-        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(HttpClientFactory.SharedUntrustedFetch);
         IReadOnlyList<AuthoredRebuildFidelityResult> results =
             await EvaluateAssembliesAsync(
                 assemblies,
@@ -86,7 +86,7 @@ static class AuthoredRebuildFidelity
             IReadOnlyList<string> assemblies,
             int cap,
             HttpClient httpClient,
-            SourceFetcher fetcher,
+            SourceFetch fetcher,
             IPdbStore? pdbStore = null)
     {
         ArgumentNullException.ThrowIfNull(assemblies);
@@ -212,7 +212,7 @@ static class AuthoredRebuildFidelity
 
     internal static async Task<AuthoredRebuildFidelityResult> EvaluateAsync(
         SourceLinkService source,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         ReturnToSender.Result decompilerResult,
         RecordedBuildContext buildContext)
     {

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -133,7 +133,7 @@ static class AuthoredSourceHarvest
 
         HttpClientFactory.Initialize(new HttpClientFactoryOptions());
         using var httpClient = HttpClientFactory.CreateClient();
-        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(HttpClientFactory.SharedUntrustedFetch);
 
         var libraries = new List<LibraryState>();
         try
@@ -293,7 +293,7 @@ static class AuthoredSourceHarvest
     static async Task<HarvestAttempt> TryHarvestAsync(
         LibraryState library,
         RealMethodTargetEnumerator.RealMethodTarget candidate,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         bool evil,
         IReadOnlyList<string>? repositoryPaths)
         => await TryHarvestAsync(
@@ -319,7 +319,7 @@ static class AuthoredSourceHarvest
         SourceLinkService source,
         HarvestIdentity identity,
         RealMethodTargetEnumerator.RealMethodTarget candidate,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         bool evil,
         IReadOnlyList<string>? repositoryPaths)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -177,7 +177,7 @@ static partial class ReturnToSenderSourceProbe
         HttpClientFactory.Initialize(new HttpClientFactoryOptions());
         NuGetCache.Initialize("dotnet-inspect");
         using var httpClient = HttpClientFactory.CreateClient();
-        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(HttpClientFactory.SharedUntrustedFetch);
         var results = await EvaluateSourceCorrespondenceAsync(
             assemblies,
             cap,
@@ -372,7 +372,7 @@ static partial class ReturnToSenderSourceProbe
             IReadOnlyList<string> assemblies,
             int cap,
             HttpClient httpClient,
-            SourceFetcher fetcher,
+            SourceFetch fetcher,
             IReadOnlyList<string>? repositoryPaths = null,
             IReadOnlyDictionary<string, NuGetPackageCoordinate>? packageCoordinates = null,
             IPdbStore? pdbStore = null)
@@ -479,7 +479,7 @@ static partial class ReturnToSenderSourceProbe
 
     internal static async Task<SourceAcquisitionAttempt> AcquireSourceAsync(
         SourceLinkService source,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         ProbeTarget target,
         IReadOnlyList<string>? repositoryPaths = null)
     {

--- a/tools/DecompilerHarness/SourceOracleCandidateLedger.cs
+++ b/tools/DecompilerHarness/SourceOracleCandidateLedger.cs
@@ -1282,7 +1282,7 @@ static class SourceOracleCandidateLedger
 
         HttpClientFactory.Initialize(new HttpClientFactoryOptions());
         using var httpClient = HttpClientFactory.CreateClient();
-        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        var fetcher = new SourceFetch(HttpClientFactory.SharedUntrustedFetch);
 
         var scanned = new List<ScannedAssembly>();
         var members = new List<CensusMember>();
@@ -1362,7 +1362,7 @@ static class SourceOracleCandidateLedger
     static async Task<bool> ScanAssemblyAsync(
         string assemblyPath,
         HttpClient httpClient,
-        SourceFetcher fetcher,
+        SourceFetch fetcher,
         IReadOnlyList<string>? repositoryPaths,
         List<ScannedAssembly> scanned,
         List<CensusMember> members,


### PR DESCRIPTION
## Demo

Before:

```csharp
public class SourceFetcher
{
    public SourceFetcher(HttpClient httpClient) { ... }
}
```

After:

```csharp
public class SourceFetch
{
    public SourceFetch(HttpClient httpClient) { ... }
}
```

## Summary

First mechanical step of the Fetch/Service/House naming convention
tracked in #6301: **Fetch** names components that acquire a resource
over the network. `SourceFetcher` already only fetches source
bytes/text over HTTP with verification and caching — it matches the
convention exactly, and its nested types (`SourceFetchFailureKind`,
`SourceFetchBytesResult`) were already correctly named. This PR is a
pure rename with no behavior change.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — succeeded.
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release` — 1212/1214 passed, 2 skipped (pre-existing, filesystem-dependent).
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — 1799/1802 passed across the two files that reference this type (`CommandExecutionTests`, `SelectedSourceDiffTests`), reproduced in isolation with 0 failures; the one full-suite failure (`ConsoleCaptureTests.SyncAndAsyncCapturesExcludeEachOther`, unrelated to this change) also passed when rerun in isolation, confirming a pre-existing flaky/timing test.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 6624/6624 passed.
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release` — 1718/1718 passed.
- `npm ci && npm run build` in `prototypes/inspect-web`, then `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 432/432 passed.

## Non-action boundary

`tools/DecompilerHarness/corpus/pr-quick-baseline.json` and
`real-world-baseline.json` still contain the old `SourceFetcher` type
name in their decompiled-output snapshots. Left unchanged: the CI step
that diffs against `pr-quick-baseline.json` runs with
`continue-on-error: true` (advisory quality-diff-card evidence, not a
blocking gate), and these are harness-generated artifacts that should
be regenerated with `--emit-corpus-baseline`, not hand-edited. Follow-up
regeneration tracked as a loose end under #6301.

## Trivial-tier review

No adversarial review round: this is a pure identifier rename
(`\bSourceFetcher\b` → `SourceFetch`) across 26 files plus a matching
file rename, with no logic, signature, or behavior changes, verified
by full test-suite runs above.

Tracks #6301.
