### PR TITLE
Add Workspace structural clone search

### DIFF
--- a/docs/design/structural-clone-search-scope.md
+++ b/docs/design/structural-clone-search-scope.md
@@ -8,8 +8,12 @@ originally established under
 under [#6289](https://github.com/richlander/dotnet-inspect/issues/6289), within
 the Diff, Clone, and immersive-viewer experience tracked by
 [#5083](https://github.com/richlander/dotnet-inspect/issues/5083).
-It is **not implemented**; the target behavior and acceptance scenarios below
-remain **unverified**.
+Stage 2 below is implemented under
+[#6303](https://github.com/richlander/dotnet-inspect/issues/6303) by the
+Queries-owned `WorkspaceStructuralCloneSearchQuery` and gated by its focused
+Release suite.
+Stages 3 through 7 are **not implemented**, so the host-facing acceptance
+scenarios below remain **unverified**.
 
 Clone separates two request dimensions:
 
@@ -197,6 +201,12 @@ Declaring-type names follow the existing Metadata type-suggestion convention:
 use the innermost simple name and remove canonical generic arity. Method names
 use the decoded metadata method name.
 
+The qualifying seed-candidate pair is also the unit of evaluation. Admission is
+not a participant-wide candidate-population property: a candidate admitted by
+seed A is ranked against seed A, and is ranked against seed B only when B
+independently clears both thresholds against it. The name scores reported with
+a result row are that row's own pair's scores, never the best unrelated seed's.
+
 The fixed `0.6` threshold follows the existing default of
 `TypeMatcher.FindClosest`. It is returned with the request and result so the
 candidate boundary is explainable. Version 1 does not add a Browser slider or
@@ -238,6 +248,27 @@ MVIDs from different retained contents do not establish pair identity.
 Endpoint identity retains the exact library/content association required by
 the Workspace and Analysis owners.
 
+An endpoint identifies its library through the opaque per-participant identity
+its bound snapshot issues, not through a public enumeration position. The
+snapshot owns a deterministic snapshot-local endpoint identity order: it
+captures its entry order once as part of its exact identity, validates that the
+order contains no repeated participant and no repeated acquisition
+registration, and issues one identity per entry. Two entries that carry equal
+MVIDs, equal tokens, and equal retained content under distinct registrations
+therefore remain distinct endpoints, and an identity carries no meaning outside
+its snapshot.
+
+A snapshot retains its entries' assembly context groups rather than their
+immutable images, so its issuer owns two obligations the search cannot check:
+that each group came from the Workspace that issued the bound revisions, and
+that each group and participant stays alive for the whole execution the
+snapshot is passed to. Both remain **unverified** until the concrete Workspace
+and registration producer lands and can own association and lifetime. Until
+then premature release is made visible rather than allowed to change results
+silently: a released containing library returns a typed failed result, and a
+released candidate becomes that library's incomplete coverage beside the
+evidence already ranked.
+
 ## Global ranking and bounded work
 
 A multi-seed search produces one globally ranked pair population. It must not
@@ -255,11 +286,45 @@ Global ties resolve deterministically by:
 2. left exact method identity; and
 3. right exact method identity.
 
+Exact method identity here is the snapshot-issued participant identity plus the
+physical method address. Both endpoints of one search come from the same bound
+snapshot, so that snapshot's owner-issued order is a total order over its
+distinct registrations and supplies the tie-break.
+
 The product result limit applies after global ranking. Per-seed candidate,
 body-production, name-work, byte, and operation limits remain independently
 visible. Reaching one of those limits cannot become a complete top-N result;
 the result distinguishes an intentional returned-row limit from incomplete
 candidate coverage.
+
+Per-library bounds alone do not bound the search. A request also binds:
+
+- the greatest number of breadth-admitted participants one search evaluates;
+  and
+- the greatest total seed-by-candidate retrieval population it submits to
+  Analysis, summed over every participant and seed.
+
+Both are whole-unit bounds, discovered at different points. The participant
+bound is preflight: it is decided over the snapshot's exact entry order before
+any candidate image is opened. The retrieval-pair bound is a whole-participant
+admission bound: under similar-name discovery a participant's pair population
+is only known while its per-seed candidate groups are being formed, so
+admission stops mid-formation and abandons that participant, and only the
+latched exhausted state that follows excludes later participants without
+opening them. Either way a participant is evaluated completely or excluded
+completely with a visible failure, so a bounded run never presents a partial
+pair population as a complete global top N. Every whole-unit exclusion makes
+candidate coverage incomplete. That remains separate from the intentional
+returned-row limit, which suppresses rows over complete evidence.
+
+A seed's admitted candidate group is submitted to Analysis in bounded
+consecutive chunks so cancellation is observed between units of retrieval work
+rather than after one whole-population call. Chunking is a scheduling decision
+only: every chunk requests its complete ranked population, the search merges
+every chunk into the same global ranking, each pair keeps its own name
+evidence, and the aggregate retrieval-pair charge is unchanged. The chunk size
+therefore moves only cancellation granularity and the seed body-production
+count.
 
 The Browser may choose a small useful default N. The CLI may expose additional
 work and result controls. Those host choices do not alter breadth or discovery
@@ -381,7 +446,10 @@ The counted production-adoption path under #5083 has seven stages:
 1. Lock this contract and transfer Clone candidate-scope ownership from the
    Browser Package target design.
 2. Add the host-neutral Workspace clone-search query and globally ranked,
-   bounded result over existing Analysis retrieval evidence.
+   bounded result over existing Analysis retrieval evidence. Landed as
+   `WorkspaceStructuralCloneSearchQuery`; breadth membership arrives with the
+   caller-supplied participant snapshot until stage 4 or a Workspace
+   registration slice supplies the concrete producer.
 3. Add the host-neutral portable clone result and presentation adapter.
 4. Adopt the shared request and result in the CLI over an explicit Workspace
    scope.
@@ -418,11 +486,16 @@ The following future outcome-level scenarios are required:
 | Exhaust name, metadata, body, or candidate work | Existing ranked evidence remains usable and incomplete coverage is visible |
 | Edit the Workspace while a search runs | The result retains its starting revision and exact effective participant snapshot; a later search binds the new revision |
 | Remove a result endpoint's library | The exact result identity remains; navigation reports current unavailability rather than retargeting |
+| Release a snapshot entry's assembly context group before the search runs | A released containing library is a typed failed result and a released candidate is visible incomplete coverage, never an escaping exception |
 
 Shared owner suites run in Release and gate request defaults, starting/effective
 revision and participant-snapshot association, breadth and discovery
-admission, name-threshold behavior, duplicate suppression, global ranking, and
-coverage. CLI tests gate shared presentation and structured output. Browser
+admission, name-threshold behavior, per-pair name admission, snapshot-local
+endpoint identity order, aggregate participant and retrieval work bounds,
+bounded name-score memoization, chunked retrieval equivalence, released-group
+containment, duplicate suppression, global ranking, and coverage;
+`WorkspaceStructuralCloneSearchQueryTests` supplies that gate. CLI tests gate
+shared presentation and structured output. Browser
 original-host and Firefox suites gate the breadth and discovery controls,
 subject narrowing, stale-result exclusion, master/detail navigation, and
 retirement of the Package-specific selector. The design remains unverified

--- a/docs/design/structural-clone-search-scope.md
+++ b/docs/design/structural-clone-search-scope.md
@@ -101,6 +101,20 @@ The selected subject supplies the seed population:
 | Type | Every MethodDef declared by the selected exact type |
 | Member | Every exact method body occupied by the selected Member subject; an exact overload or accessor selection narrows this to one body |
 
+A Member subject is a logical member, so a property or event supplies the
+bodies its accessors occupy — getter and setter, adder, remover, and raiser,
+and any other associated accessor. An indexer is a property that overloads on
+its index parameters, so those parameters are part of its exact identity and a
+selected overload supplies only its own accessors. An explicit accessor
+selection is itself an exact member identity and stays one body. A selected
+member that occupies no method body — a property or event with no accessor, and
+every field — selects an empty seed population and is reported as that typed
+outcome; it is neither a missing member nor an arbitrary body. The search reads
+the physical accessor association and the member identities from their metadata
+owner rather than re-deriving either from accessor name conventions, and an
+accessor association naming a method a different type declares is malformed
+metadata rather than a body of the selected member.
+
 The selected subject retains its owner-issued exact identity. The search does
 not recover a Library, Type, or Member from display text.
 
@@ -197,6 +211,14 @@ Both conditions are required for the same seed-candidate pair. An exact
 ordinal-ignore-case name match has similarity `1.0`. Other comparisons
 case-fold invariantly before using
 `ILInspector.MetadataPrimitives.StringDistance.Similarity`.
+
+Invariant case folding here is the mapping `StringComparison.OrdinalIgnoreCase`
+itself uses, so the two rules agree by construction. Lowercasing is not that
+mapping: Greek capital sigma lowercases to the medial sigma while the final
+sigma lowercases to itself, so a lowercased comparison would exclude a peer the
+first rule promises to score `1.0`. The same equivalence governs how the search
+indexes and memoizes seed and candidate names, so two spellings of one name
+never admit different candidates.
 Declaring-type names follow the existing Metadata type-suggestion convention:
 use the innermost simple name and remove canonical generic arity. Method names
 use the decoded metadata method name.
@@ -221,6 +243,14 @@ filter.
 Name decode failure, name-work exhaustion, or a candidate library that cannot
 be inspected remains visible candidate-coverage evidence. The search does not
 silently discard that library and report a complete result.
+
+A candidate body Analysis could not produce is the same kind of evidence and
+belongs to the participant whose candidate it was. A library carries the
+Analysis-issued blockers that omitted its candidate methods, aggregated over
+every seed and every unit of retrieval work run against it, and is incomplete
+while it carries one. A blocker that reports the seed itself could not be
+produced stays with that seed: it omits no candidate of any one participant,
+and the seed's own coverage already makes the result incomplete.
 
 ### All
 
@@ -290,6 +320,12 @@ Exact method identity here is the snapshot-issued participant identity plus the
 physical method address. Both endpoints of one search come from the same bound
 snapshot, so that snapshot's owner-issued order is a total order over its
 distinct registrations and supplies the tie-break.
+
+Name-work bounds are accounted logically, not by execution. Any memoization the
+search uses is a pure optimization: the same logical comparison work is charged
+whether a score is recomputed or reused, so changing memoization capacity alone
+cannot change the discovered methods, the retrieval pairs, the ranked rows, or
+the reported coverage of an otherwise identical request.
 
 The product result limit applies after global ranking. Per-seed candidate,
 body-production, name-work, byte, and operation limits remain independently
@@ -368,7 +404,8 @@ The host-neutral result carries:
 - fixed name threshold and qualifying name scores where applicable;
 - global result and work bounds;
 - ordered pair identities and Analysis-issued retrieval evidence;
-- per-seed and per-library coverage;
+- per-seed and per-library coverage, including the Analysis-issued blockers
+  that omitted a participant's candidate methods;
 - intentional row suppression; and
 - typed acquisition, metadata, name-selection, and Analysis failures.
 
@@ -476,6 +513,9 @@ The following future outcome-level scenarios are required:
 | Scenario | Required observation |
 | --- | --- |
 | Open Library, Type, and Member Clone without changing target settings | Each subject supplies its own seed population; all use `Everything` plus `SimilarNames` |
+| Open Clone on a property or event | The seed population is every accessor body that member occupies; selecting one accessor seeds only that body |
+| Open Clone on one overloaded indexer | The seed population is that overload's own accessor bodies, not the other overload's and not both |
+| Open Clone on a field | The typed bodyless outcome, distinct from a member the type does not declare |
 | Run one Member seed at all three breadths with `All` | `Self` stays in the containing library, the middle breadth adds registered ecosystems, and `Everything` admits every available Workspace participant |
 | Run all six breadth/discovery combinations | Breadth changes only the Workspace population and discovery changes only method admission inside that population |
 | Run a Library search | Results are one global ranking across all admitted seeds, not N rows per method or library |
@@ -492,8 +532,11 @@ Shared owner suites run in Release and gate request defaults, starting/effective
 revision and participant-snapshot association, breadth and discovery
 admission, name-threshold behavior, per-pair name admission, snapshot-local
 endpoint identity order, aggregate participant and retrieval work bounds,
-bounded name-score memoization, chunked retrieval equivalence, released-group
-containment, duplicate suppression, global ranking, and coverage;
+memoization-independent admission, chunked retrieval equivalence,
+released-group containment, duplicate suppression, global ranking, per-library
+Analysis coverage, logical-member seed expansion over ordinary compiled
+property and event accessors, overloaded-indexer selection, the field bodyless
+outcome, and cross-type accessor association;
 `WorkspaceStructuralCloneSearchQueryTests` supplies that gate. CLI tests gate
 shared presentation and structured output. Browser
 original-host and Firefox suites gate the breadth and discovery controls,

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1074,6 +1074,23 @@ silently changing results: a released containing library returns a typed
 `CandidateLibraryReleased` incomplete coverage beside the evidence already
 ranked.
 
+A Member seed is every exact method body the selected member occupies. A method
+anchor selects its own body, so an explicit accessor selection stays one body,
+and a property or event anchor expands to the bodies its `MethodSemantics` rows
+associate with it. An indexer overloads on its index parameters, so those
+parameters are part of its exact identity and a selected overload expands to
+its own accessors alone. The association is read through the metadata owner's
+accessor projection and its anchors through the metadata owner's identity
+producers, so no accessor name convention is re-derived here. An accessor
+association naming a MethodDef another type declares is malformed metadata, not
+a body of the selected member: TypeDef method ranges are validated as a
+partition of the MethodDef table at image entry, which is what makes SRM's
+declaring-type lookup answer for exactly one type. A selected member that
+occupies no method body — including every field, which is a supported Member
+subject that occupies none — is the typed `SeedMemberHasNoMethodBody` outcome
+rather than a missing member or an arbitrary body, and repeated exact
+identities remain ambiguous.
+
 `SimilarNames` admits a candidate only when one seed clears the fixed `0.6`
 normalized threshold on both the innermost declaring-type simple base name and
 the member name; both conditions must hold for the same seed, and that
@@ -1084,12 +1101,26 @@ scores are its own pair's. Names are decoded under a per-name character bound
 and every comparison and admission scan charges one shared name-work budget, so
 an artifact-authored name population cannot buy unbounded edit-distance work.
 An undecodable name and an exhausted budget are visible seed and library
-coverage rather than a silently narrowed population. Decoded-name scores are
+coverage rather than a silently narrowed population.
+
+Names equal under `StringComparison.OrdinalIgnoreCase` score `1.0` at no
+comparison cost; every other comparison folds both names invariantly before
+`StringDistance.Similarity`. Decoded names are preserved as decoded and folding
+is invariant uppercasing, which is the mapping that comparison itself uses:
+lowercasing would separate Greek capital sigma from the final sigma and exclude
+a peer the product promises to score `1.0`. That same equivalence keys the seed
+name index and the score memoization, so two spellings of one name cannot admit
+different candidates.
+
+Decoded-name scores are
 memoized under a bound on retained score cells as well as entries, because one
 entry costs one cell per distinct seed name and an entry bound alone would
-retain gigabytes for a large seed population. The exhausted name-work state is
-checked before the cache, so the cache remains a pure optimization: its
-capacity cannot change which candidates a bounded search admits.
+retain gigabytes for a large seed population. A name's whole logical comparison
+work is charged before the cache is consulted and is the same on a hit and on a
+miss, so the shared budget reaches exhaustion at the same candidate for every
+cache capacity. The cache is therefore a pure optimization: it changes how much
+`StringDistance` recomputes, never the charged work, the discovered methods,
+the ranked rows, or the reported coverage.
 
 Work is bounded per library and in aggregate. Beyond the per-library seed and
 candidate populations, a request bounds the breadth-admitted participant count
@@ -1123,16 +1154,28 @@ an ordinal never leaks across snapshots. A physical self-pair is excluded, and
 an unordered pair whose two endpoints are both seeds is returned in one
 deterministic orientation; a Member seed keeps the selected seed on the left.
 Intentional row suppression is reported separately from incomplete metadata,
-name, acquisition, work-bound, and Analysis coverage. Cross-image rank remains
+name, acquisition, work-bound, and Analysis coverage. Analysis blockers are
+attributed to both owners of the retrieval that produced them: the seed it ran
+for, and the participant whose candidate methods it omitted. A library carries
+the distinct Analysis blockers that omitted its candidates, aggregated over
+every seed and chunk, and is incomplete while it holds one, so a candidate body
+Analysis could not produce can never leave that library reporting complete
+coverage. A seed-side blocker stays with its seed: it omits no candidate of any
+one participant and is already visible as that seed's coverage. Cross-image rank remains
 retrieval evidence: the query establishes no checked clone relation and
 produces no comparison document.
 `WorkspaceStructuralCloneSearchQueryTests` gates the request defaults, all six
-breadth and discovery combinations, seed expansion, per-pair name admission,
+breadth and discovery combinations, seed expansion including property and
+event accessor bodies, overloaded-indexer selection, the field bodyless
+outcome, cross-type accessor association, and explicit accessor narrowing,
+ordinal-ignore-case name
+equality, per-pair name admission,
 pair suppression, exact endpoint identity for equal content, snapshot-local
 identity order, global ranking with a post-merge limit, revision and snapshot
 binding, snapshot validation, released-group containment for both the seed and
-a candidate, bounded name-score memoization against an unbounded-cache
-baseline, chunked-retrieval equivalence, cancellation, and the visible seed,
+a candidate, cache-independent admission under both a complete and an
+exhausted name budget, per-library Analysis blocker attribution,
+chunked-retrieval equivalence, cancellation, and the visible seed,
 candidate, participant, aggregate retrieval, name, and acquisition limits.
 
 Other domain catalogs, query authorization, concurrent execution, and broader

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1048,6 +1048,93 @@ declaring-chain traversal it performs rather than only the names it compares;
 that case pins its fixture's declaring depth, because a shallow fixture would
 exhaust the same budget while leaving the traversal unexercised.
 
+`WorkspaceStructuralCloneSearchQuery` composes that single-pair retrieval into
+one Library, Type, or Member search over an exact caller-supplied participant
+snapshot. Its request binds the seed subject, one candidate breadth (`Self`,
+`SelfAndRegisteredEcosystems`, or `Everything`), one candidate discovery value
+(`SimilarNames` or `All`), and its result and work bounds; the default is
+`Everything` plus `SimilarNames`. The normative contract is
+[Structural clone search scope](design/structural-clone-search-scope.md).
+
+Workspace registration lookup is not implemented, so breadth membership is
+supplied rather than inferred: each snapshot entry carries its own
+`ContainingLibrary`, `RegisteredEcosystem`, or `Available` membership, and the
+snapshot binds the starting and effective Workspace revisions plus one opaque
+snapshot identity. The constructor rejects a repeated participant, a repeated
+acquisition registration, a missing or duplicated containing library, and
+revisions from different Workspaces, so inconsistent or duplicated membership
+cannot be expressed. A snapshot retains groups rather than immutable images, so
+its issuer must both associate each group with the Workspace that issued those
+revisions and keep every group and participant alive for the execution it is
+passed to. Both obligations are unverified — the group exposes no
+owning-Workspace identity, and enforcement waits on the concrete Workspace and
+registration producer — so premature release is made visible instead of
+silently changing results: a released containing library returns a typed
+`SeedLibraryReleased` failure and a released candidate becomes that library's
+`CandidateLibraryReleased` incomplete coverage beside the evidence already
+ranked.
+
+`SimilarNames` admits a candidate only when one seed clears the fixed `0.6`
+normalized threshold on both the innermost declaring-type simple base name and
+the member name; both conditions must hold for the same seed, and that
+qualifying seed-candidate pair is also the unit of evaluation. Each seed owns
+its own candidate group inside a participant, so a candidate admitted by one
+seed is never retrieved against a different seed, and a row's reported name
+scores are its own pair's. Names are decoded under a per-name character bound
+and every comparison and admission scan charges one shared name-work budget, so
+an artifact-authored name population cannot buy unbounded edit-distance work.
+An undecodable name and an exhausted budget are visible seed and library
+coverage rather than a silently narrowed population. Decoded-name scores are
+memoized under a bound on retained score cells as well as entries, because one
+entry costs one cell per distinct seed name and an entry bound alone would
+retain gigabytes for a large seed population. The exhausted name-work state is
+checked before the cache, so the cache remains a pure optimization: its
+capacity cannot change which candidates a bounded search admits.
+
+Work is bounded per library and in aggregate. Beyond the per-library seed and
+candidate populations, a request bounds the breadth-admitted participant count
+and the total seed-by-candidate retrieval population submitted to Analysis.
+Both are whole-unit bounds, discovered at different points. The participant
+bound is preflight over the snapshot's exact entry order, and the containing
+library is always the first admitted participant. The retrieval-pair bound is a
+whole-participant admission bound: under `SimilarNames` a participant's pair
+population is only known while its per-seed candidate groups are formed, so
+admission stops mid-formation and abandons that participant, after which the
+latched budget excludes later participants without opening them. Either way a
+participant that does not fit is excluded whole rather than truncated. Every
+whole-unit exclusion carries its failure and makes coverage incomplete, which
+keeps it distinct from the intentional returned-row limit.
+
+Pairs are one global ranking. A seed's admitted candidate group is submitted in
+bounded consecutive chunks so cancellation is observed between units of
+retrieval work rather than after one whole-population call; each chunk requests
+its complete ranked population, so no per-seed or per-chunk truncation can
+corrupt the global top N, and chunking moves only cancellation granularity and
+the seed body-production count, never the ranked rows, the per-pair name
+evidence, or the aggregate retrieval charge. The result
+limit applies only after the merge. Ties resolve by the Analysis component
+order and then by exact endpoint identity, where an endpoint carries the
+snapshot-issued opaque participant identity rather than an MVID and token
+alone. The snapshot owns that deterministic snapshot-local order: it captures
+its owner-issued entry order once as part of its exact identity, rejects
+repeated participants and repeated acquisition registrations, and issues one
+identity per entry, so two registrations of identical content stay distinct and
+an ordinal never leaks across snapshots. A physical self-pair is excluded, and
+an unordered pair whose two endpoints are both seeds is returned in one
+deterministic orientation; a Member seed keeps the selected seed on the left.
+Intentional row suppression is reported separately from incomplete metadata,
+name, acquisition, work-bound, and Analysis coverage. Cross-image rank remains
+retrieval evidence: the query establishes no checked clone relation and
+produces no comparison document.
+`WorkspaceStructuralCloneSearchQueryTests` gates the request defaults, all six
+breadth and discovery combinations, seed expansion, per-pair name admission,
+pair suppression, exact endpoint identity for equal content, snapshot-local
+identity order, global ranking with a post-merge limit, revision and snapshot
+binding, snapshot validation, released-group containment for both the seed and
+a candidate, bounded name-score memoization against an unbounded-cache
+baseline, chunked-retrieval equivalence, cancellation, and the visible seed,
+candidate, participant, aggregate retrieval, name, and acquisition limits.
+
 Other domain catalogs, query authorization, concurrent execution, and broader
 command migration remain later slices.
 

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -83,6 +83,7 @@
     <Project Path="fixtures/metadata/ILInspector.Metadata.SpellabilityConsumer/ILInspector.Metadata.SpellabilityConsumer.csproj" />
     <Project Path="fixtures/metadata/ILInspector.Metadata.SpellabilityReference/ILInspector.Metadata.SpellabilityReference.csproj" />
     <Project Path="fixtures/metadata/ILInspector.Metadata.StateMachineFixtures/ILInspector.Metadata.StateMachineFixtures.csproj" />
+    <Project Path="fixtures/queries/DotnetInspector.CloneSearchFixtures/DotnetInspector.CloneSearchFixtures.csproj" />
     <Project Path="fixtures/queries/DotnetInspector.Queries.EmbeddedFixtures/DotnetInspector.Queries.EmbeddedFixtures.csproj" />
     <Project Path="fixtures/queries/DotnetInspector.RestoredProjectFixtures/DotnetInspector.RestoredProjectFixtures.csproj" />
     <Project Path="fixtures/queries/DotnetInspector.SourceDiff.V1/DotnetInspector.SourceDiff.V1.csproj" />

--- a/fixtures/queries/DotnetInspector.CloneSearchFixtures/CloneSearchMemberFixture.cs
+++ b/fixtures/queries/DotnetInspector.CloneSearchFixtures/CloneSearchMemberFixture.cs
@@ -103,3 +103,9 @@ public sealed class ParamsLookup
 {
     public int this[params long[] values] => values.Length;
 }
+
+/// <summary>Dynamic indexer identity canonicalizes to object.</summary>
+public sealed class DynamicLookup
+{
+    public int this[dynamic key] => key.GetHashCode();
+}

--- a/fixtures/queries/DotnetInspector.CloneSearchFixtures/CloneSearchMemberFixture.cs
+++ b/fixtures/queries/DotnetInspector.CloneSearchFixtures/CloneSearchMemberFixture.cs
@@ -78,3 +78,28 @@ public sealed class Lookup
         get { return _byIndex[key.Length]; }
     }
 }
+
+/// <summary>Indexer parameter forms whose API and metadata identities agree.</summary>
+public sealed class NullableLookup
+{
+    public string this[string? key] => key ?? "";
+}
+
+/// <summary>Generic indexer parameter identity.</summary>
+public sealed class GenericLookup
+{
+    public int this[Dictionary<int, string> key] => key.Count;
+}
+
+/// <summary>Tuple indexer parameter identity.</summary>
+public sealed class TupleLookup
+{
+    public int this[(int Count, string Name) key] =>
+        key.Count + key.Name.Length;
+}
+
+/// <summary>Parameter-array indexer identity.</summary>
+public sealed class ParamsLookup
+{
+    public int this[params long[] values] => values.Length;
+}

--- a/fixtures/queries/DotnetInspector.CloneSearchFixtures/CloneSearchMemberFixture.cs
+++ b/fixtures/queries/DotnetInspector.CloneSearchFixtures/CloneSearchMemberFixture.cs
@@ -1,0 +1,80 @@
+namespace Cases;
+
+/// <summary>
+/// An ordinary compiled property and event whose accessors carry real method
+/// bodies, so a logical Member seed has exact bodies to expand to.
+/// </summary>
+public sealed class Widget
+{
+    int _value;
+    EventHandler? _changed;
+
+    /// <summary>
+    /// A field: a supported Member subject that occupies no method body.
+    /// </summary>
+    public int Tag;
+
+    /// <summary>A property whose getter and setter both occupy a body.</summary>
+    public int Value
+    {
+        get { return _value; }
+        set { _value = value; }
+    }
+
+    /// <summary>An event whose adder and remover both occupy a body.</summary>
+    public event EventHandler? Changed
+    {
+        add { _changed += value; }
+        remove { _changed -= value; }
+    }
+
+    public void Raise() => _changed?.Invoke(this, EventArgs.Empty);
+}
+
+/// <summary>
+/// A structural peer of <see cref="Widget"/> under a similar type name, so a
+/// Member seed expanded to accessor bodies has qualifying candidates.
+/// </summary>
+public sealed class Widgets
+{
+    int _value;
+    EventHandler? _changed;
+
+    public int Value
+    {
+        get { return _value; }
+        set { _value = value; }
+    }
+
+    public event EventHandler? Changed
+    {
+        add { _changed += value; }
+        remove { _changed -= value; }
+    }
+
+    public void Raise() => _changed?.Invoke(this, EventArgs.Empty);
+}
+
+/// <summary>
+/// Two indexer overloads that differ only by their index parameter type, so
+/// they collide on <c>P:Cases.Lookup.Item</c> unless index parameters are part
+/// of property identity. Their accessor counts differ, which makes the
+/// selected overload's own bodies observable.
+/// </summary>
+public sealed class Lookup
+{
+    readonly Dictionary<int, string> _byIndex = [];
+
+    /// <summary>The int overload: a getter and a setter.</summary>
+    public string this[int index]
+    {
+        get { return _byIndex[index]; }
+        set { _byIndex[index] = value; }
+    }
+
+    /// <summary>The string overload: a getter only.</summary>
+    public string this[string key]
+    {
+        get { return _byIndex[key.Length]; }
+    }
+}

--- a/fixtures/queries/DotnetInspector.CloneSearchFixtures/DotnetInspector.CloneSearchFixtures.csproj
+++ b/fixtures/queries/DotnetInspector.CloneSearchFixtures/DotnetInspector.CloneSearchFixtures.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/CSharpText/MemberCanonicalSignature.cs
+++ b/src/CSharpText/MemberCanonicalSignature.cs
@@ -21,7 +21,7 @@ public static class MemberCanonicalSignature
     /// <param name="kind">DocId kind code: <c>"M"</c> (method/constructor/operator), <c>"P"</c>, <c>"F"</c>, or <c>"E"</c>.</param>
     /// <param name="typeFullName">Declaring type full name including generic parameters (for example <c>System.Collections.Generic.List&lt;T&gt;</c>).</param>
     /// <param name="memberName">Member name including method generic parameters (for example <c>M&lt;U&gt;</c>); <c>#ctor</c> for constructors.</param>
-    /// <param name="parameterTypeFullNames">Full-name parameter type strings; ignored for <c>P</c>/<c>F</c>/<c>E</c>.</param>
+    /// <param name="parameterTypeFullNames">Full-name parameter type strings. A <c>P</c> carries them only as an indexer's index parameters, and an empty list keeps the ordinary bare property spelling; ignored for <c>F</c>/<c>E</c>.</param>
     /// <param name="conversionReturnType">Full-name return type for a conversion operator (which overloads on return type), otherwise <see langword="null"/>.</param>
     public static string Build(
         string kind,
@@ -30,8 +30,20 @@ public static class MemberCanonicalSignature
         IReadOnlyList<string> parameterTypeFullNames,
         string? conversionReturnType = null)
     {
-        if (kind is "P" or "F" or "E")
+        if (kind is "F" or "E")
             return $"{kind}:{typeFullName}.{memberName}";
+
+        // A field or event has no parameter list at all, but an indexer is a
+        // property that overloads on its index parameters, so those belong to
+        // property identity. An ordinary property has none and keeps the bare
+        // "P:{type}.{name}" spelling it has always had -- an empty parameter
+        // list is not the same as an empty parameter list in parentheses.
+        if (kind == "P")
+        {
+            return parameterTypeFullNames.Count == 0
+                ? $"P:{typeFullName}.{memberName}"
+                : $"P:{typeFullName}.{memberName}({string.Join(",", parameterTypeFullNames)})";
+        }
 
         var signature = $"{kind}:{typeFullName}.{memberName}({string.Join(",", parameterTypeFullNames)})";
         return string.IsNullOrWhiteSpace(conversionReturnType)

--- a/src/DotnetInspector.Queries/AssemblyContextStructuralCloneRetrievalQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextStructuralCloneRetrievalQuery.cs
@@ -1,9 +1,7 @@
 using System.Collections.Immutable;
-using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using System.Text;
 
 using ILInspector.Analysis;
 using ILInspector.Metadata;
@@ -288,12 +286,12 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
     {
         cancellationToken.ThrowIfCancellationRequested();
         using var seedImage = new PEReader(seedSnapshot.Content);
-        ValidatedImage validatedSeed;
+        StructuralCloneValidatedImage validatedSeed;
         MetadataReader seedReader;
         MethodDefinitionHandle seed;
         try
         {
-            validatedSeed = ValidatedImage.Create(seedImage);
+            validatedSeed = StructuralCloneValidatedImage.Create(seedImage);
             seedReader = validatedSeed.Reader;
             SeedResolution resolution =
                 ResolveSeed(validatedSeed, input.Seed);
@@ -308,7 +306,9 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
 
             seed = resolution.Method;
         }
-        catch (Exception ex) when (IsMalformedMetadata(ex))
+        catch (Exception ex)
+            when (StructuralCloneMetadataResolution
+                .IsMalformedMetadata(ex))
         {
             return MetadataFailure(
                 seedSubject,
@@ -326,7 +326,9 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
                 population =
                     ResolvePopulation(validatedSeed, input.Population);
             }
-            catch (Exception ex) when (IsMalformedMetadata(ex))
+            catch (Exception ex)
+                when (StructuralCloneMetadataResolution
+                    .IsMalformedMetadata(ex))
             {
                 return MetadataFailure(
                     seedSubject,
@@ -411,7 +413,7 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
         {
             PopulationResolution population =
                 ResolvePopulation(
-                    ValidatedImage.Create(candidateImage),
+                    StructuralCloneValidatedImage.Create(candidateImage),
                     input.Population);
             if (population.Failure is { } failure)
             {
@@ -424,7 +426,9 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
 
             methods = population.Methods;
         }
-        catch (Exception ex) when (IsMalformedMetadata(ex))
+        catch (Exception ex)
+            when (StructuralCloneMetadataResolution
+                .IsMalformedMetadata(ex))
         {
             return MetadataFailure(
                 seedSubject,
@@ -450,7 +454,7 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
     }
 
     static SeedResolution ResolveSeed(
-        ValidatedImage image,
+        StructuralCloneValidatedImage image,
         StructuralCloneQuerySeed seed)
         => seed switch
         {
@@ -484,122 +488,27 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
         MetadataReader reader,
         StructuralCloneQuerySeed.Member seed)
     {
-        TypeResolution type =
-            ResolveType(
+        StructuralCloneMemberResolution member =
+            StructuralCloneMetadataResolution.ResolveMember(
                 reader,
                 seed.Type,
-                StructuralCloneQueryParticipantRole.Seed);
-        if (type.Failure is { } typeFailure)
+                seed.MemberIdentity);
+        return member.Status switch
         {
-            return new SeedResolution(default, typeFailure);
-        }
-
-        MethodDefinitionHandle match = default;
-        int matches = 0;
-        int inspectedMethods = 0;
-        int identityDecodeFailures = 0;
-        int anchorWorkRemaining =
-            MetadataSafetyPolicy.MaxClassificationScanWorkChars;
-        Exception? rejected = null;
-        TypeDefinition definition =
-            reader.GetTypeDefinition(type.Handle);
-        var attributeBudget = new AttributeInspectionBudget();
-        bool isExtensionContainer =
-            definition.Attributes.HasFlag(TypeAttributes.Abstract)
-            && definition.Attributes.HasFlag(TypeAttributes.Sealed)
-            && HasExtensionAttribute(
-                reader,
-                definition.GetCustomAttributes(),
-                attributeBudget);
-        foreach (MethodDefinitionHandle methodHandle
-            in definition.GetMethods())
-        {
-            inspectedMethods++;
-            if (inspectedMethods
-                > MetadataSafetyPolicy.MaxCorrespondenceMethodRows)
-            {
-                throw new BadImageFormatException(
-                    "The exact seed member lookup exceeds the MethodDef "
-                        + "row budget.");
-            }
-
-            MethodDefinition method =
-                reader.GetMethodDefinition(methodHandle);
-            MemberAnchor anchor;
-            try
-            {
-                bool isExtensionMethod =
-                    isExtensionContainer
-                    && method.Attributes.HasFlag(
-                        MethodAttributes.Static)
-                    && HasExtensionAttribute(
-                        reader,
-                        method.GetCustomAttributes(),
-                        attributeBudget);
-                anchor = ApiMemberIdentity.CreateMethodAnchorInfo(
-                        reader,
-                        type.Handle,
-                        method,
-                        ref anchorWorkRemaining,
-                        isExtensionMethod)
-                    .Anchor;
-            }
-            catch (Exception ex) when (IsMalformedMetadata(ex))
-            {
-                if (ex is AttributeInspectionBudgetException)
-                {
-                    throw;
-                }
-                if (anchorWorkRemaining <= 0)
-                {
-                    throw new BadImageFormatException(
-                        "The exact seed member lookup exceeds the "
-                            + "anchor-signature work budget.",
-                        ex);
-                }
-                identityDecodeFailures++;
-                if (identityDecodeFailures
-                    >= MetadataSafetyPolicy
-                        .MaxClassificationIdentityDecodeFailures)
-                {
-                    throw new BadImageFormatException(
-                        "The exact seed member lookup exceeds the "
-                            + "method-identity decode failure budget.",
-                        ex);
-                }
-
-                rejected ??= ex;
-                continue;
-            }
-
-            if (anchor != seed.MemberIdentity)
-            {
-                continue;
-            }
-
-            match = methodHandle;
-            matches++;
-        }
-
-        // A rejected sibling cannot be shown to decode to a different
-        // anchor, so a single healthy match does not establish
-        // uniqueness. Surface the metadata failure rather than return a
-        // confident result that a successful decode might have made
-        // ambiguous.
-        if (rejected is not null)
-        {
-            throw new BadImageFormatException(
-                "A MethodDef could not be inspected while resolving "
-                    + "the exact seed member.",
-                rejected);
-        }
-
-        return matches switch
-        {
-            0 => SeedResolution.Failed(
+            StructuralCloneMemberResolutionStatus.Resolved =>
+                SeedResolution.Resolved(member.Method),
+            StructuralCloneMemberResolutionStatus.TypeNotFound =>
+                SeedResolution.Failed(
+                    StructuralCloneQueryFailureKind.SeedTypeNotFound,
+                    $"Type '{seed.Type.ToEscapedFullName()}' does not exist."),
+            StructuralCloneMemberResolutionStatus.TypeAmbiguous =>
+                SeedResolution.Failed(
+                    StructuralCloneQueryFailureKind.SeedTypeAmbiguous,
+                    $"Type '{seed.Type.ToEscapedFullName()}' is ambiguous."),
+            StructuralCloneMemberResolutionStatus.MemberNotFound =>
+                SeedResolution.Failed(
                     StructuralCloneQueryFailureKind.SeedMemberNotFound,
                     "The exact seed member does not exist in the selected seed type."),
-            1 => SeedResolution.Resolved(match),
             _ => SeedResolution.Failed(
                 StructuralCloneQueryFailureKind.SeedMemberAmbiguous,
                 "The exact seed member identifies more than one MethodDef."),
@@ -607,7 +516,7 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
     }
 
     static PopulationResolution ResolvePopulation(
-        ValidatedImage image,
+        StructuralCloneValidatedImage image,
         StructuralCloneQueryPopulation population)
     {
         MetadataReader reader = image.Reader;
@@ -645,134 +554,24 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
         MetadataTypeDefinitionName name,
         StructuralCloneQueryParticipantRole role)
     {
-        TypeDefinitionHandle match = default;
-        int matches = 0;
-        long comparisonWork = Encoding.UTF8.GetByteCount(
-            name.Namespace);
-        foreach (string segment in name.Segments)
-        {
-            comparisonWork +=
-                Encoding.UTF8.GetByteCount(segment);
-        }
-        comparisonWork = Math.Max(comparisonWork, 1);
-        if (comparisonWork
-            > MetadataSafetyPolicy.MaxStructuralSignatureWorkChars)
-        {
-            throw new BadImageFormatException(
-                "The exact TypeDef name exceeds the structural-name "
-                    + "work budget.");
-        }
-        long remainingComparisonWork =
-            MetadataSafetyPolicy.MaxStructuralSignatureWorkChars;
-        int leafUtf8Length = Encoding.UTF8.GetByteCount(
-            name.Segments[^1]);
-        int typeNameDecodeFailures = 0;
-        MetadataTypeNameFailure? rejected = null;
-        foreach (TypeDefinitionHandle candidate
-            in reader.TypeDefinitions)
-        {
-            remainingComparisonWork--;
-            if (remainingComparisonWork < 0)
-            {
-                throw new BadImageFormatException(
-                    "The exact TypeDef lookup exceeded its "
-                        + "structural-name work budget.");
-            }
-
-            int candidateLeafUtf8Length;
-            try
-            {
-                TypeDefinition definition =
-                    reader.GetTypeDefinition(candidate);
-                candidateLeafUtf8Length =
-                    reader.GetBlobReader(definition.Name).Length;
-            }
-            catch (Exception ex) when (IsMalformedMetadata(ex))
-            {
-                NoteTypeNameDecodeFailure(
-                    ref typeNameDecodeFailures,
-                    ex);
-                rejected ??=
-                    MetadataTypeNameFailure.Malformed(
-                        candidate,
-                        ex.Message);
-                continue;
-            }
-
-            remainingComparisonWork -=
-                Math.Max(candidateLeafUtf8Length - 1, 0);
-            if (remainingComparisonWork < 0)
-            {
-                throw new BadImageFormatException(
-                    "The exact TypeDef lookup exceeded its "
-                        + "structural-name work budget.");
-            }
-            if (candidateLeafUtf8Length != leafUtf8Length)
-            {
-                continue;
-            }
-
-            // Matching a leaf walks the whole declaring chain and scans
-            // the walked prefix for cycles, so the comparison this is
-            // about to perform costs far more than the names involved.
-            // Charge that traversal at its ceiling: the leaf length
-            // alone would let a deep shared chain amplify bounded
-            // budget into unbounded work.
-            remainingComparisonWork -=
-                comparisonWork
-                + MetadataSafetyPolicy.MaxRelationshipNodes;
-            if (remainingComparisonWork < 0)
-            {
-                throw new BadImageFormatException(
-                    "The exact TypeDef lookup exceeded its "
-                        + "structural-name work budget.");
-            }
-
-            MetadataTypeDefinitionNameMatchResult result =
-                MetadataTypeDefinitionName.Matches(
-                    reader,
-                    candidate,
-                    name,
-                    out MetadataTypeNameFailure? failure);
-            if (result
-                == MetadataTypeDefinitionNameMatchResult.Rejected)
-            {
-                NoteTypeNameDecodeFailure(
-                    ref typeNameDecodeFailures);
-                rejected ??= failure;
-                continue;
-            }
-            if (result
-                != MetadataTypeDefinitionNameMatchResult.Match)
-            {
-                continue;
-            }
-
-            match = candidate;
-            matches++;
-        }
-
+        StructuralCloneTypeResolution type =
+            StructuralCloneMetadataResolution.ResolveType(reader, name);
         bool seedSide =
             role == StructuralCloneQueryParticipantRole.Seed;
-        if (matches == 0 && rejected is not null)
+        return type.Status switch
         {
-            throw new BadImageFormatException(
-                rejected.Detail);
-        }
-        return matches switch
-        {
-            0 => new TypeResolution(
-                default,
-                new StructuralCloneQueryFailure(
-                    seedSide
-                        ? StructuralCloneQueryFailureKind.SeedTypeNotFound
-                        : StructuralCloneQueryFailureKind
-                            .CandidateTypeNotFound,
-                    seedSide
-                        ? StructuralCloneQueryParticipantRole.Seed
-                        : StructuralCloneQueryParticipantRole.Candidate,
-                    $"Type '{name.ToEscapedFullName()}' does not exist.")),
-            1 => new TypeResolution(match, null),
+            StructuralCloneTypeResolutionStatus.Resolved =>
+                new TypeResolution(type.Handle, null),
+            StructuralCloneTypeResolutionStatus.NotFound =>
+                new TypeResolution(
+                    default,
+                    new StructuralCloneQueryFailure(
+                        seedSide
+                            ? StructuralCloneQueryFailureKind.SeedTypeNotFound
+                            : StructuralCloneQueryFailureKind
+                                .CandidateTypeNotFound,
+                        role,
+                        $"Type '{name.ToEscapedFullName()}' does not exist.")),
             _ => new TypeResolution(
                 default,
                 new StructuralCloneQueryFailure(
@@ -780,274 +579,9 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
                         ? StructuralCloneQueryFailureKind.SeedTypeAmbiguous
                         : StructuralCloneQueryFailureKind
                             .CandidateTypeAmbiguous,
-                    seedSide
-                        ? StructuralCloneQueryParticipantRole.Seed
-                        : StructuralCloneQueryParticipantRole.Candidate,
+                    role,
                     $"Type '{name.ToEscapedFullName()}' is ambiguous.")),
         };
-    }
-
-    /// <summary>
-    /// A metadata reader whose TypeDef method ranges are known to
-    /// partition the MethodDef table.
-    /// </summary>
-    /// <remarks>
-    /// Seed and population resolution accept only this type, so the
-    /// projection guarantee is established once at image entry rather
-    /// than re-derived at each projection site. Three review rounds
-    /// found holes of exactly that second shape.
-    /// </remarks>
-    readonly struct ValidatedImage
-    {
-        ValidatedImage(MetadataReader reader) => Reader = reader;
-
-        public MetadataReader Reader { get; }
-
-        public static ValidatedImage Create(PEReader image)
-        {
-            MetadataReader reader = image.GetMetadataReader();
-            ValidateMethodOwnership(reader);
-            return new ValidatedImage(reader);
-        }
-    }
-
-    static void NoteTypeNameDecodeFailure(
-        ref int typeNameDecodeFailures,
-        Exception? inner = null)
-    {
-        typeNameDecodeFailures++;
-        if (typeNameDecodeFailures
-            >= MetadataSafetyPolicy
-                .MaxClassificationIdentityDecodeFailures)
-        {
-            throw new BadImageFormatException(
-                "The exact TypeDef lookup exceeds the "
-                    + "type-name decode failure budget.",
-                inner);
-        }
-    }
-
-    /// <summary>
-    /// Verifies that the image's TypeDef method ranges partition the
-    /// MethodDef table exactly once.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Per-projection checks alone are not sufficient. A corrupt
-    /// <c>MethodList</c> start yields an empty range rather than an
-    /// error, which would turn a malformed image into a success-shaped
-    /// empty population, and a corrupt <c>MethodPtr</c> table can alias
-    /// one MethodDef row into two different types without repeating
-    /// within either type's own projection.
-    /// </para>
-    /// <para>
-    /// SRM exposes no raw <c>MethodList</c> column, so the partition is
-    /// checked by construction: no range may report a negative length,
-    /// every projected row must be in range and claimed exactly once,
-    /// and the claimed rows must cover the table. This holds for
-    /// optimized and unoptimized images alike, because a valid
-    /// <c>MethodPtr</c> table is itself a permutation of the MethodDef
-    /// rows.
-    /// </para>
-    /// <para>
-    /// Those requirements bound the raw column jointly, and no one of
-    /// them does it alone. A descending start is not silent: SRM reports
-    /// that range with a negative <c>Count</c> while enumerating
-    /// nothing, so rejecting a negative length is what makes the starts
-    /// non-decreasing. Coverage then supplies the rest, because with the
-    /// starts rising the enumerated total is the projected row count
-    /// less the first non-null start plus one; requiring distinct
-    /// in-range rows that total the MethodDef row count forces that
-    /// first non-null start to row 1 and holds every later start within
-    /// <c>projectionRows + 1</c>. A null start is not part of that
-    /// chain: ECMA-335 II.22.37 permits it and SRM reports its range as
-    /// length zero rather than as the difference to the next start, so
-    /// leading nulls neither rise nor break the ordering. Only a
-    /// *leading* null is expressible, though. Because each run is
-    /// delimited by the following TypeDef's start, a null after a
-    /// populated run would end the preceding run before it began, and
-    /// the negative length lands on that preceding row rather than on
-    /// the null itself. Such a column is malformed and is rejected.
-    /// Neither check
-    /// is redundant: a descending column passes coverage, and a column
-    /// starting past row 1 passes the length check.
-    /// </para>
-    /// <para>
-    /// The projection alone does not prove that permutation, because a
-    /// <c>MethodPtr</c> row that no TypeDef range covers is never
-    /// projected and so is never checked. An unreachable row still
-    /// changes what SRM reports for a reachable method, because
-    /// declaring-type lookup scans <c>MethodPtr</c> for the first row
-    /// naming a MethodDef and can land on the uncovered row. Requiring
-    /// equal row counts closes that gap: with every projected row
-    /// distinct, in range, and covering the MethodDef table, equal
-    /// counts leave no <c>MethodPtr</c> row uncovered.
-    /// </para>
-    /// </remarks>
-    static void ValidateMethodOwnership(MetadataReader reader)
-    {
-        if (reader.GetTableRowCount(TableIndex.TypeDef) == 0)
-        {
-            throw new BadImageFormatException(
-                "The image declares no TypeDef rows, so it lacks the "
-                    + "module pseudo-type that owns module-wide "
-                    + "methods.");
-        }
-
-        int methodRows = reader.GetTableRowCount(TableIndex.MethodDef);
-        int methodPtrRows =
-            reader.GetTableRowCount(TableIndex.MethodPtr);
-        if (methodPtrRows != 0 && methodPtrRows != methodRows)
-        {
-            throw new BadImageFormatException(
-                "The MethodPtr table is not a permutation of the "
-                    + "MethodDef table.");
-        }
-
-        var owned = new HashSet<MethodDefinitionHandle>();
-        foreach (TypeDefinitionHandle type in reader.TypeDefinitions)
-        {
-            MethodDefinitionHandleCollection methods =
-                reader.GetTypeDefinition(type).GetMethods();
-
-            // Checked before enumerating, because a negative range
-            // yields no elements rather than an error.
-            if (methods.Count < 0)
-            {
-                throw new BadImageFormatException(
-                    "The TypeDef MethodList column is not a "
-                        + "non-decreasing range in the projected "
-                        + "method table.");
-            }
-
-            foreach (MethodDefinitionHandle method in methods)
-            {
-                ValidateProjectedMethod(method, methodRows, owned);
-            }
-        }
-
-        if (owned.Count != methodRows)
-        {
-            throw new BadImageFormatException(
-                "The TypeDef method ranges do not cover the MethodDef "
-                    + "table exactly once.");
-        }
-    }
-
-    /// <summary>
-    /// Rejects a projected MethodDef row that is out of range or already
-    /// seen, so a malformed projection cannot reach Analysis as an
-    /// untyped argument error.
-    /// </summary>
-    static void ValidateProjectedMethod(
-        MethodDefinitionHandle method,
-        int methodRows,
-        HashSet<MethodDefinitionHandle> projected)
-    {
-        int row = MetadataTokens.GetRowNumber(method);
-        if (row == 0 || row > methodRows)
-        {
-            throw new BadImageFormatException(
-                "A projected MethodDef row falls outside the MethodDef "
-                    + "table.");
-        }
-
-        if (!projected.Add(method))
-        {
-            throw new BadImageFormatException(
-                "The selected method projection repeats a MethodDef "
-                    + "row.");
-        }
-    }
-
-    static bool HasExtensionAttribute(
-        MetadataReader reader,
-        CustomAttributeHandleCollection attributes,
-        AttributeInspectionBudget budget)
-    {
-        budget.Admit(attributes);
-        try
-        {
-            foreach (CustomAttributeHandle attributeHandle
-                in attributes)
-            {
-                CustomAttribute attribute =
-                    reader.GetCustomAttribute(attributeHandle);
-                string? attributeTypeName =
-                    AttributeReader.GetAttributeTypeName(
-                        reader,
-                        attribute.Constructor,
-                        budget.ObserveMaterialization);
-                if (attributeTypeName is null)
-                {
-                    attributeTypeName =
-                        ResolveRejectedAttributeType(
-                            reader,
-                            attribute.Constructor,
-                            budget);
-                }
-
-                if (attributeTypeName
-                    == KnownAttributeNames.ExtensionAttribute)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-        catch (AttributeInspectionBudgetSignalException ex)
-        {
-            // Signature decoding converts BadImageFormatException to a
-            // rejection, so the callback uses a private signal until it leaves
-            // that guarded boundary.
-            throw new AttributeInspectionBudgetException(
-                ex.Message,
-                ex);
-        }
-    }
-
-    static string? ResolveRejectedAttributeType(
-        MetadataReader reader,
-        EntityHandle constructor,
-        AttributeInspectionBudget budget)
-    {
-        EntityHandle type = constructor.Kind switch
-        {
-            HandleKind.MemberReference =>
-                reader.GetMemberReference(
-                    (MemberReferenceHandle)constructor).Parent,
-            HandleKind.MethodDefinition =>
-                reader.GetMethodDefinition(
-                    (MethodDefinitionHandle)constructor)
-                    .GetDeclaringType(),
-            _ => default,
-        };
-        if (type.IsNil)
-        {
-            return null;
-        }
-
-        return TypeResolver.ResolveTypeName(reader, type) switch
-        {
-            MetadataTypeNameResult.Resolved resolved =>
-                ChargeResolvedAttributeType(resolved.Value, budget),
-            MetadataTypeNameResult.Absent => null,
-            MetadataTypeNameResult.Rejected rejected =>
-                throw new BadImageFormatException(
-                    rejected.Failure.Detail),
-            _ => throw new InvalidOperationException(
-                "Unknown metadata type-name result."),
-        };
-    }
-
-    static string ChargeResolvedAttributeType(
-        string value,
-        AttributeInspectionBudget budget)
-    {
-        budget.ObserveMaterialization(
-            Encoding.UTF8.GetByteCount(value));
-        return value;
     }
 
     static AssemblyContextStructuralCloneRetrievalResult MetadataFailure(
@@ -1062,11 +596,6 @@ public static class AssemblyContextStructuralCloneRetrievalQuery
                 StructuralCloneQueryFailureKind.MetadataInspectionFailed,
                 role,
                 error.Message));
-
-    static bool IsMalformedMetadata(Exception exception)
-        => exception is BadImageFormatException
-            or ArgumentOutOfRangeException
-            or OverflowException;
 
     static void EnsureParticipant(
         AssemblyContextGroup group,

--- a/src/DotnetInspector.Queries/StructuralCloneMetadataResolution.cs
+++ b/src/DotnetInspector.Queries/StructuralCloneMetadataResolution.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -25,6 +26,14 @@ enum StructuralCloneMemberResolutionStatus
     TypeAmbiguous,
     MemberNotFound,
     MemberAmbiguous,
+
+    /// <summary>
+    /// The exact member exists and is one logical member, but it occupies no
+    /// MethodDef. A property or event whose <c>MethodSemantics</c> rows are
+    /// absent owns no method body, and a field owns none by construction, so
+    /// either selects an empty body population rather than an arbitrary one.
+    /// </summary>
+    MemberHasNoMethodBody,
 }
 
 readonly record struct StructuralCloneTypeResolution(
@@ -33,6 +42,14 @@ readonly record struct StructuralCloneTypeResolution(
 
 readonly record struct StructuralCloneMemberResolution(
     MethodDefinitionHandle Method,
+    StructuralCloneMemberResolutionStatus Status);
+
+/// <summary>
+/// Every exact method body one selected member occupies, in MethodDef row
+/// order.
+/// </summary>
+readonly record struct StructuralCloneMemberBodyResolution(
+    ImmutableArray<MethodDefinitionHandle> Methods,
     StructuralCloneMemberResolutionStatus Status);
 
 /// <summary>
@@ -71,28 +88,78 @@ readonly struct StructuralCloneValidatedImage
 /// </remarks>
 static class StructuralCloneMetadataResolution
 {
+    /// <summary>
+    /// Selects the one MethodDef carrying the exact member identity. Only a
+    /// method anchor resolves; a logical member that occupies several bodies
+    /// is not a single-body selection.
+    /// </summary>
     internal static StructuralCloneMemberResolution ResolveMember(
         MetadataReader reader,
         MetadataTypeDefinitionName typeName,
         MemberAnchor member)
+    {
+        StructuralCloneMemberBodyResolution resolved =
+            ResolveMemberCore(
+                reader,
+                typeName,
+                member,
+                expandLogicalMembers: false);
+        return new StructuralCloneMemberResolution(
+            resolved.Methods.IsDefaultOrEmpty
+                ? default
+                : resolved.Methods[0],
+            resolved.Status);
+    }
+
+    /// <summary>
+    /// Selects every exact method body the selected member occupies.
+    /// </summary>
+    /// <remarks>
+    /// A method anchor selects its own single body, so an explicit accessor
+    /// selection stays one body. A property or event anchor selects the bodies
+    /// its <c>MethodSemantics</c> rows associate with it — getter, setter,
+    /// adder, remover, raiser, and any other associated accessor — because
+    /// those are the exact bodies that logical member occupies. A field is a
+    /// supported Member subject that occupies no method body at all, so it is
+    /// selected here to distinguish a field that exists from a member that
+    /// does not. Ambiguity and malformed-metadata behavior are unchanged: a
+    /// repeated exact identity is ambiguous, and an identity that cannot be
+    /// decoded is a metadata failure rather than a confident selection.
+    /// </remarks>
+    internal static StructuralCloneMemberBodyResolution ResolveMemberBodies(
+        MetadataReader reader,
+        MetadataTypeDefinitionName typeName,
+        MemberAnchor member)
+        => ResolveMemberCore(
+            reader,
+            typeName,
+            member,
+            expandLogicalMembers: true);
+
+    static StructuralCloneMemberBodyResolution ResolveMemberCore(
+        MetadataReader reader,
+        MetadataTypeDefinitionName typeName,
+        MemberAnchor member,
+        bool expandLogicalMembers)
     {
         StructuralCloneTypeResolution type =
             ResolveType(reader, typeName);
         switch (type.Status)
         {
             case StructuralCloneTypeResolutionStatus.NotFound:
-                return new StructuralCloneMemberResolution(
-                    default,
+                return new StructuralCloneMemberBodyResolution(
+                    [],
                     StructuralCloneMemberResolutionStatus.TypeNotFound);
             case StructuralCloneTypeResolutionStatus.Ambiguous:
-                return new StructuralCloneMemberResolution(
-                    default,
+                return new StructuralCloneMemberBodyResolution(
+                    [],
                     StructuralCloneMemberResolutionStatus.TypeAmbiguous);
         }
 
-        MethodDefinitionHandle match = default;
+        var bodies =
+            ImmutableArray.CreateBuilder<MethodDefinitionHandle>();
         int matches = 0;
-        int inspectedMethods = 0;
+        int inspectedRows = 0;
         int identityDecodeFailures = 0;
         int anchorWorkRemaining =
             MetadataSafetyPolicy.MaxClassificationScanWorkChars;
@@ -110,15 +177,7 @@ static class StructuralCloneMetadataResolution
         foreach (MethodDefinitionHandle methodHandle
             in definition.GetMethods())
         {
-            inspectedMethods++;
-            if (inspectedMethods
-                > MetadataSafetyPolicy.MaxCorrespondenceMethodRows)
-            {
-                throw new BadImageFormatException(
-                    "The exact seed member lookup exceeds the MethodDef "
-                        + "row budget.");
-            }
-
+            ChargeMemberRow(ref inspectedRows);
             MethodDefinition method =
                 reader.GetMethodDefinition(methodHandle);
             MemberAnchor anchor;
@@ -146,25 +205,12 @@ static class StructuralCloneMetadataResolution
                 {
                     throw;
                 }
-                if (anchorWorkRemaining <= 0)
-                {
-                    throw new BadImageFormatException(
-                        "The exact seed member lookup exceeds the "
-                            + "anchor-signature work budget.",
-                        ex);
-                }
-                identityDecodeFailures++;
-                if (identityDecodeFailures
-                    >= MetadataSafetyPolicy
-                        .MaxClassificationIdentityDecodeFailures)
-                {
-                    throw new BadImageFormatException(
-                        "The exact seed member lookup exceeds the "
-                            + "method-identity decode failure budget.",
-                        ex);
-                }
 
-                rejected ??= ex;
+                NoteIdentityDecodeFailure(
+                    ex,
+                    anchorWorkRemaining,
+                    ref identityDecodeFailures,
+                    ref rejected);
                 continue;
             }
 
@@ -173,8 +219,172 @@ static class StructuralCloneMetadataResolution
                 continue;
             }
 
-            match = methodHandle;
+            bodies.Add(methodHandle);
             matches++;
+        }
+
+        // A logical member occupies the bodies its MethodSemantics rows
+        // associate with it. Physical accessor projection belongs to the
+        // metadata owner, so the association is read through SRM's accessor
+        // projection rather than re-derived from accessor name conventions.
+        if (expandLogicalMembers)
+        {
+            int methodRowCount =
+                reader.GetTableRowCount(TableIndex.MethodDef);
+            foreach (PropertyDefinitionHandle propertyHandle
+                in definition.GetProperties())
+            {
+                ChargeMemberRow(ref inspectedRows);
+                PropertyDefinition property =
+                    reader.GetPropertyDefinition(propertyHandle);
+                MemberAnchor anchor;
+                try
+                {
+                    anchor = ApiMemberIdentity.CreatePropertyAnchor(
+                        reader,
+                        type.Handle,
+                        property,
+                        ref anchorWorkRemaining);
+                }
+                catch (Exception ex) when (IsMalformedMetadata(ex))
+                {
+                    NoteIdentityDecodeFailure(
+                        ex,
+                        anchorWorkRemaining,
+                        ref identityDecodeFailures,
+                        ref rejected);
+                    continue;
+                }
+
+                if (anchor != member)
+                {
+                    continue;
+                }
+
+                PropertyAccessors accessors = property.GetAccessors();
+                AddAccessor(
+                    reader,
+                    accessors.Getter,
+                    type.Handle,
+                    methodRowCount,
+                    bodies);
+                AddAccessor(
+                    reader,
+                    accessors.Setter,
+                    type.Handle,
+                    methodRowCount,
+                    bodies);
+                foreach (MethodDefinitionHandle other in accessors.Others)
+                {
+                    AddAccessor(
+                        reader,
+                        other,
+                        type.Handle,
+                        methodRowCount,
+                        bodies);
+                }
+
+                matches++;
+            }
+
+            foreach (EventDefinitionHandle eventHandle
+                in definition.GetEvents())
+            {
+                ChargeMemberRow(ref inspectedRows);
+                EventDefinition eventDefinition =
+                    reader.GetEventDefinition(eventHandle);
+                MemberAnchor anchor;
+                try
+                {
+                    anchor = ApiMemberIdentity.CreateEventAnchor(
+                        reader,
+                        type.Handle,
+                        eventDefinition,
+                        ref anchorWorkRemaining);
+                }
+                catch (Exception ex) when (IsMalformedMetadata(ex))
+                {
+                    NoteIdentityDecodeFailure(
+                        ex,
+                        anchorWorkRemaining,
+                        ref identityDecodeFailures,
+                        ref rejected);
+                    continue;
+                }
+
+                if (anchor != member)
+                {
+                    continue;
+                }
+
+                EventAccessors accessors = eventDefinition.GetAccessors();
+                AddAccessor(
+                    reader,
+                    accessors.Adder,
+                    type.Handle,
+                    methodRowCount,
+                    bodies);
+                AddAccessor(
+                    reader,
+                    accessors.Remover,
+                    type.Handle,
+                    methodRowCount,
+                    bodies);
+                AddAccessor(
+                    reader,
+                    accessors.Raiser,
+                    type.Handle,
+                    methodRowCount,
+                    bodies);
+                foreach (MethodDefinitionHandle other in accessors.Others)
+                {
+                    AddAccessor(
+                        reader,
+                        other,
+                        type.Handle,
+                        methodRowCount,
+                        bodies);
+                }
+
+                matches++;
+            }
+
+            // A field is a supported Member subject that occupies no method
+            // body. Scanning fields is what makes a bodyless field the typed
+            // "member exists, has no body" outcome instead of a member the
+            // selected type does not declare.
+            foreach (FieldDefinitionHandle fieldHandle
+                in definition.GetFields())
+            {
+                ChargeMemberRow(ref inspectedRows);
+                FieldDefinition field =
+                    reader.GetFieldDefinition(fieldHandle);
+                MemberAnchor anchor;
+                try
+                {
+                    anchor = ApiMemberIdentity.CreateFieldAnchor(
+                        reader,
+                        type.Handle,
+                        field,
+                        ref anchorWorkRemaining);
+                }
+                catch (Exception ex) when (IsMalformedMetadata(ex))
+                {
+                    NoteIdentityDecodeFailure(
+                        ex,
+                        anchorWorkRemaining,
+                        ref identityDecodeFailures,
+                        ref rejected);
+                    continue;
+                }
+
+                if (anchor != member)
+                {
+                    continue;
+                }
+
+                matches++;
+            }
         }
 
         // A rejected sibling cannot be shown to decode to a different
@@ -185,23 +395,126 @@ static class StructuralCloneMetadataResolution
         if (rejected is not null)
         {
             throw new BadImageFormatException(
-                "A MethodDef could not be inspected while resolving "
+                "A member could not be inspected while resolving "
                     + "the exact seed member.",
                 rejected);
         }
 
-        return matches switch
+        if (matches == 0)
         {
-            0 => new StructuralCloneMemberResolution(
-                default,
-                StructuralCloneMemberResolutionStatus.MemberNotFound),
-            1 => new StructuralCloneMemberResolution(
-                match,
-                StructuralCloneMemberResolutionStatus.Resolved),
-            _ => new StructuralCloneMemberResolution(
-                default,
-                StructuralCloneMemberResolutionStatus.MemberAmbiguous),
-        };
+            return new StructuralCloneMemberBodyResolution(
+                [],
+                StructuralCloneMemberResolutionStatus.MemberNotFound);
+        }
+        if (matches > 1)
+        {
+            return new StructuralCloneMemberBodyResolution(
+                [],
+                StructuralCloneMemberResolutionStatus.MemberAmbiguous);
+        }
+
+        ImmutableArray<MethodDefinitionHandle> methods =
+        [
+            .. bodies
+                .Distinct()
+                .OrderBy(static handle =>
+                    MetadataTokens.GetRowNumber(handle)),
+        ];
+        return methods.IsEmpty
+            ? new StructuralCloneMemberBodyResolution(
+                [],
+                StructuralCloneMemberResolutionStatus
+                    .MemberHasNoMethodBody)
+            : new StructuralCloneMemberBodyResolution(
+                methods,
+                StructuralCloneMemberResolutionStatus.Resolved);
+    }
+
+    static void ChargeMemberRow(ref int inspectedRows)
+    {
+        inspectedRows++;
+        if (inspectedRows
+            > MetadataSafetyPolicy.MaxCorrespondenceMethodRows)
+        {
+            throw new BadImageFormatException(
+                "The exact seed member lookup exceeds the member "
+                    + "row budget.");
+        }
+    }
+
+    static void NoteIdentityDecodeFailure(
+        Exception failure,
+        int anchorWorkRemaining,
+        ref int identityDecodeFailures,
+        ref Exception? rejected)
+    {
+        if (anchorWorkRemaining <= 0)
+        {
+            throw new BadImageFormatException(
+                "The exact seed member lookup exceeds the "
+                    + "anchor-signature work budget.",
+                failure);
+        }
+
+        identityDecodeFailures++;
+        if (identityDecodeFailures
+            >= MetadataSafetyPolicy
+                .MaxClassificationIdentityDecodeFailures)
+        {
+            throw new BadImageFormatException(
+                "The exact seed member lookup exceeds the "
+                    + "member-identity decode failure budget.",
+                failure);
+        }
+
+        rejected ??= failure;
+    }
+
+    /// <summary>
+    /// Records one associated accessor body, rejecting an association that
+    /// does not name a MethodDef the selected type declares.
+    /// </summary>
+    /// <remarks>
+    /// SRM's accessor projection returns the raw <c>MethodSemantics</c>
+    /// method, so an out-of-range row is malformed metadata rather than an
+    /// absent accessor. Being in range is not sufficient: a member of the
+    /// selected type cannot be implemented by a body another type owns, so an
+    /// accessor associated across types is malformed metadata too, not a body
+    /// of the selected member. Declaring-type ownership is read through SRM
+    /// over an image whose TypeDef method ranges
+    /// <see cref="StructuralCloneValidatedImage"/> already established as a
+    /// partition of the MethodDef table, which is what makes that lookup
+    /// answer for exactly one type.
+    /// </remarks>
+    static void AddAccessor(
+        MetadataReader reader,
+        MethodDefinitionHandle handle,
+        TypeDefinitionHandle declaringType,
+        int methodRowCount,
+        ImmutableArray<MethodDefinitionHandle>.Builder bodies)
+    {
+        if (handle.IsNil)
+        {
+            return;
+        }
+
+        int row = MetadataTokens.GetRowNumber(handle);
+        if (row < 1 || row > methodRowCount)
+        {
+            throw new BadImageFormatException(
+                "A MethodSemantics accessor references a MethodDef that "
+                    + "does not exist.");
+        }
+
+        if (reader.GetMethodDefinition(handle).GetDeclaringType()
+            != declaringType)
+        {
+            throw new BadImageFormatException(
+                "A MethodSemantics accessor references a MethodDef that "
+                    + "another type declares.");
+        }
+
+        bodies.Add(handle);
     }
 
     internal static StructuralCloneTypeResolution ResolveType(

--- a/src/DotnetInspector.Queries/StructuralCloneMetadataResolution.cs
+++ b/src/DotnetInspector.Queries/StructuralCloneMetadataResolution.cs
@@ -1,0 +1,626 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>Neutral outcome of one exact TypeDef selection.</summary>
+enum StructuralCloneTypeResolutionStatus
+{
+    Resolved,
+    NotFound,
+    Ambiguous,
+}
+
+/// <summary>Neutral outcome of one exact member selection.</summary>
+enum StructuralCloneMemberResolutionStatus
+{
+    Resolved,
+    TypeNotFound,
+    TypeAmbiguous,
+    MemberNotFound,
+    MemberAmbiguous,
+}
+
+readonly record struct StructuralCloneTypeResolution(
+    TypeDefinitionHandle Handle,
+    StructuralCloneTypeResolutionStatus Status);
+
+readonly record struct StructuralCloneMemberResolution(
+    MethodDefinitionHandle Method,
+    StructuralCloneMemberResolutionStatus Status);
+
+/// <summary>
+/// A metadata reader whose TypeDef method ranges are known to partition the
+/// MethodDef table.
+/// </summary>
+/// <remarks>
+/// Seed, population, and candidate enumeration accept only this type, so the
+/// projection guarantee is established once at image entry rather than
+/// re-derived at each projection site. Three review rounds found holes of
+/// exactly that second shape.
+/// </remarks>
+readonly struct StructuralCloneValidatedImage
+{
+    StructuralCloneValidatedImage(MetadataReader reader) => Reader = reader;
+
+    public MetadataReader Reader { get; }
+
+    public static StructuralCloneValidatedImage Create(PEReader image)
+    {
+        MetadataReader reader = image.GetMetadataReader();
+        StructuralCloneMetadataResolution.ValidateMethodOwnership(reader);
+        return new StructuralCloneValidatedImage(reader);
+    }
+}
+
+/// <summary>
+/// Shared exact TypeDef and member selection over one validated image.
+/// </summary>
+/// <remarks>
+/// Both the single-pair retrieval query and the Workspace clone search bind
+/// owner-issued exact identities to the same retained content, so the bounded
+/// resolution and image-validation rules live here once instead of being
+/// duplicated per query. Callers map the neutral outcomes onto their own
+/// typed failure vocabularies.
+/// </remarks>
+static class StructuralCloneMetadataResolution
+{
+    internal static StructuralCloneMemberResolution ResolveMember(
+        MetadataReader reader,
+        MetadataTypeDefinitionName typeName,
+        MemberAnchor member)
+    {
+        StructuralCloneTypeResolution type =
+            ResolveType(reader, typeName);
+        switch (type.Status)
+        {
+            case StructuralCloneTypeResolutionStatus.NotFound:
+                return new StructuralCloneMemberResolution(
+                    default,
+                    StructuralCloneMemberResolutionStatus.TypeNotFound);
+            case StructuralCloneTypeResolutionStatus.Ambiguous:
+                return new StructuralCloneMemberResolution(
+                    default,
+                    StructuralCloneMemberResolutionStatus.TypeAmbiguous);
+        }
+
+        MethodDefinitionHandle match = default;
+        int matches = 0;
+        int inspectedMethods = 0;
+        int identityDecodeFailures = 0;
+        int anchorWorkRemaining =
+            MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+        Exception? rejected = null;
+        TypeDefinition definition =
+            reader.GetTypeDefinition(type.Handle);
+        var attributeBudget = new AttributeInspectionBudget();
+        bool isExtensionContainer =
+            definition.Attributes.HasFlag(TypeAttributes.Abstract)
+            && definition.Attributes.HasFlag(TypeAttributes.Sealed)
+            && HasExtensionAttribute(
+                reader,
+                definition.GetCustomAttributes(),
+                attributeBudget);
+        foreach (MethodDefinitionHandle methodHandle
+            in definition.GetMethods())
+        {
+            inspectedMethods++;
+            if (inspectedMethods
+                > MetadataSafetyPolicy.MaxCorrespondenceMethodRows)
+            {
+                throw new BadImageFormatException(
+                    "The exact seed member lookup exceeds the MethodDef "
+                        + "row budget.");
+            }
+
+            MethodDefinition method =
+                reader.GetMethodDefinition(methodHandle);
+            MemberAnchor anchor;
+            try
+            {
+                bool isExtensionMethod =
+                    isExtensionContainer
+                    && method.Attributes.HasFlag(
+                        MethodAttributes.Static)
+                    && HasExtensionAttribute(
+                        reader,
+                        method.GetCustomAttributes(),
+                        attributeBudget);
+                anchor = ApiMemberIdentity.CreateMethodAnchorInfo(
+                        reader,
+                        type.Handle,
+                        method,
+                        ref anchorWorkRemaining,
+                        isExtensionMethod)
+                    .Anchor;
+            }
+            catch (Exception ex) when (IsMalformedMetadata(ex))
+            {
+                if (ex is AttributeInspectionBudgetException)
+                {
+                    throw;
+                }
+                if (anchorWorkRemaining <= 0)
+                {
+                    throw new BadImageFormatException(
+                        "The exact seed member lookup exceeds the "
+                            + "anchor-signature work budget.",
+                        ex);
+                }
+                identityDecodeFailures++;
+                if (identityDecodeFailures
+                    >= MetadataSafetyPolicy
+                        .MaxClassificationIdentityDecodeFailures)
+                {
+                    throw new BadImageFormatException(
+                        "The exact seed member lookup exceeds the "
+                            + "method-identity decode failure budget.",
+                        ex);
+                }
+
+                rejected ??= ex;
+                continue;
+            }
+
+            if (anchor != member)
+            {
+                continue;
+            }
+
+            match = methodHandle;
+            matches++;
+        }
+
+        // A rejected sibling cannot be shown to decode to a different
+        // anchor, so a single healthy match does not establish
+        // uniqueness. Surface the metadata failure rather than return a
+        // confident result that a successful decode might have made
+        // ambiguous.
+        if (rejected is not null)
+        {
+            throw new BadImageFormatException(
+                "A MethodDef could not be inspected while resolving "
+                    + "the exact seed member.",
+                rejected);
+        }
+
+        return matches switch
+        {
+            0 => new StructuralCloneMemberResolution(
+                default,
+                StructuralCloneMemberResolutionStatus.MemberNotFound),
+            1 => new StructuralCloneMemberResolution(
+                match,
+                StructuralCloneMemberResolutionStatus.Resolved),
+            _ => new StructuralCloneMemberResolution(
+                default,
+                StructuralCloneMemberResolutionStatus.MemberAmbiguous),
+        };
+    }
+
+    internal static StructuralCloneTypeResolution ResolveType(
+        MetadataReader reader,
+        MetadataTypeDefinitionName name)
+    {
+        TypeDefinitionHandle match = default;
+        int matches = 0;
+        long comparisonWork = Encoding.UTF8.GetByteCount(
+            name.Namespace);
+        foreach (string segment in name.Segments)
+        {
+            comparisonWork +=
+                Encoding.UTF8.GetByteCount(segment);
+        }
+        comparisonWork = Math.Max(comparisonWork, 1);
+        if (comparisonWork
+            > MetadataSafetyPolicy.MaxStructuralSignatureWorkChars)
+        {
+            throw new BadImageFormatException(
+                "The exact TypeDef name exceeds the structural-name "
+                    + "work budget.");
+        }
+        long remainingComparisonWork =
+            MetadataSafetyPolicy.MaxStructuralSignatureWorkChars;
+        int leafUtf8Length = Encoding.UTF8.GetByteCount(
+            name.Segments[^1]);
+        int typeNameDecodeFailures = 0;
+        MetadataTypeNameFailure? rejected = null;
+        foreach (TypeDefinitionHandle candidate
+            in reader.TypeDefinitions)
+        {
+            remainingComparisonWork--;
+            if (remainingComparisonWork < 0)
+            {
+                throw new BadImageFormatException(
+                    "The exact TypeDef lookup exceeded its "
+                        + "structural-name work budget.");
+            }
+
+            int candidateLeafUtf8Length;
+            try
+            {
+                TypeDefinition definition =
+                    reader.GetTypeDefinition(candidate);
+                candidateLeafUtf8Length =
+                    reader.GetBlobReader(definition.Name).Length;
+            }
+            catch (Exception ex) when (IsMalformedMetadata(ex))
+            {
+                NoteTypeNameDecodeFailure(
+                    ref typeNameDecodeFailures,
+                    ex);
+                rejected ??=
+                    MetadataTypeNameFailure.Malformed(
+                        candidate,
+                        ex.Message);
+                continue;
+            }
+
+            remainingComparisonWork -=
+                Math.Max(candidateLeafUtf8Length - 1, 0);
+            if (remainingComparisonWork < 0)
+            {
+                throw new BadImageFormatException(
+                    "The exact TypeDef lookup exceeded its "
+                        + "structural-name work budget.");
+            }
+            if (candidateLeafUtf8Length != leafUtf8Length)
+            {
+                continue;
+            }
+
+            // Matching a leaf walks the whole declaring chain and scans
+            // the walked prefix for cycles, so the comparison this is
+            // about to perform costs far more than the names involved.
+            // Charge that traversal at its ceiling: the leaf length
+            // alone would let a deep shared chain amplify bounded
+            // budget into unbounded work.
+            remainingComparisonWork -=
+                comparisonWork
+                + MetadataSafetyPolicy.MaxRelationshipNodes;
+            if (remainingComparisonWork < 0)
+            {
+                throw new BadImageFormatException(
+                    "The exact TypeDef lookup exceeded its "
+                        + "structural-name work budget.");
+            }
+
+            MetadataTypeDefinitionNameMatchResult result =
+                MetadataTypeDefinitionName.Matches(
+                    reader,
+                    candidate,
+                    name,
+                    out MetadataTypeNameFailure? failure);
+            if (result
+                == MetadataTypeDefinitionNameMatchResult.Rejected)
+            {
+                NoteTypeNameDecodeFailure(
+                    ref typeNameDecodeFailures);
+                rejected ??= failure;
+                continue;
+            }
+            if (result
+                != MetadataTypeDefinitionNameMatchResult.Match)
+            {
+                continue;
+            }
+
+            match = candidate;
+            matches++;
+        }
+
+        if (matches == 0 && rejected is not null)
+        {
+            throw new BadImageFormatException(
+                rejected.Detail);
+        }
+        return matches switch
+        {
+            0 => new StructuralCloneTypeResolution(
+                default,
+                StructuralCloneTypeResolutionStatus.NotFound),
+            1 => new StructuralCloneTypeResolution(
+                match,
+                StructuralCloneTypeResolutionStatus.Resolved),
+            _ => new StructuralCloneTypeResolution(
+                default,
+                StructuralCloneTypeResolutionStatus.Ambiguous),
+        };
+    }
+
+    static void NoteTypeNameDecodeFailure(
+        ref int typeNameDecodeFailures,
+        Exception? inner = null)
+    {
+        typeNameDecodeFailures++;
+        if (typeNameDecodeFailures
+            >= MetadataSafetyPolicy
+                .MaxClassificationIdentityDecodeFailures)
+        {
+            throw new BadImageFormatException(
+                "The exact TypeDef lookup exceeds the "
+                    + "type-name decode failure budget.",
+                inner);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the image's TypeDef method ranges partition the
+    /// MethodDef table exactly once.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Per-projection checks alone are not sufficient. A corrupt
+    /// <c>MethodList</c> start yields an empty range rather than an
+    /// error, which would turn a malformed image into a success-shaped
+    /// empty population, and a corrupt <c>MethodPtr</c> table can alias
+    /// one MethodDef row into two different types without repeating
+    /// within either type's own projection.
+    /// </para>
+    /// <para>
+    /// SRM exposes no raw <c>MethodList</c> column, so the partition is
+    /// checked by construction: no range may report a negative length,
+    /// every projected row must be in range and claimed exactly once,
+    /// and the claimed rows must cover the table. This holds for
+    /// optimized and unoptimized images alike, because a valid
+    /// <c>MethodPtr</c> table is itself a permutation of the MethodDef
+    /// rows.
+    /// </para>
+    /// <para>
+    /// Those requirements bound the raw column jointly, and no one of
+    /// them does it alone. A descending start is not silent: SRM reports
+    /// that range with a negative <c>Count</c> while enumerating
+    /// nothing, so rejecting a negative length is what makes the starts
+    /// non-decreasing. Coverage then supplies the rest, because with the
+    /// starts rising the enumerated total is the projected row count
+    /// less the first non-null start plus one; requiring distinct
+    /// in-range rows that total the MethodDef row count forces that
+    /// first non-null start to row 1 and holds every later start within
+    /// <c>projectionRows + 1</c>. A null start is not part of that
+    /// chain: ECMA-335 II.22.37 permits it and SRM reports its range as
+    /// length zero rather than as the difference to the next start, so
+    /// leading nulls neither rise nor break the ordering. Only a
+    /// *leading* null is expressible, though. Because each run is
+    /// delimited by the following TypeDef's start, a null after a
+    /// populated run would end the preceding run before it began, and
+    /// the negative length lands on that preceding row rather than on
+    /// the null itself. Such a column is malformed and is rejected.
+    /// Neither check
+    /// is redundant: a descending column passes coverage, and a column
+    /// starting past row 1 passes the length check.
+    /// </para>
+    /// <para>
+    /// The projection alone does not prove that permutation, because a
+    /// <c>MethodPtr</c> row that no TypeDef range covers is never
+    /// projected and so is never checked. An unreachable row still
+    /// changes what SRM reports for a reachable method, because
+    /// declaring-type lookup scans <c>MethodPtr</c> for the first row
+    /// naming a MethodDef and can land on the uncovered row. Requiring
+    /// equal row counts closes that gap: with every projected row
+    /// distinct, in range, and covering the MethodDef table, equal
+    /// counts leave no <c>MethodPtr</c> row uncovered.
+    /// </para>
+    /// </remarks>
+    internal static void ValidateMethodOwnership(MetadataReader reader)
+    {
+        if (reader.GetTableRowCount(TableIndex.TypeDef) == 0)
+        {
+            throw new BadImageFormatException(
+                "The image declares no TypeDef rows, so it lacks the "
+                    + "module pseudo-type that owns module-wide "
+                    + "methods.");
+        }
+
+        int methodRows = reader.GetTableRowCount(TableIndex.MethodDef);
+        int methodPtrRows =
+            reader.GetTableRowCount(TableIndex.MethodPtr);
+        if (methodPtrRows != 0 && methodPtrRows != methodRows)
+        {
+            throw new BadImageFormatException(
+                "The MethodPtr table is not a permutation of the "
+                    + "MethodDef table.");
+        }
+
+        var owned = new HashSet<MethodDefinitionHandle>();
+        foreach (TypeDefinitionHandle type in reader.TypeDefinitions)
+        {
+            MethodDefinitionHandleCollection methods =
+                reader.GetTypeDefinition(type).GetMethods();
+
+            // Checked before enumerating, because a negative range
+            // yields no elements rather than an error.
+            if (methods.Count < 0)
+            {
+                throw new BadImageFormatException(
+                    "The TypeDef MethodList column is not a "
+                        + "non-decreasing range in the projected "
+                        + "method table.");
+            }
+
+            foreach (MethodDefinitionHandle method in methods)
+            {
+                ValidateProjectedMethod(method, methodRows, owned);
+            }
+        }
+
+        if (owned.Count != methodRows)
+        {
+            throw new BadImageFormatException(
+                "The TypeDef method ranges do not cover the MethodDef "
+                    + "table exactly once.");
+        }
+    }
+
+    /// <summary>
+    /// Rejects a projected MethodDef row that is out of range or already
+    /// seen, so a malformed projection cannot reach Analysis as an
+    /// untyped argument error.
+    /// </summary>
+    static void ValidateProjectedMethod(
+        MethodDefinitionHandle method,
+        int methodRows,
+        HashSet<MethodDefinitionHandle> projected)
+    {
+        int row = MetadataTokens.GetRowNumber(method);
+        if (row == 0 || row > methodRows)
+        {
+            throw new BadImageFormatException(
+                "A projected MethodDef row falls outside the MethodDef "
+                    + "table.");
+        }
+
+        if (!projected.Add(method))
+        {
+            throw new BadImageFormatException(
+                "The selected method projection repeats a MethodDef "
+                    + "row.");
+        }
+    }
+
+    static bool HasExtensionAttribute(
+        MetadataReader reader,
+        CustomAttributeHandleCollection attributes,
+        AttributeInspectionBudget budget)
+    {
+        budget.Admit(attributes);
+        try
+        {
+            foreach (CustomAttributeHandle attributeHandle
+                in attributes)
+            {
+                CustomAttribute attribute =
+                    reader.GetCustomAttribute(attributeHandle);
+                string? attributeTypeName =
+                    AttributeReader.GetAttributeTypeName(
+                        reader,
+                        attribute.Constructor,
+                        budget.ObserveMaterialization);
+                if (attributeTypeName is null)
+                {
+                    attributeTypeName =
+                        ResolveRejectedAttributeType(
+                            reader,
+                            attribute.Constructor,
+                            budget);
+                }
+
+                if (attributeTypeName
+                    == KnownAttributeNames.ExtensionAttribute)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (AttributeInspectionBudgetSignalException ex)
+        {
+            // Signature decoding converts BadImageFormatException to a
+            // rejection, so the callback uses a private signal until it leaves
+            // that guarded boundary.
+            throw new AttributeInspectionBudgetException(
+                ex.Message,
+                ex);
+        }
+    }
+
+    static string? ResolveRejectedAttributeType(
+        MetadataReader reader,
+        EntityHandle constructor,
+        AttributeInspectionBudget budget)
+    {
+        EntityHandle type = constructor.Kind switch
+        {
+            HandleKind.MemberReference =>
+                reader.GetMemberReference(
+                    (MemberReferenceHandle)constructor).Parent,
+            HandleKind.MethodDefinition =>
+                reader.GetMethodDefinition(
+                    (MethodDefinitionHandle)constructor)
+                    .GetDeclaringType(),
+            _ => default,
+        };
+        if (type.IsNil)
+        {
+            return null;
+        }
+
+        return TypeResolver.ResolveTypeName(reader, type) switch
+        {
+            MetadataTypeNameResult.Resolved resolved =>
+                ChargeResolvedAttributeType(resolved.Value, budget),
+            MetadataTypeNameResult.Absent => null,
+            MetadataTypeNameResult.Rejected rejected =>
+                throw new BadImageFormatException(
+                    rejected.Failure.Detail),
+            _ => throw new InvalidOperationException(
+                "Unknown metadata type-name result."),
+        };
+    }
+
+    static string ChargeResolvedAttributeType(
+        string value,
+        AttributeInspectionBudget budget)
+    {
+        budget.ObserveMaterialization(
+            Encoding.UTF8.GetByteCount(value));
+        return value;
+    }
+
+    internal static bool IsMalformedMetadata(Exception exception)
+        => exception is BadImageFormatException
+            or ArgumentOutOfRangeException
+            or OverflowException;
+
+    sealed class AttributeInspectionBudget
+    {
+        const int MinimumRowCharge = 64;
+        const string ExceededMessage =
+            "The exact seed member lookup exceeds the custom "
+                + "attribute work budget.";
+        int remaining =
+            MetadataSafetyPolicy.MaxStructuralSignatureWorkChars;
+
+        internal void Admit(
+            CustomAttributeHandleCollection attributes)
+            => Charge(
+                (long)attributes.Count * MinimumRowCharge);
+
+        internal void ObserveMaterialization(int work)
+        {
+            long charge = Math.Max(work, 1);
+            if (charge > remaining)
+            {
+                throw new AttributeInspectionBudgetSignalException(
+                    ExceededMessage);
+            }
+
+            remaining -= (int)charge;
+        }
+
+        void Charge(long work)
+        {
+            if (work > remaining)
+            {
+                throw new AttributeInspectionBudgetException(
+                    ExceededMessage);
+            }
+
+            remaining -= (int)work;
+        }
+    }
+
+    sealed class AttributeInspectionBudgetSignalException(string message)
+        : Exception(message);
+
+    sealed class AttributeInspectionBudgetException(
+        string message,
+        Exception? innerException = null)
+        : BadImageFormatException(message, innerException);
+}

--- a/src/DotnetInspector.Queries/WorkspaceStructuralCloneSearchQuery.cs
+++ b/src/DotnetInspector.Queries/WorkspaceStructuralCloneSearchQuery.cs
@@ -2412,8 +2412,6 @@ public static class WorkspaceStructuralCloneSearchQuery
             // The same retrieval is evidence for two owners: the seed it ran
             // for, and the participant whose candidate methods it produced.
             analysisBlockers.Observe(retrieval);
-            bool orientationOrdered =
-                input.Seed is not StructuralCloneSearchSeed.Member;
             bool sameLibrary =
                 ReferenceEquals(
                     candidateIdentity,
@@ -2429,8 +2427,7 @@ public static class WorkspaceStructuralCloneSearchQuery
                         _suppressed++;
                         continue;
                     }
-                    if (orientationOrdered
-                        && seeds.Handles.Contains(candidate.Method.Handle)
+                    if (seeds.Handles.Contains(candidate.Method.Handle)
                         && MetadataTokens.GetRowNumber(seed.Handle)
                             > MetadataTokens.GetRowNumber(
                                 candidate.Method.Handle))

--- a/src/DotnetInspector.Queries/WorkspaceStructuralCloneSearchQuery.cs
+++ b/src/DotnetInspector.Queries/WorkspaceStructuralCloneSearchQuery.cs
@@ -381,7 +381,9 @@ public abstract record StructuralCloneSearchSeed
         public MetadataTypeDefinitionName Definition { get; }
     }
 
-    /// <summary>One exact method body selected by member identity.</summary>
+    /// <summary>
+    /// Every exact method body occupied by one selected member identity.
+    /// </summary>
     public sealed record Member : StructuralCloneSearchSeed
     {
         public Member(
@@ -637,6 +639,13 @@ public enum StructuralCloneSearchFailureKind
     SeedTypeAmbiguous,
     SeedMemberNotFound,
     SeedMemberAmbiguous,
+
+    /// <summary>
+    /// The exact seed member exists but occupies no method body. A property or
+    /// event with no <c>MethodSemantics</c> association, and every field,
+    /// selects an empty seed population rather than an arbitrary body.
+    /// </summary>
+    SeedMemberHasNoMethodBody,
     SeedPopulationLimitReached,
     CandidatePopulationLimitReached,
     ParticipantPopulationLimitReached,
@@ -698,6 +707,12 @@ public sealed record StructuralCloneSearchSeedCoverage(
 /// The seed-candidate pairs this participant charged against the search's
 /// aggregate retrieval budget.
 /// </param>
+/// <param name="AnalysisBlockers">
+/// The distinct Analysis-issued blockers that omitted candidate methods of
+/// this participant, aggregated over every seed and every retrieval chunk run
+/// against it. The blockers are Analysis's own typed evidence, not a string
+/// rendering of it.
+/// </param>
 public sealed record StructuralCloneSearchLibraryCoverage(
     StructuralCloneParticipantIdentity Participant,
     AssemblyContextSubject Subject,
@@ -707,15 +722,27 @@ public sealed record StructuralCloneSearchLibraryCoverage(
     int DiscoveredMethods,
     long RetrievalPairs,
     long NameComparisonWork,
-    ImmutableArray<StructuralCloneSearchFailure> Failures)
+    ImmutableArray<StructuralCloneSearchFailure> Failures,
+    ImmutableArray<StructuralCloneRetrievalBlocker> AnalysisBlockers)
 {
     /// <summary>
     /// The library contributed its complete admitted candidate population.
     /// A library excluded by breadth is complete: breadth is a request
     /// decision, not missing evidence. A library excluded whole by a work
-    /// bound is not: it carries the failure that omitted its pairs.
+    /// bound is not: it carries the failure that omitted its pairs, and
+    /// neither is a candidate body Analysis could not produce, which carries
+    /// its Analysis blocker.
     /// </summary>
-    public bool CoverageIsComplete => Failures.IsEmpty;
+    /// <remarks>
+    /// A seed body Analysis could not produce is not this library's
+    /// incompleteness. It omits no candidate of this participant: the seed
+    /// produced no evidence against any library, which is already visible as
+    /// that seed's own coverage and in the whole result's coverage. Keeping
+    /// the two separate is what lets a reader ask which participant Analysis
+    /// could not fully evaluate.
+    /// </remarks>
+    public bool CoverageIsComplete =>
+        Failures.IsEmpty && AnalysisBlockers.IsEmpty;
 }
 
 /// <summary>Bounded-work receipt for one clone search.</summary>
@@ -1132,7 +1159,8 @@ public static class WorkspaceStructuralCloneSearchQuery
                             .MetadataInspectionFailed,
                         entry.Subject,
                         ex.Message),
-                ]);
+                ],
+                []);
         }
 
         ImmutableArray<StructuralCloneSearchFailure> failures =
@@ -1158,7 +1186,8 @@ public static class WorkspaceStructuralCloneSearchQuery
                         $"Candidate population {population.Methods.Length} "
                             + "exceeds "
                             + $"{search.Limits.MaximumCandidateMethods}; "
-                            + "the library contributed no ranked rows.")));
+                            + "the library contributed no ranked rows.")),
+                []);
         }
 
         long pairs = population.RetrievalPairs;
@@ -1185,9 +1214,11 @@ public static class WorkspaceStructuralCloneSearchQuery
                             + " does not fit the aggregate retrieval budget "
                             + $"of {search.Limits.MaximumRetrievalPairs}; "
                             + "the library was excluded whole and "
-                            + "contributed no ranked rows.")));
+                            + "contributed no ranked rows.")),
+                []);
         }
 
+        var analysisBlockers = new LibraryAnalysisBlockers();
         if (pairs > 0)
         {
             foreach (SeedMethod seed in search.Seeds.Methods)
@@ -1242,7 +1273,8 @@ public static class WorkspaceStructuralCloneSearchQuery
                         identity,
                         entry,
                         group,
-                        retrieval);
+                        retrieval,
+                        analysisBlockers);
                 }
             }
         }
@@ -1256,7 +1288,62 @@ public static class WorkspaceStructuralCloneSearchQuery
             population.Methods.Length,
             pairs,
             population.NameComparisonWork,
-            failures);
+            failures,
+            analysisBlockers.Build());
+    }
+
+    /// <summary>
+    /// The distinct Analysis blockers that omitted candidate methods of one
+    /// participant.
+    /// </summary>
+    /// <remarks>
+    /// One participant is retrieved once per seed and once per candidate
+    /// chunk, and a blocker carries no subject, so an identical kind and
+    /// detail from two retrievals is indistinguishable evidence and is
+    /// recorded once. That keeps the reported blockers bounded by the distinct
+    /// failures Analysis reported rather than by the seed and chunk counts.
+    /// </remarks>
+    sealed class LibraryAnalysisBlockers
+    {
+        readonly ImmutableArray<StructuralCloneRetrievalBlocker>.Builder
+            _blockers =
+                ImmutableArray.CreateBuilder<
+                    StructuralCloneRetrievalBlocker>();
+        readonly HashSet<StructuralCloneRetrievalBlocker> _seen = [];
+
+        internal void Observe(StructuralCloneRetrievalResult retrieval)
+        {
+            foreach (StructuralCloneRetrievalBlocker blocker
+                in retrieval.Blockers)
+            {
+                if (OmitsCandidates(blocker.Kind) && _seen.Add(blocker))
+                {
+                    _blockers.Add(blocker);
+                }
+            }
+        }
+
+        internal ImmutableArray<StructuralCloneRetrievalBlocker> Build()
+            => _blockers.ToImmutable();
+
+        /// <summary>
+        /// Whether one blocker omitted candidate methods of the participant it
+        /// was produced against.
+        /// </summary>
+        /// <remarks>
+        /// A seed-side blocker is excluded: it reports that the seed produced
+        /// no evidence anywhere, which belongs to that seed's coverage. Every
+        /// other blocker reports candidate methods this participant did not
+        /// contribute, so it makes this library's coverage incomplete.
+        /// </remarks>
+        static bool OmitsCandidates(
+            StructuralCloneRetrievalBlockerKind kind)
+            => kind
+                is not StructuralCloneRetrievalBlockerKind.SeedUnsupported
+                and not StructuralCloneRetrievalBlockerKind
+                    .SeedProductionLimit
+                and not StructuralCloneRetrievalBlockerKind
+                    .SeedProductionFailure;
     }
 
     static StructuralCloneSearchLibraryCoverage UnavailableLibrary(
@@ -1278,7 +1365,8 @@ public static class WorkspaceStructuralCloneSearchQuery
                         .CandidateLibraryUnavailable,
                     entry.Subject,
                     $"{failure.Kind}: {failure.Detail}"),
-            ]);
+            ],
+            []);
 
     static StructuralCloneSearchLibraryCoverage ReleasedLibrary(
         StructuralCloneParticipantIdentity identity,
@@ -1302,7 +1390,8 @@ public static class WorkspaceStructuralCloneSearchQuery
                         + "was released before the search could read its "
                         + "immutable image, so it contributed no ranked row: "
                         + failure.Message),
-            ]);
+            ],
+            []);
 
     static SeedPopulation ResolveSeeds(
         PEReader seedImage,
@@ -1313,7 +1402,8 @@ public static class WorkspaceStructuralCloneSearchQuery
             StructuralCloneValidatedImage.Create(seedImage);
         MetadataReader reader = image.Reader;
         TypeDefinitionHandle scope = default;
-        MethodDefinitionHandle exact = default;
+        FrozenSet<MethodDefinitionHandle> exact =
+            FrozenSet<MethodDefinitionHandle>.Empty;
         switch (input.Seed)
         {
             case StructuralCloneSearchSeed.Library:
@@ -1335,8 +1425,12 @@ public static class WorkspaceStructuralCloneSearchQuery
             }
             case StructuralCloneSearchSeed.Member member:
             {
-                StructuralCloneMemberResolution resolved =
-                    StructuralCloneMetadataResolution.ResolveMember(
+                // The Member seed population is every exact method body the
+                // selected member occupies, so a property or event expands to
+                // its associated accessor bodies while an explicit accessor
+                // anchor stays one body.
+                StructuralCloneMemberBodyResolution resolved =
+                    StructuralCloneMetadataResolution.ResolveMemberBodies(
                         reader,
                         member.Definition,
                         member.MemberIdentity);
@@ -1346,7 +1440,7 @@ public static class WorkspaceStructuralCloneSearchQuery
                     return SeedPopulation.Failed(failure);
                 }
 
-                exact = resolved.Method;
+                exact = resolved.Methods.ToFrozenSet();
                 break;
             }
             default:
@@ -1377,7 +1471,7 @@ public static class WorkspaceStructuralCloneSearchQuery
             foreach (MethodDefinitionHandle methodHandle
                 in definition.GetMethods())
             {
-                if (!wholeType && methodHandle != exact)
+                if (!wholeType && !exact.Contains(methodHandle))
                 {
                     continue;
                 }
@@ -1464,7 +1558,7 @@ public static class WorkspaceStructuralCloneSearchQuery
         };
 
     static StructuralCloneSearchFailure? SeedMemberFailure(
-        StructuralCloneMemberResolution resolution,
+        StructuralCloneMemberBodyResolution resolution,
         MetadataTypeDefinitionName name)
         => resolution.Status switch
         {
@@ -1484,10 +1578,16 @@ public static class WorkspaceStructuralCloneSearchQuery
                     StructuralCloneSearchFailureKind.SeedMemberNotFound,
                     null,
                     "The exact seed member does not exist in the selected seed type."),
+            StructuralCloneMemberResolutionStatus.MemberHasNoMethodBody =>
+                new StructuralCloneSearchFailure(
+                    StructuralCloneSearchFailureKind.SeedMemberHasNoMethodBody,
+                    null,
+                    "The exact seed member occupies no method body, so it "
+                        + "supplies no seed method."),
             _ => new StructuralCloneSearchFailure(
                 StructuralCloneSearchFailureKind.SeedMemberAmbiguous,
                 null,
-                "The exact seed member identifies more than one MethodDef."),
+                "The exact seed member identifies more than one member."),
         };
 
     /// <summary>
@@ -1495,6 +1595,11 @@ public static class WorkspaceStructuralCloneSearchQuery
     /// bound, so an artifact-authored name cannot buy unbounded decode or
     /// edit-distance work.
     /// </summary>
+    /// <remarks>
+    /// The decoded name is preserved as decoded. Case folding belongs to
+    /// comparison, not to decoding: folding here would lose the distinction
+    /// between names the product must still treat as exactly equal.
+    /// </remarks>
     static string? DecodeName(
         MetadataReader reader,
         StringHandle handle,
@@ -1513,9 +1618,29 @@ public static class WorkspaceStructuralCloneSearchQuery
 
         return stripArity
             ? MetadataNameArity.StripFromFlattenedName(value)
-                .ToLowerInvariant()
-            : value.ToLowerInvariant();
+            : value;
     }
+
+    /// <summary>
+    /// The invariant case-folded form of one decoded name.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two names are exactly equal under
+    /// <see cref="StringComparison.OrdinalIgnoreCase"/> exactly when their
+    /// folded forms are ordinally equal, because that comparison is defined by
+    /// the same invariant uppercase mapping. Lowercasing is not equivalent:
+    /// Greek capital sigma lowercases to the medial sigma while the final
+    /// sigma lowercases to itself, so a lowercased comparison excludes two
+    /// names the product promises to score <c>1.0</c>.
+    /// </para>
+    /// <para>
+    /// Folding is therefore also the memoization currency: two names that must
+    /// score identically share one cached score vector, and two names that
+    /// must score differently never do.
+    /// </para>
+    /// </remarks>
+    static string Fold(string name) => name.ToUpperInvariant();
 
     static WorkspaceStructuralCloneSearchResult Failed(
         AssemblyContextSubject subject,
@@ -1559,28 +1684,47 @@ public static class WorkspaceStructuralCloneSearchQuery
     {
         internal SeedNameIndex(
             ImmutableArray<string> declaringTypes,
+            ImmutableArray<string> foldedDeclaringTypes,
             ImmutableArray<string> members,
+            ImmutableArray<string> foldedMembers,
             ImmutableArray<SeedNameKey> pairs)
         {
             DeclaringTypes = declaringTypes;
+            FoldedDeclaringTypes = foldedDeclaringTypes;
             Members = members;
+            FoldedMembers = foldedMembers;
             Pairs = pairs;
         }
 
         internal ImmutableArray<string> DeclaringTypes { get; }
+        internal ImmutableArray<string> FoldedDeclaringTypes { get; }
         internal ImmutableArray<string> Members { get; }
+        internal ImmutableArray<string> FoldedMembers { get; }
         internal ImmutableArray<SeedNameKey> Pairs { get; }
     }
 
+    /// <summary>
+    /// Interns the distinct seed names by exact ordinal-ignore-case identity.
+    /// </summary>
+    /// <remarks>
+    /// Two seed names that must score <c>1.0</c> against the same candidates
+    /// are one entry, so a candidate cannot be admitted against one spelling
+    /// of a name and excluded against another spelling of the same name.
+    /// </remarks>
     sealed class SeedNameIndexBuilder
     {
-        readonly Dictionary<string, int> _types = new(StringComparer.Ordinal);
+        readonly Dictionary<string, int> _types =
+            new(StringComparer.OrdinalIgnoreCase);
         readonly Dictionary<string, int> _members =
-            new(StringComparer.Ordinal);
+            new(StringComparer.OrdinalIgnoreCase);
         readonly Dictionary<SeedNameKey, int> _pairs = [];
         readonly ImmutableArray<string>.Builder _typeNames =
             ImmutableArray.CreateBuilder<string>();
+        readonly ImmutableArray<string>.Builder _foldedTypeNames =
+            ImmutableArray.CreateBuilder<string>();
         readonly ImmutableArray<string>.Builder _memberNames =
+            ImmutableArray.CreateBuilder<string>();
+        readonly ImmutableArray<string>.Builder _foldedMemberNames =
             ImmutableArray.CreateBuilder<string>();
         readonly ImmutableArray<SeedNameKey>.Builder _pairList =
             ImmutableArray.CreateBuilder<SeedNameKey>();
@@ -1592,12 +1736,14 @@ public static class WorkspaceStructuralCloneSearchQuery
             {
                 typeIndex = _typeNames.Count;
                 _typeNames.Add(declaringType);
+                _foldedTypeNames.Add(Fold(declaringType));
                 _types.Add(declaringType, typeIndex);
             }
             if (!_members.TryGetValue(member, out int memberIndex))
             {
                 memberIndex = _memberNames.Count;
                 _memberNames.Add(member);
+                _foldedMemberNames.Add(Fold(member));
                 _members.Add(member, memberIndex);
             }
 
@@ -1616,7 +1762,9 @@ public static class WorkspaceStructuralCloneSearchQuery
         internal SeedNameIndex Build()
             => new(
                 _typeNames.ToImmutable(),
+                _foldedTypeNames.ToImmutable(),
                 _memberNames.ToImmutable(),
+                _foldedMemberNames.ToImmutable(),
                 _pairList.ToImmutable());
     }
 
@@ -1642,7 +1790,7 @@ public static class WorkspaceStructuralCloneSearchQuery
             StructuralCloneSearchFailure failure)
             => new(
                 [],
-                new SeedNameIndex([], [], []),
+                new SeedNameIndex([], [], [], [], []),
                 failure);
     }
 
@@ -1709,9 +1857,6 @@ public static class WorkspaceStructuralCloneSearchQuery
         internal long Charged { get; private set; }
         internal bool Exhausted { get; private set; }
 
-        internal bool TryCharge(string left, string right)
-            => TryChargeUnits(((long)left.Length + 1) * (right.Length + 1));
-
         internal bool TryChargeUnits(long work)
         {
             if (Exhausted || work > _remaining)
@@ -1731,13 +1876,22 @@ public static class WorkspaceStructuralCloneSearchQuery
     /// shared by the declaring-type and member name populations.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Retained memory is bounded on both axes a large seed population can
     /// grow: the entry count bounds the retained decoded-name keys, and the
     /// shared cell budget bounds the retained score vectors, which are one
     /// cell per distinct seed name each. A vector that does not fit the
     /// remaining cells whole is not retained, so a partial vector can never be
-    /// served. The cache changes no admission decision: callers check the
-    /// shared name-work budget before consulting it.
+    /// served.
+    /// </para>
+    /// <para>
+    /// The cache changes no admission decision. Callers charge the whole
+    /// logical comparison work of a name before consulting it, so a hit and a
+    /// miss cost the shared budget the same amount and the cache only avoids
+    /// recomputing <see cref="StringDistance"/>. Names are keyed by exact
+    /// ordinal-ignore-case identity, which is the same equivalence the scores
+    /// themselves respect.
+    /// </para>
     /// </remarks>
     sealed class NameScoreCache(long maximumCells, int maximumEntries)
     {
@@ -1745,10 +1899,10 @@ public static class WorkspaceStructuralCloneSearchQuery
         int _remainingEntries = maximumEntries;
 
         internal Dictionary<string, double[]> DeclaringTypes { get; } =
-            new(StringComparer.Ordinal);
+            new(StringComparer.OrdinalIgnoreCase);
 
         internal Dictionary<string, double[]> Members { get; } =
-            new(StringComparer.Ordinal);
+            new(StringComparer.OrdinalIgnoreCase);
 
         internal void Retain(
             Dictionary<string, double[]> cache,
@@ -1851,6 +2005,7 @@ public static class WorkspaceStructuralCloneSearchQuery
                     DiscoveredMethods: 0,
                     RetrievalPairs: 0,
                     NameComparisonWork: 0,
+                    [],
                     []));
         }
 
@@ -1881,7 +2036,8 @@ public static class WorkspaceStructuralCloneSearchQuery
                             kind,
                             entry.Subject,
                             detail),
-                    ]));
+                    ],
+                    []));
         }
 
         internal void AddLibrary(
@@ -1999,6 +2155,7 @@ public static class WorkspaceStructuralCloneSearchQuery
                         : Score(
                             typeName,
                             seeds.Names.DeclaringTypes,
+                            seeds.Names.FoldedDeclaringTypes,
                             cache,
                             cache.DeclaringTypes);
                 foreach (MethodDefinitionHandle methodHandle
@@ -2034,6 +2191,7 @@ public static class WorkspaceStructuralCloneSearchQuery
                         Score(
                             memberName,
                             seeds.Names.Members,
+                            seeds.Names.FoldedMembers,
                             cache,
                             cache.Members);
                     if (memberScores is null)
@@ -2099,18 +2257,59 @@ public static class WorkspaceStructuralCloneSearchQuery
         /// returning null when the bounded name work is exhausted.
         /// </summary>
         /// <remarks>
-        /// The exhausted state is checked before the cache, so a cached vector
-        /// can never continue admission past the shared name-work bound. That
-        /// keeps the cache a pure optimization: changing its capacity cannot
-        /// change which candidates a bounded search admits.
+        /// <para>
+        /// A name exactly equal to a seed name under
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> scores <c>1.0</c>
+        /// at no cost; every other comparison folds both names invariantly and
+        /// charges its edit-distance cells before
+        /// <see cref="StringDistance.Similarity"/> runs.
+        /// </para>
+        /// <para>
+        /// The whole vector's logical work is charged before the cache is
+        /// consulted, and the charge is the same on a hit and on a miss. The
+        /// name-work budget therefore reaches exhaustion at the same candidate
+        /// for every cache capacity, which is what keeps
+        /// <see cref="WorkspaceStructuralCloneSearchLimits.MaximumNameCacheCells"/>
+        /// a pure optimization: it can change how much
+        /// <see cref="StringDistance"/> runs, never which candidates a bounded
+        /// search admits.
+        /// </para>
+        /// <para>
+        /// The charge is also atomic per name. A vector that does not fit the
+        /// remaining budget latches exhaustion instead of admitting the
+        /// candidate on a partially scored vector.
+        /// </para>
         /// </remarks>
         double[]? Score(
             string candidate,
             ImmutableArray<string> seedNames,
+            ImmutableArray<string> foldedSeedNames,
             NameScoreCache cache,
             Dictionary<string, double[]> names)
         {
             if (_nameWork.Exhausted)
+            {
+                return null;
+            }
+
+            string folded = Fold(candidate);
+            long work = 0;
+            for (int index = 0; index < seedNames.Length; index++)
+            {
+                if (string.Equals(
+                        candidate,
+                        seedNames[index],
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                work +=
+                    ((long)folded.Length + 1)
+                    * (foldedSeedNames[index].Length + 1);
+            }
+
+            if (!_nameWork.TryChargeUnits(work))
             {
                 return null;
             }
@@ -2122,19 +2321,15 @@ public static class WorkspaceStructuralCloneSearchQuery
             var scores = new double[seedNames.Length];
             for (int index = 0; index < seedNames.Length; index++)
             {
-                string seedName = seedNames[index];
-                if (string.Equals(candidate, seedName, StringComparison.Ordinal))
-                {
-                    scores[index] = 1.0;
-                    continue;
-                }
-                if (!_nameWork.TryCharge(candidate, seedName))
-                {
-                    return null;
-                }
-
                 scores[index] =
-                    StringDistance.Similarity(candidate, seedName);
+                    string.Equals(
+                        candidate,
+                        seedNames[index],
+                        StringComparison.OrdinalIgnoreCase)
+                        ? 1.0
+                        : StringDistance.Similarity(
+                            folded,
+                            foldedSeedNames[index]);
             }
 
             cache.Retain(names, candidate, scores);
@@ -2207,11 +2402,16 @@ public static class WorkspaceStructuralCloneSearchQuery
             StructuralCloneParticipantIdentity candidateIdentity,
             StructuralCloneParticipantEntry candidateEntry,
             CandidateGroup group,
-            StructuralCloneRetrievalResult retrieval)
+            StructuralCloneRetrievalResult retrieval,
+            LibraryAnalysisBlockers analysisBlockers)
         {
             _retrievalCalls++;
             SeedCoverageState coverage = SeedCoverage(seed);
             coverage.Observe(retrieval);
+
+            // The same retrieval is evidence for two owners: the seed it ran
+            // for, and the participant whose candidate methods it produced.
+            analysisBlockers.Observe(retrieval);
             bool orientationOrdered =
                 input.Seed is not StructuralCloneSearchSeed.Member;
             bool sameLibrary =

--- a/src/DotnetInspector.Queries/WorkspaceStructuralCloneSearchQuery.cs
+++ b/src/DotnetInspector.Queries/WorkspaceStructuralCloneSearchQuery.cs
@@ -1,0 +1,2514 @@
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Which Workspace populations may contribute candidate methods to one
+/// structural-clone search.
+/// </summary>
+public enum StructuralCloneCandidateBreadth
+{
+    /// <summary>The selected subject's containing exact library only.</summary>
+    Self,
+
+    /// <summary>
+    /// <see cref="Self"/> plus every realized participant contributed by an
+    /// ecosystem registration in the bound Workspace revision.
+    /// </summary>
+    SelfAndRegisteredEcosystems,
+
+    /// <summary>
+    /// Every participant realized for the bound Workspace revision.
+    /// </summary>
+    Everything,
+}
+
+/// <summary>
+/// Which methods inside the selected breadth may be ranked against the seeds.
+/// </summary>
+public enum StructuralCloneCandidateDiscovery
+{
+    /// <summary>
+    /// Methods whose decoded declaring-type and member names both qualify
+    /// against at least one seed.
+    /// </summary>
+    SimilarNames,
+
+    /// <summary>Every method in the realized breadth.</summary>
+    All,
+}
+
+/// <summary>
+/// The breadth membership one realized participant carries, as issued by the
+/// Workspace and registration owner.
+/// </summary>
+/// <remarks>
+/// Membership is supplied, never inferred. This query has no registration
+/// lookup, so it cannot recover ecosystem membership from package names,
+/// assembly identities, or provenance.
+/// </remarks>
+public enum StructuralCloneParticipantMembership
+{
+    /// <summary>
+    /// The selected subject's containing exact library. Exactly one snapshot
+    /// entry carries this membership and every breadth admits it.
+    /// </summary>
+    ContainingLibrary,
+
+    /// <summary>
+    /// A participant contributed by an ecosystem registration in the bound
+    /// Workspace revision.
+    /// </summary>
+    RegisteredEcosystem,
+
+    /// <summary>
+    /// A participant available through the bound Workspace revision without
+    /// ecosystem registration.
+    /// </summary>
+    Available,
+}
+
+/// <summary>
+/// One realized participant and the breadth membership its owner issued.
+/// </summary>
+public sealed class StructuralCloneParticipantEntry
+{
+    public StructuralCloneParticipantEntry(
+        AssemblyContextGroup group,
+        AssemblyContextParticipant participant,
+        StructuralCloneParticipantMembership membership)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(participant);
+        if (!Enum.IsDefined(membership))
+        {
+            throw new ArgumentOutOfRangeException(nameof(membership));
+        }
+        if (!group.Participants.Any(
+                candidate => ReferenceEquals(candidate, participant)))
+        {
+            throw new ArgumentException(
+                "The selected participant is not a member of its assembly context group.",
+                nameof(participant));
+        }
+
+        Group = group;
+        Participant = participant;
+        Membership = membership;
+        Subject = new AssemblyContextSubject(participant.Assembly);
+    }
+
+    public AssemblyContextGroup Group { get; }
+    public AssemblyContextParticipant Participant { get; }
+    public StructuralCloneParticipantMembership Membership { get; }
+
+    /// <summary>
+    /// The participant's exact registration, identity, and provenance without
+    /// its content-opening capability.
+    /// </summary>
+    public AssemblyContextSubject Subject { get; }
+
+    internal bool AdmittedBy(StructuralCloneCandidateBreadth breadth)
+        => breadth switch
+        {
+            StructuralCloneCandidateBreadth.Self =>
+                Membership
+                    == StructuralCloneParticipantMembership
+                        .ContainingLibrary,
+            StructuralCloneCandidateBreadth.SelfAndRegisteredEcosystems =>
+                Membership
+                    is StructuralCloneParticipantMembership
+                            .ContainingLibrary
+                        or StructuralCloneParticipantMembership
+                            .RegisteredEcosystem,
+            _ => true,
+        };
+}
+
+/// <summary>
+/// Opaque process-local identity for one immutable clone-search participant
+/// snapshot.
+/// </summary>
+/// <remarks>Equality is reference identity.</remarks>
+public sealed class StructuralCloneParticipantSnapshotIdentity
+{
+    internal StructuralCloneParticipantSnapshotIdentity()
+    {
+    }
+}
+
+/// <summary>
+/// Opaque snapshot-local identity for one participant in one immutable
+/// clone-search participant snapshot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Equality is reference identity. A snapshot issues exactly one identity per
+/// entry, so two entries that carry equal MVIDs, equal MethodDef tokens, equal
+/// retained content, or equal <see cref="AssemblyContextSubject"/> values still
+/// receive distinct identities. This is the endpoint identity component that
+/// keeps two distinct acquisition registrations of the same bytes apart.
+/// </para>
+/// <para>
+/// <see cref="Ordinal"/> is the participant's position in the snapshot's
+/// owner-issued entry order. That order is part of the snapshot's exact
+/// identity: the snapshot owner chooses it, the snapshot validates that it
+/// contains no repeated participant or repeated acquisition registration, and
+/// the search uses it as the snapshot-local total order for deterministic
+/// endpoint tie-breaking. It is meaningful only within
+/// <see cref="Snapshot"/> and carries no cross-snapshot, Workspace, or
+/// registration meaning.
+/// </para>
+/// </remarks>
+public sealed class StructuralCloneParticipantIdentity
+{
+    internal StructuralCloneParticipantIdentity(
+        StructuralCloneParticipantSnapshotIdentity snapshot,
+        int ordinal)
+    {
+        Snapshot = snapshot;
+        Ordinal = ordinal;
+    }
+
+    /// <summary>The snapshot that issued this identity.</summary>
+    public StructuralCloneParticipantSnapshotIdentity Snapshot { get; }
+
+    /// <summary>
+    /// The participant's position in its snapshot's owner-issued entry order.
+    /// </summary>
+    public int Ordinal { get; }
+
+    public override string ToString() => $"participant #{Ordinal}";
+}
+
+/// <summary>
+/// One complete owner-issued participant snapshot and the exact Workspace
+/// revisions it is bound to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Breadth realization belongs to the Workspace and registration owner. This
+/// type is the exact hand-off: the caller supplies the finite realized
+/// participants and their breadth membership, and the search evaluates
+/// candidates only against this snapshot. A later Workspace edit does not
+/// change a bound snapshot.
+/// </para>
+/// <para>
+/// The constructor rejects a snapshot that could carry inconsistent or
+/// duplicated membership: one acquisition registration may appear once, one
+/// participant may appear once, exactly one entry may be the containing
+/// library, and both revisions must come from the same Workspace.
+/// </para>
+/// <para>
+/// The snapshot owns a deterministic snapshot-local endpoint identity order.
+/// The supplied entry order is part of this snapshot's exact identity: it is
+/// captured once, never reordered, and each entry receives one opaque
+/// <see cref="StructuralCloneParticipantIdentity"/> whose ordinal is its
+/// position in that order. Because the constructor rejects a repeated
+/// participant and a repeated acquisition registration, those ordinals are a
+/// total order over distinct registrations, which is what the search uses for
+/// deterministic tie-breaking. The same entry supplied to two snapshots
+/// receives two identities; the ordinal has no meaning outside its snapshot.
+/// </para>
+/// <para>
+/// That an entry's assembly context group was created by the Workspace that
+/// issued the bound revisions is <c>unverified</c>: the group exposes no
+/// owning-Workspace identity, so the snapshot's issuer owns that association.
+/// The issuer also owns lifetime: it must keep every entry's assembly context
+/// group and participant alive for the whole execution the snapshot is passed
+/// to, because a snapshot retains group references rather than immutable
+/// images. Neither obligation is enforced here, and enforcement stays
+/// <c>unverified</c> until the concrete Workspace and registration producer
+/// lands. Premature release is made visible instead of silently changing
+/// results: a released containing library returns
+/// <see cref="StructuralCloneSearchFailureKind.SeedLibraryReleased"/> as a
+/// typed failed result, and a released candidate becomes that library's
+/// <see cref="StructuralCloneSearchFailureKind.CandidateLibraryReleased"/>
+/// incomplete coverage beside the evidence already ranked.
+/// </para>
+/// </remarks>
+public sealed class StructuralCloneParticipantSnapshot
+{
+    public StructuralCloneParticipantSnapshot(
+        WorkspaceScopeRevision startingRevision,
+        WorkspaceScopeRevision effectiveRevision,
+        IEnumerable<StructuralCloneParticipantEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(startingRevision);
+        ArgumentNullException.ThrowIfNull(effectiveRevision);
+        ArgumentNullException.ThrowIfNull(entries);
+        if (!ReferenceEquals(
+                startingRevision.Workspace,
+                effectiveRevision.Workspace))
+        {
+            throw new ArgumentException(
+                "The starting and effective Workspace revisions must come from the same Workspace.",
+                nameof(effectiveRevision));
+        }
+
+        var builder =
+            ImmutableArray.CreateBuilder<
+                StructuralCloneParticipantEntry>();
+        var participants =
+            new HashSet<AssemblyContextParticipant>(
+                ReferenceEqualityComparer.Instance);
+        var registrations =
+            new HashSet<AssemblyAcquisitionRegistration>(
+                ReferenceEqualityComparer.Instance);
+        StructuralCloneParticipantEntry? containing = null;
+        int containingOrdinal = -1;
+        foreach (StructuralCloneParticipantEntry entry in entries)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+            if (!participants.Add(entry.Participant))
+            {
+                throw new ArgumentException(
+                    "A participant may appear only once in a clone-search participant snapshot.",
+                    nameof(entries));
+            }
+            if (!registrations.Add(
+                    entry.Participant.Assembly.Registration))
+            {
+                throw new ArgumentException(
+                    "An acquisition registration may appear only once in a clone-search participant snapshot.",
+                    nameof(entries));
+            }
+            if (entry.Membership
+                == StructuralCloneParticipantMembership
+                    .ContainingLibrary)
+            {
+                if (containing is not null)
+                {
+                    throw new ArgumentException(
+                        "A clone-search participant snapshot has exactly one containing library.",
+                        nameof(entries));
+                }
+
+                containing = entry;
+                containingOrdinal = builder.Count;
+            }
+
+            builder.Add(entry);
+        }
+
+        ContainingLibrary =
+            containing
+            ?? throw new ArgumentException(
+                "A clone-search participant snapshot requires the selected subject's containing library.",
+                nameof(entries));
+        StartingRevision = startingRevision;
+        EffectiveRevision = effectiveRevision;
+        Entries = builder.ToImmutable();
+        Identity = new StructuralCloneParticipantSnapshotIdentity();
+        var identities =
+            ImmutableArray.CreateBuilder<
+                StructuralCloneParticipantIdentity>(Entries.Length);
+        for (int ordinal = 0; ordinal < Entries.Length; ordinal++)
+        {
+            identities.Add(
+                new StructuralCloneParticipantIdentity(Identity, ordinal));
+        }
+
+        ParticipantIdentities = identities.MoveToImmutable();
+        ContainingLibraryIdentity =
+            ParticipantIdentities[containingOrdinal];
+    }
+
+    public StructuralCloneParticipantSnapshotIdentity Identity { get; }
+
+    /// <summary>The exact Workspace revision the request was bound to.</summary>
+    public WorkspaceScopeRevision StartingRevision { get; }
+
+    /// <summary>
+    /// The exact Workspace revision this snapshot was realized against. It may
+    /// differ from <see cref="StartingRevision"/> when bounded discovery,
+    /// resolution, or acquisition committed additional participants.
+    /// </summary>
+    public WorkspaceScopeRevision EffectiveRevision { get; }
+
+    public ImmutableArray<StructuralCloneParticipantEntry> Entries { get; }
+
+    /// <summary>
+    /// One opaque snapshot-local identity per entry, in the snapshot's exact
+    /// owner-issued order and aligned with <see cref="Entries"/>.
+    /// </summary>
+    public ImmutableArray<StructuralCloneParticipantIdentity>
+        ParticipantIdentities
+    { get; }
+
+    /// <summary>The selected subject's containing exact library.</summary>
+    public StructuralCloneParticipantEntry ContainingLibrary { get; }
+
+    /// <summary>
+    /// The snapshot-local identity issued to <see cref="ContainingLibrary"/>.
+    /// </summary>
+    public StructuralCloneParticipantIdentity ContainingLibraryIdentity
+    {
+        get;
+    }
+}
+
+/// <summary>
+/// The exact owner-issued subject that supplies the seed population.
+/// </summary>
+public abstract record StructuralCloneSearchSeed
+{
+    private protected StructuralCloneSearchSeed()
+    {
+    }
+
+    /// <summary>Every MethodDef in the containing exact library.</summary>
+    public sealed record Library : StructuralCloneSearchSeed;
+
+    /// <summary>Every MethodDef declared by one exact type.</summary>
+    public sealed record Type : StructuralCloneSearchSeed
+    {
+        public Type(MetadataTypeDefinitionName definition)
+        {
+            Definition =
+                definition
+                ?? throw new ArgumentNullException(nameof(definition));
+        }
+
+        public MetadataTypeDefinitionName Definition { get; }
+    }
+
+    /// <summary>One exact method body selected by member identity.</summary>
+    public sealed record Member : StructuralCloneSearchSeed
+    {
+        public Member(
+            MetadataTypeDefinitionName type,
+            MemberAnchor member)
+        {
+            Definition =
+                type
+                ?? throw new ArgumentNullException(nameof(type));
+            MemberIdentity =
+                member
+                ?? throw new ArgumentNullException(nameof(member));
+        }
+
+        public MetadataTypeDefinitionName Definition { get; }
+        public MemberAnchor MemberIdentity { get; }
+    }
+}
+
+/// <summary>
+/// Independent result and work bounds for one clone search.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bounds are layered. <see cref="MaximumSeedMethods"/> and
+/// <see cref="MaximumCandidateMethods"/> bound one library's contribution;
+/// <see cref="MaximumParticipants"/> and <see cref="MaximumRetrievalPairs"/>
+/// bound the whole search, because per-library bounds alone permit an
+/// arbitrary number of libraries each contributing a quadratic
+/// seed-by-candidate retrieval population.
+/// </para>
+/// <para>
+/// The two aggregate bounds are discovered at different points, and both are
+/// whole-unit exclusions. <see cref="MaximumParticipants"/> is a preflight
+/// bound: it is decided over the snapshot's exact entry order before any
+/// candidate image is opened. <see cref="MaximumRetrievalPairs"/> is a
+/// whole-participant admission bound: under
+/// <see cref="StructuralCloneCandidateDiscovery.SimilarNames"/> a
+/// participant's pair population is only known while its per-seed candidate
+/// groups are being formed, so admission stops mid-formation and abandons the
+/// participant, and only the latched exhausted state that follows excludes
+/// later participants without opening them. Either way a participant is
+/// evaluated completely or excluded completely with a visible failure, so a
+/// bounded run can never present a partial pair population as a complete
+/// global top N. Every whole-unit exclusion makes coverage incomplete, which
+/// is separate from
+/// <see cref="StructuralCloneSearchReceipt.ResultLimitReached"/>, the
+/// intentional row bound over complete evidence.
+/// </para>
+/// <para>
+/// Name work is bounded three ways: one decoded name may not exceed
+/// <see cref="MaximumNameCharacters"/>, the whole search may not charge more
+/// than <see cref="MaximumNameComparisonWork"/> edit-distance cells, and the
+/// memoized score vectors may not retain more than
+/// <see cref="MaximumNameCacheCells"/> cells. Reaching either work bound is
+/// visible library coverage, never a silently narrowed candidate population;
+/// reaching the cache bound is invisible because the cache is a pure
+/// optimization.
+/// </para>
+/// </remarks>
+/// <param name="MaximumResults">
+/// Intentional returned-row bound, applied only after the global merge.
+/// </param>
+/// <param name="MaximumParticipants">
+/// The greatest number of breadth-admitted participants one search may
+/// evaluate. The containing library is always the first admitted participant;
+/// every later admitted participant beyond this bound is excluded whole.
+/// </param>
+/// <param name="MaximumRetrievalPairs">
+/// The greatest total number of seed-by-candidate retrieval methods one search
+/// may submit to Analysis, summed over every participant and seed.
+/// </param>
+/// <param name="MaximumRetrievalChunkMethods">
+/// The greatest number of candidate methods one <c>RetrieveSimilar</c> call
+/// submits. One seed's candidate group is retrieved in consecutive chunks of
+/// this size so cancellation is observed between bounded units of Analysis
+/// work. Every chunk requests its complete ranked population and the search
+/// merges the chunks into one global ranking, so the chunk size changes only
+/// cancellation granularity and the seed-body production count, never the
+/// ranked rows or the aggregate <see cref="MaximumRetrievalPairs"/> charge.
+/// </param>
+/// <param name="MaximumNameCacheCells">
+/// The greatest number of memoized name-similarity score cells one
+/// participant's decoded-name caches may retain at once, shared by the
+/// declaring-type and member caches. One cached name costs one cell per
+/// distinct seed name, so an entry-count bound alone would let a large seed
+/// population retain gigabytes. A name whose whole score vector does not fit
+/// the remaining cells is scored without being retained.
+/// </param>
+public sealed record WorkspaceStructuralCloneSearchLimits(
+    int MaximumResults = 100,
+    int MaximumSeedMethods = 50_000,
+    int MaximumCandidateMethods = 50_000,
+    int MaximumParticipants = 256,
+    long MaximumRetrievalPairs = 1L << 20,
+    int MaximumRetrievalChunkMethods = 1024,
+    int MaximumNameCharacters = 256,
+    long MaximumNameComparisonWork = 1L << 30,
+    long MaximumNameCacheCells = 1L << 20,
+    StructuralCloneComparisonLimits? ComparisonLimits = null)
+{
+    internal void Validate()
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumResults,
+            1,
+            nameof(MaximumResults));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumSeedMethods,
+            1,
+            nameof(MaximumSeedMethods));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumCandidateMethods,
+            1,
+            nameof(MaximumCandidateMethods));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumParticipants,
+            1,
+            nameof(MaximumParticipants));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumRetrievalPairs,
+            1L,
+            nameof(MaximumRetrievalPairs));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumRetrievalChunkMethods,
+            1,
+            nameof(MaximumRetrievalChunkMethods));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumNameCharacters,
+            1,
+            nameof(MaximumNameCharacters));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumNameComparisonWork,
+            1L,
+            nameof(MaximumNameComparisonWork));
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            MaximumNameCacheCells,
+            1L,
+            nameof(MaximumNameCacheCells));
+    }
+}
+
+/// <summary>The bound request for one Workspace structural-clone search.</summary>
+public sealed record WorkspaceStructuralCloneSearchInput
+{
+    public WorkspaceStructuralCloneSearchInput(
+        StructuralCloneParticipantSnapshot participants,
+        StructuralCloneSearchSeed seed,
+        StructuralCloneCandidateBreadth breadth =
+            StructuralCloneCandidateBreadth.Everything,
+        StructuralCloneCandidateDiscovery discovery =
+            StructuralCloneCandidateDiscovery.SimilarNames,
+        WorkspaceStructuralCloneSearchLimits? limits = null)
+    {
+        Participants =
+            participants
+            ?? throw new ArgumentNullException(nameof(participants));
+        Seed =
+            seed
+            ?? throw new ArgumentNullException(nameof(seed));
+        if (!Enum.IsDefined(breadth))
+        {
+            throw new ArgumentOutOfRangeException(nameof(breadth));
+        }
+        if (!Enum.IsDefined(discovery))
+        {
+            throw new ArgumentOutOfRangeException(nameof(discovery));
+        }
+
+        limits?.Validate();
+        Breadth = breadth;
+        Discovery = discovery;
+        Limits = limits;
+    }
+
+    public StructuralCloneParticipantSnapshot Participants { get; }
+    public StructuralCloneSearchSeed Seed { get; }
+    public StructuralCloneCandidateBreadth Breadth { get; }
+    public StructuralCloneCandidateDiscovery Discovery { get; }
+    public WorkspaceStructuralCloneSearchLimits? Limits { get; }
+}
+
+/// <summary>
+/// One exact method endpoint: the participant that retains the content, its
+/// owner-issued registration identity, and the physical method address.
+/// </summary>
+/// <remarks>
+/// Equal MethodDef tokens in different modules, and equal MVIDs from different
+/// retained contents, do not establish endpoint identity. The opaque
+/// <see cref="Participant"/> identity is issued once per snapshot entry, so
+/// two distinct acquisition registrations of identical bytes remain distinct
+/// endpoints, and the <see cref="Subject"/> reference carries the exact
+/// registration and content association.
+/// </remarks>
+public sealed record StructuralCloneSearchEndpoint
+{
+    internal StructuralCloneSearchEndpoint(
+        StructuralCloneParticipantIdentity participant,
+        StructuralCloneParticipantEntry entry,
+        MetadataMethodAddress method)
+    {
+        Participant = participant;
+        Subject = entry.Subject;
+        Membership = entry.Membership;
+        Method = method;
+    }
+
+    /// <summary>
+    /// The endpoint's opaque snapshot-local participant identity. Its ordinal
+    /// is the snapshot's owner-issued order, which supplies the deterministic
+    /// tie-break order for one search.
+    /// </summary>
+    public StructuralCloneParticipantIdentity Participant { get; }
+
+    public AssemblyContextSubject Subject { get; }
+    public StructuralCloneParticipantMembership Membership { get; }
+    public MetadataMethodAddress Method { get; }
+}
+
+/// <summary>
+/// The decoded-name evidence that admitted one candidate method against the
+/// exact seed it is paired with under
+/// <see cref="StructuralCloneCandidateDiscovery.SimilarNames"/>.
+/// </summary>
+/// <remarks>
+/// Both scores belong to the same seed-candidate pair as the row that carries
+/// them. A candidate admitted by one seed is never ranked against a different
+/// seed that did not itself clear both thresholds.
+/// </remarks>
+public sealed record StructuralCloneNameQualification(
+    double DeclaringTypeSimilarity,
+    double MemberSimilarity);
+
+/// <summary>
+/// One globally ranked pair of exact method bodies and the Analysis-issued
+/// retrieval evidence for that orientation.
+/// </summary>
+/// <remarks>
+/// Retrieval rank is evidence for candidate selection. It is not a checked
+/// clone relation, correspondence, or provenance conclusion.
+/// </remarks>
+public sealed record StructuralCloneSearchPair(
+    int Rank,
+    StructuralCloneSearchEndpoint Left,
+    StructuralCloneSearchEndpoint Right,
+    StructuralCloneSimilarityEvidence Similarity,
+    StructuralCloneNameQualification? NameQualification);
+
+/// <summary>Typed clone-search coverage and target failures.</summary>
+public enum StructuralCloneSearchFailureKind
+{
+    SeedTypeNotFound,
+    SeedTypeAmbiguous,
+    SeedMemberNotFound,
+    SeedMemberAmbiguous,
+    SeedPopulationLimitReached,
+    CandidatePopulationLimitReached,
+    ParticipantPopulationLimitReached,
+    RetrievalWorkLimitReached,
+    CandidateLibraryUnavailable,
+
+    /// <summary>
+    /// The containing library's assembly context group or participant was
+    /// released before the search could read its immutable image. The snapshot
+    /// issuer must retain both for the search's execution.
+    /// </summary>
+    SeedLibraryReleased,
+
+    /// <summary>
+    /// A candidate participant's assembly context group or participant was
+    /// released before the search could read its immutable image. The library
+    /// contributes no ranked row and its coverage is incomplete.
+    /// </summary>
+    CandidateLibraryReleased,
+    MetadataInspectionFailed,
+    NameDecodeFailed,
+    NameWorkLimitReached,
+}
+
+/// <summary>One visible clone-search failure.</summary>
+public sealed record StructuralCloneSearchFailure(
+    StructuralCloneSearchFailureKind Kind,
+    AssemblyContextSubject? Subject,
+    string Detail);
+
+/// <summary>Per-seed coverage for one clone search.</summary>
+public sealed record StructuralCloneSearchSeedCoverage(
+    StructuralCloneSearchEndpoint Seed,
+    StructuralCloneRetrievalDisposition Disposition,
+    int RankedPairs,
+    int SuppressedPairs,
+    ImmutableArray<StructuralCloneRetrievalBlocker> Blockers,
+    ImmutableArray<StructuralCloneSearchFailure> Failures)
+{
+    /// <summary>
+    /// Every admitted candidate of this seed was evaluated. Row limits are a
+    /// separate, intentional result bound.
+    /// </summary>
+    public bool CoverageIsComplete =>
+        Disposition == StructuralCloneRetrievalDisposition.Completed
+        && Blockers.IsEmpty
+        && Failures.IsEmpty;
+}
+
+/// <summary>Per-library coverage for one clone search.</summary>
+/// <param name="Admitted">
+/// The participant passed both admission decisions: the requested breadth and
+/// the search's aggregate work bounds. A per-library outcome after that
+/// point — an unreadable image, malformed metadata, or a rejected candidate
+/// population — leaves this true and is recorded in
+/// <paramref name="Failures"/>.
+/// </param>
+/// <param name="RetrievalPairs">
+/// The seed-candidate pairs this participant charged against the search's
+/// aggregate retrieval budget.
+/// </param>
+public sealed record StructuralCloneSearchLibraryCoverage(
+    StructuralCloneParticipantIdentity Participant,
+    AssemblyContextSubject Subject,
+    StructuralCloneParticipantMembership Membership,
+    bool Admitted,
+    int CandidateMethods,
+    int DiscoveredMethods,
+    long RetrievalPairs,
+    long NameComparisonWork,
+    ImmutableArray<StructuralCloneSearchFailure> Failures)
+{
+    /// <summary>
+    /// The library contributed its complete admitted candidate population.
+    /// A library excluded by breadth is complete: breadth is a request
+    /// decision, not missing evidence. A library excluded whole by a work
+    /// bound is not: it carries the failure that omitted its pairs.
+    /// </summary>
+    public bool CoverageIsComplete => Failures.IsEmpty;
+}
+
+/// <summary>Bounded-work receipt for one clone search.</summary>
+/// <param name="RetrievalPairs">
+/// The seed-by-candidate methods submitted to Analysis, summed over every
+/// participant and seed. It is independent of how those methods were divided
+/// into calls.
+/// </param>
+/// <param name="RetrievalCalls">
+/// The <c>RetrieveSimilar</c> calls the search issued. One seed's candidate
+/// group in one participant is retrieved in bounded chunks, so this counts
+/// chunks, not seed-participant pairs.
+/// </param>
+public sealed record StructuralCloneSearchReceipt(
+    int SeedMethods,
+    int AdmittedLibraries,
+    int ExcludedLibraries,
+    int CandidateMethods,
+    int DiscoveredCandidateMethods,
+    long RetrievalPairs,
+    int RetrievalCalls,
+    int RankedPairs,
+    int SuppressedPairs,
+    int ReturnedPairs,
+    bool ResultLimitReached);
+
+/// <summary>
+/// Typed outcome of one Workspace structural-clone search.
+/// </summary>
+public abstract record WorkspaceStructuralCloneSearchResult
+{
+    private protected WorkspaceStructuralCloneSearchResult()
+    {
+    }
+
+    /// <summary>
+    /// The search ran against the bound participant snapshot. Pairs are one
+    /// global ranking; coverage reports what the ranking is over.
+    /// </summary>
+    public sealed record Available(
+        AssemblyContextSubject SeedSubject,
+        StructuralCloneSearchSeed Seed,
+        StructuralCloneCandidateBreadth Breadth,
+        StructuralCloneCandidateDiscovery Discovery,
+        double NameSimilarityThreshold,
+        WorkspaceStructuralCloneSearchLimits Limits,
+        WorkspaceScopeRevision StartingRevision,
+        WorkspaceScopeRevision EffectiveRevision,
+        StructuralCloneParticipantSnapshotIdentity ParticipantSnapshot,
+        ImmutableArray<StructuralCloneSearchPair> Pairs,
+        ImmutableArray<StructuralCloneSearchSeedCoverage> Seeds,
+        ImmutableArray<StructuralCloneSearchLibraryCoverage> Libraries,
+        StructuralCloneSearchReceipt Receipt)
+        : WorkspaceStructuralCloneSearchResult
+    {
+        /// <summary>
+        /// Every admitted seed and library was evaluated completely. This is
+        /// independent of <see cref="StructuralCloneSearchReceipt.ResultLimitReached"/>,
+        /// which reports intentional row suppression over complete evidence.
+        /// </summary>
+        public bool CoverageIsComplete =>
+            Seeds.All(static seed => seed.CoverageIsComplete)
+            && Libraries.All(
+                static library => library.CoverageIsComplete);
+    }
+
+    /// <summary>The containing library's immutable image could not be acquired.</summary>
+    public sealed record Rejected(
+        AssemblyContextSubject SeedSubject,
+        CandidateOpenFailure Failure)
+        : WorkspaceStructuralCloneSearchResult;
+
+    /// <summary>
+    /// The seed population could not be selected from the containing library.
+    /// </summary>
+    public sealed record Failed(
+        AssemblyContextSubject SeedSubject,
+        StructuralCloneSearchFailure Failure)
+        : WorkspaceStructuralCloneSearchResult;
+}
+
+/// <summary>
+/// Runs one Library, Type, or Member structural-clone search over an exact
+/// caller-supplied participant snapshot, returning one globally ranked bounded
+/// result.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Breadth selects the Workspace population, discovery selects which methods
+/// inside it may be ranked, and the result limit applies only after the global
+/// merge. The query never infers registered-ecosystem membership and never
+/// degrades <see cref="StructuralCloneCandidateBreadth.SelfAndRegisteredEcosystems"/>
+/// to <see cref="StructuralCloneCandidateBreadth.Self"/>: membership arrives
+/// with the snapshot.
+/// </para>
+/// <para>
+/// Ranking currency is Analysis-issued. Cross-image rank remains retrieval
+/// evidence; this query establishes no checked clone relation and produces no
+/// comparison document.
+/// </para>
+/// <para>
+/// The normative contract is
+/// <c>docs/design/structural-clone-search-scope.md</c>.
+/// </para>
+/// </remarks>
+public static class WorkspaceStructuralCloneSearchQuery
+{
+    /// <summary>
+    /// The fixed normalized name-similarity threshold. It follows the existing
+    /// default of <c>TypeMatcher.FindClosest</c> and is not a user control.
+    /// </summary>
+    public const double NameSimilarityThreshold = 0.6;
+
+    /// <summary>
+    /// Maximum decoded candidate names memoized per participant. It bounds the
+    /// retained decoded-name keys;
+    /// <see cref="WorkspaceStructuralCloneSearchLimits.MaximumNameCacheCells"/>
+    /// separately bounds the retained score cells, which grow with the seed
+    /// name population. The cache is an optimization: an exhausted name-work
+    /// budget is checked before a cached vector is returned, so neither bound
+    /// can change admission.
+    /// </summary>
+    const int MaximumNameCacheEntries = 4096;
+
+    public static InspectionQuery<WorkspaceStructuralCloneSearchResult>
+        Definition { get; } =
+            new(
+                "Workspace structural-clone search",
+                InspectionCost.Unbounded);
+
+    public static WorkspaceStructuralCloneSearchResult Execute(
+        WorkspaceStructuralCloneSearchInput input)
+        => Execute(input, CancellationToken.None);
+
+    public static WorkspaceStructuralCloneSearchResult Execute(
+        WorkspaceStructuralCloneSearchInput input,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        StructuralCloneParticipantSnapshot snapshot = input.Participants;
+        StructuralCloneParticipantEntry self = snapshot.ContainingLibrary;
+        WorkspaceStructuralCloneSearchLimits limits =
+            input.Limits ?? new WorkspaceStructuralCloneSearchLimits();
+        limits.Validate();
+
+        AssemblyImageAccessResult<WorkspaceStructuralCloneSearchResult>
+            access;
+        try
+        {
+            access =
+                self.Group.UseSnapshot(
+                    self.Participant,
+                    cancellationToken,
+                    seedSnapshot => ExecuteWithSeedImage(
+                        seedSnapshot,
+                        input,
+                        limits,
+                        cancellationToken));
+        }
+        catch (ObjectDisposedException ex)
+        {
+            // The snapshot issuer owns group and participant lifetime. A
+            // release before execution is a visible typed failure, never an
+            // exception escaping the query or a silently narrowed result. A
+            // candidate release is contained at its own access boundary, so
+            // only the seed's own access can reach this handler.
+            return Failed(
+                self.Subject,
+                StructuralCloneSearchFailureKind.SeedLibraryReleased,
+                "The containing library's assembly context group or "
+                    + "participant was released before the search could read "
+                    + $"its immutable image: {ex.Message}");
+        }
+
+        return access switch
+        {
+            AssemblyImageAccessResult<WorkspaceStructuralCloneSearchResult>
+                .Available available =>
+                    available.Value,
+            AssemblyImageAccessResult<WorkspaceStructuralCloneSearchResult>
+                .Rejected rejected =>
+                    new WorkspaceStructuralCloneSearchResult.Rejected(
+                        self.Subject,
+                        rejected.Failure),
+            _ => throw new InvalidOperationException(
+                "Unknown seed image access result."),
+        };
+    }
+
+    static WorkspaceStructuralCloneSearchResult ExecuteWithSeedImage(
+        AssemblyImageSnapshot seedSnapshot,
+        WorkspaceStructuralCloneSearchInput input,
+        WorkspaceStructuralCloneSearchLimits limits,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        StructuralCloneParticipantSnapshot snapshot = input.Participants;
+        StructuralCloneParticipantEntry self = snapshot.ContainingLibrary;
+        using var seedImage = new PEReader(seedSnapshot.Content);
+        SeedPopulation seeds;
+        try
+        {
+            seeds = ResolveSeeds(seedImage, input, limits);
+        }
+        catch (Exception ex)
+            when (StructuralCloneMetadataResolution
+                .IsMalformedMetadata(ex))
+        {
+            return Failed(
+                self.Subject,
+                StructuralCloneSearchFailureKind.MetadataInspectionFailed,
+                ex.Message);
+        }
+
+        if (seeds.Failure is { } seedFailure)
+        {
+            return new WorkspaceStructuralCloneSearchResult.Failed(
+                self.Subject,
+                seedFailure);
+        }
+
+        var search = new SearchState(input, limits, seeds);
+        FrozenSet<int> beyondParticipantLimit =
+            SelectParticipantsBeyondLimit(snapshot, input.Breadth, limits);
+        for (int index = 0; index < snapshot.Entries.Length; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StructuralCloneParticipantEntry entry =
+                snapshot.Entries[index];
+            StructuralCloneParticipantIdentity identity =
+                snapshot.ParticipantIdentities[index];
+            if (!entry.AdmittedBy(input.Breadth))
+            {
+                search.AddExcludedLibrary(identity, entry);
+                continue;
+            }
+
+            if (beyondParticipantLimit.Contains(index))
+            {
+                search.AddLimitExcludedLibrary(
+                    identity,
+                    entry,
+                    StructuralCloneSearchFailureKind
+                        .ParticipantPopulationLimitReached,
+                    "The breadth-admitted participant population exceeds "
+                        + $"{limits.MaximumParticipants}; this participant "
+                        + "was excluded whole and contributed no ranked "
+                        + "pair.");
+                continue;
+            }
+
+            // The aggregate retrieval bound latches: once one participant's
+            // pair population does not fit, no later participant is opened,
+            // so a bounded run cannot silently interleave partial evidence.
+            if (search.RetrievalBudgetExhausted)
+            {
+                search.AddLimitExcludedLibrary(
+                    identity,
+                    entry,
+                    StructuralCloneSearchFailureKind
+                        .RetrievalWorkLimitReached,
+                    "The aggregate retrieval budget of "
+                        + $"{limits.MaximumRetrievalPairs} seed-candidate "
+                        + "pairs was already exhausted; this participant was "
+                        + "excluded whole and contributed no ranked pair.");
+                continue;
+            }
+
+            if (ReferenceEquals(entry, self))
+            {
+                search.AddLibrary(
+                    SearchParticipant(
+                        search,
+                        identity,
+                        entry,
+                        seedImage,
+                        seedImage,
+                        sameImage: true,
+                        cancellationToken));
+                continue;
+            }
+
+            AssemblyImageAccessResult<
+                StructuralCloneSearchLibraryCoverage> access;
+            try
+            {
+                access =
+                    entry.Group.UseSnapshot(
+                        entry.Participant,
+                        cancellationToken,
+                        candidateSnapshot =>
+                        {
+                            using var candidateImage =
+                                new PEReader(candidateSnapshot.Content);
+                            return SearchParticipant(
+                                search,
+                                identity,
+                                entry,
+                                seedImage,
+                                candidateImage,
+                                sameImage: false,
+                                cancellationToken);
+                        });
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // Group and participant lifetime belongs to the snapshot
+                // issuer. Release is detected before the callback runs, so no
+                // pair was merged and no retrieval budget was reserved for
+                // this participant: the evidence already ranked stays intact
+                // beside this library's visible incomplete coverage.
+                search.AddLibrary(
+                    ReleasedLibrary(identity, entry, ex));
+                continue;
+            }
+
+            search.AddLibrary(
+                access switch
+                {
+                    AssemblyImageAccessResult<
+                        StructuralCloneSearchLibraryCoverage>
+                        .Available available =>
+                            available.Value,
+                    AssemblyImageAccessResult<
+                        StructuralCloneSearchLibraryCoverage>
+                        .Rejected rejected =>
+                            UnavailableLibrary(
+                                identity,
+                                entry,
+                                rejected.Failure),
+                    _ => throw new InvalidOperationException(
+                        "Unknown candidate image access result."),
+                });
+        }
+
+        return search.Complete(self.Subject);
+    }
+
+    /// <summary>
+    /// Preflights the participant bound over the snapshot's exact order,
+    /// returning the snapshot positions excluded whole.
+    /// </summary>
+    /// <remarks>
+    /// The containing library is always the first admitted participant, so a
+    /// bound of one keeps <c>Self</c> rather than whichever entry the snapshot
+    /// owner happened to list first.
+    /// </remarks>
+    static FrozenSet<int> SelectParticipantsBeyondLimit(
+        StructuralCloneParticipantSnapshot snapshot,
+        StructuralCloneCandidateBreadth breadth,
+        WorkspaceStructuralCloneSearchLimits limits)
+    {
+        var excluded = new HashSet<int>();
+        int admitted = 1;
+        for (int index = 0; index < snapshot.Entries.Length; index++)
+        {
+            StructuralCloneParticipantEntry entry =
+                snapshot.Entries[index];
+            if (ReferenceEquals(entry, snapshot.ContainingLibrary)
+                || !entry.AdmittedBy(breadth))
+            {
+                continue;
+            }
+            if (admitted >= limits.MaximumParticipants)
+            {
+                excluded.Add(index);
+                continue;
+            }
+
+            admitted++;
+        }
+
+        return excluded.ToFrozenSet();
+    }
+
+    /// <summary>
+    /// Ranks every seed against its own admitted candidate population inside
+    /// one participant and merges the results into the shared global ranking.
+    /// </summary>
+    static StructuralCloneSearchLibraryCoverage SearchParticipant(
+        SearchState search,
+        StructuralCloneParticipantIdentity identity,
+        StructuralCloneParticipantEntry entry,
+        PEReader seedImage,
+        PEReader candidateImage,
+        bool sameImage,
+        CancellationToken cancellationToken)
+    {
+        CandidatePopulation population;
+        try
+        {
+            population =
+                search.ResolveCandidates(
+                    entry.Subject,
+                    candidateImage,
+                    cancellationToken);
+        }
+        catch (Exception ex)
+            when (StructuralCloneMetadataResolution
+                .IsMalformedMetadata(ex))
+        {
+            return new StructuralCloneSearchLibraryCoverage(
+                identity,
+                entry.Subject,
+                entry.Membership,
+                Admitted: true,
+                CandidateMethods: 0,
+                DiscoveredMethods: 0,
+                RetrievalPairs: 0,
+                NameComparisonWork: 0,
+                [
+                    new StructuralCloneSearchFailure(
+                        StructuralCloneSearchFailureKind
+                            .MetadataInspectionFailed,
+                        entry.Subject,
+                        ex.Message),
+                ]);
+        }
+
+        ImmutableArray<StructuralCloneSearchFailure> failures =
+            population.Failures;
+        if (!population.OverRetrievalBudget
+            && population.Methods.Length
+                > search.Limits.MaximumCandidateMethods)
+        {
+            return new StructuralCloneSearchLibraryCoverage(
+                identity,
+                entry.Subject,
+                entry.Membership,
+                Admitted: true,
+                population.InspectedMethods,
+                population.Methods.Length,
+                RetrievalPairs: 0,
+                population.NameComparisonWork,
+                failures.Add(
+                    new StructuralCloneSearchFailure(
+                        StructuralCloneSearchFailureKind
+                            .CandidatePopulationLimitReached,
+                        entry.Subject,
+                        $"Candidate population {population.Methods.Length} "
+                            + "exceeds "
+                            + $"{search.Limits.MaximumCandidateMethods}; "
+                            + "the library contributed no ranked rows.")));
+        }
+
+        long pairs = population.RetrievalPairs;
+        if (!search.TryReserveRetrievalPairs(pairs))
+        {
+            return new StructuralCloneSearchLibraryCoverage(
+                identity,
+                entry.Subject,
+                entry.Membership,
+                Admitted: false,
+                population.InspectedMethods,
+                population.Methods.Length,
+                RetrievalPairs: 0,
+                population.NameComparisonWork,
+                failures.Add(
+                    new StructuralCloneSearchFailure(
+                        StructuralCloneSearchFailureKind
+                            .RetrievalWorkLimitReached,
+                        entry.Subject,
+                        "The participant's seed-candidate pair population "
+                            + (population.OverRetrievalBudget
+                                ? $"passed {pairs} before admission stopped"
+                                : $"of {pairs}")
+                            + " does not fit the aggregate retrieval budget "
+                            + $"of {search.Limits.MaximumRetrievalPairs}; "
+                            + "the library was excluded whole and "
+                            + "contributed no ranked rows.")));
+        }
+
+        if (pairs > 0)
+        {
+            foreach (SeedMethod seed in search.Seeds.Methods)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CandidateGroup group = population.GroupFor(seed);
+                if (group.Methods.IsEmpty)
+                {
+                    continue;
+                }
+
+                // One seed's candidate group is retrieved in consecutive
+                // bounded chunks so cancellation is observed between units of
+                // Analysis work rather than after one whole-population call.
+                // Each chunk requests its complete ranked population and the
+                // search merges every chunk into the same global ranking, so
+                // the chunk size cannot reorder or drop a row.
+                int chunkSize = search.Limits.MaximumRetrievalChunkMethods;
+                for (int start = 0;
+                    start < group.Methods.Length;
+                    start += chunkSize)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    int length =
+                        Math.Min(
+                            chunkSize,
+                            group.Methods.Length - start);
+                    ImmutableArray<MethodDefinitionHandle> chunk =
+                        group.Methods.Slice(start, length);
+                    var retrievalLimits =
+                        new StructuralCloneRetrievalLimits(
+                            MaximumMethods: search.Limits
+                                .MaximumCandidateMethods,
+                            MaximumResults: length,
+                            ComparisonLimits: search.Limits
+                                .ComparisonLimits);
+                    StructuralCloneRetrievalResult retrieval =
+                        sameImage
+                            ? StructuralCloneAnalysis.RetrieveSimilar(
+                                seedImage,
+                                seed.Handle,
+                                chunk,
+                                retrievalLimits)
+                            : StructuralCloneAnalysis.RetrieveSimilar(
+                                seedImage,
+                                seed.Handle,
+                                candidateImage,
+                                chunk,
+                                retrievalLimits);
+                    search.Merge(
+                        seed,
+                        identity,
+                        entry,
+                        group,
+                        retrieval);
+                }
+            }
+        }
+
+        return new StructuralCloneSearchLibraryCoverage(
+            identity,
+            entry.Subject,
+            entry.Membership,
+            Admitted: true,
+            population.InspectedMethods,
+            population.Methods.Length,
+            pairs,
+            population.NameComparisonWork,
+            failures);
+    }
+
+    static StructuralCloneSearchLibraryCoverage UnavailableLibrary(
+        StructuralCloneParticipantIdentity identity,
+        StructuralCloneParticipantEntry entry,
+        CandidateOpenFailure failure)
+        => new(
+            identity,
+            entry.Subject,
+            entry.Membership,
+            Admitted: true,
+            CandidateMethods: 0,
+            DiscoveredMethods: 0,
+            RetrievalPairs: 0,
+            NameComparisonWork: 0,
+            [
+                new StructuralCloneSearchFailure(
+                    StructuralCloneSearchFailureKind
+                        .CandidateLibraryUnavailable,
+                    entry.Subject,
+                    $"{failure.Kind}: {failure.Detail}"),
+            ]);
+
+    static StructuralCloneSearchLibraryCoverage ReleasedLibrary(
+        StructuralCloneParticipantIdentity identity,
+        StructuralCloneParticipantEntry entry,
+        ObjectDisposedException failure)
+        => new(
+            identity,
+            entry.Subject,
+            entry.Membership,
+            Admitted: true,
+            CandidateMethods: 0,
+            DiscoveredMethods: 0,
+            RetrievalPairs: 0,
+            NameComparisonWork: 0,
+            [
+                new StructuralCloneSearchFailure(
+                    StructuralCloneSearchFailureKind
+                        .CandidateLibraryReleased,
+                    entry.Subject,
+                    "The participant's assembly context group or participant "
+                        + "was released before the search could read its "
+                        + "immutable image, so it contributed no ranked row: "
+                        + failure.Message),
+            ]);
+
+    static SeedPopulation ResolveSeeds(
+        PEReader seedImage,
+        WorkspaceStructuralCloneSearchInput input,
+        WorkspaceStructuralCloneSearchLimits limits)
+    {
+        StructuralCloneValidatedImage image =
+            StructuralCloneValidatedImage.Create(seedImage);
+        MetadataReader reader = image.Reader;
+        TypeDefinitionHandle scope = default;
+        MethodDefinitionHandle exact = default;
+        switch (input.Seed)
+        {
+            case StructuralCloneSearchSeed.Library:
+                break;
+            case StructuralCloneSearchSeed.Type type:
+            {
+                StructuralCloneTypeResolution resolved =
+                    StructuralCloneMetadataResolution.ResolveType(
+                        reader,
+                        type.Definition);
+                if (SeedTypeFailure(resolved, type.Definition)
+                    is { } failure)
+                {
+                    return SeedPopulation.Failed(failure);
+                }
+
+                scope = resolved.Handle;
+                break;
+            }
+            case StructuralCloneSearchSeed.Member member:
+            {
+                StructuralCloneMemberResolution resolved =
+                    StructuralCloneMetadataResolution.ResolveMember(
+                        reader,
+                        member.Definition,
+                        member.MemberIdentity);
+                if (SeedMemberFailure(resolved, member.Definition)
+                    is { } failure)
+                {
+                    return SeedPopulation.Failed(failure);
+                }
+
+                exact = resolved.Method;
+                break;
+            }
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown structural-clone seed '{input.Seed.GetType().Name}'.");
+        }
+
+        bool namesRequired =
+            input.Discovery
+                == StructuralCloneCandidateDiscovery.SimilarNames;
+        var methods = ImmutableArray.CreateBuilder<SeedMethod>();
+        var names = new SeedNameIndexBuilder();
+        foreach (TypeDefinitionHandle typeHandle in reader.TypeDefinitions)
+        {
+            TypeDefinition definition =
+                reader.GetTypeDefinition(typeHandle);
+            bool wholeType =
+                input.Seed is StructuralCloneSearchSeed.Library
+                || typeHandle == scope;
+            if (!wholeType
+                && input.Seed is not StructuralCloneSearchSeed.Member)
+            {
+                continue;
+            }
+
+            string? typeName = null;
+            bool typeNameDecoded = false;
+            foreach (MethodDefinitionHandle methodHandle
+                in definition.GetMethods())
+            {
+                if (!wholeType && methodHandle != exact)
+                {
+                    continue;
+                }
+                if (methods.Count >= limits.MaximumSeedMethods)
+                {
+                    return SeedPopulation.Failed(
+                        new StructuralCloneSearchFailure(
+                            StructuralCloneSearchFailureKind
+                                .SeedPopulationLimitReached,
+                            null,
+                            "The seed population exceeds "
+                                + $"{limits.MaximumSeedMethods} methods."));
+                }
+
+                bool nameAdmitted = true;
+
+                // Under All discovery every seed shares the participant's one
+                // candidate group. Under SimilarNames a seed's group is its
+                // own decoded (declaring type, member) name pair, so a
+                // candidate admitted by one seed is never handed to another.
+                int candidateGroup = 0;
+                if (namesRequired)
+                {
+                    if (!typeNameDecoded)
+                    {
+                        typeNameDecoded = true;
+                        typeName =
+                            DecodeName(
+                                reader,
+                                definition.Name,
+                                limits.MaximumNameCharacters,
+                                stripArity: true);
+                    }
+
+                    string? methodName =
+                        DecodeName(
+                            reader,
+                            reader.GetMethodDefinition(methodHandle).Name,
+                            limits.MaximumNameCharacters,
+                            stripArity: false);
+
+                    // A seed whose own names cannot be decoded admits no
+                    // candidate. That is visible per-seed coverage, not a
+                    // silently narrowed search.
+                    nameAdmitted =
+                        typeName is not null && methodName is not null;
+                    candidateGroup =
+                        nameAdmitted
+                            ? names.Add(typeName!, methodName!)
+                            : SeedMethod.NoCandidateGroup;
+                }
+
+                methods.Add(
+                    new SeedMethod(
+                        methodHandle,
+                        MetadataMethodAddress.Create(
+                            reader,
+                            methodHandle),
+                        nameAdmitted,
+                        candidateGroup));
+            }
+        }
+
+        return SeedPopulation.Resolved(
+            methods.ToImmutable(),
+            names.Build());
+    }
+
+    static StructuralCloneSearchFailure? SeedTypeFailure(
+        StructuralCloneTypeResolution resolution,
+        MetadataTypeDefinitionName name)
+        => resolution.Status switch
+        {
+            StructuralCloneTypeResolutionStatus.Resolved => null,
+            StructuralCloneTypeResolutionStatus.NotFound =>
+                new StructuralCloneSearchFailure(
+                    StructuralCloneSearchFailureKind.SeedTypeNotFound,
+                    null,
+                    $"Type '{name.ToEscapedFullName()}' does not exist."),
+            _ => new StructuralCloneSearchFailure(
+                StructuralCloneSearchFailureKind.SeedTypeAmbiguous,
+                null,
+                $"Type '{name.ToEscapedFullName()}' is ambiguous."),
+        };
+
+    static StructuralCloneSearchFailure? SeedMemberFailure(
+        StructuralCloneMemberResolution resolution,
+        MetadataTypeDefinitionName name)
+        => resolution.Status switch
+        {
+            StructuralCloneMemberResolutionStatus.Resolved => null,
+            StructuralCloneMemberResolutionStatus.TypeNotFound =>
+                new StructuralCloneSearchFailure(
+                    StructuralCloneSearchFailureKind.SeedTypeNotFound,
+                    null,
+                    $"Type '{name.ToEscapedFullName()}' does not exist."),
+            StructuralCloneMemberResolutionStatus.TypeAmbiguous =>
+                new StructuralCloneSearchFailure(
+                    StructuralCloneSearchFailureKind.SeedTypeAmbiguous,
+                    null,
+                    $"Type '{name.ToEscapedFullName()}' is ambiguous."),
+            StructuralCloneMemberResolutionStatus.MemberNotFound =>
+                new StructuralCloneSearchFailure(
+                    StructuralCloneSearchFailureKind.SeedMemberNotFound,
+                    null,
+                    "The exact seed member does not exist in the selected seed type."),
+            _ => new StructuralCloneSearchFailure(
+                StructuralCloneSearchFailureKind.SeedMemberAmbiguous,
+                null,
+                "The exact seed member identifies more than one MethodDef."),
+        };
+
+    /// <summary>
+    /// Decodes one metadata name only when it fits the per-name character
+    /// bound, so an artifact-authored name cannot buy unbounded decode or
+    /// edit-distance work.
+    /// </summary>
+    static string? DecodeName(
+        MetadataReader reader,
+        StringHandle handle,
+        int maximumCharacters,
+        bool stripArity)
+    {
+        int remaining = maximumCharacters;
+        if (!MetadataSafetyPolicy.TryReadTypeNameComponent(
+                reader,
+                handle,
+                ref remaining,
+                out string value))
+        {
+            return null;
+        }
+
+        return stripArity
+            ? MetadataNameArity.StripFromFlattenedName(value)
+                .ToLowerInvariant()
+            : value.ToLowerInvariant();
+    }
+
+    static WorkspaceStructuralCloneSearchResult Failed(
+        AssemblyContextSubject subject,
+        StructuralCloneSearchFailureKind kind,
+        string detail)
+        => new WorkspaceStructuralCloneSearchResult.Failed(
+            subject,
+            new StructuralCloneSearchFailure(kind, subject, detail));
+
+    /// <summary>One resolved seed method and the candidate group it owns.</summary>
+    /// <param name="CandidateGroup">
+    /// The index of this seed's own candidate group inside one participant's
+    /// <see cref="CandidatePopulation"/>. Under
+    /// <see cref="StructuralCloneCandidateDiscovery.All"/> every seed shares
+    /// group <c>0</c>; under
+    /// <see cref="StructuralCloneCandidateDiscovery.SimilarNames"/> it is the
+    /// seed's distinct decoded name pair, or
+    /// <see cref="NoCandidateGroup"/> when the seed's own names could not be
+    /// decoded.
+    /// </param>
+    internal sealed record SeedMethod(
+        MethodDefinitionHandle Handle,
+        MetadataMethodAddress Address,
+        bool NameAdmitted,
+        int CandidateGroup)
+    {
+        internal const int NoCandidateGroup = -1;
+    }
+
+    internal readonly record struct SeedNameKey(
+        int DeclaringTypeIndex,
+        int MemberIndex);
+
+    /// <summary>
+    /// Distinct seed declaring-type and member names plus the exact pairs that
+    /// occur. Both conditions must hold for the same seed, so the pairs are
+    /// kept rather than the two name sets alone, and each pair is one seed
+    /// candidate group.
+    /// </summary>
+    internal sealed class SeedNameIndex
+    {
+        internal SeedNameIndex(
+            ImmutableArray<string> declaringTypes,
+            ImmutableArray<string> members,
+            ImmutableArray<SeedNameKey> pairs)
+        {
+            DeclaringTypes = declaringTypes;
+            Members = members;
+            Pairs = pairs;
+        }
+
+        internal ImmutableArray<string> DeclaringTypes { get; }
+        internal ImmutableArray<string> Members { get; }
+        internal ImmutableArray<SeedNameKey> Pairs { get; }
+    }
+
+    sealed class SeedNameIndexBuilder
+    {
+        readonly Dictionary<string, int> _types = new(StringComparer.Ordinal);
+        readonly Dictionary<string, int> _members =
+            new(StringComparer.Ordinal);
+        readonly Dictionary<SeedNameKey, int> _pairs = [];
+        readonly ImmutableArray<string>.Builder _typeNames =
+            ImmutableArray.CreateBuilder<string>();
+        readonly ImmutableArray<string>.Builder _memberNames =
+            ImmutableArray.CreateBuilder<string>();
+        readonly ImmutableArray<SeedNameKey>.Builder _pairList =
+            ImmutableArray.CreateBuilder<SeedNameKey>();
+
+        /// <summary>Returns the candidate-group index for one seed name pair.</summary>
+        internal int Add(string declaringType, string member)
+        {
+            if (!_types.TryGetValue(declaringType, out int typeIndex))
+            {
+                typeIndex = _typeNames.Count;
+                _typeNames.Add(declaringType);
+                _types.Add(declaringType, typeIndex);
+            }
+            if (!_members.TryGetValue(member, out int memberIndex))
+            {
+                memberIndex = _memberNames.Count;
+                _memberNames.Add(member);
+                _members.Add(member, memberIndex);
+            }
+
+            var key = new SeedNameKey(typeIndex, memberIndex);
+            if (_pairs.TryGetValue(key, out int group))
+            {
+                return group;
+            }
+
+            group = _pairList.Count;
+            _pairList.Add(key);
+            _pairs.Add(key, group);
+            return group;
+        }
+
+        internal SeedNameIndex Build()
+            => new(
+                _typeNames.ToImmutable(),
+                _memberNames.ToImmutable(),
+                _pairList.ToImmutable());
+    }
+
+    internal sealed record SeedPopulation(
+        ImmutableArray<SeedMethod> Methods,
+        SeedNameIndex Names,
+        StructuralCloneSearchFailure? Failure)
+    {
+        internal FrozenSet<MethodDefinitionHandle> Handles { get; init; } =
+            FrozenSet<MethodDefinitionHandle>.Empty;
+
+        internal static SeedPopulation Resolved(
+            ImmutableArray<SeedMethod> methods,
+            SeedNameIndex names)
+            => new(methods, names, null)
+            {
+                Handles = methods
+                    .Select(static method => method.Handle)
+                    .ToFrozenSet(),
+            };
+
+        internal static SeedPopulation Failed(
+            StructuralCloneSearchFailure failure)
+            => new(
+                [],
+                new SeedNameIndex([], [], []),
+                failure);
+    }
+
+    /// <summary>
+    /// One seed candidate group inside one participant: the exact candidate
+    /// methods admitted for that seed, and the name evidence that admitted
+    /// each of them against that seed.
+    /// </summary>
+    internal sealed record CandidateGroup(
+        ImmutableArray<MethodDefinitionHandle> Methods,
+        FrozenDictionary<
+            MethodDefinitionHandle,
+            StructuralCloneNameQualification> Qualifications)
+    {
+        internal static CandidateGroup Empty { get; } =
+            new(
+                [],
+                FrozenDictionary<
+                    MethodDefinitionHandle,
+                    StructuralCloneNameQualification>.Empty);
+    }
+
+    /// <summary>
+    /// The candidate methods one participant contributes, plus the visible
+    /// cost and coverage of producing them.
+    /// </summary>
+    /// <param name="Methods">
+    /// The union of every group's methods, used for the per-library candidate
+    /// bound and coverage. It is not a retrieval population: a seed is only
+    /// ever ranked against its own <see cref="Groups"/> entry.
+    /// </param>
+    /// <param name="RetrievalPairs">
+    /// The exact seed-candidate pairs these groups would submit to Analysis,
+    /// or the running total at the point admission abandoned the participant.
+    /// </param>
+    /// <param name="OverRetrievalBudget">
+    /// Admission stopped because the participant's pair population already
+    /// exceeded the search's remaining aggregate retrieval budget. The groups
+    /// are partial and the participant is excluded whole.
+    /// </param>
+    internal sealed record CandidatePopulation(
+        ImmutableArray<MethodDefinitionHandle> Methods,
+        ImmutableArray<CandidateGroup> Groups,
+        int InspectedMethods,
+        long RetrievalPairs,
+        bool OverRetrievalBudget,
+        long NameComparisonWork,
+        ImmutableArray<StructuralCloneSearchFailure> Failures)
+    {
+        internal CandidateGroup GroupFor(SeedMethod seed)
+            => (uint)seed.CandidateGroup < (uint)Groups.Length
+                ? Groups[seed.CandidateGroup]
+                : CandidateGroup.Empty;
+    }
+
+    /// <summary>
+    /// Charges normalized-similarity work so a hostile name population cannot
+    /// buy quadratic edit-distance work under a bounded request.
+    /// </summary>
+    sealed class NameWorkBudget(long maximum)
+    {
+        long _remaining = maximum;
+
+        internal long Charged { get; private set; }
+        internal bool Exhausted { get; private set; }
+
+        internal bool TryCharge(string left, string right)
+            => TryChargeUnits(((long)left.Length + 1) * (right.Length + 1));
+
+        internal bool TryChargeUnits(long work)
+        {
+            if (Exhausted || work > _remaining)
+            {
+                Exhausted = true;
+                return false;
+            }
+
+            _remaining -= work;
+            Charged += work;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Bounded memoization of decoded-name score vectors for one participant,
+    /// shared by the declaring-type and member name populations.
+    /// </summary>
+    /// <remarks>
+    /// Retained memory is bounded on both axes a large seed population can
+    /// grow: the entry count bounds the retained decoded-name keys, and the
+    /// shared cell budget bounds the retained score vectors, which are one
+    /// cell per distinct seed name each. A vector that does not fit the
+    /// remaining cells whole is not retained, so a partial vector can never be
+    /// served. The cache changes no admission decision: callers check the
+    /// shared name-work budget before consulting it.
+    /// </remarks>
+    sealed class NameScoreCache(long maximumCells, int maximumEntries)
+    {
+        long _remainingCells = maximumCells;
+        int _remainingEntries = maximumEntries;
+
+        internal Dictionary<string, double[]> DeclaringTypes { get; } =
+            new(StringComparer.Ordinal);
+
+        internal Dictionary<string, double[]> Members { get; } =
+            new(StringComparer.Ordinal);
+
+        internal void Retain(
+            Dictionary<string, double[]> cache,
+            string name,
+            double[] scores)
+        {
+            if (_remainingEntries <= 0 || scores.Length > _remainingCells)
+            {
+                return;
+            }
+            if (!cache.TryAdd(name, scores))
+            {
+                return;
+            }
+
+            _remainingEntries--;
+            _remainingCells -= scores.Length;
+        }
+    }
+
+    /// <summary>
+    /// Shared seed population, ranking accumulator, and coverage for one
+    /// search.
+    /// </summary>
+    sealed class SearchState(
+        WorkspaceStructuralCloneSearchInput input,
+        WorkspaceStructuralCloneSearchLimits limits,
+        SeedPopulation seeds)
+    {
+        readonly List<StructuralCloneSearchPair> _rows = [];
+        readonly Dictionary<
+            MethodDefinitionHandle,
+            SeedCoverageState> _seedCoverage = [];
+        readonly List<StructuralCloneSearchLibraryCoverage> _libraries = [];
+        readonly NameWorkBudget _nameWork =
+            new(limits.MaximumNameComparisonWork);
+        readonly int _trimThreshold =
+            (int)Math.Min(
+                (long)limits.MaximumResults * 4L + 64L,
+                1L << 20);
+        int _ranked;
+        int _suppressed;
+        int _retrievalCalls;
+        int _candidateMethods;
+        int _discoveredMethods;
+        int _admittedLibraries;
+        int _excludedLibraries;
+        long _retrievalPairs;
+        long _retrievalPairBudget = limits.MaximumRetrievalPairs;
+
+        /// <summary>
+        /// The seeds sharing each candidate group. One admitted candidate in
+        /// group <c>g</c> costs <c>_seedsPerGroup[g]</c> retrieval pairs, so
+        /// admission can charge the aggregate budget as it builds.
+        /// </summary>
+        readonly int[] _seedsPerGroup = SeedsPerGroup(input, seeds);
+
+        internal WorkspaceStructuralCloneSearchLimits Limits => limits;
+        internal SeedPopulation Seeds => seeds;
+
+        static int[] SeedsPerGroup(
+            WorkspaceStructuralCloneSearchInput input,
+            SeedPopulation seeds)
+        {
+            if (input.Discovery == StructuralCloneCandidateDiscovery.All)
+            {
+                return [seeds.Methods.Length];
+            }
+
+            var counts = new int[seeds.Names.Pairs.Length];
+            foreach (SeedMethod seed in seeds.Methods)
+            {
+                if ((uint)seed.CandidateGroup < (uint)counts.Length)
+                {
+                    counts[seed.CandidateGroup]++;
+                }
+            }
+
+            return counts;
+        }
+
+        /// <summary>
+        /// The aggregate retrieval budget latched. Every remaining admitted
+        /// participant is excluded whole rather than partially evaluated.
+        /// </summary>
+        internal bool RetrievalBudgetExhausted { get; private set; }
+
+        internal void AddExcludedLibrary(
+            StructuralCloneParticipantIdentity identity,
+            StructuralCloneParticipantEntry entry)
+        {
+            _excludedLibraries++;
+            _libraries.Add(
+                new StructuralCloneSearchLibraryCoverage(
+                    identity,
+                    entry.Subject,
+                    entry.Membership,
+                    Admitted: false,
+                    CandidateMethods: 0,
+                    DiscoveredMethods: 0,
+                    RetrievalPairs: 0,
+                    NameComparisonWork: 0,
+                    []));
+        }
+
+        /// <summary>
+        /// Records one whole-unit exclusion forced by an aggregate work bound.
+        /// The failure keeps the omitted pair population visible, so the
+        /// result cannot present itself as a complete global top N.
+        /// </summary>
+        internal void AddLimitExcludedLibrary(
+            StructuralCloneParticipantIdentity identity,
+            StructuralCloneParticipantEntry entry,
+            StructuralCloneSearchFailureKind kind,
+            string detail)
+        {
+            _excludedLibraries++;
+            _libraries.Add(
+                new StructuralCloneSearchLibraryCoverage(
+                    identity,
+                    entry.Subject,
+                    entry.Membership,
+                    Admitted: false,
+                    CandidateMethods: 0,
+                    DiscoveredMethods: 0,
+                    RetrievalPairs: 0,
+                    NameComparisonWork: 0,
+                    [
+                        new StructuralCloneSearchFailure(
+                            kind,
+                            entry.Subject,
+                            detail),
+                    ]));
+        }
+
+        internal void AddLibrary(
+            StructuralCloneSearchLibraryCoverage coverage)
+        {
+            _libraries.Add(coverage);
+            if (!coverage.Admitted)
+            {
+                _excludedLibraries++;
+                return;
+            }
+
+            _admittedLibraries++;
+            _candidateMethods += coverage.CandidateMethods;
+            _discoveredMethods += coverage.DiscoveredMethods;
+        }
+
+        /// <summary>
+        /// Reserves one participant's whole pair population against the
+        /// aggregate budget, latching exhaustion so no later participant is
+        /// opened or partially evaluated.
+        /// </summary>
+        internal bool TryReserveRetrievalPairs(long pairs)
+        {
+            if (RetrievalBudgetExhausted)
+            {
+                return false;
+            }
+            if (pairs > _retrievalPairBudget)
+            {
+                RetrievalBudgetExhausted = true;
+                return false;
+            }
+
+            _retrievalPairBudget -= pairs;
+            _retrievalPairs += pairs;
+            return true;
+        }
+
+        /// <summary>
+        /// Selects the candidate methods one participant contributes, applying
+        /// name discovery before any method body is produced.
+        /// </summary>
+        internal CandidatePopulation ResolveCandidates(
+            AssemblyContextSubject subject,
+            PEReader candidateImage,
+            CancellationToken cancellationToken)
+        {
+            StructuralCloneValidatedImage image =
+                StructuralCloneValidatedImage.Create(candidateImage);
+            MetadataReader reader = image.Reader;
+            if (input.Discovery == StructuralCloneCandidateDiscovery.All)
+            {
+                ImmutableArray<MethodDefinitionHandle> all =
+                    reader.MethodDefinitions.ToImmutableArray();
+                long allPairs = (long)all.Length * _seedsPerGroup[0];
+                return new CandidatePopulation(
+                    all,
+                    [
+                        new CandidateGroup(
+                            all,
+                            FrozenDictionary<
+                                MethodDefinitionHandle,
+                                StructuralCloneNameQualification>.Empty),
+                    ],
+                    all.Length,
+                    allPairs,
+                    allPairs > _retrievalPairBudget,
+                    NameComparisonWork: 0,
+                    []);
+            }
+
+            long chargedBefore = _nameWork.Charged;
+            var union =
+                ImmutableArray.CreateBuilder<MethodDefinitionHandle>();
+            var groups =
+                new CandidateGroupBuilder[seeds.Names.Pairs.Length];
+            for (int group = 0; group < groups.Length; group++)
+            {
+                groups[group] = new CandidateGroupBuilder();
+            }
+
+            var cache =
+                new NameScoreCache(
+                    limits.MaximumNameCacheCells,
+                    MaximumNameCacheEntries);
+            int inspected = 0;
+            int undecodableNames = 0;
+
+            // Group construction charges the aggregate retrieval budget as it
+            // builds, so a hostile name population cannot materialize a
+            // quadratic admitted-pair structure before the bound is checked.
+            long pairs = 0;
+            bool overBudget = false;
+            foreach (TypeDefinitionHandle typeHandle
+                in reader.TypeDefinitions)
+            {
+                if (overBudget)
+                {
+                    break;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                TypeDefinition definition =
+                    reader.GetTypeDefinition(typeHandle);
+                string? typeName =
+                    DecodeName(
+                        reader,
+                        definition.Name,
+                        limits.MaximumNameCharacters,
+                        stripArity: true);
+                double[]? typeScores =
+                    typeName is null
+                        ? null
+                        : Score(
+                            typeName,
+                            seeds.Names.DeclaringTypes,
+                            cache,
+                            cache.DeclaringTypes);
+                foreach (MethodDefinitionHandle methodHandle
+                    in definition.GetMethods())
+                {
+                    inspected++;
+
+                    // An undecodable or unscored name excludes the method
+                    // and stays visible; it never becomes a silent absence.
+                    if (typeName is null)
+                    {
+                        undecodableNames++;
+                        continue;
+                    }
+                    if (typeScores is null)
+                    {
+                        continue;
+                    }
+
+                    string? memberName =
+                        DecodeName(
+                            reader,
+                            reader.GetMethodDefinition(methodHandle).Name,
+                            limits.MaximumNameCharacters,
+                            stripArity: false);
+                    if (memberName is null)
+                    {
+                        undecodableNames++;
+                        continue;
+                    }
+
+                    double[]? memberScores =
+                        Score(
+                            memberName,
+                            seeds.Names.Members,
+                            cache,
+                            cache.Members);
+                    if (memberScores is null)
+                    {
+                        continue;
+                    }
+
+                    if (Qualify(
+                            typeScores,
+                            memberScores,
+                            methodHandle,
+                            groups,
+                            ref pairs,
+                            out overBudget))
+                    {
+                        union.Add(methodHandle);
+                    }
+                    if (overBudget)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            var failures =
+                ImmutableArray.CreateBuilder<
+                    StructuralCloneSearchFailure>();
+            if (undecodableNames > 0)
+            {
+                failures.Add(
+                    new StructuralCloneSearchFailure(
+                        StructuralCloneSearchFailureKind.NameDecodeFailed,
+                        subject,
+                        $"{undecodableNames} candidate methods carry names "
+                            + "that could not be decoded within "
+                            + $"{limits.MaximumNameCharacters} characters; "
+                            + "they were not admitted."));
+            }
+            if (_nameWork.Exhausted)
+            {
+                failures.Add(
+                    new StructuralCloneSearchFailure(
+                        StructuralCloneSearchFailureKind
+                            .NameWorkLimitReached,
+                        subject,
+                        "The name-similarity work budget of "
+                            + $"{limits.MaximumNameComparisonWork} cells was "
+                            + "exhausted; candidate admission is incomplete."));
+            }
+
+            return new CandidatePopulation(
+                union.ToImmutable(),
+                [.. groups.Select(static group => group.Build())],
+                inspected,
+                pairs,
+                overBudget,
+                _nameWork.Charged - chargedBefore,
+                failures.ToImmutable());
+        }
+
+        /// <summary>
+        /// Scores one decoded candidate name against every distinct seed name,
+        /// returning null when the bounded name work is exhausted.
+        /// </summary>
+        /// <remarks>
+        /// The exhausted state is checked before the cache, so a cached vector
+        /// can never continue admission past the shared name-work bound. That
+        /// keeps the cache a pure optimization: changing its capacity cannot
+        /// change which candidates a bounded search admits.
+        /// </remarks>
+        double[]? Score(
+            string candidate,
+            ImmutableArray<string> seedNames,
+            NameScoreCache cache,
+            Dictionary<string, double[]> names)
+        {
+            if (_nameWork.Exhausted)
+            {
+                return null;
+            }
+            if (names.TryGetValue(candidate, out double[]? cached))
+            {
+                return cached;
+            }
+
+            var scores = new double[seedNames.Length];
+            for (int index = 0; index < seedNames.Length; index++)
+            {
+                string seedName = seedNames[index];
+                if (string.Equals(candidate, seedName, StringComparison.Ordinal))
+                {
+                    scores[index] = 1.0;
+                    continue;
+                }
+                if (!_nameWork.TryCharge(candidate, seedName))
+                {
+                    return null;
+                }
+
+                scores[index] =
+                    StringDistance.Similarity(candidate, seedName);
+            }
+
+            cache.Retain(names, candidate, scores);
+            return scores;
+        }
+
+        /// <summary>
+        /// Records one candidate in the group of every seed name pair that
+        /// clears the fixed threshold on both its declaring-type and member
+        /// name, with that pair's own scores as the admission evidence.
+        /// </summary>
+        /// <remarks>
+        /// Admission is per seed-candidate pair. A candidate that qualifies
+        /// only against seed A joins only seed A's group, so seed B never
+        /// retrieves it. A candidate that qualifies against several seeds
+        /// joins each of their groups and is ranked against each of them under
+        /// that pair's own evidence.
+        /// </remarks>
+        /// <returns>
+        /// Whether the candidate joined at least one seed's group.
+        /// </returns>
+        bool Qualify(
+            double[] typeScores,
+            double[] memberScores,
+            MethodDefinitionHandle candidate,
+            CandidateGroupBuilder[] groups,
+            ref long pairs,
+            out bool overBudget)
+        {
+            overBudget = false;
+
+            // The admission scan itself is quadratic in seed and candidate
+            // populations, so it charges the same visible name-work budget as
+            // the edit-distance comparisons.
+            if (!_nameWork.TryChargeUnits(seeds.Names.Pairs.Length + 1))
+            {
+                return false;
+            }
+
+            bool admitted = false;
+            for (int group = 0; group < groups.Length; group++)
+            {
+                SeedNameKey key = seeds.Names.Pairs[group];
+                double type = typeScores[key.DeclaringTypeIndex];
+                double member = memberScores[key.MemberIndex];
+                if (type < NameSimilarityThreshold
+                    || member < NameSimilarityThreshold)
+                {
+                    continue;
+                }
+
+                pairs += _seedsPerGroup[group];
+                if (pairs > _retrievalPairBudget)
+                {
+                    overBudget = true;
+                    return admitted;
+                }
+
+                groups[group].Add(
+                    candidate,
+                    new StructuralCloneNameQualification(type, member));
+                admitted = true;
+            }
+
+            return admitted;
+        }
+
+        internal void Merge(
+            SeedMethod seed,
+            StructuralCloneParticipantIdentity candidateIdentity,
+            StructuralCloneParticipantEntry candidateEntry,
+            CandidateGroup group,
+            StructuralCloneRetrievalResult retrieval)
+        {
+            _retrievalCalls++;
+            SeedCoverageState coverage = SeedCoverage(seed);
+            coverage.Observe(retrieval);
+            bool orientationOrdered =
+                input.Seed is not StructuralCloneSearchSeed.Member;
+            bool sameLibrary =
+                ReferenceEquals(
+                    candidateIdentity,
+                    input.Participants.ContainingLibraryIdentity);
+            foreach (StructuralCloneRetrievalCandidate candidate
+                in retrieval.Candidates)
+            {
+                if (sameLibrary)
+                {
+                    if (candidate.Method.Handle == seed.Handle)
+                    {
+                        coverage.Suppress();
+                        _suppressed++;
+                        continue;
+                    }
+                    if (orientationOrdered
+                        && seeds.Handles.Contains(candidate.Method.Handle)
+                        && MetadataTokens.GetRowNumber(seed.Handle)
+                            > MetadataTokens.GetRowNumber(
+                                candidate.Method.Handle))
+                    {
+                        coverage.Suppress();
+                        _suppressed++;
+                        continue;
+                    }
+                }
+
+                group.Qualifications.TryGetValue(
+                    candidate.Method.Handle,
+                    out StructuralCloneNameQualification? qualification);
+                Add(
+                    new StructuralCloneSearchPair(
+                        Rank: 0,
+                        coverage.Endpoint,
+                        new StructuralCloneSearchEndpoint(
+                            candidateIdentity,
+                            candidateEntry,
+                            candidate.Method),
+                        candidate.Similarity,
+                        qualification));
+                coverage.Rank();
+            }
+        }
+
+        void Add(StructuralCloneSearchPair pair)
+        {
+            _ranked++;
+            _rows.Add(pair);
+            if (_rows.Count >= _trimThreshold
+                && _rows.Count > limits.MaximumResults)
+            {
+                Trim();
+            }
+        }
+
+        void Trim()
+        {
+            _rows.Sort(StructuralCloneSearchPairComparer.Instance);
+            if (_rows.Count > limits.MaximumResults)
+            {
+                _rows.RemoveRange(
+                    limits.MaximumResults,
+                    _rows.Count - limits.MaximumResults);
+            }
+        }
+
+        SeedCoverageState SeedCoverage(SeedMethod seed)
+        {
+            if (!_seedCoverage.TryGetValue(
+                    seed.Handle,
+                    out SeedCoverageState? state))
+            {
+                state =
+                    new SeedCoverageState(
+                        new StructuralCloneSearchEndpoint(
+                            input.Participants.ContainingLibraryIdentity,
+                            input.Participants.ContainingLibrary,
+                            seed.Address),
+                        seed.NameAdmitted
+                            ? []
+                            :
+                            [
+                                new StructuralCloneSearchFailure(
+                                    StructuralCloneSearchFailureKind
+                                        .NameDecodeFailed,
+                                    input.Participants.ContainingLibrary
+                                        .Subject,
+                                    "The seed method's declaring-type or "
+                                        + "member name could not be decoded "
+                                        + "within "
+                                        + $"{limits.MaximumNameCharacters} "
+                                        + "characters, so it admitted no "
+                                        + "candidate by name."),
+                            ]);
+                _seedCoverage.Add(seed.Handle, state);
+            }
+
+            return state;
+        }
+
+        internal WorkspaceStructuralCloneSearchResult Complete(
+            AssemblyContextSubject seedSubject)
+        {
+            Trim();
+            ImmutableArray<StructuralCloneSearchPair> pairs =
+            [
+                .. _rows.Select(
+                    (row, index) => row with { Rank = index + 1 }),
+            ];
+            ImmutableArray<StructuralCloneSearchSeedCoverage> seedCoverage =
+            [
+                .. seeds.Methods.Select(
+                    seed => SeedCoverage(seed).Build()),
+            ];
+            return new WorkspaceStructuralCloneSearchResult.Available(
+                seedSubject,
+                input.Seed,
+                input.Breadth,
+                input.Discovery,
+                NameSimilarityThreshold,
+                limits,
+                input.Participants.StartingRevision,
+                input.Participants.EffectiveRevision,
+                input.Participants.Identity,
+                pairs,
+                seedCoverage,
+                [.. _libraries],
+                new StructuralCloneSearchReceipt(
+                    seeds.Methods.Length,
+                    _admittedLibraries,
+                    _excludedLibraries,
+                    _candidateMethods,
+                    _discoveredMethods,
+                    _retrievalPairs,
+                    _retrievalCalls,
+                    _ranked,
+                    _suppressed,
+                    pairs.Length,
+                    _ranked > pairs.Length));
+        }
+    }
+
+    /// <summary>Accumulates one seed's candidate group for one participant.</summary>
+    sealed class CandidateGroupBuilder
+    {
+        readonly ImmutableArray<MethodDefinitionHandle>.Builder _methods =
+            ImmutableArray.CreateBuilder<MethodDefinitionHandle>();
+        readonly Dictionary<
+            MethodDefinitionHandle,
+            StructuralCloneNameQualification> _qualifications = [];
+
+        internal void Add(
+            MethodDefinitionHandle method,
+            StructuralCloneNameQualification qualification)
+        {
+            _methods.Add(method);
+            _qualifications.Add(method, qualification);
+        }
+
+        internal CandidateGroup Build()
+            => _methods.Count == 0
+                ? CandidateGroup.Empty
+                : new CandidateGroup(
+                    _methods.ToImmutable(),
+                    _qualifications.ToFrozenDictionary());
+    }
+
+    sealed class SeedCoverageState(
+        StructuralCloneSearchEndpoint endpoint,
+        ImmutableArray<StructuralCloneSearchFailure> failures)
+    {
+        readonly ImmutableArray<StructuralCloneRetrievalBlocker>.Builder
+            _blockers =
+                ImmutableArray.CreateBuilder<
+                    StructuralCloneRetrievalBlocker>();
+        readonly HashSet<StructuralCloneRetrievalBlocker> _seenBlockers = [];
+        StructuralCloneRetrievalDisposition _disposition =
+            StructuralCloneRetrievalDisposition.Completed;
+        int _ranked;
+        int _suppressed;
+
+        internal StructuralCloneSearchEndpoint Endpoint => endpoint;
+
+        /// <summary>
+        /// Folds one retrieval outcome into this seed's coverage.
+        /// </summary>
+        /// <remarks>
+        /// One seed observes many retrievals — one per candidate chunk per
+        /// participant — and a blocker carries no subject, so an identical
+        /// kind and detail from two retrievals is indistinguishable evidence.
+        /// It is recorded once, which keeps the reported blockers bounded by
+        /// the distinct failures Analysis reported rather than by the chunk
+        /// and participant counts. The most severe disposition still wins, so
+        /// no failure becomes success-shaped.
+        /// </remarks>
+        internal void Observe(StructuralCloneRetrievalResult retrieval)
+        {
+            if (Severity(retrieval.Disposition) > Severity(_disposition))
+            {
+                _disposition = retrieval.Disposition;
+            }
+
+            foreach (StructuralCloneRetrievalBlocker blocker
+                in retrieval.Blockers)
+            {
+                if (_seenBlockers.Add(blocker))
+                {
+                    _blockers.Add(blocker);
+                }
+            }
+        }
+
+        internal void Rank() => _ranked++;
+
+        internal void Suppress() => _suppressed++;
+
+        internal StructuralCloneSearchSeedCoverage Build()
+            => new(
+                endpoint,
+                _disposition,
+                _ranked,
+                _suppressed,
+                _blockers.ToImmutable(),
+                failures);
+
+        static int Severity(StructuralCloneRetrievalDisposition disposition)
+            => disposition switch
+            {
+                StructuralCloneRetrievalDisposition.Completed => 0,
+                StructuralCloneRetrievalDisposition.Unsupported => 1,
+                StructuralCloneRetrievalDisposition.LimitReached => 2,
+                _ => 3,
+            };
+    }
+
+    /// <summary>
+    /// The single global ranking order: the Analysis score and its existing
+    /// component order, then the exact left and right endpoint identities.
+    /// </summary>
+    /// <remarks>
+    /// Endpoint identity is the snapshot's opaque participant identity and the
+    /// physical method address. The participant ordinal is the snapshot's
+    /// owner-issued snapshot-local order, which is part of that snapshot's
+    /// exact identity; both endpoints of one search always come from the same
+    /// snapshot, so the ordinal is a total order over distinct registrations.
+    /// </remarks>
+    sealed class StructuralCloneSearchPairComparer
+        : IComparer<StructuralCloneSearchPair>
+    {
+        internal static StructuralCloneSearchPairComparer Instance { get; } =
+            new();
+
+        public int Compare(
+            StructuralCloneSearchPair? left,
+            StructuralCloneSearchPair? right)
+        {
+            ArgumentNullException.ThrowIfNull(left);
+            ArgumentNullException.ThrowIfNull(right);
+            int result =
+                right.Similarity.Score.CompareTo(left.Similarity.Score);
+            if (result != 0) return result;
+            result = right.Similarity.OperationScore.CompareTo(
+                left.Similarity.OperationScore);
+            if (result != 0) return result;
+            result = right.Similarity.PositionScore.CompareTo(
+                left.Similarity.PositionScore);
+            if (result != 0) return result;
+            result = right.Similarity.BlockScore.CompareTo(
+                left.Similarity.BlockScore);
+            if (result != 0) return result;
+            result = right.Similarity.EdgeScore.CompareTo(
+                left.Similarity.EdgeScore);
+            if (result != 0) return result;
+            result = right.Similarity.LocalScore.CompareTo(
+                left.Similarity.LocalScore);
+            if (result != 0) return result;
+            result = CompareEndpoints(left.Left, right.Left);
+            return result != 0
+                ? result
+                : CompareEndpoints(left.Right, right.Right);
+        }
+
+        static int CompareEndpoints(
+            StructuralCloneSearchEndpoint left,
+            StructuralCloneSearchEndpoint right)
+        {
+            int result =
+                left.Participant.Ordinal.CompareTo(
+                    right.Participant.Ordinal);
+            return result != 0
+                ? result
+                : MetadataTokens.GetRowNumber(left.Method.Handle)
+                    .CompareTo(
+                        MetadataTokens.GetRowNumber(
+                            right.Method.Handle));
+        }
+    }
+}

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -1187,31 +1187,27 @@ public static class ApiMemberIdentity
         ImmutableArray<string> parameterTypes = [];
         if (property is { } declared)
         {
-            workBudget.ChargeProjectionNodes(
-                type.GetGenericParameters().Count);
-            GenericContext context =
-                GenericContext.ForType(
-                    reader,
-                    type,
-                    workBudget.ChargeProjection);
-            MethodSignature<string> decoded =
-                GuardedSignatureText
-                    .PropertyText(reader, declared, context)
-                    .GetValueOrThrow();
-            EnsureAnchorSignatureBudget(
-                decoded.ReturnType,
-                decoded.ParameterTypes);
+            parameterTypes =
+            [
+                .. ApiSurfaceExtractor
+                    .GetCanonicalPropertyParameterTypes(
+                        reader,
+                        typeHandle,
+                        declared,
+                        text => workBudget.ChargeProjection(text.Length),
+                        workBudget.ChargeProjection)
+                    .Select(NormalizeCanonicalCommas),
+            ];
+            EnsureAnchorSignatureBudget("", parameterTypes);
             workBudget.ChargeProjection(
-                decoded.ReturnType.Length
-                    + decoded.ParameterTypes.Sum(
-                        static parameter => (long)parameter.Length),
+                parameterTypes.Sum(
+                    static parameter => (long)parameter.Length),
                 "property signature projection");
 
             // An indexer's index parameters are part of property identity, so
             // they use the same canonical spelling as the API-surface anchor.
             // An ordinary property decodes zero of them and keeps its bare
             // canonical spelling.
-            parameterTypes = decoded.ParameterTypes;
         }
 
         string typeFullName =

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -1041,6 +1041,206 @@ public static class ApiMemberIdentity
         }
     }
 
+    /// <summary>
+    /// Creates the anchor of one property declared by
+    /// <paramref name="typeHandle"/>, drawing from the same caller-owned
+    /// cumulative work counter as the method anchor producers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An ordinary property's canonical signature is <c>P:{type}.{name}</c>:
+    /// its return type is not part of member identity. An indexer is a
+    /// property that overloads on its index parameters, so those parameters
+    /// are part of its identity and the canonical signature becomes
+    /// <c>P:{type}.{name}({parameters})</c>. This is the same discrimination
+    /// the surface producer performs, so two overloaded indexers do not
+    /// collide on one identity and get selected by declaration order.
+    /// </para>
+    /// <para>
+    /// The parameters are decoded through the same guarded C#-spelling
+    /// projection as the API surface, then charged to this producer's
+    /// caller-owned work budget. The resulting anchor therefore matches the
+    /// owner-issued surface anchor that a selected Member carries while still
+    /// rejecting an unsafe or undecodable signature.
+    /// </para>
+    /// </remarks>
+    public static MemberAnchor CreatePropertyAnchor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        PropertyDefinition property,
+        ref int scanWorkRemaining)
+        => CreateNonMethodAnchor(
+            reader,
+            typeHandle,
+            property.Name,
+            "P",
+            property,
+            ref scanWorkRemaining);
+
+    /// <summary>
+    /// Creates the anchor of one event declared by
+    /// <paramref name="typeHandle"/>, drawing from the same caller-owned
+    /// cumulative work counter as the method anchor producers.
+    /// </summary>
+    /// <remarks>
+    /// An event's canonical signature is <c>E:{type}.{name}</c> and its
+    /// handler type is not part of member identity, so no signature is
+    /// decoded. An event carries no parameter list to overload on, so unlike a
+    /// property this identity cannot grow one.
+    /// </remarks>
+    public static MemberAnchor CreateEventAnchor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        EventDefinition eventDefinition,
+        ref int scanWorkRemaining)
+        => CreateNonMethodAnchor(
+            reader,
+            typeHandle,
+            eventDefinition.Name,
+            "E",
+            property: null,
+            ref scanWorkRemaining);
+
+    /// <summary>
+    /// Creates the anchor of one field declared by
+    /// <paramref name="typeHandle"/>, drawing from the same caller-owned
+    /// cumulative work counter as the method anchor producers.
+    /// </summary>
+    /// <remarks>
+    /// A field's canonical signature is <c>F:{type}.{name}</c>, matching the
+    /// anchor the surface producer issues for kind <c>"field"</c>. A field
+    /// cannot be overloaded, so its type is not part of member identity and no
+    /// signature is decoded — the same reason an event decodes none.
+    /// A field is a supported Member subject that occupies no method body, so
+    /// a consumer resolving bodies needs this anchor to tell a field that
+    /// exists apart from a member that does not.
+    /// </remarks>
+    public static MemberAnchor CreateFieldAnchor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        FieldDefinition field,
+        ref int scanWorkRemaining)
+        => CreateNonMethodAnchor(
+            reader,
+            typeHandle,
+            field.Name,
+            "F",
+            property: null,
+            ref scanWorkRemaining);
+
+    static MemberAnchor CreateNonMethodAnchor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        StringHandle nameHandle,
+        string kind,
+        PropertyDefinition? property,
+        ref int scanWorkRemaining)
+    {
+        if (scanWorkRemaining <= 0)
+        {
+            throw new BadImageFormatException(
+                "The assembly exceeds the classification scan work budget.");
+        }
+
+        int anchorAllowance = scanWorkRemaining;
+        if (anchorAllowance > MetadataSafetyPolicy.MaxAnchorSignatureWorkChars)
+            anchorAllowance = MetadataSafetyPolicy.MaxAnchorSignatureWorkChars;
+
+        var workBudget = new AnchorSignatureWorkBudget(
+            anchorAllowance,
+            chargeProjectionWork: true);
+        try
+        {
+            MemberAnchor anchor = CreateNonMethodAnchorShape(
+                reader,
+                typeHandle,
+                nameHandle,
+                kind,
+                property,
+                workBudget);
+            int spent = anchorAllowance - workBudget.Remaining;
+            scanWorkRemaining -= spent;
+            if (scanWorkRemaining < 0)
+                scanWorkRemaining = 0;
+            return anchor;
+        }
+        catch (BadImageFormatException)
+        {
+            scanWorkRemaining = workBudget.Remaining;
+            throw;
+        }
+    }
+
+    static MemberAnchor CreateNonMethodAnchorShape(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        StringHandle nameHandle,
+        string kind,
+        PropertyDefinition? property,
+        AnchorSignatureWorkBudget workBudget)
+    {
+        var type = reader.GetTypeDefinition(typeHandle);
+        string memberName = ReadProjectionString(
+            reader,
+            nameHandle,
+            workBudget);
+        ImmutableArray<string> parameterTypes = [];
+        if (property is { } declared)
+        {
+            workBudget.ChargeProjectionNodes(
+                type.GetGenericParameters().Count);
+            GenericContext context =
+                GenericContext.ForType(
+                    reader,
+                    type,
+                    workBudget.ChargeProjection);
+            MethodSignature<string> decoded =
+                GuardedSignatureText
+                    .PropertyText(reader, declared, context)
+                    .GetValueOrThrow();
+            EnsureAnchorSignatureBudget(
+                decoded.ReturnType,
+                decoded.ParameterTypes);
+            workBudget.ChargeProjection(
+                decoded.ReturnType.Length
+                    + decoded.ParameterTypes.Sum(
+                        static parameter => (long)parameter.Length),
+                "property signature projection");
+
+            // An indexer's index parameters are part of property identity, so
+            // they use the same canonical spelling as the API-surface anchor.
+            // An ordinary property decodes zero of them and keeps its bare
+            // canonical spelling.
+            parameterTypes = decoded.ParameterTypes;
+        }
+
+        string typeFullName =
+            FormatDefinitionName(reader, typeHandle, workBudget);
+        ChargeCanonicalSignatureProjection(
+            workBudget,
+            typeFullName,
+            memberName,
+            parameterTypes,
+            conversionReturnType: null);
+        string canonicalSignature = MemberCanonicalSignature.Build(
+            kind,
+            typeFullName,
+            memberName,
+            parameterTypes);
+        ChargeSelectorProjection(workBudget, memberName);
+
+        // A property, event, or field selector is its own name for every
+        // accessibility and for explicit interface implementations, matching
+        // the surface producer's selector for kind "property", "event", and
+        // "field".
+        return CreateAnchor(
+            typeFullName,
+            memberName,
+            memberName,
+            canonicalSignature,
+            workBudget);
+    }
+
     public static ExtensionMemberAnchorInfo CreateExtensionMethodAnchorInfo(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,
@@ -1318,6 +1518,24 @@ public static class ApiMemberIdentity
                     throw AnchorSignatureBudgetExceeded();
                 remaining -= parameter.Length;
             }
+        }
+    }
+
+    static void EnsureAnchorSignatureBudget(
+        string returnType,
+        ImmutableArray<string> parameters)
+    {
+        int remaining =
+            MetadataSafetyPolicy.MaxStructuralSignatureChars
+            - returnType.Length;
+        if (remaining < 0)
+            throw AnchorSignatureBudgetExceeded();
+
+        foreach (string parameter in parameters)
+        {
+            if (parameter.Length > remaining)
+                throw AnchorSignatureBudgetExceeded();
+            remaining -= parameter.Length;
         }
     }
 

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -1196,6 +1196,7 @@ public static class ApiMemberIdentity
                         declared,
                         text => workBudget.ChargeProjection(text.Length),
                         workBudget.ChargeProjection)
+                    .Select(XmlDocumentationNotation.NormalizeDynamicToObject)
                     .Select(NormalizeCanonicalCommas),
             ];
             EnsureAnchorSignatureBudget("", parameterTypes);

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -4828,93 +4828,15 @@ public static class ApiSurfaceExtractor
                     parameterAccessorMethod.GetCustomAttributes(),
                     beforeDecodeWork)
                 ?? typeNullableContext;
-        var paramTypes = treeSignature.ParameterTypes;
-        List<string> indexerParameters = [];
-        List<ApiParameter> parameterModels = [];
-        var parameterInfos = Enumerable.Range(1, paramTypes.Length)
-            .Select(sequenceNumber => GetParameterInfo(
+        (List<string> indexerParameters, List<ApiParameter> parameterModels) =
+            ProjectPropertyParameters(
                 reader,
+                treeSignature.ParameterTypes,
                 paramHandles,
-                sequenceNumber,
+                parameterNullableContext,
                 beforeRetainText,
-                attributeMaterialize))
-            .ToArray();
-        string[] parameterNames = CSharpParameterNames.Allocate(
-            parameterInfos.Select(info => info.name).ToArray());
-        for (var i = 0; i < paramTypes.Length; i++)
-        {
-            var paramBytes = NullabilityReader.GetParameterNullableBytes(
-                reader,
-                paramHandles,
-                i + 1,
-                beforeDecodeWork);
-            pos = 0;
-            paramTypes[i].ApplyNullability(paramBytes, ref pos, parameterNullableContext);
-            var paramDynamicFlags = DynamicReader.GetParameterDynamicFlags(
-                reader,
-                paramHandles,
-                i + 1,
-                beforeDecodeWork);
-            pos = 0;
-            paramTypes[i].ApplyDynamic(paramDynamicFlags, ref pos);
-            paramTypes[i].ApplyTupleNames(
-                TupleElementNamesReader.GetParameterTupleElementNames(
-                    reader,
-                    paramHandles,
-                    i + 1,
-                    beforeDecodeWork));
-            var paramType = paramTypes[i].Render();
-            var canonicalParamType = paramTypes[i].RenderCanonical();
-            var (_, isParams, refKind, hasDefault, defaultValue, attributes) =
-                parameterInfos[i];
-            var isByRef = paramType.StartsWith("ref ", StringComparison.Ordinal);
-            if (isByRef)
-            {
-                paramType = paramType["ref ".Length..];
-                canonicalParamType = canonicalParamType["ref ".Length..];
-                refKind ??= "ref";
-            }
-            else
-            {
-                refKind = null;
-            }
-
-            var modifier = isParams ? "params" : refKind;
-            bool acceptsNullDefault = AcceptsNullDefault(paramTypes[i]);
-            string? defaultValueText = DefaultValueText(
-                reader,
-                defaultValue,
-                paramType,
-                hasDefault,
-                acceptsNullDefault,
-                beforeDecodeWork);
-            var parameter = FormatParameter(
-                paramType,
-                parameterNames[i],
-                modifier,
-                hasDefault,
-                defaultValue,
-                defaultValueText);
-            beforeRetainText?.Invoke(parameter);
-            var parameterModel = new ApiParameter
-            {
-                Attributes = attributes,
-                Name = parameterNames[i],
-                Type = paramType,
-                CanonicalType = canonicalParamType,
-                StructuralType = paramTypes[i].HasStructuralPayload
-                    ? paramTypes[i].StructuralIdentity()
-                    : null,
-                TypeReferences =
-                    [.. paramTypes[i].ReferencedTypes().Distinct()],
-                Modifier = modifier,
-                HasDefault = hasDefault,
-                DefaultValueText = defaultValueText
-            };
-            ObserveText(parameterModel, beforeRetainText);
-            indexerParameters.Add(parameter);
-            parameterModels.Add(parameterModel);
-        }
+                beforeDecodeWork,
+                attributeMaterialize);
 
         var returnType = FormatMethodReturnType(
             reader,
@@ -4958,6 +4880,175 @@ public static class ApiSurfaceExtractor
             model,
             treeSignature.ReturnType.IsDegraded
                 || treeSignature.ParameterTypes.Any(parameter => parameter.IsDegraded));
+    }
+
+    internal static ImmutableArray<string> GetCanonicalPropertyParameterTypes(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        PropertyDefinition property,
+        Action<string>? beforeRetainText = null,
+        Action<int>? beforeDecodeWork = null)
+    {
+        var typeDefinition = reader.GetTypeDefinition(typeHandle);
+        var typeNodeProvider = beforeRetainText is null
+            ? TypeNodeProvider.Instance
+            : new TypeNodeProvider(beforeRetainText, beforeDecodeWork);
+        MethodSignature<TypeNode> signature =
+            GuardedProviderDecode.Property(
+                reader,
+                property,
+                typeNodeProvider,
+                GenericContext.ForType(reader, typeDefinition),
+                (TypeNode)new DegradedTypeNode());
+        if (signature.ReturnType.IsDegraded
+            || signature.ParameterTypes.Any(
+                static parameter => parameter.IsDegraded))
+        {
+            throw new BadImageFormatException(
+                "The property signature could not be decoded.");
+        }
+        PropertyAccessors accessors = property.GetAccessors();
+        MethodDefinitionHandle parameterAccessor = !accessors.Getter.IsNil
+            ? accessors.Getter
+            : accessors.Setter;
+        var parameterAccessorMethod = parameterAccessor.IsNil
+            ? default
+            : reader.GetMethodDefinition(parameterAccessor);
+        var parameterHandles = parameterAccessor.IsNil
+            ? default
+            : parameterAccessorMethod.GetParameters();
+        byte typeNullableContext =
+            NullabilityReader.GetTypeNullableContext(
+                reader,
+                typeHandle,
+                beforeDecodeWork);
+        byte parameterNullableContext = parameterAccessor.IsNil
+            ? typeNullableContext
+            : NullabilityReader.GetNullableContext(
+                    reader,
+                    parameterAccessorMethod.GetCustomAttributes(),
+                    beforeDecodeWork)
+                ?? typeNullableContext;
+        (_, List<ApiParameter> parameters) = ProjectPropertyParameters(
+            reader,
+            signature.ParameterTypes,
+            parameterHandles,
+            parameterNullableContext,
+            beforeRetainText,
+            beforeDecodeWork,
+            beforeDecodeWork);
+        return
+        [
+            .. parameters.Select(
+                static parameter => parameter.CanonicalTypeWithModifier),
+        ];
+    }
+
+    static (List<string> Display, List<ApiParameter> Models)
+        ProjectPropertyParameters(
+            MetadataReader reader,
+            ImmutableArray<TypeNode> parameterTypes,
+            ParameterHandleCollection parameterHandles,
+            byte parameterNullableContext,
+            Action<string>? beforeRetainText,
+            Action<int>? beforeDecodeWork,
+            Action<int>? beforeAttributeMaterialize)
+    {
+        List<string> display = [];
+        List<ApiParameter> models = [];
+        var parameterInfos = Enumerable.Range(1, parameterTypes.Length)
+            .Select(sequenceNumber => GetParameterInfo(
+                reader,
+                parameterHandles,
+                sequenceNumber,
+                beforeRetainText,
+                beforeAttributeMaterialize))
+            .ToArray();
+        string[] parameterNames = CSharpParameterNames.Allocate(
+            parameterInfos.Select(info => info.name).ToArray());
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            var parameterType = parameterTypes[i];
+            var nullableBytes =
+                NullabilityReader.GetParameterNullableBytes(
+                    reader,
+                    parameterHandles,
+                    i + 1,
+                    beforeDecodeWork);
+            int position = 0;
+            parameterType.ApplyNullability(
+                nullableBytes,
+                ref position,
+                parameterNullableContext);
+            var dynamicFlags =
+                DynamicReader.GetParameterDynamicFlags(
+                    reader,
+                    parameterHandles,
+                    i + 1,
+                    beforeDecodeWork);
+            position = 0;
+            parameterType.ApplyDynamic(dynamicFlags, ref position);
+            parameterType.ApplyTupleNames(
+                TupleElementNamesReader.GetParameterTupleElementNames(
+                    reader,
+                    parameterHandles,
+                    i + 1,
+                    beforeDecodeWork));
+            string renderedType = parameterType.Render();
+            string canonicalType = parameterType.RenderCanonical();
+            var (_, isParams, refKind, hasDefault, defaultValue, attributes) =
+                parameterInfos[i];
+            bool isByRef =
+                renderedType.StartsWith("ref ", StringComparison.Ordinal);
+            if (isByRef)
+            {
+                renderedType = renderedType["ref ".Length..];
+                canonicalType = canonicalType["ref ".Length..];
+                refKind ??= "ref";
+            }
+            else
+            {
+                refKind = null;
+            }
+
+            string? modifier = isParams ? "params" : refKind;
+            bool acceptsNullDefault = AcceptsNullDefault(parameterType);
+            string? defaultValueText = DefaultValueText(
+                reader,
+                defaultValue,
+                renderedType,
+                hasDefault,
+                acceptsNullDefault,
+                beforeDecodeWork);
+            string renderedParameter = FormatParameter(
+                renderedType,
+                parameterNames[i],
+                modifier,
+                hasDefault,
+                defaultValue,
+                defaultValueText);
+            beforeRetainText?.Invoke(renderedParameter);
+            var parameterModel = new ApiParameter
+            {
+                Attributes = attributes,
+                Name = parameterNames[i],
+                Type = renderedType,
+                CanonicalType = canonicalType,
+                StructuralType = parameterType.HasStructuralPayload
+                    ? parameterType.StructuralIdentity()
+                    : null,
+                TypeReferences =
+                    [.. parameterType.ReferencedTypes().Distinct()],
+                Modifier = modifier,
+                HasDefault = hasDefault,
+                DefaultValueText = defaultValueText
+            };
+            ObserveText(parameterModel, beforeRetainText);
+            display.Add(renderedParameter);
+            models.Add(parameterModel);
+        }
+
+        return (display, models);
     }
 
     static void ApplyAccessorStructuralReturns(

--- a/tests/CSharpText.Tests/MemberCanonicalSignatureTests.cs
+++ b/tests/CSharpText.Tests/MemberCanonicalSignatureTests.cs
@@ -38,15 +38,40 @@ public class MemberCanonicalSignatureTests
     }
 
     [Theory]
-    [InlineData("P", "P:System.String.Length")]
     [InlineData("F", "F:System.String.Empty")]
     [InlineData("E", "E:System.AppDomain.ProcessExit")]
-    public void Build_PropertyFieldEvent_HasNoParameterList(string kind, string expected)
+    public void Build_FieldAndEvent_HaveNoParameterList(string kind, string expected)
     {
-        var memberName = kind switch { "P" => "Length", "F" => "Empty", _ => "ProcessExit" };
+        var memberName = kind == "F" ? "Empty" : "ProcessExit";
         var typeName = kind == "E" ? "System.AppDomain" : "System.String";
-        // Parameter list is ignored for P/F/E even if provided.
+        // Parameter list is ignored for F/E even if provided: neither can be
+        // overloaded, so neither identity can carry one.
         Assert.Equal(expected, MemberCanonicalSignature.Build(kind, typeName, memberName, ["System.Int32"]));
+    }
+
+    [Fact]
+    public void Build_OrdinaryProperty_HasNoParameterList()
+    {
+        Assert.Equal(
+            "P:System.String.Length",
+            MemberCanonicalSignature.Build("P", "System.String", "Length", []));
+    }
+
+    [Fact]
+    public void Build_Indexer_IncludesIndexParameters()
+    {
+        // An indexer overloads on its index parameters, so they are part of
+        // property identity; two overloads must not collide on "P:Type.Item".
+        Assert.Equal(
+            "P:System.Collections.Generic.List<T>.Item(System.Int32)",
+            MemberCanonicalSignature.Build(
+                "P",
+                "System.Collections.Generic.List<T>",
+                "Item",
+                ["System.Int32"]));
+        Assert.NotEqual(
+            MemberCanonicalSignature.Build("P", "N.C", "Item", ["System.Int32"]),
+            MemberCanonicalSignature.Build("P", "N.C", "Item", ["System.String"]));
     }
 
     [Fact]

--- a/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
+++ b/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
@@ -59,6 +59,7 @@ public static class FixtureIds
     public const string DiffV2 = "diff.v2";
     public const string SourceDiffV1 = "source-diff.v1";
     public const string SourceDiffV2 = "source-diff.v2";
+    public const string CloneSearchMembers = "clone-search.members";
     public const string LibraryApiDiffV1 = "library-api-diff.v1";
     public const string LibraryApiDiffV2 = "library-api-diff.v2";
     public const string DiffAsmCaller = "diff-asm.caller";
@@ -300,6 +301,13 @@ public static class FixtureCatalog
         "SourceDiffFixture.dll",
         Boundaries(FixtureBoundary.VersionPair, FixtureBoundary.SourceLinkMap),
         "queries", "source", "version-pair");
+
+    public static readonly FixtureDefinition CloneSearchMembers = Fixture(
+        FixtureIds.CloneSearchMembers,
+        "DotnetInspector.CloneSearchFixtures",
+        "DotnetInspector.CloneSearchFixtures.dll",
+        Boundaries(FixtureBoundary.CompilerLowering),
+        "queries", "clone-search", "member");
 
     public static readonly FixtureDefinition LibraryApiDiffV1 = Fixture(
         FixtureIds.LibraryApiDiffV1,
@@ -796,6 +804,7 @@ public static class FixtureCatalog
         DiffV2,
         SourceDiffV1,
         SourceDiffV2,
+        CloneSearchMembers,
         LibraryApiDiffV1,
         LibraryApiDiffV2,
         DiffAsmCaller,
@@ -1170,6 +1179,8 @@ public static class FixtureCatalog
             "DiffFixtures.V2" => "fixtures/diff/DiffFixtures.V2",
             "DotnetInspector.SourceDiff.V1" => "fixtures/queries/DotnetInspector.SourceDiff.V1",
             "DotnetInspector.SourceDiff.V2" => "fixtures/queries/DotnetInspector.SourceDiff.V2",
+            "DotnetInspector.CloneSearchFixtures" =>
+                "fixtures/queries/DotnetInspector.CloneSearchFixtures",
             "LibraryApiDiff.V1" => "fixtures/presentation/LibraryApiDiff.V1",
             "LibraryApiDiff.V2" => "fixtures/presentation/LibraryApiDiff.V2",
             "DotnetInspector.HostileNameFixtures" => "fixtures/cli/DotnetInspector.HostileNameFixtures",

--- a/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
@@ -381,6 +381,59 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
         Assert.True(keyed.CoverageIsComplete);
     }
 
+    [Theory]
+    [InlineData("Cases.NullableLookup")]
+    [InlineData("Cases.GenericLookup")]
+    [InlineData("Cases.TupleLookup")]
+    [InlineData("Cases.ParamsLookup")]
+    public async Task Execute_SurfaceIndexerAnchorResolvesOrdinaryParameterForms(
+        string typeFullName)
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.MemberSnapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName(typeFullName),
+                            fixture.LogicalAnchor(typeFullName, "Item")),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.Single(result.Seeds);
+        Assert.True(result.CoverageIsComplete);
+    }
+
+    [Fact]
+    public async Task Execute_MultiBodyMemberSuppressesOppositeSeedOrientations()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.MemberSnapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Widget"),
+                            fixture.LogicalAnchor("Changed")),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+        HashSet<MethodDefinitionHandle> seedHandles =
+            [.. result.Seeds.Select(seed => seed.Seed.Method.Handle)];
+        StructuralCloneSearchPair pair = Assert.Single(
+            result.Pairs.Where(
+                pair => seedHandles.Contains(pair.Left.Method.Handle)
+                    && seedHandles.Contains(pair.Right.Method.Handle)));
+
+        Assert.True(
+            MetadataTokens.GetRowNumber(pair.Left.Method.Handle)
+                < MetadataTokens.GetRowNumber(pair.Right.Method.Handle));
+        Assert.True(result.CoverageIsComplete);
+    }
+
     /// <summary>
     /// A <c>MethodSemantics</c> row associating an accessor a different type
     /// declares is malformed metadata, not a body of the selected member. An
@@ -2149,15 +2202,27 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
         /// event of <c>Cases.Widget</c>.
         /// </summary>
         internal MemberAnchor LogicalAnchor(string memberName)
+            => LogicalAnchor("Cases.Widget", memberName);
+
+        internal MemberAnchor LogicalAnchor(
+            string typeFullName,
+            string memberName)
         {
             using var image = new PEReader(MemberImage);
             ApiSurface surface =
                 ApiSurfaceExtractor.Extract(image, includeAll: true);
+            int separator = typeFullName.LastIndexOf('.');
+            string typeNamespace = separator < 0
+                ? ""
+                : typeFullName[..separator];
+            string typeName = separator < 0
+                ? typeFullName
+                : typeFullName[(separator + 1)..];
             ApiType type =
                 Assert.Single(
                     surface.Types,
-                    candidate => candidate.Namespace == "Cases"
-                        && candidate.Name == "Widget");
+                    candidate => candidate.Namespace == typeNamespace
+                        && candidate.Name == typeName);
             ApiMember member =
                 Assert.Single(
                     type.Members,

--- a/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
@@ -5,6 +5,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 
+using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
@@ -15,10 +16,12 @@ namespace DotnetInspector.Queries.Tests;
 /// Outcome-level gates for the host-neutral Workspace structural-clone search.
 /// </summary>
 /// <remarks>
-/// The fixtures are synthetic assemblies so seed populations, decoded names,
-/// and body shapes are exact. Every method carries the same
+/// Most fixtures are synthetic assemblies so seed populations, decoded names,
+/// and body shapes are exact. Their methods carry the same
 /// <c>static void()</c> signature, so Analysis ranks the whole population and
 /// the assertions observe search behavior rather than scoring calibration.
+/// Logical property, event, field, and indexer cases use an ordinary compiled
+/// fixture so the accessor associations are compiler-emitted metadata.
 /// </remarks>
 public sealed class WorkspaceStructuralCloneSearchQueryTests
 {
@@ -28,6 +31,9 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
     const string CrossSeedAssembly = "CloneSearchCrossSeed";
     const string CrossSeedCandidateAssembly = "CloneSearchCrossSeedPeer";
     const string RepeatedNamesAssembly = "CloneSearchRepeatedNames";
+    const string SigmaAssembly = "CloneSearchSigma";
+    const string AccessorlessAssembly = "CloneSearchAccessorless";
+    const string CrossTypeAccessorAssembly = "CloneSearchCrossTypeAccessor";
     const int RepeatedNameTypes = 4;
     const int RepeatedNameMethods = 8;
 
@@ -160,6 +166,351 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
         Assert.Equal(
             1,
             SeedCount(fixture, fixture.MemberSeed("Compute0")));
+    }
+
+    /// <summary>
+    /// A Member seed is every exact method body the selected member occupies.
+    /// A Metadata-issued property or event anchor therefore expands to its
+    /// associated accessor bodies rather than selecting nothing.
+    /// </summary>
+    [Fact]
+    public async Task Execute_MemberSeedExpandsPropertyAndEventBodies()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available property =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.MemberSnapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Widget"),
+                            fixture.LogicalAnchor("Value")),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames)));
+        WorkspaceStructuralCloneSearchResult.Available @event =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.MemberSnapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Widget"),
+                            fixture.LogicalAnchor("Changed")),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames)));
+
+        Assert.Equal(
+            ["get_Value", "set_Value"],
+            fixture.MemberNames(property.Seeds.Select(seed => seed.Seed)));
+        Assert.Equal(
+            ["add_Changed", "remove_Changed"],
+            fixture.MemberNames(@event.Seeds.Select(seed => seed.Seed)));
+
+        // The expansion is a real search, not just a larger seed count: the
+        // similarly named peer type supplies one exact counterpart per body.
+        Assert.Equal(
+            ["get_Value", "set_Value"],
+            fixture.MemberNames(
+                property.Pairs.Select(pair => pair.Right)));
+        Assert.All(
+            property.Pairs,
+            pair => Assert.Equal(
+                1.0,
+                Qualification(pair).MemberSimilarity));
+        Assert.True(property.CoverageIsComplete);
+        Assert.True(@event.CoverageIsComplete);
+    }
+
+    /// <summary>
+    /// An explicit accessor anchor selects that one body. Narrowing to one
+    /// accessor is the caller's choice, so expansion must not widen it back.
+    /// </summary>
+    [Fact]
+    public async Task Execute_ExplicitAccessorSeedSelectsOneBody()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.MemberSnapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Widget"),
+                            fixture.AccessorAnchor("get_Value")),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames)));
+
+        Assert.Equal(
+            ["get_Value"],
+            fixture.MemberNames(result.Seeds.Select(seed => seed.Seed)));
+        Assert.Equal(1, result.Receipt.SeedMethods);
+        Assert.True(result.CoverageIsComplete);
+    }
+
+    /// <summary>
+    /// A logical member that occupies no method body selects an empty seed
+    /// population, which is a typed outcome rather than a missing member or an
+    /// arbitrary body.
+    /// </summary>
+    [Fact]
+    public async Task Execute_MemberSeedWithoutBodiesIsTypedFailure()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult result =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.AccessorlessSnapshot(),
+                    new StructuralCloneSearchSeed.Member(
+                        TypeName("N.Holder"),
+                        fixture.AccessorlessAnchor())));
+
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedMemberHasNoMethodBody,
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    result)
+                .Failure.Kind);
+    }
+
+    /// <summary>
+    /// A field is a supported Member subject that occupies no method body, so
+    /// it is the bodyless outcome the product promises rather than a member the
+    /// selected type does not declare.
+    /// </summary>
+    [Fact]
+    public async Task Execute_FieldSeedIsTheBodylessOutcome()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult result =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.MemberSnapshot(),
+                    new StructuralCloneSearchSeed.Member(
+                        TypeName("Cases.Widget"),
+                        fixture.FieldAnchor("Tag"))));
+
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedMemberHasNoMethodBody,
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    result)
+                .Failure.Kind);
+    }
+
+    /// <summary>
+    /// A field the selected type does not declare stays the not-found outcome,
+    /// so scanning fields did not turn a missing member into a bodyless one.
+    /// </summary>
+    [Fact]
+    public async Task Execute_UndeclaredFieldSeedIsStillNotFound()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult result =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.MemberSnapshot(),
+                    new StructuralCloneSearchSeed.Member(
+                        TypeName("Cases.Widget"),
+                        fixture.UndeclaredFieldAnchor())));
+
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedMemberNotFound,
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    result)
+                .Failure.Kind);
+    }
+
+    /// <summary>
+    /// Two indexer overloads share one property name, so a selected overload
+    /// must expand to its own accessors alone: neither not-found, nor
+    /// ambiguous, nor the other overload's bodies.
+    /// </summary>
+    [Fact]
+    public async Task Execute_IndexerSeedExpandsOnlyItsOwnAccessors()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        MemberAnchor indexedAnchor = fixture.IndexerAnchor("int");
+        MemberAnchor keyedAnchor = fixture.IndexerAnchor("string");
+
+        // Index parameters are part of property identity, so the two overloads
+        // do not collide on one "P:Cases.Lookup.Item" identity that would make
+        // either selection ambiguous.
+        Assert.NotEqual(indexedAnchor, keyedAnchor);
+
+        WorkspaceStructuralCloneSearchResult.Available indexed =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.MemberSnapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Lookup"),
+                            indexedAnchor),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+        WorkspaceStructuralCloneSearchResult.Available keyed =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.MemberSnapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Lookup"),
+                            keyedAnchor),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        // Each seed population is exactly the accessor set of the selected
+        // overload's own PropertyDef, compared by MethodDef handle because both
+        // overloads spell their accessors "get_Item"/"set_Item".
+        Assert.Equal(
+            fixture.IndexerAccessors("int"),
+            SeedHandles(indexed));
+        Assert.Equal(
+            fixture.IndexerAccessors("string"),
+            SeedHandles(keyed));
+
+        // The int overload has a getter and a setter; the string overload has
+        // a getter only. So neither selection could have picked up the other's
+        // bodies, and neither collapsed into a shared "P:Cases.Lookup.Item".
+        Assert.Equal(2, indexed.Receipt.SeedMethods);
+        Assert.Equal(1, keyed.Receipt.SeedMethods);
+        Assert.Empty(SeedHandles(indexed).Intersect(SeedHandles(keyed)));
+        Assert.True(indexed.CoverageIsComplete);
+        Assert.True(keyed.CoverageIsComplete);
+    }
+
+    /// <summary>
+    /// A <c>MethodSemantics</c> row associating an accessor a different type
+    /// declares is malformed metadata, not a body of the selected member. An
+    /// in-range MethodDef row alone does not establish that association.
+    /// </summary>
+    [Fact]
+    public async Task Execute_CrossTypeAccessorAssociationIsMalformed()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult result =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.CrossTypeAccessorSnapshot(),
+                    new StructuralCloneSearchSeed.Member(
+                        TypeName("N.Owner"),
+                        fixture.CrossTypeAccessorAnchor())));
+
+        StructuralCloneSearchFailure failure =
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    result)
+                .Failure;
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.MetadataInspectionFailed,
+            failure.Kind);
+        Assert.Contains(
+            "another type declares",
+            failure.Detail,
+            StringComparison.Ordinal);
+    }
+
+    static ImmutableArray<MethodDefinitionHandle> SeedHandles(
+        WorkspaceStructuralCloneSearchResult.Available result)
+        =>
+        [
+            .. result.Seeds
+                .Select(seed => seed.Seed.Method.Handle)
+                .Order(
+                    Comparer<MethodDefinitionHandle>.Create(
+                        static (left, right) =>
+                            MetadataTokens.GetRowNumber(left)
+                                .CompareTo(
+                                    MetadataTokens.GetRowNumber(right)))),
+        ];
+
+    /// <summary>
+    /// Names equal under <c>StringComparison.OrdinalIgnoreCase</c> score
+    /// <c>1.0</c>. Greek capital sigma and final sigma are exactly that pair,
+    /// and a lowercasing approximation excludes them.
+    /// </summary>
+    [Fact]
+    public async Task Execute_ScoresOrdinalIgnoreCaseEqualNamesAsExact()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.SigmaSnapshot(),
+                        fixture.SigmaSeed(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames)));
+
+        StructuralCloneSearchPair pair = Assert.Single(result.Pairs);
+        Assert.Equal("\u03c2", fixture.SigmaName(pair.Right));
+        Assert.Equal(1.0, Qualification(pair).DeclaringTypeSimilarity);
+        Assert.Equal(1.0, Qualification(pair).MemberSimilarity);
+
+        // Lowercasing maps the capital sigma to the medial sigma and leaves
+        // the final sigma alone, so the peer would be omitted from an
+        // otherwise complete search.
+        Assert.True(result.CoverageIsComplete);
+    }
+
+    /// <summary>
+    /// Analysis failures that omitted candidate methods belong to the
+    /// participant whose candidates they omitted, not only to the seed.
+    /// </summary>
+    [Fact]
+    public async Task Execute_AttributesCandidateBlockersToTheLibrary()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            ComparisonLimits:
+                                new StructuralCloneComparisonLimits(
+                                    MaximumInstructions: 1)))));
+
+        StructuralCloneSearchLibraryCoverage self =
+            Assert.Single(
+                result.Libraries,
+                library => library.Membership
+                    == StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+        Assert.Equal(
+            StructuralCloneRetrievalBlockerKind.CandidateProductionLimit,
+            Assert.Single(self.AnalysisBlockers).Kind);
+        Assert.False(self.CoverageIsComplete);
+        Assert.False(result.CoverageIsComplete);
+
+        // Attribution is per participant: a library whose candidate bodies all
+        // fit the same limit stays complete.
+        StructuralCloneSearchLibraryCoverage ecosystem =
+            Assert.Single(
+                result.Libraries,
+                library => library.Membership
+                    == StructuralCloneParticipantMembership
+                        .RegisteredEcosystem);
+        Assert.Empty(ecosystem.AnalysisBlockers);
+        Assert.True(ecosystem.CoverageIsComplete);
+
+        // Seed-level blockers are unchanged, and the evidence Analysis did
+        // produce is still ranked.
+        Assert.All(
+            result.Seeds,
+            seed => Assert.Contains(
+                seed.Blockers,
+                blocker => blocker.Kind
+                    == StructuralCloneRetrievalBlockerKind
+                        .CandidateProductionLimit));
+        Assert.NotEmpty(result.Pairs);
     }
 
     [Theory]
@@ -1143,7 +1494,10 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
 
     /// <summary>
     /// Memoized name scores are bounded by retained cells, not only by entry
-    /// count, because one entry costs one cell per distinct seed name.
+    /// count, because one entry costs one cell per distinct seed name. The
+    /// cache is a pure optimization: capacity changes what
+    /// <c>StringDistance</c> recomputes, never the charged logical name work
+    /// and never the admitted candidates.
     /// </summary>
     [Fact]
     public async Task
@@ -1203,9 +1557,76 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
                     library.CandidateMethods,
                     library.DiscoveredMethods,
                     library.RetrievalPairs)));
+
+        // Logical name work is charged before the cache is consulted, so a hit
+        // and a miss cost the same budget. If they did not, the cache capacity
+        // would decide where a bounded search stops admitting candidates.
+        Assert.Equal(NameWork(cached), NameWork(uncached));
+        Assert.Equal(
+            cached.Libraries.Select(
+                library => library.NameComparisonWork),
+            uncached.Libraries.Select(
+                library => library.NameComparisonWork));
+
+        // The same equivalence under a name budget small enough to exhaust
+        // mid-participant, which is where a cache-dependent charge changed the
+        // discovered methods, the rows, and the reported coverage.
+        WorkspaceStructuralCloneSearchResult.Available boundedCached =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500,
+                            MaximumNameComparisonWork: 6_000))));
+        WorkspaceStructuralCloneSearchResult.Available boundedUncached =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500,
+                            MaximumNameComparisonWork: 6_000,
+                            MaximumNameCacheCells: 1))));
+
+        Assert.False(boundedCached.CoverageIsComplete);
+        Assert.NotEmpty(boundedCached.Pairs);
         Assert.True(
-            NameWork(uncached) > NameWork(cached),
-            "The bounded cache must actually retain scores when it fits.");
+            boundedCached.Receipt.DiscoveredCandidateMethods
+                < cached.Receipt.DiscoveredCandidateMethods,
+            "The bounded budget must stop admission mid-participant.");
+        Assert.Equal(boundedCached.Pairs, boundedUncached.Pairs);
+        Assert.Equal(boundedCached.Receipt, boundedUncached.Receipt);
+        Assert.Equal(
+            boundedCached.Libraries.Select(
+                library => (
+                    library.Admitted,
+                    library.CandidateMethods,
+                    library.DiscoveredMethods,
+                    library.RetrievalPairs,
+                    library.NameComparisonWork,
+                    library.CoverageIsComplete)),
+            boundedUncached.Libraries.Select(
+                library => (
+                    library.Admitted,
+                    library.CandidateMethods,
+                    library.DiscoveredMethods,
+                    library.RetrievalPairs,
+                    library.NameComparisonWork,
+                    library.CoverageIsComplete)));
+        Assert.Equal(
+            boundedCached.Libraries.SelectMany(
+                library => library.Failures.Select(
+                    failure => failure.Kind)),
+            boundedUncached.Libraries.SelectMany(
+                library => library.Failures.Select(
+                    failure => failure.Kind)));
 
         Assert.Throws<ArgumentOutOfRangeException>(
             () => new WorkspaceStructuralCloneSearchInput(
@@ -1556,6 +1977,61 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
                     RepeatedNamesGroup.Participants[0],
                     StructuralCloneParticipantMembership
                         .ContainingLibrary);
+
+            // An ordinary compiled library: the accessor bodies of a property
+            // and an event are exactly what a logical Member seed expands to.
+            MemberImage =
+                ImmutableCollectionsMarshal.AsImmutableArray(
+                    File.ReadAllBytes(
+                        FixtureCatalog.CloneSearchMembers.AssemblyPath()));
+            MemberGroup = Group(workspace, MemberImage);
+            MemberEntry =
+                new StructuralCloneParticipantEntry(
+                    MemberGroup,
+                    MemberGroup.Participants[0],
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+
+            // Greek capital sigma and final sigma are equal under
+            // StringComparison.OrdinalIgnoreCase and unequal after
+            // lowercasing, and one character leaves no other similarity.
+            SigmaImage =
+                Assembly(
+                    SigmaAssembly,
+                    new Guid("1B0A0C5E-0007-4000-8000-000000000007"),
+                    [
+                        ("N", "\u03a3", [("\u03a3", 1)]),
+                        ("N", "\u03c2", [("\u03c2", 1)]),
+                    ]);
+            SigmaGroup = Group(workspace, SigmaImage);
+            SigmaEntry =
+                new StructuralCloneParticipantEntry(
+                    SigmaGroup,
+                    SigmaGroup.Participants[0],
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+
+            AccessorlessImage = AccessorlessPropertyAssembly();
+            AccessorlessGroup = Group(workspace, AccessorlessImage);
+            AccessorlessEntry =
+                new StructuralCloneParticipantEntry(
+                    AccessorlessGroup,
+                    AccessorlessGroup.Participants[0],
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+
+            // One library whose only property associates an accessor that a
+            // different type declares: an in-range MethodDef row that is not a
+            // body of the selected member.
+            CrossTypeAccessorImage = CrossTypeAccessorPropertyAssembly();
+            CrossTypeAccessorGroup =
+                Group(workspace, CrossTypeAccessorImage);
+            CrossTypeAccessorEntry =
+                new StructuralCloneParticipantEntry(
+                    CrossTypeAccessorGroup,
+                    CrossTypeAccessorGroup.Participants[0],
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
         }
 
         internal InspectionWorkspace Workspace { get; }
@@ -1578,6 +2054,19 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
         internal ImmutableArray<byte> RepeatedNamesImage { get; }
         internal AssemblyContextGroup RepeatedNamesGroup { get; }
         internal StructuralCloneParticipantEntry RepeatedNamesEntry { get; }
+        internal ImmutableArray<byte> MemberImage { get; }
+        internal AssemblyContextGroup MemberGroup { get; }
+        internal StructuralCloneParticipantEntry MemberEntry { get; }
+        internal ImmutableArray<byte> SigmaImage { get; }
+        internal AssemblyContextGroup SigmaGroup { get; }
+        internal StructuralCloneParticipantEntry SigmaEntry { get; }
+        internal ImmutableArray<byte> AccessorlessImage { get; }
+        internal AssemblyContextGroup AccessorlessGroup { get; }
+        internal StructuralCloneParticipantEntry AccessorlessEntry { get; }
+        internal ImmutableArray<byte> CrossTypeAccessorImage { get; }
+        internal AssemblyContextGroup CrossTypeAccessorGroup { get; }
+        internal StructuralCloneParticipantEntry
+            CrossTypeAccessorEntry { get; }
 
         internal AssemblyContextParticipant SelfParticipant =>
             SelfGroup.Participants[0];
@@ -1649,6 +2138,255 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
                     type,
                     reader.GetMethodDefinition(
                         Method(reader, type, "Compute00"))));
+        }
+
+        /// <summary>The ordinary compiled property/event library alone.</summary>
+        internal StructuralCloneParticipantSnapshot MemberSnapshot()
+            => new(Revision, Revision, [MemberEntry]);
+
+        /// <summary>
+        /// The anchor the Metadata surface issues for one logical property or
+        /// event of <c>Cases.Widget</c>.
+        /// </summary>
+        internal MemberAnchor LogicalAnchor(string memberName)
+        {
+            using var image = new PEReader(MemberImage);
+            ApiSurface surface =
+                ApiSurfaceExtractor.Extract(image, includeAll: true);
+            ApiType type =
+                Assert.Single(
+                    surface.Types,
+                    candidate => candidate.Namespace == "Cases"
+                        && candidate.Name == "Widget");
+            ApiMember member =
+                Assert.Single(
+                    type.Members,
+                    candidate => candidate.Name == memberName
+                        && candidate.Kind is "property" or "event");
+            return ApiMemberIdentity.GetMemberAnchor(type, member);
+        }
+
+        /// <summary>One physical accessor of <c>Cases.Widget</c>.</summary>
+        internal MemberAnchor AccessorAnchor(string methodName)
+        {
+            using var image = new PEReader(MemberImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "Cases.Widget");
+            return ApiMemberIdentity.CreateMethodAnchor(
+                reader,
+                type,
+                reader.GetMethodDefinition(
+                    Method(reader, type, methodName)));
+        }
+
+        /// <summary>One field of <c>Cases.Widget</c>.</summary>
+        internal MemberAnchor FieldAnchor(string fieldName)
+        {
+            using var image = new PEReader(MemberImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "Cases.Widget");
+            int work =
+                MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+            return ApiMemberIdentity.CreateFieldAnchor(
+                reader,
+                type,
+                reader.GetFieldDefinition(Field(reader, type, fieldName)),
+                ref work);
+        }
+
+        /// <summary>A field anchor <c>Cases.Widget</c> does not declare.</summary>
+        internal MemberAnchor UndeclaredFieldAnchor()
+        {
+            using var image = new PEReader(MemberImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "Cases.Lookup");
+            int work =
+                MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+            return ApiMemberIdentity.CreateFieldAnchor(
+                reader,
+                type,
+                reader.GetFieldDefinition(
+                    Field(reader, type, "_byIndex")),
+                ref work);
+        }
+
+        /// <summary>
+        /// The anchor of the one <c>Cases.Lookup</c> indexer overload whose
+        /// index parameter is <paramref name="parameterType"/>.
+        /// </summary>
+        internal MemberAnchor IndexerAnchor(string parameterType)
+        {
+            using var image = new PEReader(MemberImage);
+            ApiSurface surface =
+                ApiSurfaceExtractor.Extract(image, includeAll: true);
+            ApiType type =
+                Assert.Single(
+                    surface.Types,
+                    candidate => candidate.Namespace == "Cases"
+                        && candidate.Name == "Lookup");
+            ApiMember indexer =
+                Assert.Single(
+                    type.Members,
+                    candidate => candidate.Kind == "property"
+                        && ApiMemberIdentity
+                            .GetCanonicalSignature(type, candidate)
+                            .EndsWith(
+                                $"({parameterType})",
+                                StringComparison.Ordinal));
+            return ApiMemberIdentity.GetMemberAnchor(type, indexer);
+        }
+
+        /// <summary>
+        /// Every accessor MethodDef of that same overload's own PropertyDef,
+        /// in MethodDef row order.
+        /// </summary>
+        internal ImmutableArray<MethodDefinitionHandle> IndexerAccessors(
+            string parameterType)
+        {
+            using var image = new PEReader(MemberImage);
+            MetadataReader reader = image.GetMetadataReader();
+            PropertyDefinitionHandle handle =
+                Indexer(reader, parameterType, out _);
+            Assert.False(handle.IsNil, "Indexer overload not found.");
+            PropertyAccessors accessors =
+                reader.GetPropertyDefinition(handle).GetAccessors();
+            List<MethodDefinitionHandle> associated =
+            [
+                accessors.Getter,
+                accessors.Setter,
+                .. accessors.Others,
+            ];
+            return
+            [
+                .. associated
+                    .Where(accessor => !accessor.IsNil)
+                    .OrderBy(
+                        static accessor =>
+                            MetadataTokens.GetRowNumber(accessor)),
+            ];
+        }
+
+        static PropertyDefinitionHandle Indexer(
+            MetadataReader reader,
+            string parameterType,
+            out MemberAnchor anchor)
+        {
+            TypeDefinitionHandle type = Type(reader, "Cases.Lookup");
+            string suffix = $"({parameterType})";
+            foreach (PropertyDefinitionHandle handle
+                in reader.GetTypeDefinition(type).GetProperties())
+            {
+                int work =
+                    MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+                MemberAnchor candidate =
+                    ApiMemberIdentity.CreatePropertyAnchor(
+                        reader,
+                        type,
+                        reader.GetPropertyDefinition(handle),
+                        ref work);
+                if (candidate.CanonicalSignature.EndsWith(
+                        suffix,
+                        StringComparison.Ordinal))
+                {
+                    anchor = candidate;
+                    return handle;
+                }
+            }
+
+            anchor = default!;
+            return default;
+        }
+
+        /// <summary>The cross-type accessor library alone.</summary>
+        internal StructuralCloneParticipantSnapshot
+            CrossTypeAccessorSnapshot()
+            => new(Revision, Revision, [CrossTypeAccessorEntry]);
+
+        /// <summary>
+        /// The anchor of the property whose only <c>MethodSemantics</c> row
+        /// associates a method another type declares.
+        /// </summary>
+        internal MemberAnchor CrossTypeAccessorAnchor()
+        {
+            using var image = new PEReader(CrossTypeAccessorImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "N.Owner");
+            int work =
+                MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+            return ApiMemberIdentity.CreatePropertyAnchor(
+                reader,
+                type,
+                reader.GetPropertyDefinition(
+                    Assert.Single(
+                        reader.GetTypeDefinition(type).GetProperties())),
+                ref work);
+        }
+
+        /// <summary>Decoded method names of endpoints in the member library.</summary>
+        internal ImmutableArray<string> MemberNames(
+            IEnumerable<StructuralCloneSearchEndpoint> endpoints)
+        {
+            using var image = new PEReader(MemberImage);
+            MetadataReader reader = image.GetMetadataReader();
+            return
+            [
+                .. endpoints
+                    .Select(endpoint => reader.GetString(
+                        reader.GetMethodDefinition(
+                            endpoint.Method.Handle).Name))
+                    .Order(StringComparer.Ordinal),
+            ];
+        }
+
+        /// <summary>The sigma library alone.</summary>
+        internal StructuralCloneParticipantSnapshot SigmaSnapshot()
+            => new(Revision, Revision, [SigmaEntry]);
+
+        /// <summary>The Greek capital sigma method as an exact seed.</summary>
+        internal StructuralCloneSearchSeed.Member SigmaSeed()
+        {
+            using var image = new PEReader(SigmaImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "N.\u03a3");
+            return new StructuralCloneSearchSeed.Member(
+                TypeName("N.\u03a3"),
+                ApiMemberIdentity.CreateMethodAnchor(
+                    reader,
+                    type,
+                    reader.GetMethodDefinition(
+                        Method(reader, type, "\u03a3"))));
+        }
+
+        internal string SigmaName(StructuralCloneSearchEndpoint endpoint)
+        {
+            using var image = new PEReader(SigmaImage);
+            MetadataReader reader = image.GetMetadataReader();
+            return reader.GetString(
+                reader.GetMethodDefinition(endpoint.Method.Handle).Name);
+        }
+
+        /// <summary>The accessorless-property library alone.</summary>
+        internal StructuralCloneParticipantSnapshot AccessorlessSnapshot()
+            => new(Revision, Revision, [AccessorlessEntry]);
+
+        /// <summary>
+        /// The anchor of a property that carries no MethodSemantics row, so it
+        /// exists and occupies no method body.
+        /// </summary>
+        internal MemberAnchor AccessorlessAnchor()
+        {
+            using var image = new PEReader(AccessorlessImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "N.Holder");
+            int work =
+                MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+            return ApiMemberIdentity.CreatePropertyAnchor(
+                reader,
+                type,
+                reader.GetPropertyDefinition(
+                    Assert.Single(
+                        reader.GetTypeDefinition(type).GetProperties())),
+                ref work);
         }
 
         internal StructuralCloneParticipantSnapshot
@@ -1738,6 +2476,9 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
             CrossSeedGroup.Dispose();
             CrossSeedPeerGroup.Dispose();
             RepeatedNamesGroup.Dispose();
+            MemberGroup.Dispose();
+            SigmaGroup.Dispose();
+            AccessorlessGroup.Dispose();
             await Workspace.DisposeAsync();
         }
 
@@ -1840,6 +2581,16 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
                     reader.GetMethodDefinition(method).Name)
                     == name);
 
+        static FieldDefinitionHandle Field(
+            MetadataReader reader,
+            TypeDefinitionHandle type,
+            string name)
+            => Assert.Single(
+                reader.GetTypeDefinition(type).GetFields(),
+                field => reader.GetString(
+                    reader.GetFieldDefinition(field).Name)
+                    == name);
+
         static TypeDefinitionHandle Type(
             MetadataReader reader,
             string serializedName)
@@ -1907,6 +2658,162 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
                     AddMethod(metadata, encoder, method, body);
                 }
             }
+
+            var pe = new ManagedPEBuilder(
+                PEHeaderBuilder.CreateLibraryHeader(),
+                new MetadataRootBuilder(
+                    metadata,
+                    suppressValidation: true),
+                bodies,
+                flags: CorFlags.ILOnly);
+            var image = new BlobBuilder();
+            pe.Serialize(image);
+            return ImmutableCollectionsMarshal.AsImmutableArray(
+                image.ToArray());
+        }
+
+        /// <summary>
+        /// One library whose only property carries no <c>MethodSemantics</c>
+        /// row, so the property exists and occupies no method body.
+        /// </summary>
+        static ImmutableArray<byte> AccessorlessPropertyAssembly()
+        {
+            var metadata = new MetadataBuilder();
+            metadata.AddModule(
+                generation: 0,
+                metadata.GetOrAddString($"{AccessorlessAssembly}.dll"),
+                metadata.GetOrAddGuid(
+                    new Guid("1B0A0C5E-0008-4000-8000-000000000008")),
+                encId: default,
+                encBaseId: default);
+            metadata.AddAssembly(
+                metadata.GetOrAddString(AccessorlessAssembly),
+                new Version(1, 0, 0, 0),
+                culture: default,
+                publicKey: default,
+                flags: default,
+                hashAlgorithm: default);
+            metadata.AddTypeDefinition(
+                default,
+                default,
+                metadata.GetOrAddString("<Module>"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            TypeDefinitionHandle holder =
+                metadata.AddTypeDefinition(
+                    TypeAttributes.Class | TypeAttributes.Public,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Holder"),
+                    baseType: default,
+                    fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                    methodList:
+                        MetadataTokens.MethodDefinitionHandle(1));
+
+            var bodies = new BlobBuilder();
+            var encoder = new MethodBodyStreamEncoder(bodies);
+            AddMethod(metadata, encoder, "Compute", 1);
+
+            var propertySignature = new BlobBuilder();
+            new BlobEncoder(propertySignature)
+                .PropertySignature(isInstanceProperty: false)
+                .Parameters(
+                    parameterCount: 0,
+                    returnType => returnType.Type().Int32(),
+                    parameters => { });
+            metadata.AddPropertyMap(
+                holder,
+                MetadataTokens.PropertyDefinitionHandle(1));
+            metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString("Value"),
+                metadata.GetOrAddBlob(propertySignature));
+
+            var pe = new ManagedPEBuilder(
+                PEHeaderBuilder.CreateLibraryHeader(),
+                new MetadataRootBuilder(
+                    metadata,
+                    suppressValidation: true),
+                bodies,
+                flags: CorFlags.ILOnly);
+            var image = new BlobBuilder();
+            pe.Serialize(image);
+            return ImmutableCollectionsMarshal.AsImmutableArray(
+                image.ToArray());
+        }
+
+        /// <summary>
+        /// One library whose only property associates a getter that a
+        /// different type declares. The MethodDef row is in range and the
+        /// image's TypeDef method ranges still partition the MethodDef table,
+        /// so range checking alone admits this association.
+        /// </summary>
+        static ImmutableArray<byte> CrossTypeAccessorPropertyAssembly()
+        {
+            var metadata = new MetadataBuilder();
+            metadata.AddModule(
+                generation: 0,
+                metadata.GetOrAddString(
+                    $"{CrossTypeAccessorAssembly}.dll"),
+                metadata.GetOrAddGuid(
+                    new Guid("1B0A0C5E-0009-4000-8000-000000000009")),
+                encId: default,
+                encBaseId: default);
+            metadata.AddAssembly(
+                metadata.GetOrAddString(CrossTypeAccessorAssembly),
+                new Version(1, 0, 0, 0),
+                culture: default,
+                publicKey: default,
+                flags: default,
+                hashAlgorithm: default);
+            metadata.AddTypeDefinition(
+                default,
+                default,
+                metadata.GetOrAddString("<Module>"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            TypeDefinitionHandle owner =
+                metadata.AddTypeDefinition(
+                    TypeAttributes.Class | TypeAttributes.Public,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Owner"),
+                    baseType: default,
+                    fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                    methodList:
+                        MetadataTokens.MethodDefinitionHandle(1));
+            metadata.AddTypeDefinition(
+                TypeAttributes.Class | TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Other"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(2));
+
+            var bodies = new BlobBuilder();
+            var encoder = new MethodBodyStreamEncoder(bodies);
+            AddMethod(metadata, encoder, "Compute", 1);
+            AddMethod(metadata, encoder, "Foreign", 2);
+
+            var propertySignature = new BlobBuilder();
+            new BlobEncoder(propertySignature)
+                .PropertySignature(isInstanceProperty: false)
+                .Parameters(
+                    parameterCount: 0,
+                    returnType => returnType.Type().Int32(),
+                    parameters => { });
+            metadata.AddPropertyMap(
+                owner,
+                MetadataTokens.PropertyDefinitionHandle(1));
+            PropertyDefinitionHandle property =
+                metadata.AddProperty(
+                    PropertyAttributes.None,
+                    metadata.GetOrAddString("Value"),
+                    metadata.GetOrAddBlob(propertySignature));
+            metadata.AddMethodSemantics(
+                property,
+                MethodSemanticsAttributes.Getter,
+                MetadataTokens.MethodDefinitionHandle(2));
 
             var pe = new ManagedPEBuilder(
                 PEHeaderBuilder.CreateLibraryHeader(),

--- a/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
@@ -1,0 +1,1969 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries.Tests;
+
+/// <summary>
+/// Outcome-level gates for the host-neutral Workspace structural-clone search.
+/// </summary>
+/// <remarks>
+/// The fixtures are synthetic assemblies so seed populations, decoded names,
+/// and body shapes are exact. Every method carries the same
+/// <c>static void()</c> signature, so Analysis ranks the whole population and
+/// the assertions observe search behavior rather than scoring calibration.
+/// </remarks>
+public sealed class WorkspaceStructuralCloneSearchQueryTests
+{
+    const string SelfAssembly = "CloneSearchSelf";
+    const string EcosystemAssembly = "CloneSearchEcosystem";
+    const string AvailableAssembly = "CloneSearchAvailable";
+    const string CrossSeedAssembly = "CloneSearchCrossSeed";
+    const string CrossSeedCandidateAssembly = "CloneSearchCrossSeedPeer";
+    const string RepeatedNamesAssembly = "CloneSearchRepeatedNames";
+    const int RepeatedNameTypes = 4;
+    const int RepeatedNameMethods = 8;
+
+    [Fact]
+    public async Task Request_DefaultsToEverythingPlusSimilarNames()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        var input =
+            new WorkspaceStructuralCloneSearchInput(
+                fixture.Snapshot(),
+                new StructuralCloneSearchSeed.Library());
+
+        Assert.Equal(
+            StructuralCloneCandidateBreadth.Everything,
+            input.Breadth);
+        Assert.Equal(
+            StructuralCloneCandidateDiscovery.SimilarNames,
+            input.Discovery);
+        Assert.Equal(
+            0.6,
+            WorkspaceStructuralCloneSearchQuery.NameSimilarityThreshold);
+        Assert.Equal(
+            InspectionCost.Unbounded,
+            WorkspaceStructuralCloneSearchQuery.Definition.Cost);
+    }
+
+    [Fact]
+    public async Task Snapshot_RejectsInconsistentOrDuplicateMembership()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        WorkspaceScopeRevision revision = fixture.Revision;
+
+        Assert.Throws<ArgumentException>(
+            () => new StructuralCloneParticipantSnapshot(
+                revision,
+                revision,
+                [fixture.SelfEntry, fixture.SelfEntry]));
+        Assert.Throws<ArgumentException>(
+            () => new StructuralCloneParticipantSnapshot(
+                revision,
+                revision,
+                [
+                    fixture.SelfEntry,
+                    new StructuralCloneParticipantEntry(
+                        fixture.SelfGroup,
+                        fixture.SelfParticipant,
+                        StructuralCloneParticipantMembership.Available),
+                ]));
+        Assert.Throws<ArgumentException>(
+            () => new StructuralCloneParticipantSnapshot(
+                revision,
+                revision,
+                [
+                    fixture.SelfEntry,
+                    new StructuralCloneParticipantEntry(
+                        fixture.EcosystemGroup,
+                        fixture.EcosystemParticipant,
+                        StructuralCloneParticipantMembership
+                            .ContainingLibrary),
+                ]));
+        Assert.Throws<ArgumentException>(
+            () => new StructuralCloneParticipantSnapshot(
+                revision,
+                revision,
+                [fixture.EcosystemEntry]));
+        Assert.Throws<ArgumentException>(
+            () => new StructuralCloneParticipantEntry(
+                fixture.SelfGroup,
+                fixture.EcosystemParticipant,
+                StructuralCloneParticipantMembership.Available));
+
+        await using var foreign = InspectionWorkspace.CreateAsynchronous();
+        WorkspaceScopeRevision foreignRevision =
+            (await ScopeSnapshot(foreign)).Revision;
+        Assert.Throws<ArgumentException>(
+            () => new StructuralCloneParticipantSnapshot(
+                revision,
+                foreignRevision,
+                [fixture.SelfEntry]));
+    }
+
+    [Fact]
+    public async Task Execute_BindsRevisionsAndParticipantSnapshotIdentity()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        WorkspaceScopeRevision starting = fixture.Revision;
+        WorkspaceScopeRevision effective =
+            await fixture.CommitFreshRevisionAsync();
+        Assert.NotSame(starting.Identity, effective.Identity);
+        StructuralCloneParticipantSnapshot snapshot =
+            new(
+                starting,
+                effective,
+                [fixture.SelfEntry, fixture.EcosystemEntry]);
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library())));
+
+        Assert.Same(starting, result.StartingRevision);
+        Assert.Same(effective, result.EffectiveRevision);
+        Assert.Same(snapshot.Identity, result.ParticipantSnapshot);
+        Assert.Equal(100, result.Limits.MaximumResults);
+        Assert.Equal(
+            WorkspaceStructuralCloneSearchQuery.NameSimilarityThreshold,
+            result.NameSimilarityThreshold);
+        Assert.Same(
+            fixture.SelfParticipant.Assembly.Registration,
+            result.SeedSubject.Registration);
+        Assert.True(result.CoverageIsComplete);
+    }
+
+    [Fact]
+    public async Task Execute_ExpandsLibraryTypeAndMemberSeedPopulations()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        Assert.Equal(
+            6,
+            SeedCount(fixture, new StructuralCloneSearchSeed.Library()));
+        Assert.Equal(
+            5,
+            SeedCount(
+                fixture,
+                new StructuralCloneSearchSeed.Type(
+                    TypeName("N.Alpha"))));
+        Assert.Equal(
+            1,
+            SeedCount(fixture, fixture.MemberSeed("Compute0")));
+    }
+
+    [Theory]
+    [InlineData(StructuralCloneCandidateBreadth.Self, 1, 6)]
+    [InlineData(
+        StructuralCloneCandidateBreadth.SelfAndRegisteredEcosystems,
+        2,
+        7)]
+    [InlineData(StructuralCloneCandidateBreadth.Everything, 3, 8)]
+    public async Task Execute_BreadthSelectsOnlySuppliedMembership(
+        StructuralCloneCandidateBreadth breadth,
+        int expectedLibraries,
+        int expectedCandidateMethods)
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        breadth,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.Equal(breadth, result.Breadth);
+        Assert.Equal(
+            expectedLibraries,
+            result.Receipt.AdmittedLibraries);
+        Assert.Equal(
+            expectedCandidateMethods,
+            result.Receipt.CandidateMethods);
+        Assert.Equal(3, result.Libraries.Length);
+        Assert.Equal(
+            expectedLibraries,
+            result.Libraries.Count(library => library.Admitted));
+        Assert.All(
+            result.Libraries,
+            library => Assert.True(library.CoverageIsComplete));
+
+        // Every candidate method except the physical seed is ranked, so the
+        // middle breadth is observably not degraded to Self.
+        Assert.Equal(
+            expectedCandidateMethods - 1,
+            result.Pairs.Length);
+        Assert.True(result.CoverageIsComplete);
+    }
+
+    [Theory]
+    [InlineData(StructuralCloneCandidateBreadth.Self, 4, 6)]
+    [InlineData(
+        StructuralCloneCandidateBreadth.SelfAndRegisteredEcosystems,
+        5,
+        7)]
+    [InlineData(StructuralCloneCandidateBreadth.Everything, 6, 8)]
+    public async Task Execute_DiscoveryFiltersMethodsWithoutChangingBreadth(
+        StructuralCloneCandidateBreadth breadth,
+        int similarNames,
+        int all)
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available filtered =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        breadth,
+                        StructuralCloneCandidateDiscovery.SimilarNames)));
+        WorkspaceStructuralCloneSearchResult.Available exhaustive =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        breadth,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.Equal(
+            filtered.Receipt.AdmittedLibraries,
+            exhaustive.Receipt.AdmittedLibraries);
+        Assert.Equal(
+            filtered.Receipt.CandidateMethods,
+            exhaustive.Receipt.CandidateMethods);
+        Assert.Equal(
+            similarNames,
+            filtered.Receipt.DiscoveredCandidateMethods);
+        Assert.Equal(all, exhaustive.Receipt.DiscoveredCandidateMethods);
+        Assert.True(filtered.CoverageIsComplete);
+        Assert.True(exhaustive.CoverageIsComplete);
+    }
+
+    [Fact]
+    public async Task Execute_SimilarNamesRequiresTypeAndMemberForOneSeed()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames)));
+
+        // Zulu.Compute4 shares the member name and Alpha.Unrelated shares the
+        // declaring type, and neither qualifies on its own.
+        Assert.DoesNotContain(
+            "Compute4",
+            result.Pairs.Select(pair => fixture.SelfName(pair.Right)));
+        Assert.DoesNotContain(
+            "Unrelated",
+            result.Pairs.Select(pair => fixture.SelfName(pair.Right)));
+        Assert.Equal(
+            ["Compute1", "Compute2", "Compute7"],
+            result.Pairs
+                .Select(pair => fixture.SelfName(pair.Right))
+                .Order(StringComparer.Ordinal));
+        Assert.All(
+            result.Pairs,
+            pair =>
+            {
+                StructuralCloneNameQualification qualification =
+                    Assert.IsType<StructuralCloneNameQualification>(
+                        pair.NameQualification);
+                Assert.Equal(1.0, qualification.DeclaringTypeSimilarity);
+                Assert.True(
+                    qualification.MemberSimilarity
+                        >= WorkspaceStructuralCloneSearchQuery
+                            .NameSimilarityThreshold);
+            });
+
+        WorkspaceStructuralCloneSearchResult.Available exhaustive =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.Contains(
+            "Compute4",
+            exhaustive.Pairs.Select(pair => fixture.SelfName(pair.Right)));
+        Assert.Contains(
+            "Unrelated",
+            exhaustive.Pairs.Select(pair => fixture.SelfName(pair.Right)));
+        Assert.All(
+            exhaustive.Pairs,
+            pair => Assert.Null(pair.NameQualification));
+    }
+
+    [Fact]
+    public async Task Execute_SuppressesSelfPairsAndOppositeOrientations()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Type(
+                            TypeName("N.Alpha")),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 1000))));
+
+        // Five seeds over six same-library candidates: the ten unordered
+        // seed pairs are returned once each, plus one row per seed for the
+        // one candidate outside the seed population.
+        Assert.Equal(15, result.Pairs.Length);
+        Assert.Equal(10, result.Receipt.SuppressedPairs);
+        Assert.All(
+            result.Pairs,
+            pair => Assert.NotEqual(pair.Left, pair.Right));
+        Assert.All(
+            result.Pairs,
+            pair => Assert.True(
+                Row(pair.Left.Method) < Row(pair.Right.Method),
+                "Same-population pairs keep one deterministic orientation."));
+
+        Assert.Equal(
+            result.Pairs.Length,
+            result.Pairs
+                .Select(pair => (pair.Left.Method, pair.Right.Method))
+                .Distinct()
+                .Count());
+        Assert.True(result.CoverageIsComplete);
+        Assert.False(result.Receipt.ResultLimitReached);
+    }
+
+    [Fact]
+    public async Task Execute_MemberSeedKeepsSelectedSeedOnTheLeft()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute2"),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        StructuralCloneSearchSeedCoverage seed =
+            Assert.Single(result.Seeds);
+        Assert.All(
+            result.Pairs,
+            pair => Assert.Equal(seed.Seed.Method, pair.Left.Method));
+        Assert.Contains(
+            result.Pairs,
+            pair => Row(pair.Right.Method) < Row(pair.Left.Method));
+        Assert.Equal(0, result.Receipt.SuppressedPairs);
+        Assert.Equal(result.Pairs.Length, seed.RankedPairs);
+    }
+
+    [Fact]
+    public async Task Execute_KeepsExactEndpointIdentityForEqualContent()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        StructuralCloneParticipantSnapshot snapshot =
+            fixture.SnapshotWithDuplicateContent();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        StructuralCloneSearchPair[] duplicates =
+        [
+            .. result.Pairs.Where(
+                pair => pair.Right.Participant.Ordinal != 0),
+        ];
+        Assert.Equal(2, duplicates.Length);
+
+        // Equal content, equal MVID, and equal MethodDef token under two
+        // distinct acquisition registrations.
+        Assert.Equal(
+            duplicates[0].Right.Method,
+            duplicates[1].Right.Method);
+        Assert.NotSame(
+            duplicates[0].Right.Subject,
+            duplicates[1].Right.Subject);
+        Assert.NotSame(
+            duplicates[0].Right.Subject.Registration,
+            duplicates[1].Right.Subject.Registration);
+
+        // The snapshot's opaque per-entry identity keeps them apart, so pair
+        // identity never collapses onto MVID plus token.
+        Assert.NotSame(
+            duplicates[0].Right.Participant,
+            duplicates[1].Right.Participant);
+        Assert.NotEqual(
+            duplicates[0].Right.Participant.Ordinal,
+            duplicates[1].Right.Participant.Ordinal);
+        Assert.All(
+            duplicates,
+            pair => Assert.Same(
+                snapshot.Identity,
+                pair.Right.Participant.Snapshot));
+        Assert.NotEqual(duplicates[0].Right, duplicates[1].Right);
+        Assert.NotEqual(duplicates[0], duplicates[1]);
+    }
+
+    [Fact]
+    public async Task
+        Snapshot_OwnsDeterministicSnapshotLocalParticipantIdentities()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        StructuralCloneParticipantSnapshot ordered =
+            fixture.SnapshotOf(
+                fixture.SelfEntry,
+                fixture.EcosystemEntry,
+                fixture.AvailableEntry);
+        StructuralCloneParticipantSnapshot reordered =
+            fixture.SnapshotOf(
+                fixture.AvailableEntry,
+                fixture.EcosystemEntry,
+                fixture.SelfEntry);
+
+        // The snapshot captures its owner-issued entry order once and issues
+        // one opaque identity per position; the order is part of the
+        // snapshot's exact identity, not a shared global fact.
+        Assert.Equal(
+            [0, 1, 2],
+            ordered.ParticipantIdentities.Select(
+                identity => identity.Ordinal));
+        Assert.All(
+            ordered.ParticipantIdentities,
+            identity => Assert.Same(ordered.Identity, identity.Snapshot));
+        Assert.Same(
+            ordered.ParticipantIdentities[0],
+            ordered.ContainingLibraryIdentity);
+        Assert.Same(
+            reordered.ParticipantIdentities[2],
+            reordered.ContainingLibraryIdentity);
+        Assert.All(
+            reordered.ParticipantIdentities,
+            identity => Assert.DoesNotContain(
+                identity,
+                ordered.ParticipantIdentities));
+
+        // The same entry receives a different identity in each snapshot, so an
+        // ordinal never leaks across snapshots.
+        Assert.NotSame(
+            ordered.ContainingLibraryIdentity,
+            reordered.ContainingLibraryIdentity);
+
+        // Endpoints and tie-breaking use those identities, so the reordered
+        // snapshot ranks the same evidence in its own declared order.
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        reordered,
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.All(
+            result.Pairs,
+            pair =>
+            {
+                Assert.Same(
+                    reordered.Identity,
+                    pair.Left.Participant.Snapshot);
+                Assert.Same(
+                    reordered.Identity,
+                    pair.Right.Participant.Snapshot);
+                Assert.Same(
+                    reordered.ContainingLibraryIdentity,
+                    pair.Left.Participant);
+            });
+        Assert.Equal(
+            [0, 1, 2],
+            result.Libraries.Select(
+                library => library.Participant.Ordinal));
+        Assert.All(
+            result.Libraries.Select(
+                (library, index) => (library, index)),
+            row => Assert.Same(
+                reordered.ParticipantIdentities[row.index],
+                row.library.Participant));
+
+        // Distinct registrations always receive distinct identities, so pair
+        // identity stays exact even when two entries are otherwise equal.
+        Assert.Equal(
+            reordered.Entries.Length,
+            reordered.ParticipantIdentities.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task Execute_RanksGloballyAndLimitsAfterTheMerge()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        // Both runs bind the same snapshot: endpoint identity is
+        // snapshot-local, so rows are only comparable within one snapshot.
+        StructuralCloneParticipantSnapshot snapshot = fixture.Snapshot();
+        var complete =
+            new WorkspaceStructuralCloneSearchInput(
+                snapshot,
+                new StructuralCloneSearchSeed.Type(TypeName("N.Alpha")),
+                StructuralCloneCandidateBreadth.Everything,
+                StructuralCloneCandidateDiscovery.All,
+                new WorkspaceStructuralCloneSearchLimits(
+                    MaximumResults: 1000));
+
+        WorkspaceStructuralCloneSearchResult.Available all =
+            Available(Execute(complete));
+
+        Assert.False(all.Receipt.ResultLimitReached);
+        Assert.Equal(all.Pairs.Length, all.Receipt.RankedPairs);
+        for (int index = 1; index < all.Pairs.Length; index++)
+        {
+            StructuralCloneSearchPair previous = all.Pairs[index - 1];
+            StructuralCloneSearchPair current = all.Pairs[index];
+            Assert.Equal(index + 1, current.Rank);
+            Assert.True(
+                previous.Similarity.Score >= current.Similarity.Score,
+                "Pairs are one global ranking by Analysis score.");
+            if (previous.Similarity == current.Similarity)
+            {
+                Assert.True(
+                    Endpoints(previous).CompareTo(Endpoints(current)) < 0,
+                    "Ties resolve by exact endpoint identity.");
+            }
+        }
+
+        // The lower-scoring self method sorts below other libraries' rows, so
+        // the ranking cannot be a per-seed or per-library concatenation.
+        int worstSelf =
+            all.Pairs
+                .Select((pair, index) => (pair, index))
+                .Where(row => row.pair.Right.Participant.Ordinal == 0
+                    && fixture.SelfName(row.pair.Right) == "Compute7")
+                .Min(row => row.index);
+        Assert.Contains(
+            all.Pairs.Take(worstSelf),
+            pair => pair.Right.Participant.Ordinal != 0);
+
+        WorkspaceStructuralCloneSearchResult.Available limited =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Type(
+                            TypeName("N.Alpha")),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 3))));
+
+        Assert.Equal(3, limited.Pairs.Length);
+        Assert.Equal(
+            all.Pairs.Take(3).Select(pair => (pair.Left, pair.Right)),
+            limited.Pairs.Select(pair => (pair.Left, pair.Right)));
+        Assert.Equal(all.Receipt.RankedPairs, limited.Receipt.RankedPairs);
+
+        // Intentional row suppression is reported separately from coverage.
+        Assert.True(limited.Receipt.ResultLimitReached);
+        Assert.True(limited.CoverageIsComplete);
+    }
+
+    [Fact]
+    public async Task Execute_ReportsUnavailableCandidateLibrary()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.SnapshotWithUnreadableParticipant(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        StructuralCloneSearchLibraryCoverage unreadable =
+            Assert.Single(
+                result.Libraries,
+                library => !library.CoverageIsComplete);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.CandidateLibraryUnavailable,
+            Assert.Single(unreadable.Failures).Kind);
+        Assert.False(result.CoverageIsComplete);
+        Assert.False(result.Receipt.ResultLimitReached);
+
+        // Existing ranked evidence stays usable beside the visible gap.
+        Assert.NotEmpty(result.Pairs);
+        Assert.All(
+            result.Pairs,
+            pair => Assert.NotSame(
+                unreadable.Participant,
+                pair.Right.Participant));
+    }
+
+    [Fact]
+    public async Task Execute_ReportsSeedSelectionFailure()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult missingType =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.Snapshot(),
+                    new StructuralCloneSearchSeed.Type(
+                        TypeName("N.Missing"))));
+        WorkspaceStructuralCloneSearchResult missingMember =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.Snapshot(),
+                    new StructuralCloneSearchSeed.Member(
+                        TypeName("N.Alpha"),
+                        fixture.ForeignAnchor())));
+
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedTypeNotFound,
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    missingType)
+                .Failure.Kind);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedMemberNotFound,
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    missingMember)
+                .Failure.Kind);
+    }
+
+    [Fact]
+    public async Task Execute_ReportsExhaustedNameWorkAsIncompleteCoverage()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumNameComparisonWork: 32))));
+
+        Assert.Contains(
+            result.Libraries.SelectMany(library => library.Failures),
+            failure => failure.Kind
+                == StructuralCloneSearchFailureKind.NameWorkLimitReached);
+        Assert.False(result.CoverageIsComplete);
+    }
+
+    [Fact]
+    public async Task Execute_ReportsUndecodableNamesAsIncompleteCoverage()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumNameCharacters: 4))));
+
+        StructuralCloneSearchSeedCoverage seed =
+            Assert.Single(result.Seeds);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.NameDecodeFailed,
+            Assert.Single(seed.Failures).Kind);
+        Assert.False(seed.CoverageIsComplete);
+        Assert.False(result.CoverageIsComplete);
+        Assert.Empty(result.Pairs);
+    }
+
+    /// <summary>
+    /// Similar-name admission is a property of one seed-candidate pair, not of
+    /// the candidate against the best unrelated seed.
+    /// </summary>
+    [Fact]
+    public async Task Execute_RanksEachCandidateOnlyAgainstQualifyingSeeds()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        StructuralCloneParticipantSnapshot snapshot =
+            fixture.CrossSeedSnapshot();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.SimilarNames)));
+
+        // Two seeds, and each library declares one exact counterpart of each:
+        // Parser.Parse qualifies only for the Parser.Parse seed, and
+        // Zulu.Xylophone only for the Zulu.Xylophone seed. The peer library
+        // adds Parsers.Parses, which is near the first seed and far from the
+        // second.
+        Assert.Equal(2, result.Receipt.SeedMethods);
+        Assert.Equal(5, result.Receipt.DiscoveredCandidateMethods);
+
+        (string Left, string Right)[] pairs =
+        [
+            .. result.Pairs.Select(
+                pair => (
+                    fixture.CrossSeedName(pair.Left),
+                    fixture.CrossSeedName(pair.Right))),
+        ];
+
+        // Only the qualifying pairs survive: the same-library counterparts
+        // are the seeds themselves and are suppressed, and neither seed is
+        // ever ranked against the other seed's candidates.
+        Assert.Equal(
+            [
+                ("Parse", "Parse"),
+                ("Parse", "Parses"),
+                ("Xylophone", "Xylophone"),
+            ],
+            pairs.Order());
+        Assert.DoesNotContain(
+            pairs,
+            pair => pair.Left == "Xylophone" && pair.Right != "Xylophone");
+        Assert.DoesNotContain(
+            pairs,
+            pair => pair.Left == "Parse" && pair.Right == "Xylophone");
+
+        // The unqualified pairs are not merely dropped from the rows: they
+        // are never retrieved, so they charge no aggregate retrieval work.
+        // The containing library charges two pairs whose rows are suppressed
+        // self-pairs; the peer charges two for the first seed and one for the
+        // second.
+        Assert.Equal(5L, result.Receipt.RetrievalPairs);
+        Assert.Equal(4, result.Receipt.RetrievalCalls);
+
+        // Each row carries its own pair's evidence, not the best unrelated
+        // seed's scores.
+        StructuralCloneNameQualification exact =
+            Qualification(
+                Assert.Single(
+                    result.Pairs,
+                    pair => fixture.CrossSeedName(pair.Right) == "Parse"));
+        StructuralCloneNameQualification near =
+            Qualification(
+                Assert.Single(
+                    result.Pairs,
+                    pair => fixture.CrossSeedName(pair.Right) == "Parses"));
+        Assert.Equal(1.0, exact.DeclaringTypeSimilarity);
+        Assert.Equal(1.0, exact.MemberSimilarity);
+        Assert.Equal(1.0 - (1.0 / 7.0), near.DeclaringTypeSimilarity, 9);
+        Assert.Equal(1.0 - (1.0 / 6.0), near.MemberSimilarity, 9);
+        Assert.All(
+            result.Pairs,
+            pair => Assert.True(
+                Qualification(pair).DeclaringTypeSimilarity
+                    >= WorkspaceStructuralCloneSearchQuery
+                        .NameSimilarityThreshold
+                    && Qualification(pair).MemberSimilarity
+                        >= WorkspaceStructuralCloneSearchQuery
+                            .NameSimilarityThreshold,
+                "Every returned pair cleared both thresholds itself."));
+        Assert.True(result.CoverageIsComplete);
+
+        // The same population under All discovery ranks every seed against
+        // every candidate, so the difference above is admission, not breadth.
+        WorkspaceStructuralCloneSearchResult.Available exhaustive =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.Equal(
+            exhaustive.Receipt.DiscoveredCandidateMethods,
+            result.Receipt.DiscoveredCandidateMethods);
+        Assert.Equal(10L, exhaustive.Receipt.RetrievalPairs);
+        Assert.Contains(
+            exhaustive.Pairs,
+            pair => fixture.CrossSeedName(pair.Left) == "Xylophone"
+                && fixture.CrossSeedName(pair.Right) == "Parse");
+    }
+
+    /// <summary>
+    /// Per-library bounds alone permit unbounded aggregate work, so the search
+    /// bounds the breadth-admitted participant count as a whole-unit
+    /// preflight.
+    /// </summary>
+    [Fact]
+    public async Task Execute_ExcludesParticipantsBeyondTheParticipantBound()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available bounded =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumParticipants: 2))));
+
+        Assert.Equal(2, bounded.Receipt.AdmittedLibraries);
+        Assert.Equal(1, bounded.Receipt.ExcludedLibraries);
+        StructuralCloneSearchLibraryCoverage excluded =
+            Assert.Single(
+                bounded.Libraries,
+                library => !library.CoverageIsComplete);
+        Assert.Equal(2, excluded.Participant.Ordinal);
+        Assert.False(excluded.Admitted);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind
+                .ParticipantPopulationLimitReached,
+            Assert.Single(excluded.Failures).Kind);
+
+        // The omitted pair population is visible, and is not confused with
+        // the intentional returned-row bound.
+        Assert.False(bounded.CoverageIsComplete);
+        Assert.False(bounded.Receipt.ResultLimitReached);
+        Assert.All(
+            bounded.Pairs,
+            pair => Assert.NotSame(
+                excluded.Participant,
+                pair.Right.Participant));
+
+        // The containing library is always the first admitted participant,
+        // even when the snapshot lists it last.
+        WorkspaceStructuralCloneSearchResult.Available selfOnly =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.SnapshotOf(
+                            fixture.AvailableEntry,
+                            fixture.EcosystemEntry,
+                            fixture.SelfEntry),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumParticipants: 1))));
+
+        Assert.Equal(1, selfOnly.Receipt.AdmittedLibraries);
+        Assert.Equal(
+            StructuralCloneParticipantMembership.ContainingLibrary,
+            Assert.Single(
+                    selfOnly.Libraries,
+                    library => library.Admitted)
+                .Membership);
+        Assert.Equal(2, selfOnly.Receipt.ExcludedLibraries);
+        Assert.False(selfOnly.CoverageIsComplete);
+
+        WorkspaceStructuralCloneSearchResult.Available complete =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumParticipants: 3))));
+
+        Assert.Equal(3, complete.Receipt.AdmittedLibraries);
+        Assert.True(complete.CoverageIsComplete);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new WorkspaceStructuralCloneSearchInput(
+                fixture.Snapshot(),
+                new StructuralCloneSearchSeed.Library(),
+                limits: new WorkspaceStructuralCloneSearchLimits(
+                    MaximumParticipants: 0)));
+    }
+
+    /// <summary>
+    /// The aggregate seed-by-candidate retrieval population is bounded, and a
+    /// participant that does not fit is excluded whole rather than truncated
+    /// into a result that could pass for a complete global top N.
+    /// </summary>
+    [Fact]
+    public async Task Execute_ExcludesParticipantsBeyondTheRetrievalBound()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        // Six library seeds over the six same-library candidates.
+        WorkspaceStructuralCloneSearchResult.Available unbounded =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.Equal(36L, unbounded.Receipt.RetrievalPairs);
+        Assert.True(unbounded.CoverageIsComplete);
+
+        WorkspaceStructuralCloneSearchResult.Available bounded =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumRetrievalPairs: 35))));
+
+        StructuralCloneSearchLibraryCoverage excluded =
+            Assert.Single(
+                bounded.Libraries,
+                library => library.Membership
+                    == StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+        Assert.False(excluded.Admitted);
+        Assert.Equal(0L, excluded.RetrievalPairs);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.RetrievalWorkLimitReached,
+            Assert.Single(excluded.Failures).Kind);
+        Assert.Empty(bounded.Pairs);
+        Assert.Equal(0L, bounded.Receipt.RetrievalPairs);
+        Assert.Equal(0, bounded.Receipt.RetrievalCalls);
+        Assert.False(bounded.CoverageIsComplete);
+        Assert.False(bounded.Receipt.ResultLimitReached);
+
+        // The budget latches: once one participant does not fit, no later
+        // participant is opened or partially evaluated.
+        WorkspaceStructuralCloneSearchResult.Available latched =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumRetrievalPairs: 40))));
+
+        Assert.Equal(36L, latched.Receipt.RetrievalPairs);
+        Assert.Equal(1, latched.Receipt.AdmittedLibraries);
+        Assert.Equal(2, latched.Receipt.ExcludedLibraries);
+        Assert.Equal(
+            2,
+            latched.Libraries.Count(
+                library => library.Failures.Any(
+                    failure => failure.Kind
+                        == StructuralCloneSearchFailureKind
+                            .RetrievalWorkLimitReached)));
+        Assert.False(latched.CoverageIsComplete);
+        Assert.All(
+            latched.Pairs,
+            pair => Assert.Equal(
+                StructuralCloneParticipantMembership.ContainingLibrary,
+                pair.Right.Membership));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new WorkspaceStructuralCloneSearchInput(
+                fixture.Snapshot(),
+                new StructuralCloneSearchSeed.Library(),
+                limits: new WorkspaceStructuralCloneSearchLimits(
+                    MaximumRetrievalPairs: 0)));
+
+        // Under SimilarNames the pair population is built one admitted
+        // seed-candidate at a time, so the bound stops admission itself
+        // rather than measuring a materialized quadratic structure.
+        WorkspaceStructuralCloneSearchResult.Available named =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumRetrievalPairs: 2))));
+
+        StructuralCloneSearchLibraryCoverage abandoned =
+            Assert.Single(
+                named.Libraries,
+                library => library.Membership
+                    == StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+        Assert.False(abandoned.Admitted);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.RetrievalWorkLimitReached,
+            Assert.Single(abandoned.Failures).Kind);
+        Assert.Empty(named.Pairs);
+        Assert.Equal(0L, named.Receipt.RetrievalPairs);
+        Assert.Equal(0, named.Receipt.RetrievalCalls);
+        Assert.False(named.CoverageIsComplete);
+        Assert.False(named.Receipt.ResultLimitReached);
+    }
+
+    [Fact]
+    public async Task Execute_ReportsCandidateAndSeedPopulationLimits()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        WorkspaceStructuralCloneSearchResult.Available candidateLimit =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        fixture.MemberSeed("Compute0"),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumCandidateMethods: 2))));
+
+        Assert.Empty(candidateLimit.Pairs);
+        Assert.Contains(
+            candidateLimit.Libraries.SelectMany(
+                library => library.Failures),
+            failure => failure.Kind
+                == StructuralCloneSearchFailureKind
+                    .CandidatePopulationLimitReached);
+        Assert.False(candidateLimit.CoverageIsComplete);
+
+        WorkspaceStructuralCloneSearchResult seedLimit =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.Snapshot(),
+                    new StructuralCloneSearchSeed.Library(),
+                    StructuralCloneCandidateBreadth.Self,
+                    StructuralCloneCandidateDiscovery.All,
+                    new WorkspaceStructuralCloneSearchLimits(
+                        MaximumSeedMethods: 2)));
+
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedPopulationLimitReached,
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    seedLimit)
+                .Failure.Kind);
+    }
+
+    /// <summary>
+    /// Group and participant lifetime belongs to the snapshot's issuer, and
+    /// nothing enforces it yet. A release before execution must therefore be
+    /// visible rather than an exception escaping <c>Execute</c>.
+    /// </summary>
+    [Fact]
+    public async Task Execute_ReportsReleasedSeedLibraryAsTypedFailure()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        StructuralCloneParticipantSnapshot snapshot = fixture.Snapshot();
+        fixture.SelfGroup.Dispose();
+
+        WorkspaceStructuralCloneSearchResult result =
+            Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    snapshot,
+                    new StructuralCloneSearchSeed.Library()));
+
+        StructuralCloneSearchFailure failure =
+            Assert.IsType<WorkspaceStructuralCloneSearchResult.Failed>(
+                    result)
+                .Failure;
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedLibraryReleased,
+            failure.Kind);
+        Assert.Same(fixture.SelfEntry.Subject, failure.Subject);
+    }
+
+    [Fact]
+    public async Task
+        Execute_ReportsReleasedCandidateLibraryAsIncompleteCoverage()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        StructuralCloneParticipantSnapshot snapshot = fixture.Snapshot();
+        StructuralCloneSearchSeed seed = fixture.MemberSeed("Compute0");
+        fixture.EcosystemGroup.Dispose();
+
+        WorkspaceStructuralCloneSearchResult.Available result =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        seed,
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        StructuralCloneSearchLibraryCoverage released =
+            Assert.Single(
+                result.Libraries,
+                library => library.Membership
+                    == StructuralCloneParticipantMembership
+                        .RegisteredEcosystem);
+        Assert.True(released.Admitted);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.CandidateLibraryReleased,
+            Assert.Single(released.Failures).Kind);
+        Assert.Equal(0L, released.RetrievalPairs);
+        Assert.False(released.CoverageIsComplete);
+        Assert.False(result.CoverageIsComplete);
+
+        // The released participant reserved no retrieval budget, and the
+        // evidence ranked from the other libraries survives beside the gap.
+        Assert.NotEmpty(result.Pairs);
+        Assert.All(
+            result.Pairs,
+            pair => Assert.NotSame(
+                released.Participant,
+                pair.Right.Participant));
+        Assert.Contains(
+            result.Pairs,
+            pair => pair.Right.Membership
+                == StructuralCloneParticipantMembership.Available);
+    }
+
+    /// <summary>
+    /// Memoized name scores are bounded by retained cells, not only by entry
+    /// count, because one entry costs one cell per distinct seed name.
+    /// </summary>
+    [Fact]
+    public async Task
+        Execute_BoundedNameScoreCacheDoesNotChangeCompleteAdmission()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        // Four declaring types share one simple name and each repeats the
+        // same eight member names, so the caches take real hits and one
+        // score vector is eight cells wide.
+        StructuralCloneParticipantSnapshot snapshot =
+            fixture.RepeatedNamesSnapshot();
+
+        WorkspaceStructuralCloneSearchResult.Available cached =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500))));
+
+        // One cell cannot hold an eight-cell vector, so nothing that matters
+        // is retained and every name is rescored.
+        WorkspaceStructuralCloneSearchResult.Available uncached =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500,
+                            MaximumNameCacheCells: 1))));
+
+        Assert.True(cached.CoverageIsComplete);
+        Assert.True(uncached.CoverageIsComplete);
+        Assert.NotEmpty(cached.Pairs);
+
+        // Admission and ranking are identical; only the charged name work
+        // differs, which is what proves the cache is a pure optimization.
+        Assert.Equal(cached.Pairs, uncached.Pairs);
+        Assert.Equal(cached.Receipt, uncached.Receipt);
+        Assert.Equal(
+            cached.Libraries.Select(
+                library => (
+                    library.Admitted,
+                    library.CandidateMethods,
+                    library.DiscoveredMethods,
+                    library.RetrievalPairs)),
+            uncached.Libraries.Select(
+                library => (
+                    library.Admitted,
+                    library.CandidateMethods,
+                    library.DiscoveredMethods,
+                    library.RetrievalPairs)));
+        Assert.True(
+            NameWork(uncached) > NameWork(cached),
+            "The bounded cache must actually retain scores when it fits.");
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new WorkspaceStructuralCloneSearchInput(
+                snapshot,
+                new StructuralCloneSearchSeed.Library(),
+                limits: new WorkspaceStructuralCloneSearchLimits(
+                    MaximumNameCacheCells: 0)));
+    }
+
+    /// <summary>
+    /// The shared name-work budget, not the cache, decides admission: once it
+    /// is exhausted no later candidate is admitted, including one whose
+    /// declaring-type and member scores are already memoized.
+    /// </summary>
+    [Fact]
+    public async Task Execute_StopsNameAdmissionAtTheExhaustedWorkBudget()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        StructuralCloneParticipantSnapshot snapshot =
+            fixture.RepeatedNamesSnapshot();
+        StructuralCloneSearchSeed seed = fixture.RepeatedNamesSeed();
+
+        WorkspaceStructuralCloneSearchResult.Available complete =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        seed,
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500))));
+
+        Assert.True(complete.CoverageIsComplete);
+        int discovered = complete.Receipt.DiscoveredCandidateMethods;
+        Assert.True(discovered > 1);
+
+        WorkspaceStructuralCloneSearchResult.Available exhausted =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        seed,
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500,
+                            MaximumNameComparisonWork:
+                                NameWork(complete) / 2))));
+
+        Assert.Contains(
+            exhausted.Libraries.SelectMany(library => library.Failures),
+            failure => failure.Kind
+                == StructuralCloneSearchFailureKind.NameWorkLimitReached);
+        Assert.False(exhausted.CoverageIsComplete);
+        Assert.True(
+            exhausted.Receipt.DiscoveredCandidateMethods < discovered);
+
+        // Every candidate name in this fixture qualifies, so a complete run
+        // admits every method in MethodDef order. Admission after exhaustion
+        // would appear as a gap in that prefix.
+        int[] rows =
+        [
+            .. exhausted.Pairs
+                .Select(pair => Row(pair.Right.Method))
+                .Order(),
+        ];
+        Assert.NotEmpty(rows);
+        Assert.Equal(
+            Enumerable.Range(rows[0], rows.Length),
+            rows);
+    }
+
+    /// <summary>
+    /// One seed's candidate group is retrieved in bounded chunks so
+    /// cancellation is observed between units of Analysis work. Chunking is a
+    /// scheduling decision: it cannot change the global ranking or the
+    /// aggregate retrieval charge.
+    /// </summary>
+    [Fact]
+    public async Task
+        Execute_ChunkedRetrievalPreservesGlobalRankingAndPairCharge()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        StructuralCloneParticipantSnapshot snapshot =
+            fixture.RepeatedNamesSnapshot();
+
+        WorkspaceStructuralCloneSearchResult.Available whole =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500))));
+
+        // Three does not divide the candidate population, so the last chunk
+        // of every seed group is short.
+        WorkspaceStructuralCloneSearchResult.Available chunked =
+            Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        snapshot,
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.SimilarNames,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            MaximumResults: 500,
+                            MaximumRetrievalChunkMethods: 3))));
+
+        Assert.NotEmpty(whole.Pairs);
+        Assert.Equal(whole.Pairs, chunked.Pairs);
+        Assert.Equal(
+            whole.Receipt.RetrievalPairs,
+            chunked.Receipt.RetrievalPairs);
+        Assert.Equal(
+            whole.Receipt.RankedPairs,
+            chunked.Receipt.RankedPairs);
+        Assert.Equal(
+            whole.Receipt.SuppressedPairs,
+            chunked.Receipt.SuppressedPairs);
+        Assert.Equal(
+            whole.Receipt.ReturnedPairs,
+            chunked.Receipt.ReturnedPairs);
+        Assert.True(whole.CoverageIsComplete);
+        Assert.True(chunked.CoverageIsComplete);
+        Assert.Equal(
+            whole.Seeds.Select(
+                seed => (seed.Seed, seed.Disposition, seed.RankedPairs,
+                    seed.SuppressedPairs)),
+            chunked.Seeds.Select(
+                seed => (seed.Seed, seed.Disposition, seed.RankedPairs,
+                    seed.SuppressedPairs)));
+
+        // The retrieval-call count is the one receipt field chunking moves,
+        // and every pair still carries its own name evidence.
+        Assert.True(
+            chunked.Receipt.RetrievalCalls
+                > whole.Receipt.RetrievalCalls);
+        Assert.All(
+            chunked.Pairs,
+            pair => Assert.NotNull(pair.NameQualification));
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new WorkspaceStructuralCloneSearchInput(
+                snapshot,
+                new StructuralCloneSearchSeed.Library(),
+                limits: new WorkspaceStructuralCloneSearchLimits(
+                    MaximumRetrievalChunkMethods: 0)));
+    }
+
+    [Fact]
+    public async Task Execute_ObservesCancellation()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        Assert.Throws<OperationCanceledException>(
+            () => WorkspaceStructuralCloneSearchQuery.Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    fixture.RepeatedNamesSnapshot(),
+                    new StructuralCloneSearchSeed.Library()),
+                cancellation.Token));
+    }
+
+    [Fact]
+    public async Task Execute_RunsThroughTheInspectionQueryRegistry()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        var input =
+            new WorkspaceStructuralCloneSearchInput(
+                fixture.Snapshot(),
+                fixture.MemberSeed("Compute0"));
+        var registry =
+            new InspectionQueryRegistry<
+                WorkspaceStructuralCloneSearchInput>()
+                .Add(
+                    WorkspaceStructuralCloneSearchQuery.Definition,
+                    WorkspaceStructuralCloneSearchQuery.Execute);
+
+        WorkspaceStructuralCloneSearchResult result =
+            registry
+                .Run(
+                    [WorkspaceStructuralCloneSearchQuery.Definition],
+                    input)
+                .Get(WorkspaceStructuralCloneSearchQuery.Definition);
+
+        Assert.IsType<WorkspaceStructuralCloneSearchResult.Available>(
+            result);
+    }
+
+    static WorkspaceStructuralCloneSearchResult Execute(
+        WorkspaceStructuralCloneSearchInput input)
+        => WorkspaceStructuralCloneSearchQuery.Execute(
+            input,
+            TestContext.Current.CancellationToken);
+
+    static WorkspaceStructuralCloneSearchResult.Available Available(
+        WorkspaceStructuralCloneSearchResult result)
+        => Assert.IsType<
+            WorkspaceStructuralCloneSearchResult.Available>(result);
+
+    static StructuralCloneNameQualification Qualification(
+        StructuralCloneSearchPair pair)
+        => Assert.IsType<StructuralCloneNameQualification>(
+            pair.NameQualification);
+
+    static int SeedCount(Fixture fixture, StructuralCloneSearchSeed seed)
+        => Available(
+                Execute(
+                    new WorkspaceStructuralCloneSearchInput(
+                        fixture.Snapshot(),
+                        seed,
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)))
+            .Receipt.SeedMethods;
+
+    static int Row(MetadataMethodAddress address)
+        => MetadataTokens.GetRowNumber(address.Handle);
+
+    static long NameWork(
+        WorkspaceStructuralCloneSearchResult.Available result)
+        => result.Libraries.Sum(
+            library => library.NameComparisonWork);
+
+    static (int Left, int LeftRow, int Right, int RightRow) Endpoints(
+        StructuralCloneSearchPair pair)
+        => (
+            pair.Left.Participant.Ordinal,
+            Row(pair.Left.Method),
+            pair.Right.Participant.Ordinal,
+            Row(pair.Right.Method));
+
+    static MetadataTypeDefinitionName TypeName(string serializedName)
+        => Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.ParseSerialized(
+                    serializedName))
+            .Name;
+
+    static async ValueTask<WorkspaceScopeSnapshot> ScopeSnapshot(
+        InspectionWorkspace workspace)
+        => Assert.IsType<WorkspaceScopeReadResult.Available>(
+                await workspace.GetScopeSnapshotAsync())
+            .Snapshot;
+
+    /// <summary>
+    /// One Workspace, three synthetic libraries, and the owner-issued
+    /// participant snapshot the search consumes.
+    /// </summary>
+    sealed class Fixture : IAsyncDisposable
+    {
+        Fixture(
+            InspectionWorkspace workspace,
+            WorkspaceScopeRevision revision)
+        {
+            Workspace = workspace;
+            Revision = revision;
+            SelfImage =
+                Assembly(
+                    SelfAssembly,
+                    new Guid("1B0A0C5E-0001-4000-8000-000000000001"),
+                    SelfTypes());
+            ImmutableArray<byte> ecosystem =
+                Assembly(
+                    EcosystemAssembly,
+                    new Guid("1B0A0C5E-0002-4000-8000-000000000002"),
+                    [("N", "Alpha", [("Compute9", 1)])]);
+            ImmutableArray<byte> available =
+                Assembly(
+                    AvailableAssembly,
+                    new Guid("1B0A0C5E-0003-4000-8000-000000000003"),
+                    [("N", "Alpha", [("Compute8", 1)])]);
+            SelfGroup = Group(workspace, SelfImage);
+            EcosystemGroup = Group(workspace, ecosystem);
+            AvailableGroup = Group(workspace, available);
+            DuplicateGroup = Group(workspace, ecosystem);
+            UnreadableGroup =
+                Group(
+                    workspace,
+                    ImmutableCollectionsMarshal.AsImmutableArray(
+                        new byte[] { 0x4D, 0x5A, 0x00, 0x00 }));
+            SelfEntry =
+                new StructuralCloneParticipantEntry(
+                    SelfGroup,
+                    SelfParticipant,
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+            EcosystemEntry =
+                new StructuralCloneParticipantEntry(
+                    EcosystemGroup,
+                    EcosystemParticipant,
+                    StructuralCloneParticipantMembership
+                        .RegisteredEcosystem);
+            AvailableEntry =
+                new StructuralCloneParticipantEntry(
+                    AvailableGroup,
+                    AvailableGroup.Participants[0],
+                    StructuralCloneParticipantMembership.Available);
+
+            // Two seeds whose declaring-type and member names are mutually
+            // dissimilar, plus a peer library carrying one exact counterpart
+            // for each. Every candidate qualifies for exactly one seed.
+            CrossSeedImage =
+                Assembly(
+                    CrossSeedAssembly,
+                    new Guid("1B0A0C5E-0004-4000-8000-000000000004"),
+                    CrossSeedTypes());
+            CrossSeedPeerImage =
+                Assembly(
+                    CrossSeedCandidateAssembly,
+                    new Guid("1B0A0C5E-0005-4000-8000-000000000005"),
+                    [
+                        .. CrossSeedTypes(),
+
+                        // Near, but not equal, to the Parser.Parse seed and
+                        // far from the Zulu.Xylophone seed.
+                        ("N", "Parsers", [("Parses", 1)]),
+                    ]);
+            CrossSeedGroup = Group(workspace, CrossSeedImage);
+            CrossSeedPeerGroup = Group(workspace, CrossSeedPeerImage);
+            CrossSeedEntry =
+                new StructuralCloneParticipantEntry(
+                    CrossSeedGroup,
+                    CrossSeedGroup.Participants[0],
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+            CrossSeedPeerEntry =
+                new StructuralCloneParticipantEntry(
+                    CrossSeedPeerGroup,
+                    CrossSeedPeerGroup.Participants[0],
+                    StructuralCloneParticipantMembership.Available);
+
+            // Every declaring type carries the same simple name and the same
+            // member names, so decoded-name memoization takes real hits and
+            // one score vector spans every distinct seed member name.
+            RepeatedNamesImage =
+                Assembly(
+                    RepeatedNamesAssembly,
+                    new Guid("1B0A0C5E-0006-4000-8000-000000000006"),
+                    RepeatedNameTypeShapes());
+            RepeatedNamesGroup = Group(workspace, RepeatedNamesImage);
+            RepeatedNamesEntry =
+                new StructuralCloneParticipantEntry(
+                    RepeatedNamesGroup,
+                    RepeatedNamesGroup.Participants[0],
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+        }
+
+        internal InspectionWorkspace Workspace { get; }
+        internal WorkspaceScopeRevision Revision { get; private set; }
+        internal ImmutableArray<byte> SelfImage { get; }
+        internal AssemblyContextGroup SelfGroup { get; }
+        internal AssemblyContextGroup EcosystemGroup { get; }
+        internal AssemblyContextGroup AvailableGroup { get; }
+        internal AssemblyContextGroup DuplicateGroup { get; }
+        internal AssemblyContextGroup UnreadableGroup { get; }
+        internal StructuralCloneParticipantEntry SelfEntry { get; }
+        internal StructuralCloneParticipantEntry EcosystemEntry { get; }
+        internal StructuralCloneParticipantEntry AvailableEntry { get; }
+        internal ImmutableArray<byte> CrossSeedImage { get; }
+        internal ImmutableArray<byte> CrossSeedPeerImage { get; }
+        internal AssemblyContextGroup CrossSeedGroup { get; }
+        internal AssemblyContextGroup CrossSeedPeerGroup { get; }
+        internal StructuralCloneParticipantEntry CrossSeedEntry { get; }
+        internal StructuralCloneParticipantEntry CrossSeedPeerEntry { get; }
+        internal ImmutableArray<byte> RepeatedNamesImage { get; }
+        internal AssemblyContextGroup RepeatedNamesGroup { get; }
+        internal StructuralCloneParticipantEntry RepeatedNamesEntry { get; }
+
+        internal AssemblyContextParticipant SelfParticipant =>
+            SelfGroup.Participants[0];
+
+        internal AssemblyContextParticipant EcosystemParticipant =>
+            EcosystemGroup.Participants[0];
+
+        internal static async ValueTask<Fixture> CreateAsync()
+        {
+            InspectionWorkspace workspace =
+                InspectionWorkspace.CreateAsynchronous();
+            return new Fixture(
+                workspace,
+                (await ScopeSnapshot(workspace)).Revision);
+        }
+
+        internal StructuralCloneParticipantSnapshot Snapshot()
+            => new(
+                Revision,
+                Revision,
+                [SelfEntry, EcosystemEntry, AvailableEntry]);
+
+        /// <summary>One snapshot in the caller's exact entry order.</summary>
+        internal StructuralCloneParticipantSnapshot SnapshotOf(
+            params StructuralCloneParticipantEntry[] entries)
+            => new(Revision, Revision, entries);
+
+        /// <summary>
+        /// The containing library and one peer, each declaring
+        /// <c>N.Parser.Parse</c> and <c>N.Zulu.Xylophone</c>.
+        /// </summary>
+        internal StructuralCloneParticipantSnapshot CrossSeedSnapshot()
+            => new(
+                Revision,
+                Revision,
+                [CrossSeedEntry, CrossSeedPeerEntry]);
+
+        /// <summary>Decodes one cross-seed endpoint's method name.</summary>
+        internal string CrossSeedName(
+            StructuralCloneSearchEndpoint endpoint)
+        {
+            using var image =
+                new PEReader(
+                    endpoint.Participant.Ordinal == 0
+                        ? CrossSeedImage
+                        : CrossSeedPeerImage);
+            MetadataReader reader = image.GetMetadataReader();
+            return reader.GetString(
+                reader.GetMethodDefinition(endpoint.Method.Handle).Name);
+        }
+
+        /// <summary>
+        /// One library whose four declaring types share one simple name and
+        /// repeat the same eight member names.
+        /// </summary>
+        internal StructuralCloneParticipantSnapshot RepeatedNamesSnapshot()
+            => new(Revision, Revision, [RepeatedNamesEntry]);
+
+        /// <summary>The first repeated-names method as an exact seed.</summary>
+        internal StructuralCloneSearchSeed.Member RepeatedNamesSeed()
+        {
+            using var image = new PEReader(RepeatedNamesImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "N0.Group");
+            return new StructuralCloneSearchSeed.Member(
+                TypeName("N0.Group"),
+                ApiMemberIdentity.CreateMethodAnchor(
+                    reader,
+                    type,
+                    reader.GetMethodDefinition(
+                        Method(reader, type, "Compute00"))));
+        }
+
+        internal StructuralCloneParticipantSnapshot
+            SnapshotWithDuplicateContent()
+            => new(
+                Revision,
+                Revision,
+                [
+                    SelfEntry,
+                    EcosystemEntry,
+                    new StructuralCloneParticipantEntry(
+                        DuplicateGroup,
+                        DuplicateGroup.Participants[0],
+                        StructuralCloneParticipantMembership.Available),
+                ]);
+
+        internal StructuralCloneParticipantSnapshot
+            SnapshotWithUnreadableParticipant()
+            => new(
+                Revision,
+                Revision,
+                [
+                    SelfEntry,
+                    new StructuralCloneParticipantEntry(
+                        UnreadableGroup,
+                        UnreadableGroup.Participants[0],
+                        StructuralCloneParticipantMembership.Available),
+                ]);
+
+        internal async ValueTask<WorkspaceScopeRevision>
+            CommitFreshRevisionAsync()
+        {
+            var committed =
+                Assert.IsType<WorkspaceScopeOperationResult.Committed>(
+                    await Workspace.ClearScopeAsync(
+                        Revision,
+                        DateTimeOffset.UtcNow.AddMinutes(5),
+                        TestContext.Current.CancellationToken));
+            Revision = committed.Snapshot.Revision;
+            return Revision;
+        }
+
+        internal StructuralCloneSearchSeed.Member MemberSeed(
+            string methodName)
+        {
+            using var image = new PEReader(SelfImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "N.Alpha");
+            return new StructuralCloneSearchSeed.Member(
+                TypeName("N.Alpha"),
+                ApiMemberIdentity.CreateMethodAnchor(
+                    reader,
+                    type,
+                    reader.GetMethodDefinition(
+                        Method(reader, type, methodName))));
+        }
+
+        /// <summary>An anchor for a method that N.Alpha does not declare.</summary>
+        internal MemberAnchor ForeignAnchor()
+        {
+            using var image = new PEReader(SelfImage);
+            MetadataReader reader = image.GetMetadataReader();
+            TypeDefinitionHandle type = Type(reader, "N.Zulu");
+            return ApiMemberIdentity.CreateMethodAnchor(
+                reader,
+                type,
+                reader.GetMethodDefinition(
+                    Method(reader, type, "Compute4")));
+        }
+
+        internal string SelfName(StructuralCloneSearchEndpoint endpoint)
+        {
+            Assert.Equal(0, endpoint.Participant.Ordinal);
+            using var image = new PEReader(SelfImage);
+            MetadataReader reader = image.GetMetadataReader();
+            return reader.GetString(
+                reader.GetMethodDefinition(endpoint.Method.Handle).Name);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            SelfGroup.Dispose();
+            EcosystemGroup.Dispose();
+            AvailableGroup.Dispose();
+            DuplicateGroup.Dispose();
+            UnreadableGroup.Dispose();
+            CrossSeedGroup.Dispose();
+            CrossSeedPeerGroup.Dispose();
+            RepeatedNamesGroup.Dispose();
+            await Workspace.DisposeAsync();
+        }
+
+        /// <summary>
+        /// Types that share one simple name across distinct namespaces, each
+        /// repeating the same member names with differing body lengths.
+        /// </summary>
+        static (string Namespace, string Name,
+            (string Method, int Body)[] Methods)[] RepeatedNameTypeShapes()
+        {
+            var types =
+                new (string, string, (string, int)[])[RepeatedNameTypes];
+            for (int type = 0; type < RepeatedNameTypes; type++)
+            {
+                var methods = new (string, int)[RepeatedNameMethods];
+                for (int method = 0;
+                    method < RepeatedNameMethods;
+                    method++)
+                {
+                    methods[method] =
+                        ($"Compute0{method}", 1 + ((type + method) % 4));
+                }
+
+                types[type] = ($"N{type}", "Group", methods);
+            }
+
+            return types;
+        }
+
+        static (string Namespace, string Name,
+            (string Method, int Body)[] Methods)[] CrossSeedTypes()
+            =>
+            [
+                ("N", "Parser", [("Parse", 1)]),
+                ("N", "Zulu", [("Xylophone", 1)]),
+            ];
+
+        static (string Namespace, string Name,
+            (string Method, int Body)[] Methods)[] SelfTypes()
+            =>
+            [
+                (
+                    "N",
+                    "Alpha",
+                    [
+                        ("Compute0", 1),
+                        ("Compute1", 1),
+                        ("Compute2", 1),
+                        ("Compute7", 4),
+                        ("Unrelated", 1),
+                    ]),
+                ("N", "Zulu", [("Compute4", 1)]),
+            ];
+
+        static AssemblyContextGroup Group(
+            InspectionWorkspace workspace,
+            ImmutableArray<byte> image)
+            => workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        ResolvedAssemblyReference.Create(
+                            Identity(image),
+                            path: null,
+                            () => new MemoryStream(
+                                ImmutableCollectionsMarshal
+                                    .AsArray(image)!,
+                                writable: false),
+                            AssemblyResolutionProvenance.Local(
+                                "clone search tests")),
+                        new TestBindingPolicy()),
+                ]);
+
+        static AssemblyReferenceIdentity Identity(
+            ImmutableArray<byte> image)
+        {
+            try
+            {
+                using var reader = new PEReader(image);
+                return AssemblyReferenceIdentity
+                    .FromAssemblyDefinition(
+                        reader.GetMetadataReader());
+            }
+            catch (BadImageFormatException)
+            {
+                return new AssemblyReferenceIdentity(
+                    "Unreadable",
+                    new Version(1, 0, 0, 0),
+                    Culture: null,
+                    PublicKeyToken: null);
+            }
+        }
+
+        static MethodDefinitionHandle Method(
+            MetadataReader reader,
+            TypeDefinitionHandle type,
+            string name)
+            => Assert.Single(
+                reader.GetTypeDefinition(type).GetMethods(),
+                method => reader.GetString(
+                    reader.GetMethodDefinition(method).Name)
+                    == name);
+
+        static TypeDefinitionHandle Type(
+            MetadataReader reader,
+            string serializedName)
+        {
+            var index = MetadataTypeDefinitionIndex.Create(reader);
+            Assert.True(
+                index.TryGetUniqueDefinition(
+                    TypeName(serializedName),
+                    out TypeDefinitionHandle handle));
+            return handle;
+        }
+
+        /// <summary>
+        /// Builds one synthetic library whose TypeDef method ranges partition
+        /// the MethodDef table and whose bodies differ only in length.
+        /// </summary>
+        static ImmutableArray<byte> Assembly(
+            string assemblyName,
+            Guid moduleVersionId,
+            (string Namespace, string Name,
+                (string Method, int Body)[] Methods)[] types)
+        {
+            var metadata = new MetadataBuilder();
+            metadata.AddModule(
+                generation: 0,
+                metadata.GetOrAddString($"{assemblyName}.dll"),
+                metadata.GetOrAddGuid(moduleVersionId),
+                encId: default,
+                encBaseId: default);
+            metadata.AddAssembly(
+                metadata.GetOrAddString(assemblyName),
+                new Version(1, 0, 0, 0),
+                culture: default,
+                publicKey: default,
+                flags: default,
+                hashAlgorithm: default);
+            metadata.AddTypeDefinition(
+                default,
+                default,
+                metadata.GetOrAddString("<Module>"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            int nextMethod = 1;
+            foreach ((string ns, string name,
+                (string Method, int Body)[] methods) in types)
+            {
+                metadata.AddTypeDefinition(
+                    TypeAttributes.Class | TypeAttributes.Public,
+                    metadata.GetOrAddString(ns),
+                    metadata.GetOrAddString(name),
+                    baseType: default,
+                    fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                    methodList:
+                        MetadataTokens.MethodDefinitionHandle(nextMethod));
+                nextMethod += methods.Length;
+            }
+
+            var bodies = new BlobBuilder();
+            var encoder = new MethodBodyStreamEncoder(bodies);
+            foreach ((_, _, (string Method, int Body)[] methods) in types)
+            {
+                foreach ((string method, int body) in methods)
+                {
+                    AddMethod(metadata, encoder, method, body);
+                }
+            }
+
+            var pe = new ManagedPEBuilder(
+                PEHeaderBuilder.CreateLibraryHeader(),
+                new MetadataRootBuilder(
+                    metadata,
+                    suppressValidation: true),
+                bodies,
+                flags: CorFlags.ILOnly);
+            var image = new BlobBuilder();
+            pe.Serialize(image);
+            return ImmutableCollectionsMarshal.AsImmutableArray(
+                image.ToArray());
+        }
+
+        static void AddMethod(
+            MetadataBuilder metadata,
+            MethodBodyStreamEncoder bodies,
+            string name,
+            int instructions)
+        {
+            var code = new BlobBuilder();
+            for (int index = 1; index < instructions; index++)
+            {
+                code.WriteByte(0x00);
+            }
+            code.WriteByte(0x2A);
+            int body = bodies.AddMethodBody(
+                new InstructionEncoder(code),
+                maxStack: 0);
+            var signature = new BlobBuilder();
+            new BlobEncoder(signature)
+                .MethodSignature(isInstanceMethod: false)
+                .Parameters(
+                    parameterCount: 0,
+                    returnType => returnType.Void(),
+                    parameters => { });
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString(name),
+                metadata.GetOrAddBlob(signature),
+                body,
+                MetadataTokens.ParameterHandle(1));
+        }
+    }
+
+    sealed class TestBindingPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+            => new(
+                Version,
+                AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind
+                            .CandidateUnavailable)));
+    }
+}

--- a/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceStructuralCloneSearchQueryTests.cs
@@ -386,6 +386,7 @@ public sealed class WorkspaceStructuralCloneSearchQueryTests
     [InlineData("Cases.GenericLookup")]
     [InlineData("Cases.TupleLookup")]
     [InlineData("Cases.ParamsLookup")]
+    [InlineData("Cases.DynamicLookup")]
     public async Task Execute_SurfaceIndexerAnchorResolvesOrdinaryParameterForms(
         string typeFullName)
     {

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -644,7 +644,7 @@ public class ApiMemberIdentityTests
                 metadataAnchor);
         }
 
-        Assert.Equal(4, typeDefinition.GetProperties().Count);
+        Assert.Equal(5, typeDefinition.GetProperties().Count);
     }
 
     [Fact]
@@ -1319,6 +1319,8 @@ public class ApiMemberIdentityTests
             key.Count + key.Name.Length;
 
         public int this[params long[] values] => values.Length;
+
+        public int this[dynamic key] => key.GetHashCode();
     }
 
     sealed class AttributedParameterFixture

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -604,6 +604,50 @@ public class ApiMemberIdentityTests
     }
 
     [Fact]
+    public void CreatePropertyAnchor_MatchesSurfaceForOrdinaryParameterForms()
+    {
+        using var stream =
+            File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        ApiSurface surface =
+            ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        TypeDefinitionHandle typeHandle =
+            FindFixtureType(reader, nameof(IndexerParameterShapeFixture));
+        TypeDefinition typeDefinition =
+            reader.GetTypeDefinition(typeHandle);
+        ApiType apiType = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name.EndsWith(
+                nameof(IndexerParameterShapeFixture),
+                StringComparison.Ordinal));
+
+        int work = MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+        foreach (PropertyDefinitionHandle propertyHandle
+            in typeDefinition.GetProperties())
+        {
+            ApiMember surfaceProperty = Assert.Single(
+                apiType.Members,
+                member => member.DeclarationMetadataToken
+                    == MetadataTokens.GetToken(propertyHandle));
+            MemberAnchor metadataAnchor =
+                ApiMemberIdentity.CreatePropertyAnchor(
+                    reader,
+                    typeHandle,
+                    reader.GetPropertyDefinition(propertyHandle),
+                    ref work);
+
+            Assert.Equal(
+                ApiMemberIdentity.GetMemberAnchor(
+                    apiType,
+                    surfaceProperty),
+                metadataAnchor);
+        }
+
+        Assert.Equal(4, typeDefinition.GetProperties().Count);
+    }
+
+    [Fact]
     public void FallbackCanonicalSignature_DisambiguatesIndexers_AfterJsonRoundTrip()
     {
         using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
@@ -1263,6 +1307,18 @@ public class ApiMemberIdentityTests
         public int this[int index] => index;
 
         public int this[string key] => key.Length;
+    }
+
+    sealed class IndexerParameterShapeFixture
+    {
+        public int this[string? key] => key?.Length ?? 0;
+
+        public int this[Dictionary<int, string> key] => key.Count;
+
+        public int this[(int Count, string Name) key] =>
+            key.Count + key.Name.Length;
+
+        public int this[params long[] values] => values.Length;
     }
 
     sealed class AttributedParameterFixture

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -41,6 +41,193 @@ public class ApiMemberIdentityTests
         Assert.Equal(MemberAnchor.ComputeFingerprint(anchor.CanonicalSignature), anchor.Fingerprint);
     }
 
+    /// <summary>
+    /// A logical property or event anchor, and a field anchor, read directly
+    /// from metadata must be the same anchor the surface producer issues,
+    /// because both are the exact identity a caller binds a member selection
+    /// to.
+    /// </summary>
+    [Fact]
+    public void CreateNonMethodAnchors_MatchTheSurfaceIssuedAnchors()
+    {
+        using var stream =
+            File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var apiType = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "AssociationAnchorFixture");
+        var typeHandle = FindFixtureType(reader, "AssociationAnchorFixture");
+        var typeDefinition = reader.GetTypeDefinition(typeHandle);
+
+        int propertyWork = MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+        var propertyAnchor = ApiMemberIdentity.CreatePropertyAnchor(
+            reader,
+            typeHandle,
+            reader.GetPropertyDefinition(
+                Assert.Single(typeDefinition.GetProperties())),
+            ref propertyWork);
+        int eventWork = MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+        var eventAnchor = ApiMemberIdentity.CreateEventAnchor(
+            reader,
+            typeHandle,
+            reader.GetEventDefinition(
+                Assert.Single(typeDefinition.GetEvents())),
+            ref eventWork);
+        int fieldWork = MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+        var fieldAnchor = ApiMemberIdentity.CreateFieldAnchor(
+            reader,
+            typeHandle,
+            reader.GetFieldDefinition(
+                Assert.Single(
+                    typeDefinition.GetFields(),
+                    handle => reader.GetString(
+                        reader.GetFieldDefinition(handle).Name) == "Tag")),
+            ref fieldWork);
+
+        Assert.Equal(
+            "P:ILInspector.Metadata.Tests.AssociationAnchorFixture.Value",
+            propertyAnchor.CanonicalSignature);
+        Assert.Equal(
+            "E:ILInspector.Metadata.Tests.AssociationAnchorFixture.Changed",
+            eventAnchor.CanonicalSignature);
+        Assert.Equal(
+            "F:ILInspector.Metadata.Tests.AssociationAnchorFixture.Tag",
+            fieldAnchor.CanonicalSignature);
+        Assert.Equal(
+            ApiMemberIdentity.GetMemberAnchor(
+                apiType,
+                Assert.Single(
+                    apiType.Members,
+                    member => member.Kind == "property")),
+            propertyAnchor);
+        Assert.Equal(
+            ApiMemberIdentity.GetMemberAnchor(
+                apiType,
+                Assert.Single(
+                    apiType.Members,
+                    member => member.Kind == "event")),
+            eventAnchor);
+        Assert.Equal(
+            ApiMemberIdentity.GetMemberAnchor(
+                apiType,
+                Assert.Single(
+                    apiType.Members,
+                    member => member.Kind == "field"
+                        && member.Name == "Tag")),
+            fieldAnchor);
+        Assert.True(
+            propertyWork < MetadataSafetyPolicy.MaxClassificationScanWorkChars,
+            "The anchor must charge the caller-owned work counter.");
+        Assert.True(
+            eventWork < MetadataSafetyPolicy.MaxClassificationScanWorkChars,
+            "The anchor must charge the caller-owned work counter.");
+        Assert.True(
+            fieldWork < MetadataSafetyPolicy.MaxClassificationScanWorkChars,
+            "The anchor must charge the caller-owned work counter.");
+    }
+
+    /// <summary>
+    /// An indexer is a property that overloads on its index parameters, so the
+    /// SRM-direct producer must include them exactly as the surface producer
+    /// does. Without them, two overloads collide on <c>P:Type.Item</c> and a
+    /// caller selecting one either gets the other or an ambiguous outcome.
+    /// </summary>
+    /// <remarks>
+    /// The SRM-direct producer must emit the same exact anchor as the API
+    /// surface because that surface anchor is what a selected Member carries
+    /// into a consumer query.
+    /// </remarks>
+    [Fact]
+    public void CreatePropertyAnchor_DistinguishesOverloadedIndexers()
+    {
+        using var stream =
+            File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = FindFixtureType(reader, nameof(IndexerFixture));
+        var typeDefinition = reader.GetTypeDefinition(typeHandle);
+
+        int work = MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+        List<MemberAnchor> anchors = [];
+        foreach (var handle in typeDefinition.GetProperties())
+        {
+            anchors.Add(
+                ApiMemberIdentity.CreatePropertyAnchor(
+                    reader,
+                    typeHandle,
+                    reader.GetPropertyDefinition(handle),
+                    ref work));
+        }
+
+        Assert.Equal(2, anchors.Count);
+        string declaringType =
+            "ILInspector.Metadata.Tests.ApiMemberIdentityTests+IndexerFixture";
+        Assert.Equal(
+            [
+                $"P:{declaringType}.Item(int)",
+                $"P:{declaringType}.Item(string)",
+            ],
+            anchors
+                .Select(anchor => anchor.CanonicalSignature)
+                .Order(StringComparer.Ordinal));
+        Assert.Equal(
+            2,
+            anchors
+                .Select(anchor => anchor.Fingerprint)
+                .Distinct(StringComparer.Ordinal)
+                .Count());
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var apiType = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name.EndsWith(
+                nameof(IndexerFixture),
+                StringComparison.Ordinal));
+        Assert.Equal(
+            anchors.OrderBy(
+                anchor => anchor.CanonicalSignature,
+                StringComparer.Ordinal),
+            apiType.Members
+                .Where(member => member.Kind == "property")
+                .Select(member =>
+                    ApiMemberIdentity.GetMemberAnchor(apiType, member))
+                .OrderBy(
+                    anchor => anchor.CanonicalSignature,
+                    StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// An ordinary property keeps the bare canonical spelling it has always
+    /// had. Only an indexer grows a parameter list, so no parameterless
+    /// property's identity moves.
+    /// </summary>
+    [Fact]
+    public void CreatePropertyAnchor_OrdinaryPropertyHasNoParameterList()
+    {
+        using var stream =
+            File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = FindFixtureType(reader, "AssociationAnchorFixture");
+
+        int work = MetadataSafetyPolicy.MaxClassificationScanWorkChars;
+        var anchor = ApiMemberIdentity.CreatePropertyAnchor(
+            reader,
+            typeHandle,
+            reader.GetPropertyDefinition(
+                Assert.Single(
+                    reader.GetTypeDefinition(typeHandle).GetProperties())),
+            ref work);
+
+        Assert.DoesNotContain('(', anchor.CanonicalSignature);
+        Assert.EndsWith(
+            ".Value",
+            anchor.CanonicalSignature,
+            StringComparison.Ordinal);
+    }
+
     [Fact]
     public void CreateMethodAnchorInfo_IncludesCanonicalReturnType()
     {
@@ -808,6 +995,22 @@ public class ApiMemberIdentityTests
         throw new InvalidOperationException("Fixture method not found.");
     }
 
+    static TypeDefinitionHandle FindFixtureType(
+        MetadataReader reader,
+        string name)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            if (reader.GetString(
+                    reader.GetTypeDefinition(typeHandle).Name) == name)
+            {
+                return typeHandle;
+            }
+        }
+
+        throw new InvalidOperationException("Fixture type not found.");
+    }
+
     static byte[] BuildRepeatedLongMethodNameImage(
         int methodCount,
         int methodNameLength,
@@ -1076,5 +1279,29 @@ public class ApiMemberIdentityTests
             [System.Runtime.InteropServices.Optional]
             [System.Runtime.CompilerServices.DateTimeConstant(630822816000000000L)]
             DateTime when] => when.Year;
+    }
+}
+
+/// <summary>
+/// An ordinary compiled property, event, and field whose anchors must agree
+/// between the surface producer and the SRM-direct producer.
+/// </summary>
+internal sealed class AssociationAnchorFixture
+{
+    int _value;
+    EventHandler? _changed;
+
+    public int Tag = 1;
+
+    public int Value
+    {
+        get { return _value; }
+        set { _value = value; }
+    }
+
+    public event EventHandler? Changed
+    {
+        add { _changed += value; }
+        remove { _changed -= value; }
     }
 }


### PR DESCRIPTION
dotnet-inspect builds robust, capable inspection features that are foundational
or provide a compelling user experience, while remaining conventionally sound
or delightfully new. This PR supplies the host-neutral Clone search foundation:
one bounded, globally ranked query for Library, Type, and Member subjects.

Closes #6303. Part of #5083 stage 2.

## Demo

The shared request now expresses the website's future two-axis Clone control:

```csharp
var input = new WorkspaceStructuralCloneSearchInput(
    participantSnapshot,
    new StructuralCloneSearchSeed.Type(selectedType),
    StructuralCloneCandidateBreadth.Everything,
    StructuralCloneCandidateDiscovery.SimilarNames);

WorkspaceStructuralCloneSearchResult result =
    WorkspaceStructuralCloneSearchQuery.Execute(input, cancellationToken);
```

The default is `Everything + SimilarNames`. `SimilarNames` requires both the
declaring-type simple base name and method name to meet the fixed `0.6`
threshold for the same seed-candidate pair. Selecting `All` removes that
lexical admission step without changing breadth.

For multi-method Library and Type seeds, the query suppresses physical
self-pairs and opposite orientations, merges Analysis-issued evidence into one
global ranking, and applies the row limit only after that merge. A logical
property or event Member expands to its compiler-associated accessor bodies;
an explicit accessor stays one body, an overloaded indexer selects only its own
accessors, and a field returns the typed bodyless outcome.

Each endpoint retains an opaque snapshot-local participant identity plus exact
registration, assembly, provenance, MVID, and MethodDef association. If a
candidate participant is unavailable, released, malformed, excluded by a work
bound, or incomplete in Analysis body production, existing ranked rows remain
available beside typed incomplete coverage. Intentional top-N row suppression
remains separate from incomplete candidate coverage.

## Implementation

- Adds independent `Self`, `SelfAndRegisteredEcosystems`, and `Everything`
  breadth plus `SimilarNames` and `All` discovery.
- Expands Library, Type, and logical Member seed populations with shared exact
  metadata resolution and compiler-emitted `MethodSemantics`.
- Reuses the API surface's canonical indexer-parameter projection, including
  nullability, tuple erasure, dynamic-to-object normalization, generic
  punctuation, and parameter modifiers.
- Suppresses opposite orientations whenever both endpoints belong to the seed
  population, including multi-accessor logical Members.
- Preserves true ordinal-ignore-case name equality and makes name-cache
  capacity a pure optimization through cache-independent logical work
  accounting.
- Adds bounded participant, candidate, retrieval-pair, retrieval-chunk, name,
  and cache work with visible receipts and failures.
- Attributes candidate-production Analysis blockers to the affected library as
  well as the seed retrieval that observed them.
- Preserves global ranking across retrieval chunks and observes cancellation
  between bounded Analysis calls.
- Extracts the existing exact TypeDef/member resolver and MethodDef ownership
  validation so the seeded retrieval query and Workspace search use one
  contract.
- Records the stage-2 implementation and remaining adoption boundary in the
  owning design and inspection-space architecture.

Workspace registration lookup is not implemented yet. This PR does not infer
ecosystem membership or degrade `SelfAndRegisteredEcosystems` to `Self`;
membership arrives on the exact caller-supplied participant snapshot. The
future Workspace/registration producer must retain its groups through query
execution. That association and lifetime enforcement remains explicitly
unverified, while premature release is reported as typed incomplete coverage.

This PR does not add Presentation documents, CLI or Browser adoption, checked
cross-image clone relations, correspondence, or the future clone-assisted
differ.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` (0 warnings, 0 errors)
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release`
  (`1764` passed)
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
  (`3033` passed, `3` skipped)
- `dotnet run --project tests/CSharpText.Tests -c Release` (`755` passed)
- `dotnet run --project tests/DotnetInspector.FixtureInfrastructure.Tests -c Release`
  (`19` passed)
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*SurfaceAndMetadataAnchors_UseDistinctSpellings*"`
  (`1` passed)
- `npx markdownlint-cli docs/design/structural-clone-search-scope.md docs/inspection-space.md`
