### PR TITLE
Add portable Clone Candidates presentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [Finding Value Semantics](design/finding-value-equality.md) | Equality and hashing for Finding-owned structural values, ordered collections, identity sets, union cases, and operation objects. |
 | [Analysis Diff Format](design/analysis-diff.md) | Complete immutable two-version item sequences and exhaustive producer-issued N:M relations for shared CLI and browser/Wasm analysis. |
 | [Comparison Document](design/comparison-document.md) | Portable root and subject composition for shared CLI/browser diffs and clone payloads, including referenced rename/move descriptions. |
+| [Clone Candidates Presentation](design/clone-candidate-presentation.md) | Portable globally ranked Workspace clone-search candidates, exact endpoint addresses, coverage, failures, suppression, and receipts. |
 | [Library API Diff Presentation](design/library-api-diff-presentation.md) | Portable Library-root changed-Type composition with complete compatibility changes and distinct changed-member summaries. |
 | [Performance Analysis Baselines](analysis-baselines.md) | Internal baselines of what each analysis type finds over a fixed corpus, with effectiveness ratings for the one-stop-shop Performance Analysis view. |
 | [Dynamic Leak-Watch](design/dynamic-leak-watch.md) | The retention axis: how `runfaster leak-watch` separates a managed leak from a churn storm from native/committed growth, and why static triage and the allocation-tick join cannot. |

--- a/docs/design/clone-candidate-presentation.md
+++ b/docs/design/clone-candidate-presentation.md
@@ -1,0 +1,189 @@
+# Clone Candidates presentation
+
+## Status and consumer
+
+This design defines stage 3 of the Structural Clone Search production-adoption
+path tracked by
+[#5083](https://github.com/richlander/dotnet-inspect/issues/5083).
+Implementation is tracked by
+[#6306](https://github.com/richlander/dotnet-inspect/issues/6306).
+
+The immediate consumers are the planned CLI `Clone Candidates` section in
+stage 4 and the Inspect Web transport and master/detail experience in stages 5
+and 6. This owner defines neither host adoption.
+
+## Authority and exact claim
+
+This document is the normative owner of one claim:
+
+> Complete Query-issued Workspace structural-clone search evidence projects
+> into one immutable, resource-free `CloneCandidateDocument`. Its declared
+> rows preserve the Query's globally ranked candidate pairs, exact
+> snapshot-relative endpoints, request dimensions, coverage, failures,
+> suppression, and receipts without upgrading retrieval similarity into a
+> checked clone relation, correspondence, or provenance conclusion.
+
+[Structural clone search scope](structural-clone-search-scope.md) remains the
+owner of seed, breadth, discovery, ranking, suppression, Workspace association,
+and coverage semantics. Queries owns execution and process-local results.
+Presentation owns only the portable projection defined here.
+
+## Why this is not a comparison document
+
+`ComparisonDocument<T>` models one identified root and a population of subjects
+relative to that root. That topology remains suitable after a user explicitly
+selects one reference method and asks to inspect its candidate comparisons.
+
+A Library or Type clone search instead expands several seed methods and creates
+one global ranking across all seed-candidate pairs. Either endpoint can vary
+from row to row. A logical Member such as a property or event can likewise
+expand to several accessor bodies. Projecting that evidence into one comparison
+root would invent a privileged method; splitting it into one document per seed
+would destroy the product-owned global ranking.
+
+`CloneCandidateDocument` therefore declares one row per ranked pair. A later
+selected-pair operation may compose an independently owned checked comparison
+payload when Analysis supports that exact pair.
+
+## Portable identity
+
+Query participant, snapshot, registration, and Workspace revision identities
+are process-local authority handles. They are not serialized or exposed as
+portable identity.
+
+Each projected participant instead carries:
+
+- its owner-issued ordinal in the exact participant snapshot;
+- its assembly reference identity;
+- its acquisition provenance; and
+- its module version ID when acquisition established one.
+
+The ordinal is document-relative identity. It preserves two distinct
+registrations of identical bytes as distinct participants even when assembly
+identity and MVID are equal. It does not claim a stable identity across two
+search documents.
+
+Each method endpoint adds:
+
+- its MVID and MethodDef token; and
+- an inert canonical address display formed from assembly name, MVID, and
+  MethodDef token.
+
+The address preserves the Query-issued physical method coordinate without
+reopening a retained assembly or serializing acquisition authority. A later
+host may resolve richer declaring-type and member displays through its own
+exact Workspace navigation service; it must not parse the address display or
+retarget by assembly name. None of these fields establish cross-module
+correspondence.
+
+The document records whether the effective revision differed from the starting
+revision. It does not serialize either opaque revision identity. The participant
+population and receipt remain the portable evidence of what the search
+actually evaluated.
+
+## Document shape
+
+`CloneCandidateDocument` carries:
+
+- schema version;
+- Library, Type, or Member seed coordinates;
+- requested breadth and discovery;
+- the fixed name-similarity threshold;
+- requested work and result limits;
+- whether scope changed while the participant snapshot was realized;
+- overall coverage completeness;
+- globally ranked candidate rows;
+- per-seed coverage;
+- per-participant coverage; and
+- the aggregate bounded-work receipt.
+
+The future canonical result-section name is `Clone Candidates`. Stage 4 owns
+CLI registration and the deterministic `Query: Clone Candidates` discovery
+companion.
+
+### Candidate rows
+
+One declared row is one Query-issued left/right candidate pair. Rows retain:
+
+- consecutive global rank;
+- exact endpoint identities and displays;
+- every structural similarity component; and
+- the declaring-type and member name scores when `SimilarNames` admitted the
+  pair.
+
+Presentation does not rerank, refilter, reverse, deduplicate, or impose another
+result limit.
+
+### Coverage and suppression
+
+Seed coverage retains disposition, ranked-pair count, exact-pair suppression,
+and typed failures. Participant coverage retains membership, admission,
+candidate and discovered method counts, retrieval and name work, typed
+failures, and Analysis blockers.
+
+Exact-pair suppression removes self hits and the duplicate orientation of one
+same-library pair before global ranking. The intentional top-N result limit is
+separate: the receipt retains `ResultLimitReached`, while ranked minus returned
+pairs gives the omitted row count. Both are orthogonal to incomplete evidence.
+A document can reach its result limit while coverage is complete, carry
+incomplete coverage without reaching the result limit, or carry both.
+
+### Inert text
+
+Canonical endpoint address displays and all artifact-derived failure or blocker
+details cross Presentation as `InertString` field text. Hosts must render that
+typed inert text rather than reinterpret it as Markout, HTML, terminal control,
+or another active grammar.
+
+## Closed outcomes
+
+The adapter produces exactly one of:
+
+- `Available`, carrying the portable document;
+- `Rejected`, preserving a containing-library acquisition rejection;
+- `Failed`, preserving a Query-issued typed seed/search failure; or
+- `Unrepresentable`, when complete Query evidence cannot be projected without
+  invention because endpoint participants lack matching coverage or one
+  participant ordinal carries conflicting MVIDs.
+
+An inconsistent endpoint does not become an empty successful document, and
+Presentation does not recover an endpoint by assembly display name.
+
+## Non-claims
+
+This owner does not define:
+
+- CLI syntax, section planning, query facets, row selection, or Markout
+  lowering;
+- Browser transport, operation lifetime, controls, or navigation;
+- a checked clone relation or structural equivalence;
+- historical identity, rename, move, or source correspondence;
+- clone-assisted Diff;
+- cross-image checked pair comparison;
+- concrete Workspace registration lookup; or
+- stable participant identity across separate search documents.
+
+The future clone-assisted differ remains bounded by
+[Structural clone search scope](structural-clone-search-scope.md#future-clone-assisted-diff):
+retrieval may propose a pair, but ordinary Diff must validate an explicitly
+selected pairing under its own contract.
+
+## Required gates
+
+The Presentation Release suite gates:
+
+- the default `Everything` plus `SimilarNames` request projection;
+- one global Library/Type ranking with varying left-side seeds;
+- logical Member expansion to several accessor seed rows;
+- exact pair orientation, rank, score, and optional name evidence;
+- distinct participant ordinals for duplicate registrations of identical
+  bytes;
+- complete and incomplete seed/participant coverage;
+- exact-pair suppression and intentional result-limit omission independently
+  of incomplete evidence;
+- inert failure and display text;
+- closed rejected, failed, and unrepresentable outcomes; and
+- deterministic value equality for independently projected documents.
+
+Stage 4 separately gates section/query discovery and CLI output. Stages 5 and 6
+separately gate Browser transport and interaction.

--- a/docs/design/comparison-document.md
+++ b/docs/design/comparison-document.md
@@ -1036,6 +1036,11 @@ data values; no consumer must parse `display` or the human mockup's punctuation.
 
 This mockup uses
 `ComparisonDocument<StructuralCloneComparisonDocument>`.
+It describes one explicitly selected reference method and its candidate
+subjects. A multi-seed Workspace search instead uses the
+[Clone Candidates document](clone-candidate-presentation.md), because forcing
+one global pair ranking into this one-root topology would invent a privileged
+reference method or split the ranking.
 
 ```text
 Root
@@ -1187,8 +1192,10 @@ prerequisites must prove:
 - a clone payload adopter does not assume Before/After text semantics and
   preserves root-to-LeftToken and subject-to-RightToken orientation across
   same-type and distinct-type same-module fixtures;
-- cross-assembly clone retrieval preserves root/candidate module identities
-  until the clone owner supplies a portable cross-module payload; and
+- cross-assembly clone retrieval remains outside this one-root checked
+  comparison envelope; `CloneCandidateDocument` preserves retrieval endpoint
+  identities without presenting
+  `StructuralCloneComparisonDocument` as a cross-module checked payload; and
 - each producer's identifier portability, assertions, payload completeness,
   subject-coordinate-basis application, transformation classification, and
   presentation.

--- a/docs/design/structural-clone-search-scope.md
+++ b/docs/design/structural-clone-search-scope.md
@@ -8,11 +8,14 @@ originally established under
 under [#6289](https://github.com/richlander/dotnet-inspect/issues/6289), within
 the Diff, Clone, and immersive-viewer experience tracked by
 [#5083](https://github.com/richlander/dotnet-inspect/issues/5083).
-Stage 2 below is implemented under
+Stages 2 and 3 below are implemented under
 [#6303](https://github.com/richlander/dotnet-inspect/issues/6303) by the
 Queries-owned `WorkspaceStructuralCloneSearchQuery` and gated by its focused
-Release suite.
-Stages 3 through 7 are **not implemented**, so the host-facing acceptance
+Release suite, and under
+[#6306](https://github.com/richlander/dotnet-inspect/issues/6306) by the
+Presentation-owned
+[Clone Candidates document](clone-candidate-presentation.md) and adapter.
+Stages 4 through 7 are **not implemented**, so the host-facing acceptance
 scenarios below remain **unverified**.
 
 Clone separates two request dimensions:
@@ -409,11 +412,13 @@ The host-neutral result carries:
 - intentional row suppression; and
 - typed acquisition, metadata, name-selection, and Analysis failures.
 
-The result may later project into the Findings-owned
-`ComparisonDocument<T>` family or another portable clone-specific document.
-That adopter owns the portable result shape. This scope owner does not choose a
-root/subject topology or invent a cross-module pairwise relation that Analysis
-has not established.
+The result projects into the Presentation-owned
+[`CloneCandidateDocument`](clone-candidate-presentation.md), whose declared
+rows preserve the one global pair ranking. `ComparisonDocument<T>` remains
+available for a later explicitly selected one-root comparison; forcing a
+multi-seed search into that topology would invent a privileged root or split
+the product-owned ranking. The Presentation owner does not invent a
+cross-module pairwise relation that Analysis has not established.
 
 Inspect Web may render a native master/detail result list and use named Member,
 Source, and pair-diff destinations. The CLI normally lowers shared typed
@@ -474,7 +479,8 @@ clone-assisted differ.
 | [Workspace Scope and Expansion](workspace-scope-and-expansion.md) | Exact Workspace revision, registrations, participant outcomes, and lifetime |
 | Structural Clone Search Scope | Seed populations, candidate breadth and discovery, name-filter admission, pair suppression, global ranking composition, and coverage |
 | Queries | Focused execution over retained Workspace participants |
-| [Comparison Document](comparison-document.md) and Presentation | Portable clone composition and shared presentation lowering when adopted |
+| [Clone Candidates presentation](clone-candidate-presentation.md) | Portable globally ranked candidate document and Query-result adapter |
+| [Comparison Document](comparison-document.md) | Portable one-root comparison composition after an explicit pair selection, when adopted |
 | CLI host | Request binding, advanced work controls, Markout lowering, and disclosure |
 | Inspect Web | Breadth and candidate-discovery controls, operation lifetime, master/detail interaction, navigation, and host-native rendering |
 
@@ -488,6 +494,9 @@ The counted production-adoption path under #5083 has seven stages:
    caller-supplied participant snapshot until stage 4 or a Workspace
    registration slice supplies the concrete producer.
 3. Add the host-neutral portable clone result and presentation adapter.
+   Landed as `CloneCandidateDocument` and
+   `CloneCandidatePresentation`; the planned host result-section name is
+   `Clone Candidates`.
 4. Adopt the shared request and result in the CLI over an explicit Workspace
    scope.
 5. Add the managed Browser facade and transport.
@@ -537,12 +546,14 @@ released-group containment, duplicate suppression, global ranking, per-library
 Analysis coverage, logical-member seed expansion over ordinary compiled
 property and event accessors, overloaded-indexer selection, the field bodyless
 outcome, and cross-type accessor association;
-`WorkspaceStructuralCloneSearchQueryTests` supplies that gate. CLI tests gate
-shared presentation and structured output. Browser
-original-host and Firefox suites gate the breadth and discovery controls,
-subject narrowing, stale-result exclusion, master/detail navigation, and
-retirement of the Package-specific selector. The design remains unverified
-until those focused adoptions land.
+`WorkspaceStructuralCloneSearchQueryTests` supplies that gate.
+`CloneCandidatePresentationTests` gates portable request, row, identity,
+coverage, failure, suppression, and receipt projection. CLI tests later gate
+section/query discovery and structured output. Browser original-host and
+Firefox suites gate the breadth and discovery controls, subject narrowing,
+stale-result exclusion, master/detail navigation, and retirement of the
+Package-specific selector. The design remains unverified until those focused
+host adoptions land.
 
 ## Non-claims
 

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1161,9 +1161,13 @@ the distinct Analysis blockers that omitted its candidates, aggregated over
 every seed and chunk, and is incomplete while it holds one, so a candidate body
 Analysis could not produce can never leave that library reporting complete
 coverage. A seed-side blocker stays with its seed: it omits no candidate of any
-one participant and is already visible as that seed's coverage. Cross-image rank remains
-retrieval evidence: the query establishes no checked clone relation and
-produces no comparison document.
+one participant and is already visible as that seed's coverage. Cross-image
+rank remains retrieval evidence: the query establishes no checked clone
+relation and produces no comparison document. Presentation projects the
+complete Query result into the resource-free
+[`CloneCandidateDocument`](design/clone-candidate-presentation.md), preserving
+the global ranking, exact snapshot-relative endpoint addresses, coverage,
+failures, and receipts without changing that evidence boundary.
 `WorkspaceStructuralCloneSearchQueryTests` gates the request defaults, all six
 breadth and discovery combinations, seed expansion including property and
 event accessor bodies, overloaded-indexer selection, the field bodyless

--- a/src/DotnetInspector.Presentation/CloneCandidatePresentation.cs
+++ b/src/DotnetInspector.Presentation/CloneCandidatePresentation.cs
@@ -1,0 +1,825 @@
+using System.Collections.Immutable;
+using System.Globalization;
+
+using DotnetInspector.Queries;
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+using InertText;
+
+namespace DotnetInspector.Presentation;
+
+/// <summary>The selected subject population for one Clone Candidates search.</summary>
+public enum CloneCandidateSeedKind
+{
+    Library,
+    Type,
+    Member,
+}
+
+/// <summary>Portable seed coordinates for one Clone Candidates search.</summary>
+public sealed record CloneCandidateSeed
+{
+    public CloneCandidateSeed(
+        CloneCandidateSeedKind kind,
+        MetadataTypeDefinitionName? type,
+        MemberAnchor? member)
+    {
+        bool valid = kind switch
+        {
+            CloneCandidateSeedKind.Library =>
+                type is null && member is null,
+            CloneCandidateSeedKind.Type =>
+                type is not null && member is null,
+            CloneCandidateSeedKind.Member =>
+                type is not null && member is not null,
+            _ => false,
+        };
+        if (!valid)
+        {
+            throw new ArgumentException(
+                "The seed coordinates do not match the seed kind.");
+        }
+
+        Kind = kind;
+        Type = type;
+        Member = member;
+    }
+
+    public CloneCandidateSeedKind Kind { get; }
+    public MetadataTypeDefinitionName? Type { get; }
+    public MemberAnchor? Member { get; }
+}
+
+/// <summary>
+/// One snapshot-relative portable participant identity.
+/// </summary>
+/// <remarks>
+/// The ordinal preserves distinct registrations of identical bytes inside one
+/// document without serializing the Query's process-local registration or
+/// participant handles.
+/// </remarks>
+public sealed record CloneCandidateParticipantIdentity(
+    int Ordinal,
+    AssemblyReferenceIdentity Assembly,
+    AssemblyResolutionProvenance Provenance,
+    Guid? ModuleVersionId)
+{
+    public int Ordinal { get; } = Ordinal >= 0
+        ? Ordinal
+        : throw new ArgumentOutOfRangeException(nameof(Ordinal));
+
+    public AssemblyReferenceIdentity Assembly { get; } =
+        Assembly ?? throw new ArgumentNullException(nameof(Assembly));
+
+    public AssemblyResolutionProvenance Provenance { get; } =
+        Provenance ?? throw new ArgumentNullException(nameof(Provenance));
+}
+
+/// <summary>One exact portable method endpoint in a candidate pair.</summary>
+public sealed record CloneCandidateMethodIdentity
+{
+    public CloneCandidateMethodIdentity(
+        CloneCandidateParticipantIdentity participant,
+        Guid moduleVersionId,
+        int methodDefinitionToken,
+        InertString addressDisplay)
+    {
+        if ((methodDefinitionToken & unchecked((int)0xFF000000))
+            != 0x06000000
+            || (methodDefinitionToken & 0x00FFFFFF) == 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(methodDefinitionToken));
+        }
+
+        Participant =
+            participant
+            ?? throw new ArgumentNullException(nameof(participant));
+        if (moduleVersionId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "A method endpoint requires a module version ID.",
+                nameof(moduleVersionId));
+        }
+        ModuleVersionId = moduleVersionId;
+        MethodDefinitionToken = methodDefinitionToken;
+        AddressDisplay = addressDisplay;
+    }
+
+    public CloneCandidateParticipantIdentity Participant { get; }
+    public Guid ModuleVersionId { get; }
+    public int MethodDefinitionToken { get; }
+    public InertString AddressDisplay { get; }
+}
+
+/// <summary>Portable structural similarity components for one candidate row.</summary>
+public sealed record CloneCandidateSimilarity(
+    int Score,
+    int OperationScore,
+    int PositionScore,
+    int BlockScore,
+    int EdgeScore,
+    int LocalScore,
+    int SeedInstructions,
+    int CandidateInstructions,
+    int SeedBlocks,
+    int CandidateBlocks,
+    int SeedEdges,
+    int CandidateEdges,
+    int SeedLocals,
+    int CandidateLocals);
+
+/// <summary>Optional SimilarNames admission evidence for one pair.</summary>
+public sealed record CloneCandidateNameQualification(
+    double DeclaringTypeSimilarity,
+    double MemberSimilarity);
+
+/// <summary>
+/// One globally ranked retrieval candidate. It is not a checked clone relation.
+/// </summary>
+public sealed record CloneCandidateRow(
+    int Rank,
+    CloneCandidateMethodIdentity Left,
+    CloneCandidateMethodIdentity Right,
+    CloneCandidateSimilarity Similarity,
+    CloneCandidateNameQualification? NameQualification)
+{
+    public int Rank { get; } = Rank > 0
+        ? Rank
+        : throw new ArgumentOutOfRangeException(nameof(Rank));
+
+    public CloneCandidateMethodIdentity Left { get; } =
+        Left ?? throw new ArgumentNullException(nameof(Left));
+
+    public CloneCandidateMethodIdentity Right { get; } =
+        Right ?? throw new ArgumentNullException(nameof(Right));
+
+    public CloneCandidateSimilarity Similarity { get; } =
+        Similarity ?? throw new ArgumentNullException(nameof(Similarity));
+}
+
+/// <summary>One visible Clone Candidates search failure.</summary>
+public sealed record CloneCandidateFailure(
+    StructuralCloneSearchFailureKind Kind,
+    AssemblyReferenceIdentity? Subject,
+    InertString Detail);
+
+/// <summary>One visible Analysis blocker within a participant search.</summary>
+public sealed record CloneCandidateAnalysisBlocker(
+    StructuralCloneRetrievalBlockerKind Kind,
+    InertString Detail);
+
+/// <summary>Portable coverage for one exact seed method body.</summary>
+public sealed record CloneCandidateSeedCoverage
+{
+    public CloneCandidateSeedCoverage(
+        CloneCandidateMethodIdentity seed,
+        StructuralCloneRetrievalDisposition disposition,
+        int rankedPairs,
+        int suppressedPairs,
+        ImmutableArray<CloneCandidateAnalysisBlocker> blockers,
+        ImmutableArray<CloneCandidateFailure> failures)
+    {
+        Seed = seed ?? throw new ArgumentNullException(nameof(seed));
+        ArgumentOutOfRangeException.ThrowIfNegative(rankedPairs);
+        ArgumentOutOfRangeException.ThrowIfNegative(suppressedPairs);
+        CloneCandidatePresentationValidation.EnsureArray(
+            blockers,
+            nameof(blockers));
+        CloneCandidatePresentationValidation.EnsureArray(
+            failures,
+            nameof(failures));
+        Disposition = disposition;
+        RankedPairs = rankedPairs;
+        SuppressedPairs = suppressedPairs;
+        Blockers = blockers;
+        Failures = failures;
+    }
+
+    public CloneCandidateMethodIdentity Seed { get; }
+    public StructuralCloneRetrievalDisposition Disposition { get; }
+    public int RankedPairs { get; }
+    public int SuppressedPairs { get; }
+    public ImmutableArray<CloneCandidateAnalysisBlocker> Blockers { get; }
+    public ImmutableArray<CloneCandidateFailure> Failures { get; }
+    public bool IsComplete =>
+        Disposition == StructuralCloneRetrievalDisposition.Completed
+        && Blockers.IsEmpty
+        && Failures.IsEmpty;
+
+    public bool Equals(CloneCandidateSeedCoverage? other)
+        => other is not null
+            && Seed == other.Seed
+            && Disposition == other.Disposition
+            && RankedPairs == other.RankedPairs
+            && SuppressedPairs == other.SuppressedPairs
+            && PresentationValueEquality.SequenceEqual(
+                Blockers,
+                other.Blockers)
+            && PresentationValueEquality.SequenceEqual(
+                Failures,
+                other.Failures);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Seed);
+        hash.Add(Disposition);
+        hash.Add(RankedPairs);
+        hash.Add(SuppressedPairs);
+        hash.Add(PresentationValueEquality.SequenceHashCode(Blockers));
+        hash.Add(PresentationValueEquality.SequenceHashCode(Failures));
+        return hash.ToHashCode();
+    }
+}
+
+/// <summary>Portable coverage for one exact participant registration.</summary>
+public sealed record CloneCandidateLibraryCoverage
+{
+    public CloneCandidateLibraryCoverage(
+        CloneCandidateParticipantIdentity participant,
+        StructuralCloneParticipantMembership membership,
+        bool admitted,
+        int candidateMethods,
+        int discoveredMethods,
+        long retrievalPairs,
+        long nameComparisonWork,
+        ImmutableArray<CloneCandidateFailure> failures,
+        ImmutableArray<CloneCandidateAnalysisBlocker> analysisBlockers)
+    {
+        Participant =
+            participant
+            ?? throw new ArgumentNullException(nameof(participant));
+        ArgumentOutOfRangeException.ThrowIfNegative(candidateMethods);
+        ArgumentOutOfRangeException.ThrowIfNegative(discoveredMethods);
+        ArgumentOutOfRangeException.ThrowIfNegative(retrievalPairs);
+        ArgumentOutOfRangeException.ThrowIfNegative(nameComparisonWork);
+        CloneCandidatePresentationValidation.EnsureArray(
+            failures,
+            nameof(failures));
+        CloneCandidatePresentationValidation.EnsureArray(
+            analysisBlockers,
+            nameof(analysisBlockers));
+        Membership = membership;
+        Admitted = admitted;
+        CandidateMethods = candidateMethods;
+        DiscoveredMethods = discoveredMethods;
+        RetrievalPairs = retrievalPairs;
+        NameComparisonWork = nameComparisonWork;
+        Failures = failures;
+        AnalysisBlockers = analysisBlockers;
+    }
+
+    public CloneCandidateParticipantIdentity Participant { get; }
+    public StructuralCloneParticipantMembership Membership { get; }
+    public bool Admitted { get; }
+    public int CandidateMethods { get; }
+    public int DiscoveredMethods { get; }
+    public long RetrievalPairs { get; }
+    public long NameComparisonWork { get; }
+    public ImmutableArray<CloneCandidateFailure> Failures { get; }
+    public ImmutableArray<CloneCandidateAnalysisBlocker> AnalysisBlockers
+    {
+        get;
+    }
+
+    public bool IsComplete =>
+        Failures.IsEmpty && AnalysisBlockers.IsEmpty;
+
+    public bool Equals(CloneCandidateLibraryCoverage? other)
+        => other is not null
+            && Participant == other.Participant
+            && Membership == other.Membership
+            && Admitted == other.Admitted
+            && CandidateMethods == other.CandidateMethods
+            && DiscoveredMethods == other.DiscoveredMethods
+            && RetrievalPairs == other.RetrievalPairs
+            && NameComparisonWork == other.NameComparisonWork
+            && PresentationValueEquality.SequenceEqual(
+                Failures,
+                other.Failures)
+            && PresentationValueEquality.SequenceEqual(
+                AnalysisBlockers,
+                other.AnalysisBlockers);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Participant);
+        hash.Add(Membership);
+        hash.Add(Admitted);
+        hash.Add(CandidateMethods);
+        hash.Add(DiscoveredMethods);
+        hash.Add(RetrievalPairs);
+        hash.Add(NameComparisonWork);
+        hash.Add(
+            PresentationValueEquality.SequenceHashCode(Failures));
+        hash.Add(
+            PresentationValueEquality.SequenceHashCode(AnalysisBlockers));
+        return hash.ToHashCode();
+    }
+}
+
+/// <summary>Portable bounded-work receipt for one Clone Candidates search.</summary>
+public sealed record CloneCandidateReceipt(
+    int SeedMethods,
+    int CandidateMethods,
+    int DiscoveredMethods,
+    int AdmittedLibraries,
+    int ExcludedLibraries,
+    long NameComparisonWork,
+    long RetrievalPairs,
+    int RetrievalCalls,
+    int RankedPairs,
+    int SuppressedPairs,
+    int ReturnedPairs,
+    bool ResultLimitReached);
+
+/// <summary>
+/// Host-neutral Clone Candidates search evidence.
+/// </summary>
+public sealed record CloneCandidateDocument
+{
+    public const int CurrentSchemaVersion = 1;
+    public const string SectionName = "Clone Candidates";
+
+    public CloneCandidateDocument(
+        int schemaVersion,
+        CloneCandidateSeed seed,
+        StructuralCloneCandidateBreadth breadth,
+        StructuralCloneCandidateDiscovery discovery,
+        double nameSimilarityThreshold,
+        WorkspaceStructuralCloneSearchLimits limits,
+        bool scopeChangedDuringSearch,
+        bool coverageIsComplete,
+        ImmutableArray<CloneCandidateRow> rows,
+        ImmutableArray<CloneCandidateSeedCoverage> seeds,
+        ImmutableArray<CloneCandidateLibraryCoverage> libraries,
+        CloneCandidateReceipt receipt)
+    {
+        if (schemaVersion != CurrentSchemaVersion)
+        {
+            throw new ArgumentOutOfRangeException(nameof(schemaVersion));
+        }
+        if (nameSimilarityThreshold is < 0 or > 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(nameSimilarityThreshold));
+        }
+        _ = breadth switch
+        {
+            StructuralCloneCandidateBreadth.Self => breadth,
+            StructuralCloneCandidateBreadth
+                .SelfAndRegisteredEcosystems => breadth,
+            StructuralCloneCandidateBreadth.Everything => breadth,
+            _ => throw new ArgumentOutOfRangeException(nameof(breadth)),
+        };
+        _ = discovery switch
+        {
+            StructuralCloneCandidateDiscovery.SimilarNames => discovery,
+            StructuralCloneCandidateDiscovery.All => discovery,
+            _ => throw new ArgumentOutOfRangeException(nameof(discovery)),
+        };
+        CloneCandidatePresentationValidation.EnsureArray(
+            rows,
+            nameof(rows));
+        CloneCandidatePresentationValidation.EnsureArray(
+            seeds,
+            nameof(seeds));
+        CloneCandidatePresentationValidation.EnsureArray(
+            libraries,
+            nameof(libraries));
+        for (int index = 0; index < rows.Length; index++)
+        {
+            if (rows[index].Rank != index + 1)
+            {
+                throw new ArgumentException(
+                    "Candidate rows must retain consecutive global rank order.",
+                    nameof(rows));
+            }
+        }
+        ArgumentNullException.ThrowIfNull(receipt);
+        if (receipt.ReturnedPairs != rows.Length
+            || receipt.SeedMethods != seeds.Length
+            || receipt.AdmittedLibraries + receipt.ExcludedLibraries
+                != libraries.Length
+            || receipt.RankedPairs < receipt.ReturnedPairs
+            || receipt.ResultLimitReached
+                != (receipt.RankedPairs > receipt.ReturnedPairs))
+        {
+            throw new ArgumentException(
+                "The receipt does not describe the projected populations.",
+                nameof(receipt));
+        }
+        bool derivedCoverage =
+            seeds.All(seed => seed.IsComplete)
+            && libraries.All(library => library.IsComplete);
+        if (coverageIsComplete != derivedCoverage)
+        {
+            throw new ArgumentException(
+                "Overall coverage must match seed and library coverage.",
+                nameof(coverageIsComplete));
+        }
+
+        SchemaVersion = schemaVersion;
+        Seed = seed ?? throw new ArgumentNullException(nameof(seed));
+        Breadth = breadth;
+        Discovery = discovery;
+        NameSimilarityThreshold = nameSimilarityThreshold;
+        Limits = limits ?? throw new ArgumentNullException(nameof(limits));
+        ScopeChangedDuringSearch = scopeChangedDuringSearch;
+        CoverageIsComplete = coverageIsComplete;
+        Rows = rows;
+        Seeds = seeds;
+        Libraries = libraries;
+        Receipt = receipt;
+    }
+
+    public int SchemaVersion { get; }
+    public CloneCandidateSeed Seed { get; }
+    public StructuralCloneCandidateBreadth Breadth { get; }
+    public StructuralCloneCandidateDiscovery Discovery { get; }
+    public double NameSimilarityThreshold { get; }
+    public WorkspaceStructuralCloneSearchLimits Limits { get; }
+    public bool ScopeChangedDuringSearch { get; }
+    public bool CoverageIsComplete { get; }
+    public ImmutableArray<CloneCandidateRow> Rows { get; }
+    public ImmutableArray<CloneCandidateSeedCoverage> Seeds { get; }
+    public ImmutableArray<CloneCandidateLibraryCoverage> Libraries { get; }
+    public CloneCandidateReceipt Receipt { get; }
+
+    public bool ResultLimitReached => Receipt.ResultLimitReached;
+    public int ResultLimitOmittedPairs =>
+        Receipt.RankedPairs - Receipt.ReturnedPairs;
+
+    public bool Equals(CloneCandidateDocument? other)
+        => other is not null
+            && SchemaVersion == other.SchemaVersion
+            && Seed == other.Seed
+            && Breadth == other.Breadth
+            && Discovery == other.Discovery
+            && NameSimilarityThreshold.Equals(
+                other.NameSimilarityThreshold)
+            && Limits == other.Limits
+            && ScopeChangedDuringSearch == other.ScopeChangedDuringSearch
+            && CoverageIsComplete == other.CoverageIsComplete
+            && PresentationValueEquality.SequenceEqual(Rows, other.Rows)
+            && PresentationValueEquality.SequenceEqual(Seeds, other.Seeds)
+            && PresentationValueEquality.SequenceEqual(
+                Libraries,
+                other.Libraries)
+            && Receipt == other.Receipt;
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(SchemaVersion);
+        hash.Add(Seed);
+        hash.Add(Breadth);
+        hash.Add(Discovery);
+        hash.Add(NameSimilarityThreshold);
+        hash.Add(Limits);
+        hash.Add(ScopeChangedDuringSearch);
+        hash.Add(CoverageIsComplete);
+        hash.Add(PresentationValueEquality.SequenceHashCode(Rows));
+        hash.Add(PresentationValueEquality.SequenceHashCode(Seeds));
+        hash.Add(
+            PresentationValueEquality.SequenceHashCode(Libraries));
+        hash.Add(Receipt);
+        return hash.ToHashCode();
+    }
+}
+
+/// <summary>Why complete Query evidence could not be represented portably.</summary>
+public enum CloneCandidatePresentationRejectionKind
+{
+    ParticipantCoverageMissing,
+    ParticipantModuleInconsistent,
+}
+
+/// <summary>Closed Presentation outcome for one Workspace clone-search result.</summary>
+public abstract record CloneCandidatePresentationResult
+{
+    private protected CloneCandidatePresentationResult()
+    {
+    }
+
+    public sealed record Available(CloneCandidateDocument Document)
+        : CloneCandidatePresentationResult
+    {
+        public CloneCandidateDocument Document { get; } =
+            Document ?? throw new ArgumentNullException(nameof(Document));
+    }
+
+    public sealed record Rejected(
+        AssemblyReferenceIdentity SeedLibrary,
+        CandidateOpenFailureKind Kind,
+        InertString Detail,
+        MetadataRootMalformedReason? MetadataRootReason)
+        : CloneCandidatePresentationResult
+    {
+        public AssemblyReferenceIdentity SeedLibrary { get; } =
+            SeedLibrary
+            ?? throw new ArgumentNullException(nameof(SeedLibrary));
+    }
+
+    public sealed record Failed(
+        AssemblyReferenceIdentity SeedLibrary,
+        CloneCandidateFailure Failure)
+        : CloneCandidatePresentationResult
+    {
+        public AssemblyReferenceIdentity SeedLibrary { get; } =
+            SeedLibrary
+            ?? throw new ArgumentNullException(nameof(SeedLibrary));
+
+        public CloneCandidateFailure Failure { get; } =
+            Failure ?? throw new ArgumentNullException(nameof(Failure));
+    }
+
+    public sealed record Unrepresentable(
+        CloneCandidatePresentationRejectionKind Kind,
+        AssemblyReferenceIdentity Subject,
+        InertString Detail)
+        : CloneCandidatePresentationResult
+    {
+        public AssemblyReferenceIdentity Subject { get; } =
+            Subject ?? throw new ArgumentNullException(nameof(Subject));
+    }
+}
+
+/// <summary>Projects Workspace structural-clone search evidence for hosts.</summary>
+public static class CloneCandidatePresentation
+{
+    public static CloneCandidatePresentationResult Create(
+        WorkspaceStructuralCloneSearchResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return result switch
+        {
+            WorkspaceStructuralCloneSearchResult.Available available =>
+                CreateAvailable(available),
+            WorkspaceStructuralCloneSearchResult.Rejected rejected =>
+                new CloneCandidatePresentationResult.Rejected(
+                    rejected.SeedSubject.Identity,
+                    rejected.Failure.Kind,
+                    Inert(rejected.Failure.Detail),
+                    rejected.Failure.MetadataRootReason),
+            WorkspaceStructuralCloneSearchResult.Failed failed =>
+                new CloneCandidatePresentationResult.Failed(
+                    failed.SeedSubject.Identity,
+                    Project(failed.Failure)),
+            _ => throw new InvalidOperationException(
+                "Unknown Workspace structural-clone search result."),
+        };
+    }
+
+    static CloneCandidatePresentationResult CreateAvailable(
+        WorkspaceStructuralCloneSearchResult.Available result)
+    {
+        var moduleIds = new Dictionary<int, Guid>();
+        foreach (StructuralCloneSearchEndpoint endpoint in Endpoints(result))
+        {
+            if (moduleIds.TryGetValue(
+                    endpoint.Participant.Ordinal,
+                    out Guid moduleVersionId)
+                && moduleVersionId != endpoint.Method.ModuleVersionId)
+            {
+                return new CloneCandidatePresentationResult.Unrepresentable(
+                    CloneCandidatePresentationRejectionKind
+                        .ParticipantModuleInconsistent,
+                    endpoint.Subject.Identity,
+                    Inert(
+                        "One participant ordinal carries endpoint addresses "
+                        + "from more than one module version ID."));
+            }
+
+            moduleIds[endpoint.Participant.Ordinal] =
+                endpoint.Method.ModuleVersionId;
+        }
+
+        var participants =
+            new Dictionary<int, CloneCandidateParticipantIdentity>();
+        foreach (StructuralCloneSearchLibraryCoverage library
+            in result.Libraries)
+        {
+            Guid? moduleVersionId =
+                moduleIds.TryGetValue(
+                    library.Participant.Ordinal,
+                    out Guid endpointModule)
+                    ? endpointModule
+                    : library.Subject.Registration.ModuleVersionId;
+            participants.Add(
+                library.Participant.Ordinal,
+                new CloneCandidateParticipantIdentity(
+                    library.Participant.Ordinal,
+                    library.Subject.Identity,
+                    library.Subject.Provenance,
+                    moduleVersionId));
+        }
+        foreach (StructuralCloneSearchEndpoint endpoint in Endpoints(result))
+        {
+            if (!participants.ContainsKey(endpoint.Participant.Ordinal))
+            {
+                return new CloneCandidatePresentationResult.Unrepresentable(
+                    CloneCandidatePresentationRejectionKind
+                        .ParticipantCoverageMissing,
+                    endpoint.Subject.Identity,
+                    Inert(
+                        "An endpoint participant has no matching library "
+                        + "coverage entry."));
+            }
+        }
+
+        ImmutableArray<CloneCandidateRow> rows =
+        [
+            .. result.Pairs.Select(pair =>
+                new CloneCandidateRow(
+                    pair.Rank,
+                    Project(pair.Left, participants),
+                    Project(pair.Right, participants),
+                    Project(pair.Similarity),
+                    pair.NameQualification is null
+                        ? null
+                        : new CloneCandidateNameQualification(
+                            pair.NameQualification
+                                .DeclaringTypeSimilarity,
+                            pair.NameQualification.MemberSimilarity))),
+        ];
+        ImmutableArray<CloneCandidateSeedCoverage> seeds =
+        [
+            .. result.Seeds.Select(seed =>
+                new CloneCandidateSeedCoverage(
+                    Project(seed.Seed, participants),
+                    seed.Disposition,
+                    seed.RankedPairs,
+                    seed.SuppressedPairs,
+                    [
+                        .. seed.Blockers.Select(blocker =>
+                            new CloneCandidateAnalysisBlocker(
+                                blocker.Kind,
+                                Inert(blocker.Detail))),
+                    ],
+                    Project(seed.Failures))),
+        ];
+        ImmutableArray<CloneCandidateLibraryCoverage> libraries =
+        [
+            .. result.Libraries.Select(library =>
+                new CloneCandidateLibraryCoverage(
+                    participants[library.Participant.Ordinal],
+                    library.Membership,
+                    library.Admitted,
+                    library.CandidateMethods,
+                    library.DiscoveredMethods,
+                    library.RetrievalPairs,
+                    library.NameComparisonWork,
+                    Project(library.Failures),
+                    [
+                        .. library.AnalysisBlockers.Select(blocker =>
+                            new CloneCandidateAnalysisBlocker(
+                                blocker.Kind,
+                                Inert(blocker.Detail))),
+                    ])),
+        ];
+        var receipt =
+            new CloneCandidateReceipt(
+                result.Receipt.SeedMethods,
+                result.Receipt.CandidateMethods,
+                result.Receipt.DiscoveredCandidateMethods,
+                result.Receipt.AdmittedLibraries,
+                result.Receipt.ExcludedLibraries,
+                result.Libraries.Sum(
+                    library => library.NameComparisonWork),
+                result.Receipt.RetrievalPairs,
+                result.Receipt.RetrievalCalls,
+                result.Receipt.RankedPairs,
+                result.Receipt.SuppressedPairs,
+                result.Receipt.ReturnedPairs,
+                result.Receipt.ResultLimitReached);
+        return new CloneCandidatePresentationResult.Available(
+            new CloneCandidateDocument(
+                CloneCandidateDocument.CurrentSchemaVersion,
+                Project(result.Seed),
+                result.Breadth,
+                result.Discovery,
+                result.NameSimilarityThreshold,
+                result.Limits,
+                !ReferenceEquals(
+                    result.StartingRevision.Identity,
+                    result.EffectiveRevision.Identity),
+                result.CoverageIsComplete,
+                rows,
+                seeds,
+                libraries,
+                receipt));
+    }
+
+    static CloneCandidateSeed Project(StructuralCloneSearchSeed seed)
+        => seed switch
+        {
+            StructuralCloneSearchSeed.Library =>
+                new(
+                    CloneCandidateSeedKind.Library,
+                    type: null,
+                    member: null),
+            StructuralCloneSearchSeed.Type type =>
+                new(
+                    CloneCandidateSeedKind.Type,
+                    type.Definition,
+                    member: null),
+            StructuralCloneSearchSeed.Member member =>
+                new(
+                    CloneCandidateSeedKind.Member,
+                    member.Definition,
+                    member.MemberIdentity),
+            _ => throw new InvalidOperationException(
+                "Unknown structural-clone seed."),
+        };
+
+    static CloneCandidateSimilarity Project(
+        StructuralCloneSimilarityEvidence similarity)
+        => new(
+            similarity.Score,
+            similarity.OperationScore,
+            similarity.PositionScore,
+            similarity.BlockScore,
+            similarity.EdgeScore,
+            similarity.LocalScore,
+            similarity.SeedInstructions,
+            similarity.CandidateInstructions,
+            similarity.SeedBlocks,
+            similarity.CandidateBlocks,
+            similarity.SeedEdges,
+            similarity.CandidateEdges,
+            similarity.SeedLocals,
+            similarity.CandidateLocals);
+
+    static ImmutableArray<CloneCandidateFailure> Project(
+        ImmutableArray<StructuralCloneSearchFailure> failures)
+        =>
+        [
+            .. failures.Select(Project),
+        ];
+
+    static CloneCandidateFailure Project(
+        StructuralCloneSearchFailure failure)
+        => new(
+            failure.Kind,
+            failure.Subject?.Identity,
+            Inert(failure.Detail));
+
+    static CloneCandidateMethodIdentity Project(
+        StructuralCloneSearchEndpoint endpoint,
+        Dictionary<int, CloneCandidateParticipantIdentity> participants)
+        => new(
+            participants[endpoint.Participant.Ordinal],
+            endpoint.Method.ModuleVersionId,
+            endpoint.Method.Token,
+            Inert(
+                endpoint.Subject.Identity.Name
+                + "!"
+                + endpoint.Method.ModuleVersionId.ToString(
+                    "N",
+                    CultureInfo.InvariantCulture)
+                + ":0x"
+                + endpoint.Method.Token.ToString(
+                    "X8",
+                    CultureInfo.InvariantCulture)));
+
+    static IEnumerable<StructuralCloneSearchEndpoint> Endpoints(
+        WorkspaceStructuralCloneSearchResult.Available result)
+    {
+        foreach (StructuralCloneSearchPair pair in result.Pairs)
+        {
+            yield return pair.Left;
+            yield return pair.Right;
+        }
+        foreach (StructuralCloneSearchSeedCoverage seed in result.Seeds)
+            yield return seed.Seed;
+    }
+
+    static InertString Inert(string value)
+        => new(TextPolicy.Field, value);
+
+}
+
+static class CloneCandidatePresentationValidation
+{
+    internal static void EnsureArray<T>(
+        ImmutableArray<T> values,
+        string parameterName)
+    {
+        if (values.IsDefault)
+        {
+            throw new ArgumentException(
+                "The array must be initialized.",
+                parameterName);
+        }
+        if (values.Any(value => value is null))
+        {
+            throw new ArgumentException(
+                "The array must not contain null values.",
+                parameterName);
+        }
+    }
+}

--- a/tests/DotnetInspector.Presentation.Tests/CloneCandidatePresentationTests.cs
+++ b/tests/DotnetInspector.Presentation.Tests/CloneCandidatePresentationTests.cs
@@ -1,0 +1,401 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+
+using DotnetInspector.Fixtures;
+using DotnetInspector.Queries;
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Presentation.Tests;
+
+public sealed class CloneCandidatePresentationTests
+{
+    [Fact]
+    public async Task Create_ProjectsGlobalRowsAndExactParticipants()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        WorkspaceStructuralCloneSearchResult query =
+            fixture.Execute(
+                fixture.Snapshot(includeDuplicate: true),
+                new StructuralCloneSearchSeed.Library(),
+                limits: new WorkspaceStructuralCloneSearchLimits(
+                    MaximumResults: 12));
+
+        CloneCandidateDocument first = Available(
+            CloneCandidatePresentation.Create(query));
+        CloneCandidateDocument second = Available(
+            CloneCandidatePresentation.Create(query));
+
+        Assert.Equal(CloneCandidateDocument.SectionName, "Clone Candidates");
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+        Assert.Equal(CloneCandidateSeedKind.Library, first.Seed.Kind);
+        Assert.Equal(
+            StructuralCloneCandidateBreadth.Everything,
+            first.Breadth);
+        Assert.Equal(
+            StructuralCloneCandidateDiscovery.SimilarNames,
+            first.Discovery);
+        Assert.NotEmpty(first.Rows);
+        Assert.Equal(
+            Enumerable.Range(1, first.Rows.Length),
+            first.Rows.Select(row => row.Rank));
+        Assert.Equal(first.Receipt.ReturnedPairs, first.Rows.Length);
+        Assert.Contains(
+            first.Rows,
+            row =>
+                row.Left.Participant.Ordinal
+                != row.Right.Participant.Ordinal);
+
+        CloneCandidateRow crossParticipant =
+            Assert.Single(
+                first.Rows.Where(
+                    row => row.Left.Participant.Ordinal
+                        != row.Right.Participant.Ordinal).Take(1),
+                row => row.Left.Participant.Ordinal
+                    != row.Right.Participant.Ordinal);
+        Assert.Equal(
+            crossParticipant.Left.Participant.Assembly,
+            crossParticipant.Right.Participant.Assembly);
+        Assert.Equal(
+            crossParticipant.Left.ModuleVersionId,
+            crossParticipant.Right.ModuleVersionId);
+        Assert.NotEqual(
+            crossParticipant.Left.Participant,
+            crossParticipant.Right.Participant);
+        Assert.Contains(
+            ":0x06",
+            crossParticipant.Left.AddressDisplay.ToString(),
+            StringComparison.Ordinal);
+        Assert.NotNull(crossParticipant.NameQualification);
+        Assert.InRange(crossParticipant.Similarity.Score, 0, 10_000);
+    }
+
+    [Fact]
+    public async Task Create_PreservesLogicalMemberSeedCoverage()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        MemberAnchor property = fixture.LogicalProperty("Value");
+
+        CloneCandidateDocument document =
+            Available(
+                CloneCandidatePresentation.Create(
+                    fixture.Execute(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Widget"),
+                            property),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All)));
+
+        Assert.Equal(CloneCandidateSeedKind.Member, document.Seed.Kind);
+        Assert.Equal(property, document.Seed.Member);
+        Assert.Equal(2, document.Seeds.Length);
+        Assert.All(
+            document.Seeds,
+            seed => Assert.True(seed.IsComplete));
+        Assert.Contains(
+            document.Rows,
+            row => row.Left.MethodDefinitionToken
+                != row.Right.MethodDefinitionToken);
+
+        CloneCandidateDocument limited =
+            Available(
+                CloneCandidatePresentation.Create(
+                    fixture.Execute(
+                        fixture.Snapshot(),
+                        new StructuralCloneSearchSeed.Member(
+                            TypeName("Cases.Widget"),
+                            property),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All,
+                        new WorkspaceStructuralCloneSearchLimits(
+                            ComparisonLimits:
+                                new StructuralCloneComparisonLimits(
+                                    MaximumInstructions: 1)))));
+        Assert.False(limited.CoverageIsComplete);
+        Assert.Contains(
+            limited.Seeds,
+            seed => !seed.IsComplete && !seed.Blockers.IsEmpty);
+    }
+
+    [Fact]
+    public async Task Create_SeparatesSuppressionFromIncompleteCoverage()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+        var limits =
+            new WorkspaceStructuralCloneSearchLimits(MaximumResults: 1);
+
+        CloneCandidateDocument complete =
+            Available(
+                CloneCandidatePresentation.Create(
+                    fixture.Execute(
+                        fixture.Snapshot(includeDuplicate: true),
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Self,
+                        StructuralCloneCandidateDiscovery.All,
+                        limits)));
+        CloneCandidateDocument incomplete =
+            Available(
+                CloneCandidatePresentation.Create(
+                    fixture.Execute(
+                        fixture.Snapshot(includeUnreadable: true),
+                        new StructuralCloneSearchSeed.Library(),
+                        StructuralCloneCandidateBreadth.Everything,
+                        StructuralCloneCandidateDiscovery.All,
+                        limits)));
+
+        Assert.True(complete.CoverageIsComplete);
+        Assert.True(complete.ResultLimitReached);
+        Assert.True(complete.ResultLimitOmittedPairs > 0);
+        CloneCandidateLibraryCoverage breadthExcluded =
+            Assert.Single(
+                complete.Libraries,
+                library => !library.Admitted);
+        Assert.True(breadthExcluded.IsComplete);
+        Assert.False(incomplete.CoverageIsComplete);
+        Assert.True(incomplete.ResultLimitReached);
+        Assert.True(incomplete.ResultLimitOmittedPairs > 0);
+        CloneCandidateLibraryCoverage failedLibrary =
+            Assert.Single(
+                incomplete.Libraries,
+                library => !library.Failures.IsEmpty);
+        Assert.False(failedLibrary.IsComplete);
+        Assert.All(
+            failedLibrary.Failures,
+            failure => Assert.NotEqual(default, failure.Detail));
+    }
+
+    [Fact]
+    public async Task Create_PreservesFailedAndRejectedOutcomes()
+    {
+        await using Fixture fixture = await Fixture.CreateAsync();
+
+        CloneCandidatePresentationResult failed =
+            CloneCandidatePresentation.Create(
+                fixture.Execute(
+                    fixture.Snapshot(),
+                    new StructuralCloneSearchSeed.Type(
+                        TypeName("Cases.Missing"))));
+        CloneCandidatePresentationResult rejected =
+            CloneCandidatePresentation.Create(
+                fixture.Execute(
+                    fixture.InvalidSnapshot(),
+                    new StructuralCloneSearchSeed.Library()));
+
+        var failedResult =
+            Assert.IsType<CloneCandidatePresentationResult.Failed>(failed);
+        Assert.Equal(
+            StructuralCloneSearchFailureKind.SeedTypeNotFound,
+            failedResult.Failure.Kind);
+        Assert.NotEqual(default, failedResult.Failure.Detail);
+
+        var rejectedResult =
+            Assert.IsType<
+                CloneCandidatePresentationResult.Rejected>(rejected);
+        Assert.NotEqual(default, rejectedResult.Detail);
+    }
+
+    static CloneCandidateDocument Available(
+        CloneCandidatePresentationResult result)
+        => Assert.IsType<
+            CloneCandidatePresentationResult.Available>(result).Document;
+
+    static MetadataTypeDefinitionName TypeName(string serializedName)
+        => Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.ParseSerialized(
+                    serializedName))
+            .Name;
+
+    sealed class Fixture : IAsyncDisposable
+    {
+        readonly ImmutableArray<byte> _image;
+        readonly AssemblyContextGroup _self;
+        readonly AssemblyContextGroup _duplicate;
+        readonly AssemblyContextGroup _unreadable;
+        readonly AssemblyContextGroup _invalidSelf;
+        readonly StructuralCloneParticipantEntry _selfEntry;
+        readonly StructuralCloneParticipantEntry _duplicateEntry;
+        readonly StructuralCloneParticipantEntry _unreadableEntry;
+        readonly StructuralCloneParticipantEntry _invalidSelfEntry;
+
+        Fixture(
+            InspectionWorkspace workspace,
+            WorkspaceScopeRevision revision,
+            ImmutableArray<byte> image)
+        {
+            Workspace = workspace;
+            Revision = revision;
+            _image = image;
+            _self = Group(workspace, image, "clone candidates self");
+            _duplicate =
+                Group(workspace, image, "clone candidates duplicate");
+            ImmutableArray<byte> invalid =
+                ImmutableCollectionsMarshal.AsImmutableArray(
+                    new byte[] { 0x4D, 0x5A, 0x00, 0x00 });
+            _unreadable =
+                Group(workspace, invalid, "clone candidates unreadable");
+            _invalidSelf =
+                Group(workspace, invalid, "clone candidates invalid self");
+            _selfEntry =
+                Entry(
+                    _self,
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+            _duplicateEntry =
+                Entry(
+                    _duplicate,
+                    StructuralCloneParticipantMembership.Available);
+            _unreadableEntry =
+                Entry(
+                    _unreadable,
+                    StructuralCloneParticipantMembership.Available);
+            _invalidSelfEntry =
+                Entry(
+                    _invalidSelf,
+                    StructuralCloneParticipantMembership
+                        .ContainingLibrary);
+        }
+
+        internal InspectionWorkspace Workspace { get; }
+        internal WorkspaceScopeRevision Revision { get; }
+
+        internal static async ValueTask<Fixture> CreateAsync()
+        {
+            InspectionWorkspace workspace =
+                InspectionWorkspace.CreateAsynchronous();
+            WorkspaceScopeSnapshot snapshot =
+                Assert.IsType<WorkspaceScopeReadResult.Available>(
+                    await workspace.GetScopeSnapshotAsync())
+                .Snapshot;
+            ImmutableArray<byte> image =
+                ImmutableCollectionsMarshal.AsImmutableArray(
+                    File.ReadAllBytes(
+                        FixtureCatalog.CloneSearchMembers.AssemblyPath()));
+            return new Fixture(workspace, snapshot.Revision, image);
+        }
+
+        internal StructuralCloneParticipantSnapshot Snapshot(
+            bool includeDuplicate = false,
+            bool includeUnreadable = false)
+        {
+            var entries =
+                ImmutableArray.CreateBuilder<
+                    StructuralCloneParticipantEntry>();
+            entries.Add(_selfEntry);
+            if (includeDuplicate)
+                entries.Add(_duplicateEntry);
+            if (includeUnreadable)
+                entries.Add(_unreadableEntry);
+            return new(
+                Revision,
+                Revision,
+                entries.ToImmutable());
+        }
+
+        internal StructuralCloneParticipantSnapshot InvalidSnapshot()
+            => new(Revision, Revision, [_invalidSelfEntry]);
+
+        internal WorkspaceStructuralCloneSearchResult Execute(
+            StructuralCloneParticipantSnapshot participants,
+            StructuralCloneSearchSeed seed,
+            StructuralCloneCandidateBreadth breadth =
+                StructuralCloneCandidateBreadth.Everything,
+            StructuralCloneCandidateDiscovery discovery =
+                StructuralCloneCandidateDiscovery.SimilarNames,
+            WorkspaceStructuralCloneSearchLimits? limits = null)
+            => WorkspaceStructuralCloneSearchQuery.Execute(
+                new WorkspaceStructuralCloneSearchInput(
+                    participants,
+                    seed,
+                    breadth,
+                    discovery,
+                    limits),
+                TestContext.Current.CancellationToken);
+
+        internal MemberAnchor LogicalProperty(string name)
+        {
+            using var image = new PEReader(_image);
+            ApiSurface surface =
+                ApiSurfaceExtractor.Extract(image, includeAll: true);
+            ApiType type =
+                Assert.Single(
+                    surface.Types,
+                    candidate => candidate.Namespace == "Cases"
+                        && candidate.Name == "Widget");
+            ApiMember property =
+                Assert.Single(
+                    type.Members,
+                    candidate => candidate.Kind == "property"
+                        && candidate.Name == name);
+            return ApiMemberIdentity.GetMemberAnchor(type, property);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _self.Dispose();
+            _duplicate.Dispose();
+            _unreadable.Dispose();
+            _invalidSelf.Dispose();
+            await Workspace.DisposeAsync();
+        }
+
+        static StructuralCloneParticipantEntry Entry(
+            AssemblyContextGroup group,
+            StructuralCloneParticipantMembership membership)
+            => new(group, group.Participants[0], membership);
+
+        static AssemblyContextGroup Group(
+            InspectionWorkspace workspace,
+            ImmutableArray<byte> image,
+            string source)
+            => workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        ResolvedAssemblyReference.Create(
+                            Identity(image),
+                            path: null,
+                            () => new MemoryStream(
+                                ImmutableCollectionsMarshal
+                                    .AsArray(image)!,
+                                writable: false),
+                            AssemblyResolutionProvenance.Local(source)),
+                        new TestBindingPolicy()),
+                ]);
+
+        static AssemblyReferenceIdentity Identity(
+            ImmutableArray<byte> image)
+        {
+            try
+            {
+                using var reader = new PEReader(image);
+                return AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    reader.GetMetadataReader());
+            }
+            catch (BadImageFormatException)
+            {
+                return new AssemblyReferenceIdentity(
+                    "Unreadable",
+                    new Version(1, 0, 0, 0),
+                    Culture: null,
+                    PublicKeyToken: null);
+            }
+        }
+    }
+
+    sealed class TestBindingPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+            => new(
+                Version,
+                AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind.CandidateUnavailable)));
+    }
+}

--- a/tests/DotnetInspector.Presentation.Tests/DotnetInspector.Presentation.Tests.csproj
+++ b/tests/DotnetInspector.Presentation.Tests/DotnetInspector.Presentation.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\fixtures\diff\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\fixtures\presentation\LibraryApiDiff.V1\LibraryApiDiff.V1.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\fixtures\presentation\LibraryApiDiff.V2\LibraryApiDiff.V2.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\fixtures\queries\DotnetInspector.CloneSearchFixtures\DotnetInspector.CloneSearchFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\DotnetInspector.Presentation\DotnetInspector.Presentation.csproj" />
     <ProjectReference Include="..\DotnetInspector.FixtureInfrastructure\DotnetInspector.FixtureInfrastructure.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Build robust, capable Clone search foundations that support a compelling shared CLI and website experience while keeping retrieval evidence honest.

This adds stage 3 of #5083: a Presentation-owned, resource-free `CloneCandidateDocument` over `WorkspaceStructuralCloneSearchResult`. One declared row remains one globally ranked candidate pair, with exact snapshot-relative participant identity, assembly identity and provenance, MVID/MethodDef coordinates, structural and name evidence, coverage, exact-pair suppression, result-limit omission, failures, and bounded-work receipts.

The document deliberately does not use `ComparisonDocument<T>`: Library, Type, and logical Member searches can have multiple seed methods and one global ranking whose left endpoint varies. It also does not upgrade retrieval rank into a checked clone relation, correspondence, rename/move inference, or clone-assisted Diff.

## Demo

A Library search with the product defaults projects as one portable result:

```text
Clone Candidates
Seed: Library
Breadth: Everything
Discovery: SimilarNames
Coverage: Complete

Rank  Left endpoint                         Right endpoint                        Score
1     Self!<mvid>:0x06000003                Peer!<mvid>:0x06000003                10000
2     Self!<mvid>:0x06000004                Self!<mvid>:0x06000007                 8462
```

The exact address display is inert presentation text; identity remains the participant ordinal, assembly identity/provenance, MVID, and MethodDef token. Two registrations of identical bytes therefore remain distinct even when their assembly identity and MVID match.

The neighboring bounded case stays explicit:

```text
Coverage: Incomplete
Result limit reached: true
Result-limit omitted pairs: 42
Participant 2 failure: MetadataInspectionFailed
```

Incomplete evidence and intentional top-N omission remain independent. A property seed expands to its getter and setter seed coverage while preserving the same global row population.

## Validation

- `dotnet run --project tests/DotnetInspector.Presentation.Tests -c Release --no-restore` — 35 passed
- `npx markdownlint-cli docs/README.md docs/inspection-space.md docs/design/comparison-document.md docs/design/clone-candidate-presentation.md docs/design/structural-clone-search-scope.md`

## Boundaries

CLI `Clone Candidates` section registration, `-Q` facets, Markout lowering, Browser transport and controls, pairwise `match`, checked cross-image comparison, and clone-assisted Diff remain later focused owners.

Closes #6306.