### PR TITLE
Clarify source-owned population terminology

### DIFF
--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -640,7 +640,7 @@ core sequence, a curated set, or the presence of a pack identity.
 
 In particular, `ecosystem.platform` already groups product demos. It can retain
 that identity without pretending that its package-backed demos supply
-source-native Platform traversal. This slice neither creates a Platform
+platform-source-owned traversal. This slice neither creates a Platform
 package set nor substitutes a `System.*` package prefix for a platform target.
 The applicable source owner must issue its discovery/acquisition binding
 before the catalog can expose that separate capability.
@@ -943,8 +943,8 @@ add-on APIs rather than obsolete package versions of shared-framework
 fundamentals. Aspire starts with its hosting API. These choices are product
 preferences, not popularity rankings or complete ecosystem inventories.
 Platform deliberately contributes no package coordinate as a substitute for
-its future source-native discovery/acquisition binding. This metadata is not
-derived from package-set membership or demo records.
+its future platform-source-owned discovery/acquisition binding. This metadata
+is not derived from package-set membership or demo records.
 
 The initial Workspace projection is staged under
 [the focused handoff](workspace-ecosystem-registration-handoff.md). Its

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -824,7 +824,7 @@ Workspace Definitions execution remains unchanged. `RunHomeDemo` accepts both
 type-only `Methods` and member-bound
 `Call Graph` presets: the engine resolves the workspace, focus, section, and
 optional member anchor, opens one aggregate browser workspace, and returns its
-ordinary browsable surfaces plus exact source-native activation identity.
+ordinary browsable surfaces plus exact source-owner-issued activation identity.
 Package runs retain package identity; Platform runs retain family, assembly,
 version, and target-framework identity while using the shared Platform
 workspace, API-surface projection, and progressively acquired Call Graph path.

--- a/docs/design/workspace-ecosystem-registration-handoff.md
+++ b/docs/design/workspace-ecosystem-registration-handoff.md
@@ -56,8 +56,8 @@ layering boundary or creating a project cycle.
 
 Passing only `EcosystemPackId.Value` downward would avoid the project reference
 while losing the contract. A string does not carry issued correspondence,
-contribution completeness, source-native values, or the distinction between a
-known pack with no Workspace projection and an unknown pack.
+contribution completeness, owner-issued source values, or the distinction
+between a known pack with no Workspace projection and an unknown pack.
 
 Copying catalog metadata into each host is also invalid. It would create two
 default manifests, two identity maps, and host-specific decisions about which
@@ -189,9 +189,9 @@ WorkspaceEcosystemPopulationDeclaration
 ```
 
 The platform arm is a prerequisite owned by the platform source. It denotes a
-source-native family population such as the .NET runtime or ASP.NET Core
-shared framework. This document does not define its family grammar, target
-selection, library inventory, acquisition, realization, completion, or
+platform-source-owned library population such as the .NET runtime or ASP.NET
+Core shared framework. This document does not define its family grammar,
+target selection, library inventory, acquisition, realization, completion, or
 failure behavior.
 
 The package-prefix arm retains `PackagePrefixDeclaration`, not
@@ -363,11 +363,11 @@ call-graph consumer cannot form.
 
 ### Shared-framework and package overlap
 
-ASP.NET Core contributes both the source-native shared-framework population
-and `Microsoft.AspNetCore.` package-prefix intent. The handoff retains both.
-It neither deduplicates by namespace nor treats one as fallback for the other.
-The consumer and assembly-reference resolution owners decide request-relevant
-population and binding from their typed evidence.
+ASP.NET Core contributes both the platform-source-owned shared-framework
+population and `Microsoft.AspNetCore.` package-prefix intent. The handoff
+retains both. It neither deduplicates by namespace nor treats one as fallback
+for the other. The consumer and assembly-reference resolution owners decide
+request-relevant population and binding from their typed evidence.
 
 ### Prefix bound leakage
 
@@ -506,7 +506,7 @@ acquisition, or completion evidence.
 
 This design does not define:
 
-- exact-library registration identity or source-native coordinates;
+- exact-library registration identity or source-owner-issued coordinates;
 - platform family grammar, target selection, library inventory, or
   acquisition;
 - package-prefix query results, package limits, paging, source authorization,

--- a/docs/design/workspace-registration-and-call-graph-scope.md
+++ b/docs/design/workspace-registration-and-call-graph-scope.md
@@ -75,7 +75,7 @@ The version-1 registration vocabulary is a closed typed union:
 
 ```text
 WorkspaceRegistration
-  = ExactLibrary(owner-issued source-native library coordinate)
+  = ExactLibrary(source-owner-issued library coordinate)
   | PackagePrefix(owner-issued validated package-prefix declaration)
   | Ecosystem(owner-issued Workspace ecosystem declaration)
 ```
@@ -94,9 +94,9 @@ referencing or rediscovering the application catalog.
 
 ### Exact library
 
-An exact-library registration names one source-native library coordinate. It
-may identify a platform or package-origin library without converting either
-into the other's identity model.
+An exact-library registration names one source-owner-issued library
+coordinate. It may identify a platform or package-origin library without
+converting either into the other's identity model.
 
 A package Root may contribute one or more admitted libraries, but package
 membership and exact-library registration remain distinct. Opening or


### PR DESCRIPTION
dotnet-inspect's rigor serves robust, capable features that provide
foundational capabilities or compelling user experiences and are recognizably
conventionally sound, delightfully new or unique, or both.

This PR replaces the ambiguous term “source-native” with language that names
the actual owner and value:

- `platform-source-owned library population` for runtime and shared-framework
  populations; and
- `source-owner-issued` for exact library coordinates and activation identity.

No design contract changes.

## Demo

Before:

```text
source-native family population such as the .NET runtime
```

After:

```text
platform-source-owned library population such as the .NET runtime
```

The neighboring exact-library contract uses
`source-owner-issued library coordinate`, preserving its separate
package-or-platform source ownership without implying native code or source
provenance.

## Validation

- `npx markdownlint-cli docs/design/ecosystem-packs.md docs/design/workspace-definitions.md docs/design/workspace-ecosystem-registration-handoff.md docs/design/workspace-registration-and-call-graph-scope.md`
- `git diff --check`
