### PR TITLE
Rename PDB source acquisition to PdbSourceHouse

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -276,7 +276,7 @@ gates visible PDB source identity and exact/normalized checksum evidence. The
 acquisition side is gated by
 `VerifiedLocalSourceReadTests.ReturnsBytes_WhenChecksumMatches`,
 `VerifiedLocalSourceReadTests.ReturnsNull_WhenChecksumMismatches`, and
-`PdbSourceAcquisitionTests.
+`PdbSourceHouseTests.
 FromContent_MismatchedChecksumProducesFailedInspection`, while
 `FetchVerifiedSourceText_PreservesLineEndingNormalizationEvidence` gates the
 network result's typed verification. A source context is

--- a/docs/design/local-repository-source-acquisition.md
+++ b/docs/design/local-repository-source-acquisition.md
@@ -27,7 +27,7 @@ an absence Finding or a source-provenance receipt.
 | Supporting owner | Role in this contract |
 | --- | --- |
 | [PDB acquisition](../pdb-acquisition.md) | Owns acquisition ordering, PDB-recorded local-file reads, source decoding/slicing, and remote outcome interpretation. |
-| `PdbSourceAcquisition.VerifyChecksum` | Supplies the checksum-verification classification consumed by this adapter. |
+| `PdbSourceHouse.VerifyChecksum` | Supplies the checksum-verification classification consumed by this adapter. |
 | Metadata and SourceLink | Supply document/checksum observations and resolved source locators. |
 | SourceLink provenance and the host source fetcher | Own immutable-origin classification and remote destination admission; local lookup does not replace either. |
 | CLI | Accepts explicit clone paths and presents the acquired source through existing views. |
@@ -41,7 +41,7 @@ This is a consumed association, not a new PDB selection or identity contract.
 The production consumer is already shipped. Desktop `--repo` supplies clone
 paths to member PDB Source, printable type Source Files, printable member
 Source Locations, and implementation-diff PDB source. Reusable service paths
-reach the adapter through `PdbSourceAcquisition`; the CLI implementation-diff
+reach the adapter through `PdbSourceHouse`; the CLI implementation-diff
 source resolver also invokes it directly.
 
 This preserves the host split owned by [PDB acquisition](../pdb-acquisition.md):
@@ -171,7 +171,7 @@ This adapter uses the raw-content convention rather than recreating a checkout
 or borrowing working-tree conversion semantics. Git's object lookup supplies
 the candidate bytes, not their correspondence with a Portable PDB.
 
-The adjacent remote path in `PdbSourceAcquisition` likewise gates fetched bytes
+The adjacent remote path in `PdbSourceHouse` likewise gates fetched bytes
 through the shared verifier. Local lookup reuses that policy instead of
 inventing weaker checksum admission. Its deliberately different locator
 admission is justified by the distinction between a local content probe and a

--- a/docs/design/local-repository-source-acquisition.md
+++ b/docs/design/local-repository-source-acquisition.md
@@ -193,7 +193,7 @@ a skipped case supplies no execution evidence.
 | A real committed blob is returned on checksum match and refused on mismatch | `LocalRepoSourceReadTests.ReadsBlob_WhenChecksumMatches`, `ReturnsNull_WhenChecksumMismatches` |
 | Missing selector/path or a non-repository directory supplies no bytes | `LocalRepoSourceReadTests.ReturnsNull_WhenCommitNotPresent`, `ReturnsNull_WhenPathNotPresent`, `ReturnsNull_WhenDirectoryIsNotAGitRepo` |
 | A missing object in the first clone does not hide the second clone's verified blob | `LocalRepoSourceReadTests.ReadsBlob_FromSecondRepo_WhenFirstLacksCommit` |
-| Shared verifier distinguishes accepted line-ending normalization | `PdbSourceAcquisitionTests.VerifyChecksum_AcceptsLineEndingNormalization` |
+| Shared verifier distinguishes accepted line-ending normalization | `PdbSourceHouseTests.VerifyChecksum_AcceptsLineEndingNormalization` |
 | Member, type, and printable-projection service paths use a clone when PDB-recorded local-file reads are disabled | `LocalRepoSourceAcquisitionIntegrationTests.ServiceLocalClone_SatisfiesMemberAndTypeSourceWithoutRemoteFetch` |
 | The CLI accepts and propagates `--repo` for printable type Source Files while its HTTP path is offline | `LocalRepoSourceProjectionTests.TypeSourceFilesPrint_AcceptsRepoAtCliBoundaryWhileOffline` |
 

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -211,8 +211,8 @@ Owns PDB-source acquisition and verification:
 - exact member/type body slicing
 
 It consumes Metadata-owned PDB document and coordinate facts without making
-Metadata own textual C#. `PdbSourceAcquisitionTests.FromContent_VerifiedSourceProducesCompleteLineCensus`,
-`PdbSourceAcquisitionTests.FromContent_UsesSequencePointEvidenceToSelectAConditionalMember`,
+Metadata own textual C#. `PdbSourceHouseTests.FromContent_VerifiedSourceProducesCompleteLineCensus`,
+`PdbSourceHouseTests.FromContent_UsesSequencePointEvidenceToSelectAConditionalMember`,
 and
 `AssemblyContextSourceQueryTests.LocalPdbSource_DoesNotRequireSourceLinkMap`
 gate that boundary.

--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -149,7 +149,7 @@ literal metadata character. This is gated by
 Whole-document type output refuses more than 500,000 logical lines before
 materializing the Finding census; the verified text then remains a failed
 PDB-source attempt so Decompiler fallback can run.
-`PdbSourceAcquisitionTests.FromTypeContent_NewlineDenseSourceProducesVisibleFailedEvidence`
+`PdbSourceHouseTests.FromTypeContent_NewlineDenseSourceProducesVisibleFailedEvidence`
 gates that bound. A host source-content store that reports a read or write
 failure produces typed evidence and does not publish the fetched bytes to the
 process-local memory cache, so an identical retry cannot silently change from

--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -126,7 +126,7 @@ reachability and checksum statuses are operation results and presentation
 folds, not additional Findings.
 
 `MemberSourceLocationCollector` consumes member-source Findings by metadata
-token. `PdbSourceAcquisition` consumes the same token-scoped mapping and
+token. `PdbSourceHouse` consumes the same token-scoped mapping and
 document census, fetches exact bytes through the SSRF-hardened Services path,
 verifies the portable-PDB checksum, extracts the member body, and returns a
 `FindingInspection<string>`. Its type operation resolves only the exact

--- a/docs/design/source-oracle-candidate-ledger.md
+++ b/docs/design/source-oracle-candidate-ledger.md
@@ -66,7 +66,7 @@ It does not own:
 - command-line argument policy; or
 - card and JSON presentation conventions.
 
-`ILInspector.Metadata` and `PdbSourceAcquisition` own mapping and acquisition.
+`ILInspector.Metadata` and `PdbSourceHouse` own mapping and acquisition.
 `AuthoredSourceHarvest` owns authored-source harvesting.
 `AuthoredCorpusSourceEvaluator` owns source-oracle evaluation.
 `PrinterSyntaxInventory` owns feature extraction.

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1412,7 +1412,7 @@ Checksum evidence follows the portable-PDB document row rather than a display
 or canonical path. Direct member, type, and IL-offset projections join on row
 identity and verify the PDB document path; path-only heuristic projections
 attach a checksum only when that path names one document row. This is gated by
-`PdbSourceAcquisitionTests.SelectMappedDocument_UsesDocumentRowWhenPathsAreDuplicated`,
+`PdbSourceHouseTests.SelectMappedDocument_UsesDocumentRowWhenPathsAreDuplicated`,
 `...SelectMappedDocument_RejectsAMismatchedRowPathPair`, and
 `MetadataSourceFindingsTests.DocumentChecksumIndexes_PreserveRowsAndRejectAmbiguousPathFallback`.
 
@@ -1422,7 +1422,7 @@ The fetch-origin grammar is gated by
 `...FetchOrigin_UnknownSourceLinkHostCarriesNoOriginClaim`. The Services gate
 exercises the response boundary, pre-fix cache invalidation, and the
 availability/integrity projections in
-`PdbSourceAcquisitionTests.FetchSourceBytes_RejectsRedirectOutsideAttributedOrigin`,
+`PdbSourceHouseTests.FetchSourceBytes_RejectsRedirectOutsideAttributedOrigin`,
 `...FetchSourceBytes_IgnoresPreOriginValidationCache`,
 `HttpRetryHelperTests.HeaderFirstBodyRead_TimesOutAndRetriesAStalledBody`,
 `...HeaderFirstBodyRead_CapsAChunkedBodyByDecodedBytes`,
@@ -1463,7 +1463,7 @@ dispatch, omits credentials, and configures Fetch to reject redirects. A
 destination outside that set is a PDB-source acquisition limitation and may
 fall back to decompilation; it is never probed. The shared `SourceFetch`
 applies that host policy before its memory or content-store caches and before
-creating the request. `PdbSourceAcquisitionTests.FetchSourceBytes_PolicyRejectsDestinationBeforeDispatch`
+creating the request. `PdbSourceHouseTests.FetchSourceBytes_PolicyRejectsDestinationBeforeDispatch`
 and
 `BrowserEngineBoundaryTests.SourceFetchPolicy_OmitsCredentialsAndRefusesRedirects`
 gate those rules.
@@ -1572,7 +1572,7 @@ Limit exhaustion is a visible extraction failure, not an absent declaration.
 token emission boundary, while
 `DeclarationIndexTests.LineLimit_StopsLineDenseInputBeforeSplitting` gates the
 pre-allocation line boundary, and
-`PdbSourceAcquisitionTests.FromContent_TokenDenseSourceProducesVisibleFailedEvidence`
+`PdbSourceHouseTests.FromContent_TokenDenseSourceProducesVisibleFailedEvidence`
 gates the Findings-facing result, while
 `CommandExecutionTests.PdbSource_TokenDenseInputCarriesAVisibleFailureState`
 gates the member-command result.

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1399,7 +1399,7 @@ and
 `HttpRetryHelperTests.HeaderFirstBodyRead_FailureLogsCarryNoUrlOrExceptionText`.
 
 Every product consumer that renders or derives output from fetched source now
-uses `PdbSourceAcquisition.FetchVerifiedSourceTextAsync`. PDB Source,
+uses `PdbSourceHouse.FetchVerifiedSourceTextAsync`. PDB Source,
 printed Source Files and Source Locations, IL-offset source lines, and
 documentation/sample enrichment all require the portable-PDB checksum before
 using network content. `SourceAvailabilityService` and

--- a/docs/pdb-acquisition.md
+++ b/docs/pdb-acquisition.md
@@ -11,12 +11,18 @@ recognizes and interprets the SourceLink custom-debug-information document.
 ## PDB source document acquisition
 
 After a Portable PDB maps a member or type to a checksummed source document,
-`PdbSourceAcquisition` looks for the document bytes in this order:
+`PdbSourceHouse` looks for the document bytes in this order:
 
 1. The PDB-recorded local path, when local source reads are enabled.
 2. Each caller-supplied local Git clone, addressed by the revision selector and
    repository-relative path in a `raw.githubusercontent.com` SourceLink URL.
 3. The remote SourceLink URL.
+
+`PdbSourceHouse` is the clearing house for this PDB-provenance-based source
+scenario: it composes the candidate origins, fetch policy, checksum
+verification, source decoding, and typed failure outcomes into one settled
+result. It intentionally does not include decompiler-generated source.
+`AssemblyContextSourceQuery` owns that higher Queries-layer fallback.
 
 Every successful path must satisfy the shared Portable PDB checksum verifier
 (exact or accepted line-ending-normalized correspondence) before its content

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineLayeringTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineLayeringTests.cs
@@ -463,7 +463,7 @@ public sealed class BrowserEngineLayeringTests
             "DotnetInspector.Services.GitHubUrlResolver",
             "DotnetInspector.Services.LocalRepoSourceAcquisition",
             "DotnetInspector.Services.NuspecParser",
-            "DotnetInspector.Services.PdbSourceAcquisition",
+            "DotnetInspector.Services.PdbSourceHouse",
             "DotnetInspector.Services.ProjectAssetsParser",
             "DotnetInspector.Services.SignatureVerifier",
             "ILInspector.Metadata.ApiSurface",

--- a/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
@@ -828,7 +828,7 @@ public static class AssemblyContextSourceQuery
                     participant,
                     bindingPolicyVersion);
                 inspection =
-                    await PdbSourceAcquisition.AcquireMemberAsync(
+                    await PdbSourceHouse.AcquireMemberAsync(
                             source,
                             request.MetadataToken,
                             request.Member.MemberName,
@@ -863,7 +863,7 @@ public static class AssemblyContextSourceQuery
                 participant,
                 bindingPolicyVersion);
             inspection =
-                PdbSourceAcquisition
+                PdbSourceHouse
                     .MemberPdbAcquisitionFailed(
                         findingSubject,
                         sourceResult.Failure!);
@@ -935,7 +935,7 @@ public static class AssemblyContextSourceQuery
                     participant,
                     bindingPolicyVersion);
                 pdbSource =
-                    await PdbSourceAcquisition.AcquireTypeAsync(
+                    await PdbSourceHouse.AcquireTypeAsync(
                             source,
                             request.Type,
                             findingSubject,
@@ -981,7 +981,7 @@ public static class AssemblyContextSourceQuery
                 participant,
                 bindingPolicyVersion);
             pdbSource =
-                PdbSourceAcquisition
+                PdbSourceHouse
                     .TypePdbAcquisitionFailed(
                         findingSubject,
                         sourceResult.Failure!);

--- a/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
@@ -11,7 +11,7 @@ namespace DotnetInspector.Services;
 /// Reads a single PDB-mapped source file from a user-specified local git clone, keyed on the
 /// SourceLink commit + repo-relative path and authenticated against the portable-PDB checksum.
 ///
-/// This is the opt-in local-repository counterpart to <see cref="PdbSourceAcquisition"/>'s
+/// This is the opt-in local-repository counterpart to <see cref="PdbSourceHouse"/>'s
 /// remote SourceLink fetch. For a reproducible (published) build the PDB records a normalized,
 /// non-local document path plus a raw.githubusercontent URL that encodes the commit SHA and the
 /// repo-relative path. When the user names one or more local clones (<c>--repo</c>), we read the
@@ -60,7 +60,7 @@ public static partial class LocalRepoSourceAcquisition
             if (bytes is null)
                 continue;
 
-            if (PdbSourceAcquisition.VerifyChecksum(checksumAlgorithm, checksum, bytes)
+            if (PdbSourceHouse.VerifyChecksum(checksumAlgorithm, checksum, bytes)
                 is SourceChecksumVerification.Exact or SourceChecksumVerification.LineEndingNormalized)
             {
                 return bytes;

--- a/src/DotnetInspector.Services/PdbSourceHouse.cs
+++ b/src/DotnetInspector.Services/PdbSourceHouse.cs
@@ -75,10 +75,10 @@ public sealed record VerifiedSourceTextResult(
 }
 
 /// <summary>
-/// Acquires one PDB-mapped member source and verifies the portable-PDB checksum before exposing
-/// its text as evidence.
+/// Clearing house for PDB-mapped source acquisition: orders local and remote candidates,
+/// verifies the portable-PDB checksum, and exposes one settled source result as evidence.
 /// </summary>
-public static class PdbSourceAcquisition
+public static class PdbSourceHouse
 {
     internal const int MaxPdbSourceLineCount = 500_000;
 

--- a/src/DotnetInspector.Services/SourceIntegrityService.cs
+++ b/src/DotnetInspector.Services/SourceIntegrityService.cs
@@ -143,7 +143,7 @@ public static class SourceIntegrityService
                     }
 
                     SourceChecksumVerification verification =
-                        PdbSourceAcquisition.VerifyChecksum(document, body);
+                        PdbSourceHouse.VerifyChecksum(document, body);
                     if (verification == SourceChecksumVerification.Exact)
                     {
                         Interlocked.Increment(ref verified);

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -501,7 +501,7 @@ public sealed class AuthoredRebuildFidelityTests
             Mapping: null,
             Document: null,
             ChecksumVerification: null);
-        var failed = PdbSourceAcquisition.MemberPdbAcquisitionFailed(
+        var failed = PdbSourceHouse.MemberPdbAcquisitionFailed(
             Subject,
             new IOException("source fetch failed"));
 

--- a/src/ILInspector.Decompiler.Tests/SourceOracleCandidateLedgerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SourceOracleCandidateLedgerTests.cs
@@ -1094,7 +1094,7 @@ public class SourceOracleCandidateLedgerTests
     [Fact]
     public void HarvestInspection_AFailedFetchIsAnAcquisitionFailureNotMissingMapping()
     {
-        var inspection = DotnetInspector.Services.PdbSourceAcquisition
+        var inspection = DotnetInspector.Services.PdbSourceHouse
             .MemberPdbAcquisitionFailed(
                 new FindingSubject("M~source", "N.T.M"),
                 new IOException("Could not fetch PDB source."));
@@ -1127,7 +1127,7 @@ public class SourceOracleCandidateLedgerTests
             ChecksumAlgorithm: "SHA256",
             Checksum: Convert.ToHexString(
                 System.Security.Cryptography.SHA256.HashData(content)));
-        var inspection = DotnetInspector.Services.PdbSourceAcquisition.FromContent(
+        var inspection = DotnetInspector.Services.PdbSourceHouse.FromContent(
             mapping,
             document,
             content,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -2272,17 +2272,17 @@ public class ApiCommand
             string? content = null;
             SourceChecksumVerification checksumVerification =
                 SourceChecksumVerification.Unavailable;
-            var localBytes = DotnetInspector.Services.PdbSourceAcquisition.TryReadVerifiedLocalSource(
+            var localBytes = DotnetInspector.Services.PdbSourceHouse.TryReadVerifiedLocalSource(
                 methodInfo.FilePath, methodInfo.ChecksumAlgorithm, methodInfo.Checksum);
             byte[]? repoBytes;
             if (localBytes != null)
             {
-                checksumVerification = PdbSourceAcquisition.VerifyChecksum(
+                checksumVerification = PdbSourceHouse.VerifyChecksum(
                     methodInfo.ChecksumAlgorithm,
                     methodInfo.Checksum,
                     localBytes);
                 content = NormalizePdbSourceLineEndings(
-                    DotnetInspector.Services.PdbSourceAcquisition.DecodeSourceText(localBytes));
+                    DotnetInspector.Services.PdbSourceHouse.DecodeSourceText(localBytes));
             }
             // Opt-in (--repo): read the committed blob at the SourceLink commit from a local clone,
             // authenticated by the same PDB checksum, before touching the network. Useful for a
@@ -2292,17 +2292,17 @@ public class ApiCommand
                     methodInfo.SourceUrl, methodInfo.ChecksumAlgorithm, methodInfo.Checksum,
                     options.SourceRepositories)) != null)
             {
-                checksumVerification = PdbSourceAcquisition.VerifyChecksum(
+                checksumVerification = PdbSourceHouse.VerifyChecksum(
                     methodInfo.ChecksumAlgorithm,
                     methodInfo.Checksum,
                     repoBytes);
                 content = NormalizePdbSourceLineEndings(
-                    DotnetInspector.Services.PdbSourceAcquisition.DecodeSourceText(repoBytes));
+                    DotnetInspector.Services.PdbSourceHouse.DecodeSourceText(repoBytes));
             }
             else if (methodInfo.SourceUrl != null)
             {
                 var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
-                var fetch = await PdbSourceAcquisition.FetchVerifiedSourceTextAsync(
+                var fetch = await PdbSourceHouse.FetchVerifiedSourceTextAsync(
                     fetcher,
                     methodInfo.SourceUrl,
                     methodInfo.ChecksumAlgorithm,
@@ -3308,7 +3308,7 @@ public class ApiCommand
         var rawUrl = GitHubUrlResolver.ConvertBlobToRawUrl(selectedRow.Url!);
         var selectedSource = materialized.Single(row => row.Row == selectedRow.Row);
         var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
-        var fetch = await PdbSourceAcquisition.AcquireVerifiedSourceTextAsync(
+        var fetch = await PdbSourceHouse.AcquireVerifiedSourceTextAsync(
             fetcher,
             selectedSource.FilePath,
             rawUrl,

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1412,7 +1412,7 @@ public class DiffCommand
                 foreach (var target in targets)
                 {
                     var subject = subjects[target.Subject.Id];
-                    var inspection = await PdbSourceAcquisition.AcquireMemberAsync(
+                    var inspection = await PdbSourceHouse.AcquireMemberAsync(
                         source,
                         target.Method.MetadataToken,
                         target.Method.Name,

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -2250,7 +2250,7 @@ public class LibraryCommand
 
         var rawUrl = StripUrlFragment(GitHubUrlResolver.ConvertBlobToRawUrl(result.Url));
         var fetcher = new SourceFetch(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
-        var fetch = await PdbSourceAcquisition.FetchVerifiedSourceTextAsync(
+        var fetch = await PdbSourceHouse.FetchVerifiedSourceTextAsync(
             fetcher,
             rawUrl,
             result.SourceChecksumAlgorithm,

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -325,7 +325,7 @@ internal static class SourceEnricher
             new ParallelOptions { MaxDegreeOfParallelism = 16 },
             async (sourceFetch, ct) =>
             {
-                var result = await PdbSourceAcquisition.AcquireVerifiedSourceTextAsync(
+                var result = await PdbSourceHouse.AcquireVerifiedSourceTextAsync(
                     fetcher,
                     sourceFetch.FilePath,
                     sourceFetch.Url,
@@ -865,7 +865,7 @@ internal static class SourceEnricher
         foreach ((string url, string filePath, string? algorithm, byte[]? checksum) in sourceFilesToFetch)
         {
             logger.Log("Fetching SourceLink source.");
-            var fetch = await PdbSourceAcquisition.AcquireVerifiedSourceTextAsync(
+            var fetch = await PdbSourceHouse.AcquireVerifiedSourceTextAsync(
                 fetcher,
                 filePath,
                 url,

--- a/tests/DotnetInspector.CSharpBodySlicer.Tests/AuthoredSourceValidityTests.cs
+++ b/tests/DotnetInspector.CSharpBodySlicer.Tests/AuthoredSourceValidityTests.cs
@@ -367,7 +367,7 @@ public class AuthoredSourceValidityTests
 
     /// <summary>
     /// Drives the product path end to end: <see cref="PdbContext.EnumerateMemberDocuments"/>
-    /// supplies the same anchor and line range that <c>PdbSourceAcquisition</c> passes to
+    /// supplies the same anchor and line range that <c>PdbSourceHouse</c> passes to
     /// the slicer, so nothing here reconstructs a range the product would compute differently.
     /// </summary>
     private static List<Slice> SliceCorpus()

--- a/tests/DotnetInspector.Services.Tests/LocalRepoSourceAcquisitionIntegrationTests.cs
+++ b/tests/DotnetInspector.Services.Tests/LocalRepoSourceAcquisitionIntegrationTests.cs
@@ -28,7 +28,7 @@ public class LocalRepoSourceAcquisitionIntegrationTests
         var subject = new FindingSubject("local-repo-source", targetType.FullName!);
 
         PdbMemberSourceInspection member =
-            await PdbSourceAcquisition.AcquireMemberAsync(
+            await PdbSourceHouse.AcquireMemberAsync(
                 source,
                 targetMethod.MetadataToken,
                 targetMethod.Name,
@@ -38,7 +38,7 @@ public class LocalRepoSourceAcquisitionIntegrationTests
                 TestContext.Current.CancellationToken,
                 allowLocalSource: false);
         PdbTypeSourceInspection type =
-            await PdbSourceAcquisition.AcquireTypeAsync(
+            await PdbSourceHouse.AcquireTypeAsync(
                 source,
                 typeName.Name,
                 subject,
@@ -49,7 +49,7 @@ public class LocalRepoSourceAcquisitionIntegrationTests
         SourceDocumentObservation document = Assert.IsType<SourceDocumentObservation>(
             member.Document);
         VerifiedSourceTextResult projection =
-            await PdbSourceAcquisition.AcquireVerifiedSourceTextAsync(
+            await PdbSourceHouse.AcquireVerifiedSourceTextAsync(
                 fetcher,
                 document.OriginalPath,
                 document.ResolvedUrl!,

--- a/tests/DotnetInspector.Services.Tests/PdbSourceHouseTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PdbSourceHouseTests.cs
@@ -14,7 +14,7 @@ using ILInspector.SourceLink;
 namespace DotnetInspector.Services.Tests;
 
 [Collection(CoreCacheCollection.Name)]
-public class PdbSourceAcquisitionTests
+public class PdbSourceHouseTests
 {
     static readonly FindingSubject Subject = new("M~source", "Sample.M");
     const string Source = """
@@ -41,7 +41,7 @@ public class PdbSourceAcquisitionTests
                 [nameof(PdbSourceAcquisitionTests)]));
 
         PdbMemberSourceInspection member =
-            await PdbSourceAcquisition.AcquireMemberAsync(
+            await PdbSourceHouse.AcquireMemberAsync(
                 source,
                 0x06000001,
                 "M",
@@ -50,7 +50,7 @@ public class PdbSourceAcquisitionTests
                 cancellationToken:
                     TestContext.Current.CancellationToken);
         PdbTypeSourceInspection typeInspection =
-            await PdbSourceAcquisition.AcquireTypeAsync(
+            await PdbSourceHouse.AcquireTypeAsync(
                 source,
                 type.Name,
                 Subject,
@@ -90,7 +90,7 @@ public class PdbSourceAcquisitionTests
                 [nameof(PdbSourceAcquisitionTests)]));
 
         PdbMemberSourceInspection member =
-            await PdbSourceAcquisition.AcquireMemberAsync(
+            await PdbSourceHouse.AcquireMemberAsync(
                 source,
                 0x06000001,
                 "M",
@@ -99,7 +99,7 @@ public class PdbSourceAcquisitionTests
                 cancellationToken:
                     TestContext.Current.CancellationToken);
         PdbTypeSourceInspection typeInspection =
-            await PdbSourceAcquisition.AcquireTypeAsync(
+            await PdbSourceHouse.AcquireTypeAsync(
                 source,
                 type.Name,
                 Subject,
@@ -125,7 +125,7 @@ public class PdbSourceAcquisitionTests
     public void FromContent_VerifiedSourceProducesCompleteLineCensus()
     {
         byte[] content = Encoding.UTF8.GetBytes(Source);
-        var result = PdbSourceAcquisition.FromContent(
+        var result = PdbSourceHouse.FromContent(
             Mapping(),
             Document(content),
             content,
@@ -171,7 +171,7 @@ public class PdbSourceAcquisitionTests
             SequencePointStartLines = [6],
         };
 
-        var result = PdbSourceAcquisition.FromContent(
+        var result = PdbSourceHouse.FromContent(
             mapping,
             Document(content),
             content,
@@ -186,7 +186,7 @@ public class PdbSourceAcquisitionTests
     public void FromContent_MismatchedChecksumProducesFailedInspection()
     {
         byte[] content = Encoding.UTF8.GetBytes(Source);
-        var result = PdbSourceAcquisition.FromContent(
+        var result = PdbSourceHouse.FromContent(
             Mapping(),
             Document(Encoding.UTF8.GetBytes(Source + "changed")),
             content,
@@ -213,7 +213,7 @@ public class PdbSourceAcquisitionTests
             };
 
         PdbMemberSourceInspection result =
-            PdbSourceAcquisition.FromContent(
+            PdbSourceHouse.FromContent(
                 Mapping(),
                 document,
                 content,
@@ -238,7 +238,7 @@ public class PdbSourceAcquisitionTests
             + " } }";
         byte[] content = Encoding.UTF8.GetBytes(source);
 
-        var result = PdbSourceAcquisition.FromContent(
+        var result = PdbSourceHouse.FromContent(
             Mapping(),
             Document(content),
             content,
@@ -264,7 +264,7 @@ public class PdbSourceAcquisitionTests
             };
 
         PdbMemberSourceInspection result =
-            PdbSourceAcquisition.FromContent(
+            PdbSourceHouse.FromContent(
                 mapping,
                 Document(content),
                 content,
@@ -292,7 +292,7 @@ public class PdbSourceAcquisitionTests
             };
 
         PdbMemberSourceInspection result =
-            PdbSourceAcquisition.FromContent(
+            PdbSourceHouse.FromContent(
                 mapping,
                 Document(content),
                 content,
@@ -313,7 +313,7 @@ public class PdbSourceAcquisitionTests
         byte[] content = Encoding.UTF8.GetBytes(
             new string(
                 '\n',
-                PdbSourceAcquisition
+                PdbSourceHouse
                     .MaxPdbSourceLineCount));
         var mapping =
             new ILInspector.SourceLink.SourceLinkResolver
@@ -324,7 +324,7 @@ public class PdbSourceAcquisitionTests
                     GitHubBrowseUrl: null);
 
         PdbTypeSourceInspection result =
-            PdbSourceAcquisition.FromTypeContent(
+            PdbSourceHouse.FromTypeContent(
                 mapping,
                 Document(content),
                 content,
@@ -349,7 +349,7 @@ public class PdbSourceAcquisitionTests
         byte[] expected = Encoding.UTF8.GetBytes(Source.ReplaceLineEndings("\n"));
         byte[] actual = Encoding.UTF8.GetBytes(Source.ReplaceLineEndings("\r\n"));
 
-        var verification = PdbSourceAcquisition.VerifyChecksum(
+        var verification = PdbSourceHouse.VerifyChecksum(
             Document(expected),
             actual);
 
@@ -370,7 +370,7 @@ public class PdbSourceAcquisitionTests
             new InMemorySourceContentStore());
 
         VerifiedSourceTextResult result =
-            await PdbSourceAcquisition.FetchVerifiedSourceTextAsync(
+            await PdbSourceHouse.FetchVerifiedSourceTextAsync(
                 fetcher,
                 $"https://example.test/{Guid.NewGuid():N}/Sample.cs",
                 "SHA256",
@@ -394,7 +394,7 @@ public class PdbSourceAcquisitionTests
             Checksum = null,
         };
 
-        var result = PdbSourceAcquisition.FromContent(
+        var result = PdbSourceHouse.FromContent(
             Mapping(),
             document,
             content,
@@ -567,7 +567,7 @@ public class PdbSourceAcquisitionTests
             }
             """;
         byte[] content = Encoding.UTF8.GetBytes(source);
-        var result = PdbSourceAcquisition.FromContent(
+        var result = PdbSourceHouse.FromContent(
             DestructorMapping(memberName: "Finalize", startLine: 6, endLine: 7, isFinalizer: true),
             Document(content),
             content,
@@ -602,7 +602,7 @@ public class PdbSourceAcquisitionTests
             }
             """;
         byte[] content = Encoding.UTF8.GetBytes(source);
-        var result = PdbSourceAcquisition.FromContent(
+        var result = PdbSourceHouse.FromContent(
             DestructorMapping(memberName: "Finalize", startLine: 7, endLine: 8, isFinalizer: false),
             Document(content),
             content,
@@ -628,7 +628,7 @@ public class PdbSourceAcquisitionTests
         var mapping = Mapping() with { DocumentRowId = 2 };
 
         SourceDocumentObservation? selected =
-            PdbSourceAcquisition.SelectMappedDocument(
+            PdbSourceHouse.SelectMappedDocument(
                 mapping,
                 [first, second]);
 
@@ -645,7 +645,7 @@ public class PdbSourceAcquisitionTests
             OriginalPath = "/_/Other.cs",
         };
 
-        Assert.Null(PdbSourceAcquisition.SelectMappedDocument(
+        Assert.Null(PdbSourceHouse.SelectMappedDocument(
             mapping,
             [document]));
     }

--- a/tests/DotnetInspector.Services.Tests/PdbSourceHouseTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PdbSourceHouseTests.cs
@@ -38,7 +38,7 @@ public class PdbSourceHouseTests
         var type = Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
             MetadataTypeDefinitionName.Create(
                 "DotnetInspector.Services.Tests",
-                [nameof(PdbSourceAcquisitionTests)]));
+                [nameof(PdbSourceHouseTests)]));
 
         PdbMemberSourceInspection member =
             await PdbSourceHouse.AcquireMemberAsync(
@@ -87,7 +87,7 @@ public class PdbSourceHouseTests
         var type = Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
             MetadataTypeDefinitionName.Create(
                 "DotnetInspector.Services.Tests",
-                [nameof(PdbSourceAcquisitionTests)]));
+                [nameof(PdbSourceHouseTests)]));
 
         PdbMemberSourceInspection member =
             await PdbSourceHouse.AcquireMemberAsync(
@@ -699,7 +699,7 @@ public class PdbSourceHouseTests
     static SourceLinkService OpenSourceNeedingPdb()
     {
         byte[] assemblyBytes = File.ReadAllBytes(
-            typeof(PdbSourceAcquisitionTests).Assembly.Location);
+            typeof(PdbSourceHouseTests).Assembly.Location);
         AssemblyReferenceIdentity identity;
         using (var stream = new MemoryStream(
                    assemblyBytes,

--- a/tests/DotnetInspector.Services.Tests/VerifiedLocalSourceReadTests.cs
+++ b/tests/DotnetInspector.Services.Tests/VerifiedLocalSourceReadTests.cs
@@ -33,7 +33,7 @@ public class VerifiedLocalSourceReadTests
         string path = WriteTemp(".cs", content);
         try
         {
-            byte[]? result = PdbSourceAcquisition.TryReadVerifiedLocalSource(
+            byte[]? result = PdbSourceHouse.TryReadVerifiedLocalSource(
                 path, "SHA256", SHA256.HashData(content));
 
             Assert.NotNull(result);
@@ -54,7 +54,7 @@ public class VerifiedLocalSourceReadTests
         {
             // The on-disk bytes do not match the recorded hash: the read must be refused so the
             // caller falls back to the remote URL rather than surfacing unverified content.
-            byte[]? result = PdbSourceAcquisition.TryReadVerifiedLocalSource(
+            byte[]? result = PdbSourceHouse.TryReadVerifiedLocalSource(
                 path, "SHA256", SHA256.HashData(Encoding.UTF8.GetBytes(Source + "tampered")));
 
             Assert.Null(result);
@@ -74,7 +74,7 @@ public class VerifiedLocalSourceReadTests
         string path = WriteTemp(".txt", content);
         try
         {
-            byte[]? result = PdbSourceAcquisition.TryReadVerifiedLocalSource(
+            byte[]? result = PdbSourceHouse.TryReadVerifiedLocalSource(
                 path, "SHA256", SHA256.HashData(content));
 
             Assert.Null(result);
@@ -92,9 +92,9 @@ public class VerifiedLocalSourceReadTests
         string path = WriteTemp(".cs", content);
         try
         {
-            Assert.Null(PdbSourceAcquisition.TryReadVerifiedLocalSource(path, "SHA256", null));
-            Assert.Null(PdbSourceAcquisition.TryReadVerifiedLocalSource(path, null, SHA256.HashData(content)));
-            Assert.Null(PdbSourceAcquisition.TryReadVerifiedLocalSource(path, "SHA256", []));
+            Assert.Null(PdbSourceHouse.TryReadVerifiedLocalSource(path, "SHA256", null));
+            Assert.Null(PdbSourceHouse.TryReadVerifiedLocalSource(path, null, SHA256.HashData(content)));
+            Assert.Null(PdbSourceHouse.TryReadVerifiedLocalSource(path, "SHA256", []));
         }
         finally
         {
@@ -110,7 +110,7 @@ public class VerifiedLocalSourceReadTests
             Path.GetTempPath(),
             $"dotnet-inspect-missing-{Guid.NewGuid():N}.cs");
 
-        Assert.Null(PdbSourceAcquisition.TryReadVerifiedLocalSource(
+        Assert.Null(PdbSourceHouse.TryReadVerifiedLocalSource(
             path, "SHA256", SHA256.HashData(content)));
     }
 
@@ -124,7 +124,7 @@ public class VerifiedLocalSourceReadTests
         string path = WriteTemp(".cs", crlf);
         try
         {
-            byte[]? result = PdbSourceAcquisition.TryReadVerifiedLocalSource(
+            byte[]? result = PdbSourceHouse.TryReadVerifiedLocalSource(
                 path, "SHA256", SHA256.HashData(lf));
 
             Assert.NotNull(result);
@@ -152,7 +152,7 @@ public class VerifiedLocalSourceReadTests
                 ChecksumAlgorithm: "SHA256",
                 Checksum: Convert.ToHexString(SHA256.HashData(content)));
 
-            byte[]? result = PdbSourceAcquisition.TryReadVerifiedLocalSource(document);
+            byte[]? result = PdbSourceHouse.TryReadVerifiedLocalSource(document);
 
             Assert.NotNull(result);
             Assert.Equal(content, result);
@@ -170,13 +170,13 @@ public class VerifiedLocalSourceReadTests
 
         Assert.Equal(
             SourceChecksumVerification.Exact,
-            PdbSourceAcquisition.VerifyChecksum("SHA256", SHA256.HashData(content), content));
+            PdbSourceHouse.VerifyChecksum("SHA256", SHA256.HashData(content), content));
         Assert.Equal(
             SourceChecksumVerification.Mismatch,
-            PdbSourceAcquisition.VerifyChecksum("SHA256", SHA256.HashData(content), Encoding.UTF8.GetBytes("other")));
+            PdbSourceHouse.VerifyChecksum("SHA256", SHA256.HashData(content), Encoding.UTF8.GetBytes("other")));
         Assert.Equal(
             SourceChecksumVerification.Unavailable,
-            PdbSourceAcquisition.VerifyChecksum(null, SHA256.HashData(content), content));
+            PdbSourceHouse.VerifyChecksum(null, SHA256.HashData(content), content));
     }
 
     [Theory]
@@ -190,7 +190,7 @@ public class VerifiedLocalSourceReadTests
         // be rejected before any filesystem access so it cannot trigger outbound SMB/network I/O,
         // and a relative path is never honored — independent of the (here matching) checksum.
         byte[] content = Encoding.UTF8.GetBytes(Source);
-        Assert.Null(PdbSourceAcquisition.TryReadVerifiedLocalSource(
+        Assert.Null(PdbSourceHouse.TryReadVerifiedLocalSource(
             path, "SHA256", SHA256.HashData(content)));
     }
 
@@ -200,12 +200,12 @@ public class VerifiedLocalSourceReadTests
         // Non-ASCII content makes the encoding observable. A checksum-verified local file may be
         // UTF-8 (with or without BOM) or UTF-16; each must decode correctly, not as raw UTF-8.
         const string text = "héllo wörld";
-        Assert.Equal(text, PdbSourceAcquisition.DecodeSourceText(Encoding.UTF8.GetBytes(text)));
-        Assert.Equal(text, PdbSourceAcquisition.DecodeSourceText(
+        Assert.Equal(text, PdbSourceHouse.DecodeSourceText(Encoding.UTF8.GetBytes(text)));
+        Assert.Equal(text, PdbSourceHouse.DecodeSourceText(
             [.. Encoding.UTF8.GetPreamble(), .. Encoding.UTF8.GetBytes(text)]));
-        Assert.Equal(text, PdbSourceAcquisition.DecodeSourceText(
+        Assert.Equal(text, PdbSourceHouse.DecodeSourceText(
             [.. Encoding.Unicode.GetPreamble(), .. Encoding.Unicode.GetBytes(text)]));
-        Assert.Equal(text, PdbSourceAcquisition.DecodeSourceText(
+        Assert.Equal(text, PdbSourceHouse.DecodeSourceText(
             [.. Encoding.BigEndianUnicode.GetPreamble(), .. Encoding.BigEndianUnicode.GetBytes(text)]));
     }
 
@@ -218,14 +218,14 @@ public class VerifiedLocalSourceReadTests
         string path = WriteTemp(".cs", utf16);
         try
         {
-            byte[]? result = PdbSourceAcquisition.TryReadVerifiedLocalSource(
+            byte[]? result = PdbSourceHouse.TryReadVerifiedLocalSource(
                 path, "SHA256", SHA256.HashData(utf16));
 
             Assert.NotNull(result);
             Assert.Equal(utf16, result);
             Assert.Equal(
                 Source.ReplaceLineEndings("\n"),
-                PdbSourceAcquisition.DecodeSourceText(result).ReplaceLineEndings("\n"));
+                PdbSourceHouse.DecodeSourceText(result).ReplaceLineEndings("\n"));
         }
         finally
         {

--- a/tools/DecompilerHarness/AuthoredCorpusDrift.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusDrift.cs
@@ -143,7 +143,7 @@ static class AuthoredCorpusDrift
         PdbMemberSourceInspection authored;
         try
         {
-            authored = await PdbSourceAcquisition.AcquireMemberAsync(
+            authored = await PdbSourceHouse.AcquireMemberAsync(
                 source,
                 record.MetadataToken,
                 record.Method,

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -236,7 +236,7 @@ static class AuthoredRebuildFidelity
             decompilerResult.MemberAnchor?.StableSelector
                 ?? $"{request.FullType}.{request.MethodName}",
             $"{request.FullType}.{request.MethodName}");
-        var authored = await PdbSourceAcquisition.AcquireMemberAsync(
+        var authored = await PdbSourceHouse.AcquireMemberAsync(
             source,
             MetadataTokens.GetToken(request.TargetMethod),
             request.MethodName,

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -335,7 +335,7 @@ static class AuthoredSourceHarvest
         PdbMemberSourceInspection authored;
         try
         {
-            authored = await PdbSourceAcquisition.AcquireMemberAsync(
+            authored = await PdbSourceHouse.AcquireMemberAsync(
                 source,
                 candidate.MetadataToken,
                 candidate.Method,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -524,7 +524,7 @@ the ones that produce no candidate.
 assembly the ledger reads the complete portable-PDB MethodDef-to-document
 mapping through `SourceLinkFindings.InspectMemberSources` and
 `InspectSourceDocuments`, selects each MethodDef's primary document exactly as
-`PdbSourceAcquisition.AcquireMemberAsync` does (`IsPrimaryDocument` descending,
+`PdbSourceHouse.AcquireMemberAsync` does (`IsPrimaryDocument` descending,
 then `DocumentRowId`), and intersects that mapping with the real-method targets.
 A file's denominator is therefore never inferred from the rows that happened to
 harvest successfully. That distinction is the reason this mode exists: a full

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -486,7 +486,7 @@ static partial class ReturnToSenderSourceProbe
         var subject = new FindingSubject(
             TargetId(target.Target),
             TargetDisplay(target.Target));
-        PdbMemberSourceInspection authored = await PdbSourceAcquisition.AcquireMemberAsync(
+        PdbMemberSourceInspection authored = await PdbSourceHouse.AcquireMemberAsync(
             source,
             target.MetadataToken,
             target.Target.Method,

--- a/tools/DecompilerHarness/SourceOracleCandidateLedger.cs
+++ b/tools/DecompilerHarness/SourceOracleCandidateLedger.cs
@@ -1002,7 +1002,7 @@ static class SourceOracleCandidateLedger
     /// the portable PDB before any source is acquired.
     ///
     /// <para>Primary selection matches
-    /// <see cref="PdbSourceAcquisition.AcquireMemberAsync"/> exactly —
+    /// <see cref="PdbSourceHouse.AcquireMemberAsync"/> exactly —
     /// <c>IsPrimaryDocument</c> descending, then <c>DocumentRowId</c> — because a census
     /// that picked a different document than acquisition would attribute a member's
     /// result to a file the acquisition never read.</para>
@@ -1125,7 +1125,7 @@ static class SourceOracleCandidateLedger
     /// <summary>
     /// The single document a mapping points at, or <see langword="null"/> when the
     /// portable PDB does not identify one uniquely. Mirrors
-    /// <c>PdbSourceAcquisition.SelectMappedDocument</c>, which is internal to the
+    /// <c>PdbSourceHouse.SelectMappedDocument</c>, which is internal to the
     /// services assembly.
     /// </summary>
     static SourceDocumentObservation? SelectMappedDocument(


### PR DESCRIPTION
## Summary

Rename `PdbSourceAcquisition` to `PdbSourceHouse`, establishing it as the major clearing-house Service for PDB-provenance source acquisition. The House composes SourceLink mapping, authorized local/repository/network acquisition, checksum verification, caching, and visible failure policy.

This is a mechanical ownership rename with no behavior change. Decompiler-generated source remains outside the House in the higher `AssemblyContextSourceQuery` layer.

## Demo

Before:

```csharp
PdbMemberSourceInspection source =
    await PdbSourceAcquisition.AcquireMemberAsync(...);
```

After:

```csharp
PdbMemberSourceInspection source =
    await PdbSourceHouse.AcquireMemberAsync(...);
```

The neighboring boundary remains explicit:

```text
PdbSourceHouse
  verified source from PDB provenance

AssemblyContextSourceQuery
  PDB source attempt + separate decompiler fallback
```

## Design

`docs/pdb-acquisition.md` remains the normative owner. The rename applies the Fetch/Service/House convention from #6301: House is reserved for a foundational Service with broad acquisition and policy composition, while targeted services retain `Service` names.

The production file is a 99% rename and the test file is a 95% rename. Remaining edits update callers, test gate names, browser layering expectations, and owning documentation. The generated decompiler corpus snapshot is intentionally unchanged; that advisory artifact is regenerated by its harness rather than manually edited.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.Services.Tests -c Release --no-build` — 1,212 passed, 2 skipped
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release --no-build` — 1,775 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build` — 6,687 passed, 31 skipped
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build` — 6,616 passed, 8 skipped
- `npm ci --no-audit --no-fund && npm run build` in `prototypes/inspect-web`
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 432 passed
- `npx markdownlint-cli` for all changed Markdown
- `git diff --check`

## Stack

- Parent: #6312
- This slice: `PdbSourceHouse`
- Remaining architecture slices: PackageHouse and PlatformHouse
