### PR TITLE
Align CoreCLR deployment with production promotion

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Use when shipping a new dotnet-inspect version; coordinate certification, NuGet and GitHub publication, and the matching dotnet-inspect.net production deployment.
+description: Use when shipping a new dotnet-inspect version; coordinate certification, NuGet and GitHub publication, and matching production and CoreCLR site deployments.
 ---
 
 # Release dotnet-inspect
@@ -12,8 +12,8 @@ the release contract and failure handling. This skill is an operator playbook,
 not a substitute for that document or the workflows.
 
 A release is one exact `(commit SHA, VersionPrefix)` pair shared by the NuGet
-packages, GitHub release, and `https://dotnet-inspect.net`. Never advance only
-the packages or only the site.
+packages, GitHub release, `https://dotnet-inspect.net`, and the CoreCLR
+comparison site. Never advance only the packages or only one site.
 
 ## Collect the release evidence
 
@@ -97,13 +97,16 @@ Open `release.yml` and `promote-inspect-web.yml` together:
 5. Wait for the package workflow and GitHub release to succeed, then approve
    the production-site environment. Never promote the site first.
 
-Do not substitute a newer run after the SHA comparison. The release is complete
-only when both workflows succeed.
+Do not substitute a newer run after the SHA comparison. Production promotion
+automatically invokes the CoreCLR deployment with the resolved SHA, staging run
+ID, and artifact ID. The release is complete only when both top-level workflows
+and the nested CoreCLR deployment succeed.
 
 ## Verify and recover
 
 Verify the package version and commit in NuGet and the GitHub release. Then
-check the production site's status bar for the same version and linked commit.
+check the production and CoreCLR sites' status bars for the same version and
+linked commit.
 
 If the package workflow fails, leave site production unapproved and retry with
 the same CI and certification run IDs. Package retries tolerate
@@ -111,6 +114,10 @@ already-published artifacts with `--skip-duplicate`. If site promotion fails
 after package publication, retry with the same staging run ID; site retries
 revalidate and promote the same staged artifact. A different SHA, ancestry-only
 relationship, or matching version string is not a valid substitute.
+
+If the CoreCLR deployment fails after production promotion, rerun the failed
+jobs in that promotion run. Do not dispatch a new promotion or substitute a
+newer staging run; the nested deployment retains the exact promoted identity.
 
 If a newer `main` push cancels the release commit's staging run, wait for active
 staging work to finish and rerun the original push-triggered run:

--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -1,11 +1,20 @@
 name: Deploy inspect-web CoreCLR staging
 
 on:
-  workflow_run:
-    workflows:
-      - Deploy inspect-web staging
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      staging_run_id:
+        description: 'Staging run whose exact site artifact was promoted'
+        required: true
+        type: string
+      source_sha:
+        description: 'Exact product commit promoted to production'
+        required: true
+        type: string
+      artifact_id:
+        description: 'Exact staged site artifact promoted to production'
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -24,52 +33,27 @@ env:
 
 jobs:
   publish:
-    name: Build and publish latest CoreCLR staging
-    if: >-
-      github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.head_branch == 'main'
-      && github.event.workflow_run.event == 'push'
+    name: Build and publish promoted CoreCLR comparison
     concurrency:
       group: deploy-inspect-web-coreclr-staging
-      cancel-in-progress: true
+      cancel-in-progress: false
     environment:
       name: inspect-web-coreclr-staging
       url: https://coreclr.dotnet-inspect.ca
     runs-on: ubuntu-26.04
     steps:
-      - name: Resolve latest successful staging run
-        id: latest
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          latest=$(
-            gh api --method GET \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-inspect-web.yml/runs" \
-              -f branch=main \
-              -f event=push \
-              -f status=success \
-              -f per_page=100 \
-              --jq '.workflow_runs | max_by(.run_number) | [.id, .head_sha] | @tsv'
-          )
-          IFS=$'\t' read -r run_id head_sha <<< "$latest"
-          test -n "$run_id"
-          test -n "$head_sha"
-          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ steps.latest.outputs.head_sha }}
+          ref: ${{ inputs.source_sha }}
 
       - name: Download compiler-async staging artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: inspect-web-site
+          artifact-ids: ${{ inputs.artifact_id }}
           path: artifacts/inspect-web-compiler-publish
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          run-id: ${{ steps.latest.outputs.run_id }}
+          run-id: ${{ inputs.staging_run_id }}
           digest-mismatch: error
 
       - name: Install pinned .NET 12 SDK
@@ -218,7 +202,7 @@ jobs:
             -c Release \
             --output artifacts/inspect-web-coreclr-publish \
             -p:VersionPrefix="$version" \
-            -p:SourceRevisionId="${{ steps.latest.outputs.head_sha }}" \
+            -p:SourceRevisionId="${{ inputs.source_sha }}" \
             -p:BuildTimestampUtc="$built_at" \
             -p:Features=runtime-async=on \
             -p:UseMonoRuntime=false \
@@ -600,24 +584,6 @@ jobs:
             "$(jq -r '.runtime.assets.nativeWasmSha256' "$cohort/runtime-cohort.json")"
           test "$(sha256sum "$site"/_framework/dotnet.native.*.js | awk '{print $1}')" = \
             "$(jq -r '.runtime.assets.nativeJavaScriptSha256' "$cohort/runtime-cohort.json")"
-
-      - name: Verify newest eligible staging run
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SELECTED_RUN_ID: ${{ steps.latest.outputs.run_id }}
-        run: |
-          set -euo pipefail
-          latest_run_id=$(
-            gh api --method GET \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-inspect-web.yml/runs" \
-              -f branch=main \
-              -f event=push \
-              -f status=success \
-              -f per_page=100 \
-              --jq '.workflow_runs | max_by(.run_number) | .id // empty'
-          )
-          test -n "$latest_run_id"
-          test "$latest_run_id" = "$SELECTED_RUN_ID"
 
       - name: Deploy to CoreCLR staging
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -235,3 +235,15 @@ jobs:
           output_location: ''
           skip_app_build: true
           skip_api_build: true
+
+  coreclr:
+    name: Publish matching CoreCLR comparison
+    needs:
+      - resolve
+      - deploy
+    uses: ./.github/workflows/deploy-inspect-web-coreclr.yml
+    with:
+      staging_run_id: ${{ inputs.staging_run_id }}
+      source_sha: ${{ needs.resolve.outputs.sha }}
+      artifact_id: ${{ needs.resolve.outputs.artifact_id }}
+    secrets: inherit

--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -782,18 +782,14 @@ summary but does not establish graph equality. Their lowering counts remain the
 expected all-or-nothing inverse. A receipt for only `InspectWeb.Engine.dll` is
 incomplete after partitioning even if its local counts are correct.
 
-CoreCLR staging follows only the highest-run-number successful `main`/`push`
-run of the compiler-async staging workflow. A successful completion is a
-wakeup, not deployment authority: after entering one static job-level
-concurrency group, the atomic build-and-deploy job resolves the current highest
-successful run and uses that run's exact artifact and head SHA. It checks the
-selected identity again immediately before deployment. A later rerun of an
-older successful staging run may restart the job, but the restarted job still
-builds and deploys the current highest successful run instead of the older
-wakeup. A newer failed, cancelled, or in-progress run does not make older
-successful evidence false; its later successful completion supplies the
-superseding wakeup. Failed, cancelled, manual, and non-`main` completions do
-not enter the group.
+CoreCLR staging follows production promotion rather than every compiler-async
+staging build. After production deploys successfully, the promotion workflow
+calls the CoreCLR workflow with the exact validated product SHA, staging run
+ID, and staged artifact ID that it promoted. The CoreCLR build checks out that
+SHA and compares against that exact compiler-async artifact; it never resolves
+a newer staging run independently. The promotion concurrency group serializes
+the production and CoreCLR deployments, and the CoreCLR deployment does not
+start before production succeeds.
 
 The deployment smoke initializes every module, which acquires its exact
 assembly export root and validates every expected runtime path, then invokes

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -6,8 +6,10 @@ the dotnet-inspect packages and the production site at
 rules live in [AGENTS.md](../AGENTS.md). The executable sources of truth are
 [release.yml](../.github/workflows/release.yml),
 [deploy-inspect-web.yml](../.github/workflows/deploy-inspect-web.yml), and
-[promote-inspect-web.yml](../.github/workflows/promote-inspect-web.yml); update
-this document when those workflows change. The repo-local
+[promote-inspect-web.yml](../.github/workflows/promote-inspect-web.yml), which
+calls
+[deploy-inspect-web-coreclr.yml](../.github/workflows/deploy-inspect-web-coreclr.yml);
+update this document when those workflows change. The repo-local
 [release skill](../.github/skills/release/SKILL.md) is the operator playbook and
 must stay aligned with this contract.
 
@@ -23,6 +25,7 @@ responsibilities:
 | `release.yml` | Manual dispatch | Verify certification, rebuild packages, and publish one selected commit |
 | `deploy-inspect-web.yml` | Pushes to `main` or manual dispatch from `main` | Build and deploy a staging site artifact for that commit |
 | `promote-inspect-web.yml` | Manual dispatch | Verify and promote one staged artifact to `https://dotnet-inspect.net` |
+| `deploy-inspect-web-coreclr.yml` | Called after production promotion | Build and deploy the same product commit and staged artifact identity with CoreCLR |
 
 The publish workflow accepts a successful `main` CI run ID to resolve the exact
 commit SHA and a Deep Inspect run ID as its heavy-validation evidence. It does
@@ -61,7 +64,11 @@ release unit:
   its push trigger and exceptionally from an operator dispatch, embedding that
   commit's `VersionPrefix`, full source SHA, and build timestamp.
 - `promote-inspect-web.yml` promotes that exact staged artifact without
-  rebuilding it.
+  rebuilding it, then calls `deploy-inspect-web-coreclr.yml` with the resolved
+  product SHA, staging run ID, and artifact ID.
+- `deploy-inspect-web-coreclr.yml` rebuilds the browser host with the pinned
+  CoreCLR cohort from that exact product SHA and compares it with the exact
+  compiler-async artifact promoted to production.
 
 Publish and promote together. Do not publish a new package version without
 promoting its matching site, and do not promote a site from a commit that is
@@ -258,9 +265,11 @@ publication succeeds, approve the site workflow; it revalidates the staging run
 and artifact identity, downloads the exact staged artifact with digest
 verification, and deploys it to `https://dotnet-inspect.net`.
 
-The release is complete only when both workflows succeed. Verify that the
-published package and GitHub release use the intended version and commit, then
-check the production site's status bar for the same version and linked commit.
+The release is complete only when both workflows succeed, including the
+promotion workflow's matching CoreCLR deployment. Verify that the published
+package and GitHub release use the intended version and commit, then check the
+production and CoreCLR sites' status bars for the same version and linked
+commit.
 
 ## Failure handling
 
@@ -303,6 +312,9 @@ check the production site's status bar for the same version and linked commit.
   successful Deep Inspect certification before the next ordinary release.
 - **Site promotion fails after package publication:** retry promotion with the
   same staging run ID. Do not advance the package version or staging SHA.
+- **CoreCLR deployment fails after production promotion:** rerun the failed
+  jobs in the same promotion run so the CoreCLR workflow retains the promoted
+  SHA, staging run ID, and artifact ID.
 - **Either side resolves a different SHA:** cancel the package workflow
   and the promotion workflow immediately, then select matching evidence. If
   package publication already started, audit the partial immutable package set

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -52,39 +52,6 @@ internal static class PromotionWorkflowContract
           artifacts/inspect-web-compiler-publish/async-lowering.json \
           artifacts/inspect-web-coreclr-publish/async-lowering.json
         """;
-    private const string NewestEligibleStagingRunCheck =
-        """
-        set -euo pipefail
-        latest_run_id=$(
-          gh api --method GET \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-inspect-web.yml/runs" \
-            -f branch=main \
-            -f event=push \
-            -f status=success \
-            -f per_page=100 \
-            --jq '.workflow_runs | max_by(.run_number) | .id // empty'
-        )
-        test -n "$latest_run_id"
-        test "$latest_run_id" = "$SELECTED_RUN_ID"
-        """;
-    private const string ResolveLatestSuccessfulStagingRun =
-        """
-        set -euo pipefail
-        latest=$(
-          gh api --method GET \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-inspect-web.yml/runs" \
-            -f branch=main \
-            -f event=push \
-            -f status=success \
-            -f per_page=100 \
-            --jq '.workflow_runs | max_by(.run_number) | [.id, .head_sha] | @tsv'
-        )
-        IFS=$'\t' read -r run_id head_sha <<< "$latest"
-        test -n "$run_id"
-        test -n "$head_sha"
-        echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-        echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-        """;
     internal static void AssertMutations(string repository)
     {
         string promotionPath = Path.Combine(
@@ -165,13 +132,6 @@ internal static class PromotionWorkflowContract
             stagingCheckout,
             ValidateStaging,
             "Staging workflow contract accepted candidate code in the deployment job.");
-
-        AssertMutationRejected(
-            coreClrStagingWorkflow,
-            "          --jq '.workflow_runs | max_by(.run_number) | .id // empty'\n",
-            "          --jq '.workflow_runs[0].id // empty'\n",
-            ValidateCoreClrStaging,
-            "CoreCLR staging contract accepted arrival-ordered freshness.");
 
         AssertMutationRejected(
             promotionWorkflow,
@@ -463,44 +423,52 @@ internal static class PromotionWorkflowContract
             "Staging workflow contract accepted PR-head checkout.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
-            "  workflow_run:\n",
-            "  workflow_run:\n  pull_request_target:\n",
+            "  workflow_call:\n",
+            "  workflow_call:\n  pull_request_target:\n",
             ValidateCoreClrStaging,
             "CoreCLR staging contract accepted pull_request_target.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
-            "          ref: ${{ steps.latest.outputs.head_sha }}\n",
-            "          ref: ${{ github.event.workflow_run.head_sha }}\n",
+            "          ref: ${{ inputs.source_sha }}\n",
+            "          ref: ${{ github.sha }}\n",
             ValidateCoreClrStaging,
-            "CoreCLR staging contract accepted checkout of the wakeup revision.");
+            "CoreCLR staging contract accepted checkout outside the promoted revision.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
-            "          run-id: ${{ steps.latest.outputs.run_id }}\n",
-            "          run-id: ${{ github.event.workflow_run.id }}\n",
+            "          artifact-ids: ${{ inputs.artifact_id }}\n",
+            "          name: inspect-web-site\n",
             ValidateCoreClrStaging,
-            "CoreCLR staging contract accepted the wakeup artifact.");
+            "CoreCLR staging contract accepted artifact selection by name.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
-            "      && github.event.workflow_run.head_branch == 'main'\n"
-                + "      && github.event.workflow_run.event == 'push'\n",
+            "          run-id: ${{ inputs.staging_run_id }}\n",
+            "          run-id: ${{ github.run_id }}\n",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted the caller run as artifact authority.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "      cancel-in-progress: false\n",
+            "      cancel-in-progress: true\n",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted cancellation between promotions.");
+        AssertMutationRejected(
+            promotionWorkflow,
+            "      - deploy\n",
             "",
-            ValidateCoreClrStaging,
-            "CoreCLR staging contract accepted ineligible wakeups.");
+            ValidatePromotion,
+            "Promotion workflow contract allowed CoreCLR deployment before production.");
         AssertMutationRejected(
-            coreClrStagingWorkflow,
-            "      group: deploy-inspect-web-coreclr-staging\n",
-            "      group: >-\n"
-                + "        deploy-inspect-web-coreclr-staging-"
-                + "${{ github.event.workflow_run.id }}\n",
-            ValidateCoreClrStaging,
-            "CoreCLR staging contract accepted per-wakeup concurrency.");
+            promotionWorkflow,
+            "      source_sha: ${{ needs.resolve.outputs.sha }}\n",
+            "      source_sha: ${{ github.sha }}\n",
+            ValidatePromotion,
+            "Promotion workflow contract accepted a non-promoted CoreCLR revision.");
         AssertMutationRejected(
-            coreClrStagingWorkflow,
-            "          echo \"run_id=$run_id\" >> \"$GITHUB_OUTPUT\"\n",
-            "          echo \"run_id=${{ github.event.workflow_run.id }}\" "
-                + ">> \"$GITHUB_OUTPUT\"\n",
-            ValidateCoreClrStaging,
-            "CoreCLR staging contract accepted wakeup identity as deployment authority.");
+            promotionWorkflow,
+            "      artifact_id: ${{ needs.resolve.outputs.artifact_id }}\n",
+            "      artifact_id: latest\n",
+            ValidatePromotion,
+            "Promotion workflow contract accepted a non-promoted CoreCLR artifact.");
 
         AssertRejected(
             coreClrStagingWorkflow +
@@ -555,7 +523,7 @@ internal static class PromotionWorkflowContract
             },
             "promotion workflow.concurrency");
         YamlMappingNode jobs = GetRequiredMapping(root, "jobs", "promotion workflow");
-        RequireExactKeys(jobs, ["resolve", "deploy"], "promotion jobs");
+        RequireExactKeys(jobs, ["resolve", "deploy", "coreclr"], "promotion jobs");
         YamlMappingNode resolve = GetRequiredMapping(jobs, "resolve", "promotion jobs");
         RequireExactKeys(
             resolve,
@@ -737,6 +705,47 @@ internal static class PromotionWorkflowContract
                 ["skip_api_build"] = "true",
             },
             "production deploy step.with");
+
+        YamlMappingNode coreClr =
+            GetRequiredMapping(jobs, "coreclr", "promotion jobs");
+        RequireExactKeys(
+            coreClr,
+            ["name", "needs", "uses", "with", "secrets"],
+            "jobs.coreclr");
+        RequireScalarValue(
+            coreClr,
+            "name",
+            "Publish matching CoreCLR comparison",
+            "jobs.coreclr");
+        YamlSequenceNode coreClrNeeds =
+            GetRequiredSequence(coreClr, "needs", "jobs.coreclr");
+        string[] actualCoreClrNeeds = coreClrNeeds.Children
+            .Select(node => RequireScalar(node, "jobs.coreclr need"))
+            .ToArray();
+        if (!actualCoreClrNeeds.SequenceEqual(["resolve", "deploy"]))
+        {
+            throw new InvalidOperationException(
+                "jobs.coreclr.needs must require resolution and production deployment.");
+        }
+        RequireScalarValue(
+            coreClr,
+            "uses",
+            "./.github/workflows/deploy-inspect-web-coreclr.yml",
+            "jobs.coreclr");
+        RequireExactScalarValues(
+            GetRequiredMapping(coreClr, "with", "jobs.coreclr"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["staging_run_id"] = "${{ inputs.staging_run_id }}",
+                ["source_sha"] = "${{ needs.resolve.outputs.sha }}",
+                ["artifact_id"] = "${{ needs.resolve.outputs.artifact_id }}",
+            },
+            "jobs.coreclr.with");
+        RequireScalarValue(
+            coreClr,
+            "secrets",
+            "inherit",
+            "jobs.coreclr");
     }
 
     private static void ValidateStaging(string workflow)
@@ -1108,19 +1117,12 @@ internal static class PromotionWorkflowContract
             GetRequiredMapping(jobs, "publish", "CoreCLR staging jobs");
         RequireExactKeys(
             publishJob,
-            ["name", "if", "concurrency", "environment", "runs-on", "steps"],
+            ["name", "concurrency", "environment", "runs-on", "steps"],
             "CoreCLR jobs.publish");
         RequireScalarValue(
             publishJob,
             "name",
-            "Build and publish latest CoreCLR staging",
-            "CoreCLR jobs.publish");
-        RequireScalarValue(
-            publishJob,
-            "if",
-            "github.event.workflow_run.conclusion == 'success' "
-                + "&& github.event.workflow_run.head_branch == 'main' "
-                + "&& github.event.workflow_run.event == 'push'",
+            "Build and publish promoted CoreCLR comparison",
             "CoreCLR jobs.publish");
         RequireExactScalarValues(
             GetRequiredMapping(
@@ -1130,7 +1132,7 @@ internal static class PromotionWorkflowContract
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["group"] = "deploy-inspect-web-coreclr-staging",
-                ["cancel-in-progress"] = "true",
+                ["cancel-in-progress"] = "false",
             },
             "CoreCLR jobs.publish.concurrency");
         RequireExactScalarValues(
@@ -1152,23 +1154,14 @@ internal static class PromotionWorkflowContract
 
         YamlSequenceNode publishSteps =
             GetRequiredSequence(publishJob, "steps", "CoreCLR jobs.publish");
-        if (publishSteps.Children.Count != 16)
+        if (publishSteps.Children.Count != 14)
         {
             throw new InvalidOperationException(
-                "CoreCLR publish must atomically resolve latest staging, build, "
-                + "verify freshness, and deploy.");
+                "CoreCLR publish must build and deploy the promoted product identity.");
         }
 
-        ValidateResolveLatestSuccessfulStagingRun(
-            RequireStep(
-                publishSteps,
-                0,
-                "Resolve latest successful staging run",
-                "CoreCLR jobs.publish"),
-            "CoreCLR latest-run resolver");
-
         YamlMappingNode checkout =
-            RequireStep(publishSteps, 1, null, "CoreCLR jobs.publish");
+            RequireStep(publishSteps, 0, null, "CoreCLR jobs.publish");
         RequireExactKeys(
             checkout,
             ["uses", "with"],
@@ -1185,14 +1178,14 @@ internal static class PromotionWorkflowContract
                 "CoreCLR staging build checkout"),
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["ref"] = "${{ steps.latest.outputs.head_sha }}",
+                ["ref"] = "${{ inputs.source_sha }}",
             },
             "CoreCLR staging build checkout.with");
 
         YamlMappingNode compilerArtifact =
             RequireStep(
                 publishSteps,
-                2,
+                1,
                 "Download compiler-async staging artifact",
                 "CoreCLR jobs.build");
         RequireExactKeys(
@@ -1211,11 +1204,11 @@ internal static class PromotionWorkflowContract
                 "CoreCLR compiler artifact download step"),
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["name"] = "inspect-web-site",
+                ["artifact-ids"] = "${{ inputs.artifact_id }}",
                 ["path"] = "artifacts/inspect-web-compiler-publish",
                 ["github-token"] = "${{ secrets.GITHUB_TOKEN }}",
                 ["repository"] = "${{ github.repository }}",
-                ["run-id"] = "${{ steps.latest.outputs.run_id }}",
+                ["run-id"] = "${{ inputs.staging_run_id }}",
                 ["digest-mismatch"] = "error",
             },
             "CoreCLR compiler artifact download step.with");
@@ -1223,7 +1216,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode setup =
             RequireStep(
                 publishSteps,
-                3,
+                2,
                 "Install pinned .NET 12 SDK",
                 "CoreCLR jobs.publish");
         RequireExactKeys(
@@ -1265,7 +1258,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode setupNode =
             RequireStep(
                 publishSteps,
-                4,
+                3,
                 "Setup Node",
                 "CoreCLR jobs.build");
         RequireExactKeys(
@@ -1293,7 +1286,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode install =
             RequireStep(
                 publishSteps,
-                5,
+                4,
                 "Install browser Wasm workload",
                 "CoreCLR jobs.build");
         RequireExactKeys(
@@ -1417,7 +1410,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode frontend =
             RequireStep(
                 publishSteps,
-                6,
+                5,
                 "Build browser frontend",
                 "CoreCLR jobs.build");
         RequireExactScalarValues(
@@ -1437,7 +1430,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode publish =
             RequireStep(
                 publishSteps,
-                7,
+                6,
                 "Publish CoreCLR browser app",
                 "CoreCLR jobs.build");
         RequireExactKeys(
@@ -1459,7 +1452,7 @@ internal static class PromotionWorkflowContract
               -c Release \
               --output artifacts/inspect-web-coreclr-publish \
               -p:VersionPrefix="$version" \
-              -p:SourceRevisionId="${{ steps.latest.outputs.head_sha }}" \
+              -p:SourceRevisionId="${{ inputs.source_sha }}" \
               -p:BuildTimestampUtc="$built_at" \
               -p:Features=runtime-async=on \
               -p:UseMonoRuntime=false \
@@ -1488,7 +1481,7 @@ internal static class PromotionWorkflowContract
         ValidateAsyncDeploymentCheck(
             RequireStep(
                 publishSteps,
-                8,
+                7,
                 "Verify runtime-async deployment",
                 "CoreCLR jobs.build"),
             RuntimeAsyncDeploymentCheck,
@@ -1497,7 +1490,7 @@ internal static class PromotionWorkflowContract
         ValidateManagedApiPublish(
             RequireStep(
                 publishSteps,
-                9,
+                8,
                 "Publish MSDL managed API",
                 "CoreCLR jobs.build"),
             "artifacts/inspect-web-coreclr-publish/api",
@@ -1506,7 +1499,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode buildVerify =
             RequireStep(
                 publishSteps,
-                10,
+                9,
                 "Verify CoreCLR site artifact",
                 "CoreCLR jobs.build");
         ValidateCoreClrArtifactVerification(
@@ -1516,7 +1509,7 @@ internal static class PromotionWorkflowContract
         ValidateAsyncDeploymentCheck(
             RequireStep(
                 publishSteps,
-                11,
+                10,
                 "Compare compiler-async and runtime-async receipts",
                 "CoreCLR jobs.build"),
             PairedAsyncDeploymentCheck,
@@ -1525,7 +1518,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode upload =
             RequireStep(
                 publishSteps,
-                12,
+                11,
                 "Upload CoreCLR staged site artifact",
                 "CoreCLR jobs.build");
         RequireExactKeys(
@@ -1555,22 +1548,14 @@ internal static class PromotionWorkflowContract
         YamlMappingNode deployVerify =
             RequireStep(
                 publishSteps,
-                13,
+                12,
                 "Verify CoreCLR staged site artifact");
         ValidateCoreClrArtifactVerification(
             deployVerify,
             "CoreCLR staging artifact verification step");
 
-        ValidateNewestEligibleStagingRun(
-            RequireStep(
-                publishSteps,
-                14,
-                "Verify newest eligible staging run",
-                "CoreCLR jobs.publish"),
-            "CoreCLR deploy newest-run step");
-
         YamlMappingNode deployStep =
-            RequireStep(publishSteps, 15, "Deploy to CoreCLR staging");
+            RequireStep(publishSteps, 13, "Deploy to CoreCLR staging");
         RequireExactKeys(
             deployStep,
             ["name", "uses", "with"],
@@ -1599,55 +1584,6 @@ internal static class PromotionWorkflowContract
                 ["skip_api_build"] = "true",
             },
             "CoreCLR staging deploy step.with");
-    }
-
-    private static void ValidateResolveLatestSuccessfulStagingRun(
-        YamlMappingNode step,
-        string context)
-    {
-        RequireExactKeys(step, ["name", "id", "env", "run"], context);
-        RequireScalarValue(step, "id", "latest", context);
-        RequireExactScalarValues(
-            GetRequiredMapping(step, "env", context),
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["GH_TOKEN"] = "${{ secrets.GITHUB_TOKEN }}",
-            },
-            $"{context}.env");
-        if (GetRequiredScalar(step, "run", context).TrimEnd()
-            != ResolveLatestSuccessfulStagingRun)
-        {
-            throw new InvalidOperationException(
-                $"{context} does not resolve the latest successful main-push staging run.");
-        }
-    }
-
-    private static void ValidateNewestEligibleStagingRun(
-        YamlMappingNode step,
-        string context)
-    {
-        RequireExactKeys(step, ["name", "env", "run"], context);
-        ValidateNewestEligibleStagingRunEnvironment(step, context);
-        if (GetRequiredScalar(step, "run", context).TrimEnd()
-            != NewestEligibleStagingRunCheck)
-        {
-            throw new InvalidOperationException(
-                $"{context} does not select the newest successful main-push staging run.");
-        }
-    }
-
-    private static void ValidateNewestEligibleStagingRunEnvironment(
-        YamlMappingNode step,
-        string context)
-    {
-        RequireExactScalarValues(
-            GetRequiredMapping(step, "env", context),
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["GH_TOKEN"] = "${{ secrets.GITHUB_TOKEN }}",
-                ["SELECTED_RUN_ID"] = "${{ steps.latest.outputs.run_id }}",
-            },
-            $"{context}.env");
     }
 
     private static void ValidateManagedApiPublish(
@@ -2138,39 +2074,60 @@ internal static class PromotionWorkflowContract
 
     private static void ValidateCoreClrStagingTrigger(YamlMappingNode on)
     {
-        RequireExactKeys(on, ["workflow_run"], "CoreCLR staging workflow.on");
-        YamlMappingNode workflowRun =
-            GetRequiredMapping(on, "workflow_run", "CoreCLR staging workflow.on");
+        RequireExactKeys(on, ["workflow_call"], "CoreCLR staging workflow.on");
+        YamlMappingNode workflowCall =
+            GetRequiredMapping(on, "workflow_call", "CoreCLR staging workflow.on");
         RequireExactKeys(
-            workflowRun,
-            ["workflows", "types"],
-            "CoreCLR staging workflow.on.workflow_run");
-        YamlSequenceNode workflows =
-            GetRequiredSequence(
-                workflowRun,
-                "workflows",
-                "CoreCLR staging workflow.on.workflow_run");
-        if (workflows.Children.Count != 1
-            || RequireScalar(
-                workflows.Children[0],
-                "CoreCLR triggering workflow") != "Deploy inspect-web staging")
-        {
-            throw new InvalidOperationException(
-                "CoreCLR staging must be triggered only by the Mono staging workflow.");
-        }
-        YamlSequenceNode types =
-            GetRequiredSequence(
-                workflowRun,
-                "types",
-                "CoreCLR staging workflow.on.workflow_run");
-        if (types.Children.Count != 1
-            || RequireScalar(
-                types.Children[0],
-                "CoreCLR workflow_run type") != "completed")
-        {
-            throw new InvalidOperationException(
-                "CoreCLR staging must trigger only when Mono staging completes.");
-        }
+            workflowCall,
+            ["inputs"],
+            "CoreCLR staging workflow.on.workflow_call");
+        YamlMappingNode inputs =
+            GetRequiredMapping(
+                workflowCall,
+                "inputs",
+                "CoreCLR staging workflow.on.workflow_call");
+        RequireExactKeys(
+            inputs,
+            ["staging_run_id", "source_sha", "artifact_id"],
+            "CoreCLR staging workflow_call.inputs");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                inputs,
+                "staging_run_id",
+                "CoreCLR staging workflow_call.inputs"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["description"] =
+                    "Staging run whose exact site artifact was promoted",
+                ["required"] = "true",
+                ["type"] = "string",
+            },
+            "CoreCLR staging_run_id input");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                inputs,
+                "source_sha",
+                "CoreCLR staging workflow_call.inputs"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["description"] = "Exact product commit promoted to production",
+                ["required"] = "true",
+                ["type"] = "string",
+            },
+            "CoreCLR source_sha input");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                inputs,
+                "artifact_id",
+                "CoreCLR staging workflow_call.inputs"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["description"] =
+                    "Exact staged site artifact promoted to production",
+                ["required"] = "true",
+                ["type"] = "string",
+            },
+            "CoreCLR artifact_id input");
     }
 
     private static void ValidateResolveSteps(YamlSequenceNode steps)

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -2278,13 +2278,17 @@ runs in the staging deployment job. The separate
 `inspect-web-staging` GitHub environment accepts only `main` and holds a
 deployment token scoped to the staging Azure Static Web App.
 
-Successful main-push completion of `.github/workflows/deploy-inspect-web.yml`
-triggers `.github/workflows/deploy-inspect-web-coreclr.yml`, which checks out
-that run's exact head and downloads its exact `inspect-web-site` artifact before
-publishing the same commit to the isolated comparison site at
-`https://coreclr.dotnet-inspect.ca`. It uses a third Azure Static Web App, the
-main-only `inspect-web-coreclr-staging` environment, a distinct deployment
-token, and the non-promotable `inspect-web-coreclr-site` artifact. The site is
+After `.github/workflows/promote-inspect-web.yml` successfully deploys a staged
+artifact to production, it calls
+`.github/workflows/deploy-inspect-web-coreclr.yml` with that promotion's exact
+product SHA, staging run ID, and staged artifact ID. The CoreCLR workflow checks
+out that SHA and downloads the same `inspect-web-site` artifact before
+publishing the matching commit to the isolated comparison site at
+`https://coreclr.dotnet-inspect.ca`. It therefore advances at the production
+promotion cadence rather than for every `main` staging build. It uses a third
+Azure Static Web App, the main-only `inspect-web-coreclr-staging` environment, a
+distinct deployment token, and the non-promotable `inspect-web-coreclr-site`
+artifact. The site is
 interpreter-only while CoreCLR native relinking remains outside the comparison
 scope. Mono staging stays on the repository's .NET 11 Preview 7 SDK. The
 CoreCLR workflow instead installs the exact runtime-main daily cohort


### PR DESCRIPTION
Build robust, capable deployment plumbing by keeping the CoreCLR comparison aligned with the production product instead of transient staging commits.

## Demo

Before: every successful `main` staging deployment triggered CoreCLR, so `coreclr.dotnet-inspect.ca` could advance ahead of `dotnet-inspect.net`.

After: production promotion invokes the reusable CoreCLR workflow only after the production deployment succeeds, passing the exact validated source SHA, staging run ID, and artifact ID.

## Summary

- couple CoreCLR deployment cadence to production promotion
- build CoreCLR from the exact promoted commit and compare against the exact promoted compiler-async artifact
- update the deployment contract, release guidance, and maintainer release skill

## Validation

- `dotnet run eng/test-ci-change-detection.cs`
- `npx markdownlint-cli docs/design/inspect-web-jsexport-partitioning.md docs/release-workflow.md prototypes/inspect-web/README.md .github/skills/release/SKILL.md`

Related to #6077.