### PR TITLE
Add Gallery search to Inspect Web Package Query

### DIFF
--- a/docs/design/package-query-experience.md
+++ b/docs/design/package-query-experience.md
@@ -17,7 +17,8 @@ browser front end for that one product surface.
 end-to-end latency and Browser-pressure work.
 
 **What is enforced.** The production integration supplies the `/query` page,
-exact package and terminal-star prefix input, explicit Gallery discovery,
+exact package and terminal-star prefix input, explicit termful Gallery search
+and blank Gallery browse,
 source-owned type/order catalog, product-issued inspection facets, streaming
 Browser engine source,
 explicitly bounded package-content acquisition, cancellation, honest partial
@@ -86,9 +87,10 @@ selected opaque inspection facets, and independent candidate and match limits.
 The normal Run action interprets an exact package ID or one terminal-star
 literal prefix through the shared
 [Package Query input selection](package-query-input-selection.md) contract.
-Blank package input stays idle. **Feeling lucky** explicitly selects a finite,
-termless Gallery response; package type and order apply only while that input
-kind remains selected. The source controls project
+Blank package input stays idle. **Search packages** explicitly selects a finite
+Gallery response using the editor text, or a termless browse response when the
+editor is blank; package type and order apply only while that input kind
+remains selected. The source controls project
 `NuGetGalleryDiscoveryCatalog`, while the shared Package Query input contract
 owns composition with local selection. The user approved ordinary shared
 acquisition before Source Delegation for [#6019](https://github.com/richlander/dotnet-inspect/issues/6019);
@@ -147,7 +149,7 @@ and
 
 ```text
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ Package ID/prefix [ Microsoft.Extensions.* ] [Run] [Feeling lucky]            │
+│ Package ID, prefix, or terms [ JSON serializer ] [Inspect] [Search packages]  │
 ├───────────────┬────────────────────────────────────────────────────────────--┤
 │ Facets         │  Microsoft.Extensions.Hosting           nuspec              │
 │                │    Verified source · Has dependencies                       │
@@ -161,10 +163,12 @@ and
 └───────────────┴────────────────────────────────────────────────────────────--┘
 ```
 
-- **Query bar**: exact package ID or one terminal-star literal prefix plus Run
-  and, while streaming, Cancel. Blank text stays idle. **Feeling lucky** is a
-  separate explicit action that acquires a bounded termless Gallery response
-  with the same selected inspection facets.
+- **Query bar**: **Inspect** treats the editor as an exact package ID or one
+  terminal-star literal prefix and, while streaming, exposes Cancel. Blank
+  text stays idle. **Search packages** is a separate explicit action that
+  acquires a bounded Gallery response with the editor text as source-owned
+  search terms; blank text explicitly browses popular packages. Both actions
+  retain the same selected inspection facets.
 - **Gallery filters**: catalog-driven package-type and source-order controls,
   available only while Gallery discovery remains selected. All types and
   automatic ordering mean omitted source selections, not invented provider
@@ -522,13 +526,16 @@ and browser-history and focus-return outcomes are proved by
    to 20 candidates, archive acquisition uses the Browser package store and
    deadline, and acquisition/evaluation failures remain visible. Remove the
    final package-content facet and confirm the default returns to 200.
-10. Select **Feeling lucky**, then select tools and templates from the source
-    catalog. Confirm source and facet changes preserve Gallery mode, use the
+10. Enter natural search terms and select **Search packages**. Confirm the
+    unchanged text reaches Gallery relevance search. Then clear the editor and
+    select **Search packages** to browse with the source-owned most-downloaded
+    default. Select tools and templates from the source catalog. Confirm source
+    and facet changes preserve Gallery mode and the executed text, use the
     source-owned order defaults or explicit override, and acquire no manifests
-    or archives without inspection facets. Confirm the normal Run action
-    switches back to package input, Gallery type/order do not constrain exact
-    or prefix acquisition, and lifetime-download counts, unavailable metadata,
-    and estimated totals remain distinct.
+    or archives without inspection facets. Confirm **Inspect** switches back to
+    package input, Gallery type/order do not constrain exact or prefix
+    acquisition, and lifetime-download counts, unavailable metadata, and
+    estimated totals remain distinct.
 11. Confirm that the assembly control is absent when the engine returns no
    descriptors. With the first descriptor present, run one to five exact
    `ID@VERSION` packages using the unchanged literal operand, `net10.0`

--- a/docs/design/package-query-input-selection.md
+++ b/docs/design/package-query-input-selection.md
@@ -62,9 +62,11 @@ owner's identity rules rather than changing the spelling into another search.
 An absent exact result stays absent; it does not fall back to prefix or
 keyword discovery.
 
-Gallery discovery is selected by an explicit host action, separately from the
-package editor. It supplies the existing Gallery request as candidate input,
-then uses the same requested inspections. An empty editor is not that action.
+Gallery discovery is selected by an explicit host action, separately from
+exact/prefix submission. That action supplies the editor text as the existing
+Gallery request's optional search text, then uses the same requested
+inspections. Nonempty text uses Gallery search semantics; empty text browses.
+An empty editor alone is not that action and starts no work.
 Source controls retain their Gallery meaning when discovery is selected; they
 must not silently constrain or reinterpret an exact-ID or prefix input.
 
@@ -111,8 +113,9 @@ The production path has three steps:
    package/prefix intent or accepts explicit Gallery input, and acquires the
    corresponding candidates.
 2. The Browser Query consumer uses that shared choice. Blank input remains
-   idle; a separate discovery gesture replaces implicit blank-input browsing.
-   The existing operation feedback and demand-credit adapter are retained.
+   idle until the explicit Gallery action; the same action sends nonempty
+   editor text as Gallery search and blank text as browse. The existing
+   operation feedback and demand-credit adapter are retained.
 3. CLI package/prefix consumers and the planned CLI query binding use the same
    source distinction. An explicitly named `--package-prefix` remains prefix
    intent; the new editor convention does not turn that option into exact-ID
@@ -139,8 +142,9 @@ behavior is described as supported:
   exact-ID miss.
 - `Newtonsoft.*` excludes a neighboring `NewtonsoftOther` ID, whereas
   `Newtonsoft*` permits it.
-- Invalid spellings cause no acquisition. An empty Browser editor stays idle;
-  only the explicit discovery action submits a Gallery request.
+- Invalid package spellings cause no package acquisition. An empty Browser
+  editor stays idle until the explicit Gallery action submits a browse request;
+  nonempty Gallery text is not parsed as package spelling.
 - Exact selection respects stable/prerelease and authoritative listing
   evidence, distinguishing no eligible candidate from failed acquisition.
 - Basic rows avoid unnecessary manifest/content work; selected inspection
@@ -164,6 +168,7 @@ generation check gates the changed interop signature and declarations.
 
 The real-Wasm `browser/package-adoption.spec.ts` scenarios run against the
 Release-published website in `eng/test-inspect-web-package-adoption-gate.sh`.
-They gate initially idle input, explicit Gallery discovery, exact-ID resource
-selection, neighboring literal-prefix results, missing-ID non-fallback, and
-metadata-only acquisition through the actual Browser application.
+They gate initially idle input, explicit termful Gallery relevance search,
+explicit blank Gallery browse, exact-ID resource selection, neighboring
+literal-prefix results, missing-ID non-fallback, and metadata-only acquisition
+through the actual Browser application.

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1226,10 +1226,13 @@ routes use the navigation fallback, while API, asset, and framework requests
 remain excluded.
 
 Search also exposes a `Package query` action that opens the routed `/query`
-surface. Leave search text empty to browse, then select a package type or
-source order from NuGetFetch's Gallery catalog. Basic discovery uses search
-metadata only; the separate inspection facets explicitly add manifest or
-bounded package-content evaluation. Browser Wasm streams shared product rows
+surface. **Inspect** treats the editor as an exact package ID or terminal-star
+literal prefix. **Search packages** sends nonempty text to NuGet Gallery
+relevance search, or explicitly browses popular packages when the editor is
+blank; package type and source order come from NuGetFetch's Gallery catalog.
+Basic discovery uses search metadata only; the separate inspection facets
+explicitly add manifest or bounded package-content evaluation. Browser Wasm
+streams shared product rows
 and visible failures, then hands an exact result coordinate to the normal
 Workspace package-opening path. Results disclose one bounded Gallery response,
 not a globally exhaustive or exact top-N result; provider totals are estimates.

--- a/prototypes/inspect-web/browser/package-adoption.spec.ts
+++ b/prototypes/inspect-web/browser/package-adoption.spec.ts
@@ -403,7 +403,7 @@ function firstOccurrence(view: OccurrenceView): OccurrenceRow {
 }
 
 test.describe("Package Query website over real Wasm", () => {
-  test("requires explicit discovery before browsing by source type", async ({
+  test("keeps Gallery relevance search and blank browse explicit", async ({
     page,
     context,
   }) => {
@@ -456,9 +456,20 @@ test.describe("Package Query website over real Wasm", () => {
     await expect(page.locator("#package-query-type")).toHaveCount(0);
     expect(requests).toHaveLength(0);
 
-    await page.locator("#package-query-discover").click();
+    const input = page.locator("#package-query-prefix");
+    await input.fill("json serializer");
+    await page.locator("#package-query-search").click();
     await expect(page.locator(".query-row h2")).toHaveText(["Contoso.Package"]);
     await expect(page.locator("#package-query-type")).toBeVisible();
+    expect(requests.at(-1)?.searchParams.get("q")).toBe("json serializer");
+    expect(requests.at(-1)?.searchParams.get("sortBy")).toBe("relevance");
+
+    await input.fill("");
+    await page.locator("#package-query-search").click();
+    await expect(page.locator(".query-row h2")).toHaveText(["Contoso.Package"]);
+    expect(requests.at(-1)?.searchParams.get("q")).toBeFalsy();
+    expect(requests.at(-1)?.searchParams.get("sortBy")).toBe("totalDownloads-desc");
+
     await page.locator("#package-query-type").selectOption({ label: ".NET tools" });
     await expect(page.locator(".query-row")).toHaveCount(20);
     await expect(page.locator(".query-row h2")).toContainText(["Contoso.ToolA", "Contoso.ToolB"]);
@@ -481,7 +492,6 @@ test.describe("Package Query website over real Wasm", () => {
     await expect(page.locator(".query-row h2")).toHaveText(["Contoso.Package"]);
     await page.locator("#package-query-order").selectOption("");
     await expect.poll(() => requests.at(-1)?.searchParams.get("sortBy")).toBe("totalDownloads-desc");
-    expect(requests.every(request => !request.searchParams.get("q"))).toBe(true);
     expect(requests.every(request => request.searchParams.get("take") === "200")).toBe(true);
     expect(enrichment).toEqual([]);
   });
@@ -572,8 +582,8 @@ test.describe("Package Query website over real Wasm", () => {
   test("live Gallery tool browse uses the production page and CORS path", async ({ page }) => {
     test.skip(process.env.INSPECT_WEB_GALLERY_LIVE !== "1", "Opt-in live provider observation.");
     await page.goto("/query");
-    await expect(page.locator("#package-query-discover")).toBeVisible({ timeout: 120_000 });
-    await page.locator("#package-query-discover").click();
+    await expect(page.locator("#package-query-search")).toBeVisible({ timeout: 120_000 });
+    await page.locator("#package-query-search").click();
     await expect(page.locator("#package-query-type")).toBeVisible();
     await page.locator("#package-query-type").selectOption({ label: ".NET tools" });
     await expect(page.locator(".query-row").first()).toBeVisible({ timeout: 60_000 });

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -9702,8 +9702,8 @@ function runPackageQuery(text: string) {
   submitPackageQueryRequest(request);
 }
 
-function discoverPackages() {
-  const request = preparePackageQueryRequest("", "gallery");
+function searchPackages(text: string) {
+  const request = preparePackageQueryRequest(text, "gallery");
   submitPackageQueryRequest(request);
 }
 
@@ -9791,7 +9791,7 @@ async function openPackageQueryRow(
 const packageQueryActions: PackageQueryBindingActions = {
   onBack: closePackageQueryRoute,
   onCancel: () => packageQueryController.cancel(),
-  onDiscover: discoverPackages,
+  onGallerySearch: searchPackages,
   onAssemblyRun: request => {
     state.packageQueryNavigationError = "";
     packageQueryLiveAnnouncer.reset();

--- a/prototypes/inspect-web/src/package-query-view.ts
+++ b/prototypes/inspect-web/src/package-query-view.ts
@@ -21,7 +21,7 @@ const MAX_ASSEMBLY_QUERY_PACKAGES = 5;
 export interface PackageQueryBindingActions {
   onBack: () => void;
   onCancel: () => void;
-  onDiscover: () => void;
+  onGallerySearch: (searchText: string) => void;
   onAssemblyRun?: (request: QueryRequest) => void;
   onFacetToggle: (facetKey: string, prefix: string) => void;
   onPrefixInput: (prefix: string) => void;
@@ -47,7 +47,7 @@ export type PackageQueryFocusSnapshot =
   | { kind: "product" }
   | { kind: "back" }
   | { kind: "run" }
-  | { kind: "discover" }
+  | { kind: "search" }
   | { kind: "type" | "order" | "prerelease" }
   | {
       kind: "assembly";
@@ -106,7 +106,7 @@ export function capturePackageQueryFocus(
   if (active.id === "package-query-product") return { kind: "product" };
   if (active.id === "package-query-back") return { kind: "back" };
   if (active.id === "package-query-run") return { kind: "run" };
-  if (active.id === "package-query-discover") return { kind: "discover" };
+  if (active.id === "package-query-search") return { kind: "search" };
   if (active.id === "package-query-type") return { kind: "type" };
   if (active.id === "package-query-order") return { kind: "order" };
   if (active.id === "package-query-prerelease") return { kind: "prerelease" };
@@ -152,8 +152,8 @@ export function restorePackageQueryFocus(
     case "run":
       target = root.querySelector("#package-query-run");
       break;
-    case "discover":
-      target = root.querySelector("#package-query-discover");
+    case "search":
+      target = root.querySelector("#package-query-search");
       break;
     case "type":
     case "order":
@@ -227,8 +227,9 @@ export function bindPackageQueryView(
       event.preventDefault();
       actions.onRun(prefixInput()?.value ?? "");
     });
-  root.querySelector("#package-query-discover")
-    ?.addEventListener("click", actions.onDiscover);
+  root.querySelector("#package-query-search")
+    ?.addEventListener("click", () =>
+      actions.onGallerySearch(prefixInput()?.value ?? ""));
   prefixInput()?.addEventListener("input", event => {
     const input = event.currentTarget;
     if (input instanceof HTMLInputElement) actions.onPrefixInput(input.value);
@@ -661,7 +662,7 @@ function renderSourceControls(
       </label>
       <p id="package-query-order-description">${escapeHtml(orderSummary)}</p>`
     : request.inputKind === "package"
-      ? "<p>Gallery package type and order apply only after Feeling lucky.</p>"
+      ? "<p>Gallery package type and order apply only after Search packages.</p>"
       : "";
   return `
     <div class="query-source-controls" role="group" aria-label="Package query options">
@@ -753,7 +754,7 @@ function renderEmptyState(
       <section class="query-empty">
         <span class="large-glyph">⌕</span>
         <h2>Select package input</h2>
-        <p>Enter an exact package ID or add one terminal <code>*</code> for a literal prefix. Feeling lucky explicitly browses one bounded Gallery response.</p>
+        <p>Inspect an exact package ID or one terminal-star prefix. Search packages uses Gallery relevance for text, or browses popular packages when blank.</p>
       </section>`;
   }
   if (completion.kind === "idle") {
@@ -761,7 +762,7 @@ function renderEmptyState(
       <section class="query-empty">
         <span class="large-glyph">⌕</span>
         <h2>Ready to query</h2>
-        <p>Enter a package ID or terminal-star prefix, or use Feeling lucky for explicit Gallery discovery. Selected inspection facets remain configured.</p>
+        <p>Inspect an exact package ID or terminal-star prefix, or explicitly search Gallery with natural terms. Selected inspection facets remain configured.</p>
       </section>`;
   }
   if (completion.kind === "cancelled") {
@@ -810,7 +811,7 @@ function renderEmptyState(
     <section class="query-empty">
       <span class="large-glyph">◇</span>
       <h2>No matches</h2>
-      <p>Try a broader explicit prefix, choose Feeling lucky, or select fewer inspection facets.</p>
+      <p>Try a broader explicit prefix, search Gallery with different terms, or select fewer inspection facets.</p>
     </section>`;
 }
 
@@ -929,16 +930,16 @@ export function renderPackageQueryView(
       </header>
       <main class="query-main">
         <div class="query-heading">
-          <p class="query-kicker">Exact package + literal prefix + explicit Gallery discovery · nuget.org</p>
+          <p class="query-kicker">Exact package + literal prefix + Gallery search · nuget.org</p>
           <h1 id="package-query-heading" tabindex="-1">Package query</h1>
-          <p>Select an exact package ID or literal prefix. Gallery discovery is a separate explicit action; manifests and package content are acquired only with inspection facets.</p>
+          <p>Inspect treats the editor as an exact package ID or literal prefix. Search packages uses Gallery relevance for text, or popular-package browse when blank; manifests and package content are acquired only with inspection facets.</p>
         </div>
         <form id="package-query-form" class="query-bar" role="search">
-          <label for="package-query-prefix">Package ID or prefix</label>
-          <input id="package-query-prefix" name="search" value="${escapeHtml(prefix)}" autocomplete="off" spellcheck="false" placeholder="Newtonsoft.Json or Newtonsoft.*" />
+          <label for="package-query-prefix">Package ID, prefix, or search terms</label>
+          <input id="package-query-prefix" name="search" value="${escapeHtml(prefix)}" autocomplete="off" spellcheck="false" placeholder="Newtonsoft.Json, Newtonsoft.*, or JSON serializer" />
           <span>
-            <button id="package-query-run" type="submit">Run query</button>
-            <button id="package-query-discover" type="button">Feeling lucky</button>
+            <button id="package-query-run" type="submit">Inspect</button>
+            <button id="package-query-search" type="button">Search packages</button>
           </span>
           <span id="package-query-cancel-region">${renderStreamingCancel(state)}</span>
         </form>

--- a/prototypes/inspect-web/test/package-query-source.test.ts
+++ b/prototypes/inspect-web/test/package-query-source.test.ts
@@ -102,6 +102,7 @@ test("Browser source dispatches package and explicit Gallery input with unchange
     ["Newtonsoft.Json", "package", false],
     ["Newtonsoft.*", "package", false],
     [`${"a".repeat(100)}*`, "package", false],
+    ["json serializer", "gallery", true],
     ["", "gallery", true],
   ] as const) {
     for (const matchLimit of [100, 7]) {
@@ -139,6 +140,7 @@ test("Browser source dispatches package and explicit Gallery input with unchange
 test("Browser source leaves automatic source selections unresolved in either mode", async () => {
   for (const [searchText, inputKind, discovery] of [
     ["Newtonsoft.Json", "package", false],
+    ["json serializer", "gallery", true],
     ["", "gallery", true],
   ] as const) {
     const engine: BrowserPackageQueryEngine = {

--- a/prototypes/inspect-web/test/package-query-view.test.ts
+++ b/prototypes/inspect-web/test/package-query-view.test.ts
@@ -143,9 +143,10 @@ test("an unstarted query renders the composing empty state", () => {
   });
 
   assert.match(html, /Select package input/);
-  assert.match(html, /Package ID or prefix/);
-  assert.match(html, /Feeling lucky/);
-  assert.match(html, /terminal <code>\*<\/code>/);
+  assert.match(html, /Package ID, prefix, or search terms/);
+  assert.match(html, /Search packages/);
+  assert.match(html, /popular packages when blank/);
+  assert.match(html, /terminal-star prefix/);
   assert.doesNotMatch(html, /maxlength=/);
 });
 
@@ -171,7 +172,7 @@ test("prerelease remains available while Gallery controls require explicit disco
     escapeHtml,
   });
   assert.match(packageHtml, /<h2>Package options<\/h2>/);
-  assert.match(packageHtml, /Feeling lucky/);
+  assert.match(packageHtml, /Search packages/);
   assert.match(packageHtml, /id="package-query-prerelease"/);
   assert.doesNotMatch(packageHtml, /id="package-query-(type|order)"/);
 
@@ -194,7 +195,7 @@ test("prerelease remains available while Gallery controls require explicit disco
   assert.match(html, /value="Producer.Tool">Producer tools<\/option>/);
   assert.match(html, /value="producer.order.second" title="Second producer ordering description.">Producer second order<\/option>/);
   assert.match(html, /id="package-query-prerelease" type="checkbox" \/>/);
-  assert.match(html, /Gallery discovery is a separate explicit action/);
+  assert.match(html, /Search packages uses Gallery relevance/);
   assert.match(html, /manifests and package content are acquired only with inspection facets/);
   assert.ok(html.indexOf('aria-label="Package query options"') < html.indexOf("<h2>Inspection facets</h2>"));
 });
@@ -1110,9 +1111,9 @@ test("query focus snapshots restore semantic controls after a full render", () =
       replacement: new FakeElement({}, "package-query-run"),
     },
     {
-      active: new FakeElement({}, "package-query-discover"),
-      selector: "#package-query-discover",
-      replacement: new FakeElement({}, "package-query-discover"),
+      active: new FakeElement({}, "package-query-search"),
+      selector: "#package-query-search",
+      replacement: new FakeElement({}, "package-query-search"),
     },
     {
       active: new FakeElement({}, "package-query-product"),
@@ -1282,10 +1283,13 @@ test("query prefix focus preserves its selection across a full render", () => {
   assert.deepEqual(replacement.selectionRange, [3, 8]);
 });
 
-test("bindPackageQueryView wires back, discovery, row-open, facet, and cancel", () => {
+test("bindPackageQueryView wires back, Gallery search, row-open, facet, and cancel", () => {
   const root = new FakeRoot();
   const [back] = root.add("#package-query-back", new FakeElement());
-  const [discover] = root.add("#package-query-discover", new FakeElement());
+  const input = new FakeElement({}, "package-query-prefix");
+  input.value = "json serializer";
+  const [search] = root.add("#package-query-search", new FakeElement());
+  root.add("#package-query-prefix", input);
   const [open] = root.add("[data-query-row-open]", new FakeElement({ queryRowOpen: "A", queryRowVersion: "1.0.0" }));
   const [facet] = root.add("[data-query-facet]", new FakeElement({ queryFacet: "tfm-out-of-support" }));
   const [cancel] = root.add("[data-query-cancel]", new FakeElement());
@@ -1294,7 +1298,7 @@ test("bindPackageQueryView wires back, discovery, row-open, facet, and cancel", 
   const actions: PackageQueryBindingActions = {
     onBack: () => calls.push("back"),
     onCancel: () => calls.push("cancel"),
-    onDiscover: () => calls.push("discover"),
+    onGallerySearch: text => calls.push(`search:${text}`),
     onFacetToggle: key => calls.push(`facet:${key}`),
     onPrefixInput: () => {},
     onResultPressure: () => calls.push("pressure"),
@@ -1306,14 +1310,14 @@ test("bindPackageQueryView wires back, discovery, row-open, facet, and cancel", 
   bindPackageQueryView(fakeDom.parentNode(root), actions);
 
   back?.dispatch("click");
-  discover?.dispatch("click");
+  search?.dispatch("click");
   open?.dispatch("click");
   facet?.dispatch("click");
   cancel?.dispatch("click");
 
   assert.deepEqual(calls, [
     "back",
-    "discover",
+    "search:json serializer",
     "open:A:1.0.0",
     "facet:tfm-out-of-support",
     "cancel",
@@ -1347,7 +1351,7 @@ test("bindPackageQueryView clears corrected assembly input and preserves the ope
   bindPackageQueryView(fakeDom.parentNode(root), {
     onBack: () => {},
     onCancel: () => {},
-    onDiscover: () => {},
+    onGallerySearch: () => {},
     onAssemblyRun: request => requests.push(request),
     onFacetToggle: () => {},
     onPrefixInput: () => {},
@@ -1396,7 +1400,7 @@ test("assembly row binding forwards the exact opaque Root request", () => {
   bindPackageQueryView(fakeDom.parentNode(root), {
     onBack: () => {},
     onCancel: () => {},
-    onDiscover: () => {},
+    onGallerySearch: () => {},
     onFacetToggle: () => {},
     onPrefixInput: () => {},
     onResultPressure: () => {},
@@ -1430,7 +1434,7 @@ test("source control changes forward the complete selection and current unmodifi
   bindPackageQueryView(fakeDom.parentNode(root), {
     onBack: () => {},
     onCancel: () => {},
-    onDiscover: () => {},
+    onGallerySearch: () => {},
     onFacetToggle: () => assert.fail("source controls are not inspection facets"),
     onPrefixInput: () => {},
     onResultPressure: () => {},
@@ -1479,20 +1483,20 @@ test("source control changes forward the complete selection and current unmodifi
   ]);
 });
 
-test("query form submits package text while Feeling lucky is a separate action", () => {
+test("query form inspects package input while Search packages submits Gallery text", () => {
   const root = new FakeRoot();
   const form = new FakeElement({}, "package-query-form");
   const input = new FakeElement({}, "package-query-prefix");
-  const discover = new FakeElement({}, "package-query-discover");
+  const search = new FakeElement({}, "package-query-search");
   root.add("#package-query-form", form);
   root.add("#package-query-prefix", input);
-  root.add("#package-query-discover", discover);
+  root.add("#package-query-search", search);
   const calls: string[] = [];
   let prevented = 0;
   bindPackageQueryView(fakeDom.parentNode(root), {
     onBack: () => {},
     onCancel: () => {},
-    onDiscover: () => calls.push("gallery:"),
+    onGallerySearch: text => calls.push(`gallery:${text}`),
     onFacetToggle: () => {},
     onPrefixInput: () => {},
     onResultPressure: () => {},
@@ -1506,12 +1510,16 @@ test("query form submits package text while Feeling lucky is a separate action",
       preventDefault() { prevented++; },
     }));
   }
-  discover.dispatch("click");
+  for (const text of ["json serializer", ""]) {
+    input.value = text;
+    search.dispatch("click");
+  }
 
   assert.deepEqual(calls, [
     "",
     " hosting libraries ",
     "System.*",
+    "gallery:json serializer",
     "gallery:",
   ]);
   assert.equal(prevented, 3);
@@ -1540,7 +1548,7 @@ test("bindPackageQueryView reports near-end scroll pressure and disconnects it",
   const binding = bindPackageQueryView(fakeDom.parentNode(root), {
     onBack: () => {},
     onCancel: () => {},
-    onDiscover: () => {},
+    onGallerySearch: () => {},
     onFacetToggle: () => {},
     onPrefixInput: () => {},
     onResultPressure: () => { pressure++; },
@@ -1583,7 +1591,7 @@ test("patchPackageQueryStream updates only dynamic query regions", () => {
     {
       onBack: () => {},
       onCancel: () => {},
-      onDiscover: () => {},
+      onGallerySearch: () => {},
       onFacetToggle: () => {},
       onPrefixInput: () => {},
       onResultPressure: () => { pressure++; },

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3362,7 +3362,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /function runPackageQuery\(text: string\) \{\s*const request = preparePackageQueryRequest\(text, "package"\);\s*submitPackageQueryRequest\(request\)/);
   assert.match(
     appSource,
-    /function discoverPackages\(\) \{\s*const request = preparePackageQueryRequest\("", "gallery"\);\s*submitPackageQueryRequest\(request\)/);
+    /function searchPackages\(text: string\) \{\s*const request = preparePackageQueryRequest\(text, "gallery"\);\s*submitPackageQueryRequest\(request\)/);
   assert.match(
     appSource,
     /state\.packageQueryState\.request\?\.inputKind === "gallery"[\s\S]*return state\.packageQueryState\.request/);


### PR DESCRIPTION
Package Query now has a production Browser gesture for NuGet Gallery relevance
search, so natural package discovery can feed the same bounded inspection and
Workspace-opening path as exact package selection.

## Demo

On `/query`:

1. Enter `json serializer` and choose **Search packages**. Inspect Web sends the
   unchanged text to NuGet Gallery with the source-owned relevance default,
   streams the bounded result rows, and can open an exact result in Workspace.
2. Clear the editor and choose **Search packages**. The explicit action browses
   popular packages with the source-owned most-downloaded default.
3. Enter `Newtonsoft.Json` or `Newtonsoft.*` and choose **Inspect**. Exact package
   and literal-prefix selection remain distinct and never fall back to Gallery.

## What changed

- Replaced the termless-only **Feeling lucky** action with **Search packages**,
  which submits the current editor text as explicit Gallery input.
- Renamed the exact/prefix form action to **Inspect** and clarified the shared
  editor's label, placeholder, help text, and empty states.
- Preserved metadata-only Gallery search unless an inspection facet explicitly
  authorizes manifest or bounded package-content acquisition.
- Extended frontend and published Firefox/Wasm coverage for termful relevance
  search, blank browse, exact/prefix separation, focus restoration, and managed
  adapter dispatch.
- Updated the focused design and Inspect Web documentation to state the
  production interaction contract.

This uses the existing Gallery owner's ranking and optional search text; it does
not add local fuzzy scoring, change assembly-pattern matching, or combine
ecosystem and Gallery ranking.

## Validation

- `npm test` in `prototypes/inspect-web` — 1586 passed
- `npm run lint` in `prototypes/inspect-web`
- `npm run build` in `prototypes/inspect-web`
- `eng/test-inspect-web-package-adoption-gate.sh --grep 'keeps Gallery relevance search and blank browse explicit'`
- `npx markdownlint-cli docs/design/package-query-experience.md docs/design/package-query-input-selection.md prototypes/inspect-web/README.md`
- `git diff --check`

Closes #6322
Part of #5919
Supports #5766