### PR TITLE
Keep unsafe accessor fixture valid on .NET 11 RC1

### DIFF
--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -712,8 +712,8 @@ public static class UnsafeFixtures
 
 public sealed class AccessorContractFixtures
 {
-    public int Property
+    public unsafe int Property
     {
-        unsafe get => 42;
+        get => 42;
     }
 }

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using LegacyFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
 using LegacyDynamicStackallocFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.DynamicStackallocFixtures;
 using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
+using NewAccessorFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.AccessorContractFixtures;
 using NewDynamicStackallocFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.DynamicStackallocFixtures;
 using NewStackallocFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
 using ChainB = ILInspector.Decompiler.Fixtures.UnsafeChainB.LibraryB;
@@ -32,6 +33,20 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 public class UnsafeEmitterTests
 {
+    [Fact]
+    public void UpdatedRules_PropertyUnsafe_PreservesGetterContract()
+    {
+        using var source =
+            MetadataSource.Open(typeof(NewAccessorFixtures).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(NewAccessorFixtures).FullName!,
+            "get_Property");
+
+        Assert.NotNull(function);
+        Assert.True(function.RequiresUnsafeContract);
+    }
+
     static DecompilerResult DecompileResult(string assemblyPath, string typeFullName, string method)
     {
         var source = MetadataSource.Open(assemblyPath);


### PR DESCRIPTION
dotnet-inspect keeps its compiler-produced fixtures portable and faithful so
the Decompiler's safety-contract evidence remains trustworthy across supported
build environments.

## Summary

- Move `unsafe` from the sole getter to its containing property, matching the
  .NET 11 RC1 compiler requirement reported by CS9397.
- Preserve the getter's normalized explicit unsafe caller contract with a
  focused metadata-import assertion.
- Keep the fixture's emitted getter behavior unchanged; this is a source-form
  compatibility update, not a Decompiler policy change.

## Demo

The newer compiler rejects the previous getter-only spelling:

```csharp
public int Property
{
    unsafe get => 42;
}
```

The equivalent property-level spelling compiles while preserving the getter
contract:

```csharp
public unsafe int Property
{
    get => 42;
}
```

The focused test imports `get_Property` from the built updated-rules fixture
and verifies that Decompiler still observes an explicit unsafe caller contract.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `UnsafeEmitterTests`: 58 passed
- Focused getter-contract test: 1 passed
- `git diff --check`

Closes #6331
