### PR TITLE
Pin the repository .NET SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Self-test change detection
         shell: bash
@@ -296,8 +296,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -355,8 +354,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -395,8 +393,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -433,8 +430,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -471,8 +467,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -502,8 +497,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -531,8 +525,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install .NET 10 runtime (inspect-web test target)
         run: |
@@ -599,8 +592,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -721,8 +713,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Publish MSDL managed API
         run: >
@@ -788,8 +779,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -817,8 +807,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -876,8 +865,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -1203,8 +1191,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -1239,8 +1226,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -1311,8 +1297,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       # Caches packages only. Do not add build outputs (artifacts/, bin/, obj/)
       # here. The completeness check compares a discovery listing against XML
@@ -1432,8 +1417,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -1533,8 +1517,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -1637,8 +1620,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Pack pointer package
         # SelfContained=true forces the pack TFM segment to 'any', so the pointer

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -53,8 +53,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -117,8 +116,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -199,8 +197,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -318,8 +315,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -387,8 +383,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser Wasm workload
         run: dotnet workload install wasm-experimental
@@ -418,8 +413,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -760,8 +754,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6

--- a/.github/workflows/nuget-audit-scheduled.yml
+++ b/.github/workflows/nuget-audit-scheduled.yml
@@ -33,8 +33,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Install browser workload
         if: matrix.scope == 'inspect-web'

--- a/.github/workflows/nuget-dependency-submission.yml
+++ b/.github/workflows/nuget-dependency-submission.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Restore the dependency roots configured in Dependabot
         run: |

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -53,8 +53,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: preview
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Validate staged site
         id: evidence
@@ -83,8 +82,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: preview
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Revalidate staged site
         shell: bash

--- a/.github/workflows/publish-package-fixtures.yml
+++ b/.github/workflows/publish-package-fixtures.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Read fixture version
         id: fixture

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Validate certification and resolve commit
         id: sha
@@ -83,8 +82,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Pack RID-specific package
         run: dotnet pack src/dotnet-inspect -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
@@ -110,8 +108,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Pack pointer package
         # SelfContained=true forces the pack TFM segment to 'any', so the pointer
@@ -195,8 +192,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Revalidate certification before publish
         env:

--- a/.github/workflows/windows-pr.yml
+++ b/.github/workflows/windows-pr.yml
@@ -45,8 +45,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '11.0.100-preview.7.26381.103'
 
       - name: Cache NuGet packages
         uses: actions/cache@v6

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ dnx dotnet-inspect -y -- <command>
 ## Repository development SDK
 
 Published tool users can install or run `dotnet-inspect` with the commands
-above. Contributors building this repository should use the current .NET 11
-preview SDK.
+above. Contributors building this repository should use the .NET SDK selected
+by `global.json`: `11.0.100-preview.7.26381.103`.
 
 Check the selected SDK first:
 

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -599,8 +599,8 @@ internal static class PromotionWorkflowContract
             GetRequiredMapping(setup, "with", "production setup step"),
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["dotnet-version"] = "11.0.x",
-                ["dotnet-quality"] = "preview",
+                ["dotnet-version"] =
+                    WorkflowContract.RepositoryDotNetSdkVersion,
             },
             "production setup step.with");
 
@@ -2193,8 +2193,8 @@ internal static class PromotionWorkflowContract
             GetRequiredMapping(setup, "with", "resolution setup step"),
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["dotnet-version"] = "11.0.x",
-                ["dotnet-quality"] = "preview",
+                ["dotnet-version"] =
+                    WorkflowContract.RepositoryDotNetSdkVersion,
             },
             "resolution setup step.with");
 

--- a/eng/CiChangeDetection/WorkflowContract.Consumers.cs
+++ b/eng/CiChangeDetection/WorkflowContract.Consumers.cs
@@ -120,8 +120,7 @@ internal static partial class WorkflowContract
                 "jobs.repository-guards setup step"),
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["dotnet-version"] = "11.0.x",
-                ["dotnet-quality"] = "preview",
+                ["dotnet-version"] = RepositoryDotNetSdkVersion,
             },
             "jobs.repository-guards setup step.with");
 

--- a/eng/CiChangeDetection/WorkflowContract.cs
+++ b/eng/CiChangeDetection/WorkflowContract.cs
@@ -5,6 +5,9 @@ namespace CiChangeDetection;
 
 internal static partial class WorkflowContract
 {
+    internal const string RepositoryDotNetSdkVersion =
+        "11.0.100-preview.7.26381.103";
+
     private static readonly string[] InspectWebLeafJobs =
     [
         "inspect-web-platform",
@@ -282,15 +285,12 @@ internal static partial class WorkflowContract
                 webSdkSteps[0],
                 "with",
                 $"jobs.{jobName} setup-dotnet");
-            RequireScalarValue(
+            RequireExactScalarValues(
                 webSdkWith,
-                "dotnet-version",
-                "11.0.x",
-                $"jobs.{jobName} setup-dotnet.with");
-            RequireScalarValue(
-                webSdkWith,
-                "dotnet-quality",
-                "preview",
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["dotnet-version"] = RepositoryDotNetSdkVersion,
+                },
                 $"jobs.{jobName} setup-dotnet.with");
         }
     }
@@ -647,7 +647,7 @@ internal static partial class WorkflowContract
                 "jobs.changes .NET setup step"),
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["dotnet-version"] = "11.0.x",
+                ["dotnet-version"] = RepositoryDotNetSdkVersion,
             },
             "jobs.changes .NET setup step.with");
     }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "11.0.100-preview.7.26381.103",
+    "rollForward": "disable",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
dotnet-inspect builds robust, capable foundations for compelling inspection experiences; deterministic compiler evidence is part of that foundation.

## Demo

Before this change, the same workflow input changed compilers between two runs:

```text
green:  dotnet-version: 11.0.x + preview -> 11.0.100-preview.7.26381.103
failed: dotnet-version: 11.0.x + preview -> 11.0.100-rc.1.26425.128
```

The RC1 compiler rejects the intentional accessor-level memory-safety fixture with CS9397. After this change, repository and workflow selection resolve to the same SDK:

```text
$ dotnet --version
11.0.100-preview.7.26381.103
```

## Summary

- Add `global.json` as the repository-owned SDK selection with exact roll-forward disabled.
- Pin every floating .NET 11 workflow setup to `11.0.100-preview.7.26381.103` and remove channel-quality resolution.
- Update the CI and production-promotion workflow contracts to enforce the exact repository SDK.
- Document the exact contributor SDK in the README.
- Leave the updated-memory-safety fixture unchanged; the failure was compiler drift, not a fixture or Analysis-project regression.

## Compatibility

This changes build-tool selection only. Product behavior and fixture semantics are unchanged.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet build fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe/ILInspector.Decompiler.Fixtures.NewUnsafe.csproj -c Release -t:Rebuild`
- `dotnet run eng/test-ci-change-detection.cs`
- Parsed every workflow YAML file.
- `npx markdownlint-cli README.md`

Fixes #6331
Unblocks #6325