### PR TITLE
Measure assembly-pattern Package Query performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1033,6 +1033,9 @@ jobs:
       - name: Exercise Catalog research probe (offline)
         run: dotnet run tools/CatalogChangeBenchmark.cs -c Release -- --self-test
 
+      - name: Exercise package assembly-query benchmark (offline)
+        run: dotnet run tools/PackageAssemblyQueryBenchmark.cs -c Release -- --self-test
+
       # InertText sits below every other project, so a regression here reaches every assembly
       # that prints artifact-derived text. The gates are pure and fast — a full BMP sweep and a
       # round-trip — so they run unconditionally rather than behind a path filter.

--- a/docs/data/package-query/assembly-query-cold-2026-09-09.json
+++ b/docs/data/package-query/assembly-query-cold-2026-09-09.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": 1,
+  "timestampUtc": "2026-09-09T01:49:33.665983+00:00",
+  "revision": "cf96f4e7be43e905a2bd1908ac1d8f42687cc095",
+  "scenarioId": "decoded-literal-five-packages-v1",
+  "cacheState": "cold",
+  "host": "merritt",
+  "os": "Ubuntu 24.04.4 LTS",
+  "architecture": "X64",
+  "processorCount": 24,
+  "framework": ".NET 11.0.0-rc.1.26425.128",
+  "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0",
+  "samples": [
+    {
+      "trial": 1,
+      "elapsedMilliseconds": 869.7103,
+      "cpuMilliseconds": 470,
+      "peakWorkingSetBytes": 120991744,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 5.74904080128751,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    },
+    {
+      "trial": 2,
+      "elapsedMilliseconds": 1005.1743,
+      "cpuMilliseconds": 430,
+      "peakWorkingSetBytes": 121061376,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 4.974261677800556,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    },
+    {
+      "trial": 3,
+      "elapsedMilliseconds": 669.4991,
+      "cpuMilliseconds": 400,
+      "peakWorkingSetBytes": 121094144,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 7.468269934940913,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    }
+  ],
+  "summary": {
+    "elapsedMilliseconds": {
+      "median": 869.7103,
+      "mean": 848.1279,
+      "minimum": 669.4991,
+      "maximum": 1005.1743,
+      "p95": 1005.1743
+    },
+    "cpuMilliseconds": {
+      "median": 430,
+      "mean": 433.3333333333333,
+      "minimum": 400,
+      "maximum": 470,
+      "p95": 470
+    },
+    "peakWorkingSetBytes": {
+      "median": 121061376,
+      "mean": 121049088,
+      "minimum": 120991744,
+      "maximum": 121094144,
+      "p95": 121094144
+    },
+    "httpRequests": {
+      "median": 5,
+      "mean": 5,
+      "minimum": 5,
+      "maximum": 5,
+      "p95": 5
+    },
+    "candidatesPerSecond": {
+      "median": 5.74904080128751,
+      "mean": 6.063857471342993,
+      "minimum": 4.974261677800556,
+      "maximum": 7.468269934940913,
+      "p95": 7.468269934940913
+    }
+  }
+}

--- a/docs/data/package-query/assembly-query-warm-2026-09-09.json
+++ b/docs/data/package-query/assembly-query-warm-2026-09-09.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "timestampUtc": "2026-09-09T01:49:38.6815033+00:00",
+  "revision": "cf96f4e7be43e905a2bd1908ac1d8f42687cc095",
+  "scenarioId": "decoded-literal-five-packages-v1",
+  "cacheState": "warm",
+  "host": "merritt",
+  "os": "Ubuntu 24.04.4 LTS",
+  "architecture": "X64",
+  "processorCount": 24,
+  "framework": ".NET 11.0.0-rc.1.26425.128",
+  "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0",
+  "samples": [
+    {
+      "trial": 1,
+      "elapsedMilliseconds": 669.0017,
+      "cpuMilliseconds": 390,
+      "peakWorkingSetBytes": 121114624,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 7.473822562782725,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    },
+    {
+      "trial": 2,
+      "elapsedMilliseconds": 837.3201,
+      "cpuMilliseconds": 420,
+      "peakWorkingSetBytes": 121167872,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 5.9714319529651805,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    },
+    {
+      "trial": 3,
+      "elapsedMilliseconds": 663.4933,
+      "cpuMilliseconds": 400,
+      "peakWorkingSetBytes": 120922112,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 7.535871123340658,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    },
+    {
+      "trial": 4,
+      "elapsedMilliseconds": 775.9779,
+      "cpuMilliseconds": 400,
+      "peakWorkingSetBytes": 121069568,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 6.443482475467407,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    },
+    {
+      "trial": 5,
+      "elapsedMilliseconds": 727.5272,
+      "cpuMilliseconds": 409.9999,
+      "peakWorkingSetBytes": 121118720,
+      "candidates": 5,
+      "matches": 1,
+      "semanticMisses": 4,
+      "notApplicable": 0,
+      "failures": 0,
+      "httpRequests": 5,
+      "candidatesPerSecond": 6.872595278911908,
+      "semanticFingerprint": "68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0"
+    }
+  ],
+  "summary": {
+    "elapsedMilliseconds": {
+      "median": 727.5272,
+      "mean": 734.6640399999999,
+      "minimum": 663.4933,
+      "maximum": 837.3201,
+      "p95": 837.3201
+    },
+    "cpuMilliseconds": {
+      "median": 400,
+      "mean": 403.99998,
+      "minimum": 390,
+      "maximum": 420,
+      "p95": 420
+    },
+    "peakWorkingSetBytes": {
+      "median": 121114624,
+      "mean": 121078579.2,
+      "minimum": 120922112,
+      "maximum": 121167872,
+      "p95": 121167872
+    },
+    "httpRequests": {
+      "median": 5,
+      "mean": 5,
+      "minimum": 5,
+      "maximum": 5,
+      "p95": 5
+    },
+    "candidatesPerSecond": {
+      "median": 6.872595278911908,
+      "mean": 6.859440678693576,
+      "minimum": 5.9714319529651805,
+      "maximum": 7.535871123340658,
+      "p95": 7.535871123340658
+    }
+  }
+}

--- a/docs/design/package-query-assembly-evaluation.md
+++ b/docs/design/package-query-assembly-evaluation.md
@@ -753,6 +753,74 @@ This linear one-candidate operation adds no independent concurrent state
 machine. Bounded concurrency and result ordering belong to the later streaming
 pipeline; no TLA+ model is required for this contract.
 
+### Measured production baseline
+
+Issue [#6350](https://github.com/richlander/dotnet-inspect/issues/6350)
+establishes the first milestone-11 baseline without selecting a performance
+threshold. `tools/PackageAssemblyQueryBenchmark.json` pins five exact package
+coordinates, `net6.0`, the ordinal operand
+`Unexpected end when reading JSON`, the production default limits, and the
+complete expected CLI projection after excluding opaque Root reopening tokens.
+The file-based probe launches the built Release CLI and refuses a sample unless
+all five candidates complete without failure and reproduce the pinned semantic
+fingerprint.
+
+The product revision was
+`cf96f4e7be43e905a2bd1908ac1d8f42687cc095`, running .NET
+`11.0.0-rc.1.26425.128` on an AMD Ryzen 9 9900X Linux host with 24 logical
+processors. The raw reports preserve every sample:
+
+- [isolated-cache samples](../data/package-query/assembly-query-cold-2026-09-09.json);
+- [post-warmup samples](../data/package-query/assembly-query-warm-2026-09-09.json).
+
+| Cache state | Samples | Median elapsed | Median CPU | Median peak working set | Median candidates/s | HTTP requests/sample |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Isolated private cache | 3 | 870 ms | 430 ms | 115.5 MiB | 5.75 | 5 |
+| Shared private cache after warmup | 5 | 728 ms | 400 ms | 115.5 MiB | 6.87 | 5 |
+
+The warm samples ranged from 663 to 837 ms; 837 ms is the nearest-rank p95 for
+this five-sample observation. Every sample reported one matched candidate, four
+semantic misses, three matching occurrences, no failure or non-applicability,
+and fingerprint
+`68761A316A9607EF7ABF31C5F87BAD7D8270C80751EE5B3DB463CFF75CD180F0`.
+
+Build and reproduce from the repository root with the selected SDK:
+
+```bash
+"$DOTNET_ROOT/dotnet" build \
+  src/dotnet-inspect/dotnet-inspect.csproj -c Release
+"$DOTNET_ROOT/dotnet" run \
+  tools/PackageAssemblyQueryBenchmark.cs -c Release -- \
+  cf96f4e7be43e905a2bd1908ac1d8f42687cc095 \
+  artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
+  cold 3 artifacts/package-assembly-query-cold.json
+"$DOTNET_ROOT/dotnet" run \
+  tools/PackageAssemblyQueryBenchmark.cs -c Release --no-build -- \
+  cf96f4e7be43e905a2bd1908ac1d8f42687cc095 \
+  artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
+  warm 5 artifacts/package-assembly-query-warm.json
+```
+
+These are end-to-end process observations: CLI startup, configured acquisition,
+serial sparse projection and evaluation, rendering, and cleanup are all inside
+the measured boundary. "Isolated" gives each sample fresh private
+product-cache and `NUGET_PACKAGES` roots and disables the ordinary global NuGet
+cache; it does not reset DNS, CDN, kernel, or runtime state. "Warm" uses one
+unmeasured warmup and one shared private cache while retaining a fresh CLI
+process per measured sample. Both states still made five HTTP requests, so
+neither is isolated semantic-producer CPU evidence. Peak memory is the maximum
+process working set observed through the operating system counter at
+five-millisecond intervals, not managed live-heap bytes and not a restatement
+of the retained-image bound.
+
+**Decision:** retain the current serial five-candidate limit and conservative
+resource defaults. This first descriptive baseline does not justify the
+optional byte prefilter, concurrency, or larger limits. A later optimization
+proposal must first attribute acquisition and evaluator time separately; the
+persistent one-request-per-candidate behavior makes an acquisition experiment
+at least as relevant as a semantic prefilter, but this observation does not
+select either implementation.
+
 ## Outcome algebra
 
 One completed evaluation returns exactly one resource-free outcome. Every arm

--- a/tools/PackageAssemblyQueryBenchmark.cs
+++ b/tools/PackageAssemblyQueryBenchmark.cs
@@ -1,0 +1,523 @@
+#:project ../src/DotnetInspector.PackageQueries/DotnetInspector.PackageQueries.csproj
+#:property EnablePreviewFeatures=true
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotnetInspector.PackageQueries;
+
+const string Usage =
+    "Usage:\n"
+    + "  dotnet run tools/PackageAssemblyQueryBenchmark.cs -c Release -- --self-test\n"
+    + "  dotnet run tools/PackageAssemblyQueryBenchmark.cs -c Release -- "
+    + "<revision> <cli-dll> <cold|warm> <trials> <output-json>";
+BenchmarkJsonContext json = BenchmarkJsonContext.Default;
+
+if (args is ["--emit-self-test"])
+{
+    Console.Write(
+        """{"candidates":[{"package":"probe","version":"1.0.0","outcome":"no-match","asset":"lib/net8.0/Probe.dll","target_framework":"net8.0","detail":"complete"}],"matches":[]}""");
+    await Task.Delay(30);
+    return 0;
+}
+
+if (args is ["--self-test"])
+{
+    await SelfTestAsync(json);
+    Console.WriteLine("Package assembly-query benchmark self-test passed.");
+    return 0;
+}
+
+if (args.Length != 5
+    || args[0].Length == 0
+    || !File.Exists(args[1])
+    || args[2] is not ("cold" or "warm")
+    || !int.TryParse(args[3], out int trials)
+    || trials is < 1 or > 20)
+{
+    Console.Error.WriteLine(Usage);
+    return 1;
+}
+
+string revision = args[0];
+string cliPath = Path.GetFullPath(args[1]);
+string cacheState = args[2];
+string outputPath = Path.GetFullPath(args[4]);
+string manifestPath = Path.Combine(
+    Directory.GetCurrentDirectory(),
+    "tools",
+    "PackageAssemblyQueryBenchmark.json");
+BenchmarkManifest manifest =
+    JsonSerializer.Deserialize<BenchmarkManifest>(
+        await File.ReadAllTextAsync(manifestPath),
+        json.BenchmarkManifest)
+    ?? throw new InvalidOperationException("The benchmark manifest is empty.");
+ValidateManifest(manifest);
+
+string expectedJson = JsonSerializer.Serialize(
+    manifest.Expected,
+    json.SemanticProjection);
+string expectedFingerprint = Fingerprint(expectedJson);
+string scratchRoot = Directory.CreateTempSubdirectory(
+    "inspect-package-query-benchmark-").FullName;
+var samples = new List<BenchmarkSample>();
+try
+{
+    string warmCache = Path.Combine(scratchRoot, "warm");
+    if (cacheState == "warm")
+    {
+        _ = await RunCliAsync(
+            cliPath,
+            manifest,
+            warmCache,
+            trial: 0,
+            expectedFingerprint,
+            json);
+    }
+
+    for (int trial = 1; trial <= trials; trial++)
+    {
+        string cacheRoot = cacheState == "warm"
+            ? warmCache
+            : Path.Combine(scratchRoot, $"cold-{trial}");
+        samples.Add(
+            await RunCliAsync(
+                cliPath,
+                manifest,
+                cacheRoot,
+                trial,
+                expectedFingerprint,
+                json));
+    }
+}
+finally
+{
+    Directory.Delete(scratchRoot, recursive: true);
+}
+
+var report = new BenchmarkReport(
+    SchemaVersion: 1,
+    TimestampUtc: DateTimeOffset.UtcNow,
+    Revision: revision,
+    ScenarioId: manifest.ScenarioId,
+    CacheState: cacheState,
+    Host: Environment.MachineName,
+    OS: RuntimeInformation.OSDescription,
+    Architecture: RuntimeInformation.OSArchitecture.ToString(),
+    ProcessorCount: Environment.ProcessorCount,
+    Framework: RuntimeInformation.FrameworkDescription,
+    SemanticFingerprint: expectedFingerprint,
+    Samples: samples,
+    Summary: Summarize(samples));
+Directory.CreateDirectory(
+    Path.GetDirectoryName(outputPath)
+        ?? throw new InvalidOperationException("The output path has no directory."));
+await File.WriteAllTextAsync(
+    outputPath,
+    JsonSerializer.Serialize(report, json.BenchmarkReport) + Environment.NewLine);
+Console.WriteLine(outputPath);
+return 0;
+
+static async Task<BenchmarkSample> RunCliAsync(
+    string cliPath,
+    BenchmarkManifest manifest,
+    string cacheRoot,
+    int trial,
+    string expectedFingerprint,
+    BenchmarkJsonContext json)
+{
+    Directory.CreateDirectory(cacheRoot);
+    var arguments = new List<string>
+    {
+        cliPath,
+        "find",
+        "--literal",
+        manifest.Literal,
+    };
+    foreach (string package in manifest.Packages)
+    {
+        arguments.Add("--package");
+        arguments.Add(package);
+    }
+    arguments.Add("--tfm");
+    arguments.Add(manifest.TargetFramework);
+    arguments.Add("-v:n");
+    arguments.Add("--json");
+    arguments.Add("--info");
+    arguments.Add("--no-nuget-cache");
+
+    ChildMeasurement measured = await RunChildAsync(
+        DotnetHostPath(),
+        arguments,
+        cacheRoot);
+    if (measured.ExitCode != 0)
+    {
+        throw new InvalidOperationException(
+            $"Package Query trial {trial} failed with exit code {measured.ExitCode}: "
+            + measured.StandardError.Trim());
+    }
+
+    SemanticProjection projection =
+        JsonSerializer.Deserialize(
+            measured.StandardOutput,
+            json.SemanticProjection)
+        ?? throw new InvalidOperationException(
+            $"Package Query trial {trial} returned an empty document.");
+    string fingerprint = Fingerprint(
+        JsonSerializer.Serialize(projection, json.SemanticProjection));
+    if (fingerprint != expectedFingerprint)
+    {
+        throw new InvalidOperationException(
+            $"Package Query trial {trial} returned semantic fingerprint {fingerprint}; "
+            + $"expected {expectedFingerprint}.");
+    }
+
+    int candidates = projection.Candidates.Count;
+    int matched = projection.Candidates.Count(
+        static candidate => candidate.Outcome == "matched");
+    int misses = projection.Candidates.Count(
+        static candidate => candidate.Outcome == "no-match");
+    int notApplicable = projection.Candidates.Count(
+        static candidate => candidate.Outcome == "not-applicable");
+    int failures = candidates - matched - misses - notApplicable;
+    int requests = ParseRequestCount(measured.StandardError);
+    if (candidates != manifest.Packages.Count || failures != 0)
+    {
+        throw new InvalidOperationException(
+            $"Package Query trial {trial} completed {candidates} of "
+            + $"{manifest.Packages.Count} candidates with {failures} failures.");
+    }
+
+    return new(
+        trial,
+        measured.ElapsedMilliseconds,
+        measured.CpuMilliseconds,
+        measured.PeakWorkingSetBytes,
+        candidates,
+        matched,
+        misses,
+        notApplicable,
+        failures,
+        requests,
+        candidates / (measured.ElapsedMilliseconds / 1000d),
+        fingerprint);
+}
+
+static int ParseRequestCount(string standardError)
+{
+    foreach (string line in standardError.Split('\n'))
+    {
+        if (!line.StartsWith("| HTTP |", StringComparison.Ordinal))
+            continue;
+        string[] cells = line.Split('|', StringSplitOptions.TrimEntries);
+        string[] value = cells[2].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (value.Length == 2
+            && value[1] == "requests"
+            && int.TryParse(value[0], out int requests))
+        {
+            return requests;
+        }
+    }
+    throw new InvalidOperationException(
+        "The CLI did not report its --info HTTP request count.");
+}
+
+static async Task<ChildMeasurement> RunChildAsync(
+    string executable,
+    IReadOnlyList<string> arguments,
+    string cacheRoot)
+{
+    var startInfo = new ProcessStartInfo(executable)
+    {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+    };
+    foreach (string argument in arguments)
+        startInfo.ArgumentList.Add(argument);
+    startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+    startInfo.Environment["DOTNET_NOLOGO"] = "1";
+    startInfo.Environment["DOTNET_INSPECT_CACHE_DIR"] =
+        Path.Combine(cacheRoot, "product");
+    startInfo.Environment["NUGET_PACKAGES"] = Path.Combine(cacheRoot, "nuget");
+
+    using var process = new Process { StartInfo = startInfo };
+    long started = Stopwatch.GetTimestamp();
+    if (!process.Start())
+        throw new InvalidOperationException($"Could not start {executable}.");
+    Task<string> stdout = process.StandardOutput.ReadToEndAsync();
+    Task<string> stderr = process.StandardError.ReadToEndAsync();
+    long peakWorkingSet = 0;
+    double cpuMilliseconds = 0;
+    while (!process.HasExited)
+    {
+        ObserveProcess(process, ref peakWorkingSet, ref cpuMilliseconds);
+        await Task.Delay(5);
+    }
+    await process.WaitForExitAsync();
+    ObserveProcess(process, ref peakWorkingSet, ref cpuMilliseconds);
+    return new(
+        process.ExitCode,
+        await stdout,
+        await stderr,
+        Stopwatch.GetElapsedTime(started).TotalMilliseconds,
+        cpuMilliseconds,
+        peakWorkingSet);
+}
+
+static string DotnetHostPath()
+{
+    string? host = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+    if (!string.IsNullOrWhiteSpace(host) && File.Exists(host))
+        return host;
+
+    string? root = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+    string executable = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
+    string rooted = Path.Combine(root ?? "", executable);
+    if (!string.IsNullOrWhiteSpace(root) && File.Exists(rooted))
+        return rooted;
+
+    throw new InvalidOperationException(
+        "DOTNET_HOST_PATH or DOTNET_ROOT must identify the dotnet host.");
+}
+
+static void ObserveProcess(
+    Process process,
+    ref long peakWorkingSet,
+    ref double cpuMilliseconds)
+{
+    try
+    {
+        process.Refresh();
+        peakWorkingSet = Math.Max(
+            peakWorkingSet,
+            Math.Max(process.WorkingSet64, process.PeakWorkingSet64));
+        cpuMilliseconds = Math.Max(
+            cpuMilliseconds,
+            process.TotalProcessorTime.TotalMilliseconds);
+    }
+    catch (InvalidOperationException) when (process.HasExited)
+    {
+        // The process may exit between HasExited and reading live counters.
+    }
+}
+
+static void ValidateManifest(BenchmarkManifest manifest)
+{
+    if (manifest.SchemaVersion != 1
+        || manifest.Packages.Count != PackageAssemblyQuery.MaximumPackages
+        || manifest.Expected.Candidates.Count != manifest.Packages.Count)
+    {
+        throw new InvalidOperationException(
+            "The benchmark manifest must use schema 1 and the complete five-package product limit.");
+    }
+
+    PackageAssemblyEvaluationBudget budget = PackageAssemblyEvaluationBudget.Default;
+    var actual = new BenchmarkLimits(
+        PackageAssemblyQuery.MaximumPackages,
+        budget.MaximumEntryBytes,
+        budget.MaximumRetainedImageBytes,
+        budget.SemanticBudget.MaximumMethods,
+        budget.SemanticBudget.MaximumMethodBodyBytes,
+        budget.SemanticBudget.MaximumMethodBodyBytesVisited,
+        budget.SemanticBudget.MaximumInstructions,
+        budget.SemanticBudget.MaximumDecodedUserStringCharacters,
+        budget.SemanticBudget.MaximumOccurrences,
+        (int)budget.MaximumDuration.TotalSeconds);
+    if (actual != manifest.Limits)
+    {
+        throw new InvalidOperationException(
+            "The pinned benchmark limits no longer match the production defaults.");
+    }
+}
+
+static BenchmarkSummary Summarize(IReadOnlyList<BenchmarkSample> samples) =>
+    new(
+        Statistics(samples.Select(static sample => sample.ElapsedMilliseconds)),
+        Statistics(samples.Select(static sample => sample.CpuMilliseconds)),
+        Statistics(samples.Select(static sample => (double)sample.PeakWorkingSetBytes)),
+        Statistics(samples.Select(static sample => (double)sample.HttpRequests)),
+        Statistics(samples.Select(static sample => sample.CandidatesPerSecond)));
+
+static MetricSummary Statistics(IEnumerable<double> values)
+{
+    double[] ordered = [.. values.Order()];
+    int middle = ordered.Length / 2;
+    double median = ordered.Length % 2 == 0
+        ? (ordered[middle - 1] + ordered[middle]) / 2d
+        : ordered[middle];
+    int p95 = Math.Max(0, (int)Math.Ceiling(ordered.Length * 0.95) - 1);
+    return new(
+        median,
+        ordered.Average(),
+        ordered[0],
+        ordered[^1],
+        ordered[p95]);
+}
+
+static string Fingerprint(string value) =>
+    Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+static async Task SelfTestAsync(BenchmarkJsonContext json)
+{
+    var expected = new SemanticProjection(
+        [
+            new(
+                "probe",
+                "1.0.0",
+                "no-match",
+                "lib/net8.0/Probe.dll",
+                "net8.0",
+                "complete"),
+        ],
+        []);
+    string source = Path.Combine(
+        Directory.GetCurrentDirectory(),
+        "tools",
+        "PackageAssemblyQueryBenchmark.cs");
+    string scratchRoot = Directory.CreateTempSubdirectory(
+        "inspect-package-query-benchmark-self-test-").FullName;
+    try
+    {
+        ChildMeasurement measured = await RunChildAsync(
+            DotnetHostPath(),
+            ["run", source, "-c", "Release", "--", "--emit-self-test"],
+            scratchRoot);
+        if (measured.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                "The fake child process failed: "
+                + measured.StandardError.Trim());
+        }
+        SemanticProjection actual =
+            JsonSerializer.Deserialize(
+                measured.StandardOutput,
+                json.SemanticProjection)
+            ?? throw new InvalidOperationException("The fake child returned no projection.");
+        if (measured.ElapsedMilliseconds <= 0
+            || measured.CpuMilliseconds < 0
+            || measured.PeakWorkingSetBytes <= 0
+            || Fingerprint(JsonSerializer.Serialize(actual, json.SemanticProjection))
+                != Fingerprint(
+                    JsonSerializer.Serialize(expected, json.SemanticProjection)))
+        {
+            throw new InvalidOperationException(
+                "The fake child process did not produce one complete measured projection.");
+        }
+
+        MetricSummary summary = Statistics([3, 1, 2, 5, 4]);
+        if (summary != new MetricSummary(3, 3, 1, 5, 5))
+            throw new InvalidOperationException("Benchmark summary statistics are incorrect.");
+        if (ParseRequestCount("# Info\n| HTTP | 5 requests |\n") != 5)
+            throw new InvalidOperationException("CLI HTTP metrics were not parsed.");
+    }
+    finally
+    {
+        Directory.Delete(scratchRoot, recursive: true);
+    }
+}
+
+sealed record BenchmarkManifest(
+    int SchemaVersion,
+    string ScenarioId,
+    string Literal,
+    string TargetFramework,
+    List<string> Packages,
+    BenchmarkLimits Limits,
+    SemanticProjection Expected);
+
+sealed record BenchmarkLimits(
+    int MaximumPackages,
+    long MaximumEntryBytes,
+    long MaximumRetainedImageBytes,
+    int MaximumMethods,
+    int MaximumMethodBodyBytes,
+    long MaximumMethodBodyBytesVisited,
+    long MaximumInstructions,
+    long MaximumDecodedUserStringCharacters,
+    int MaximumOccurrences,
+    int MaximumDurationSeconds);
+
+sealed record SemanticProjection(
+    [property: JsonPropertyName("candidates")]
+    List<CandidateProjection> Candidates,
+    [property: JsonPropertyName("matches")]
+    List<MatchProjection> Matches);
+
+sealed record CandidateProjection(
+    [property: JsonPropertyName("package")] string Package,
+    [property: JsonPropertyName("version")] string Version,
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("asset")] string Asset,
+    [property: JsonPropertyName("target_framework")] string TargetFramework,
+    [property: JsonPropertyName("detail")] string Detail);
+
+sealed record MatchProjection(
+    [property: JsonPropertyName("package")] string Package,
+    [property: JsonPropertyName("version")] string Version,
+    [property: JsonPropertyName("assembly")] string Assembly,
+    [property: JsonPropertyName("method")] string Method,
+    [property: JsonPropertyName("offset")] string Offset,
+    [property: JsonPropertyName("literal")] string Literal);
+
+readonly record struct ChildMeasurement(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError,
+    double ElapsedMilliseconds,
+    double CpuMilliseconds,
+    long PeakWorkingSetBytes);
+
+sealed record BenchmarkSample(
+    int Trial,
+    double ElapsedMilliseconds,
+    double CpuMilliseconds,
+    long PeakWorkingSetBytes,
+    int Candidates,
+    int Matches,
+    int SemanticMisses,
+    int NotApplicable,
+    int Failures,
+    int HttpRequests,
+    double CandidatesPerSecond,
+    string SemanticFingerprint);
+
+sealed record BenchmarkReport(
+    int SchemaVersion,
+    DateTimeOffset TimestampUtc,
+    string Revision,
+    string ScenarioId,
+    string CacheState,
+    string Host,
+    string OS,
+    string Architecture,
+    int ProcessorCount,
+    string Framework,
+    string SemanticFingerprint,
+    List<BenchmarkSample> Samples,
+    BenchmarkSummary Summary);
+
+sealed record BenchmarkSummary(
+    MetricSummary ElapsedMilliseconds,
+    MetricSummary CpuMilliseconds,
+    MetricSummary PeakWorkingSetBytes,
+    MetricSummary HttpRequests,
+    MetricSummary CandidatesPerSecond);
+
+readonly record struct MetricSummary(
+    double Median,
+    double Mean,
+    double Minimum,
+    double Maximum,
+    double P95);
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true)]
+[JsonSerializable(typeof(BenchmarkManifest))]
+[JsonSerializable(typeof(SemanticProjection))]
+[JsonSerializable(typeof(BenchmarkReport))]
+partial class BenchmarkJsonContext : JsonSerializerContext;

--- a/tools/PackageAssemblyQueryBenchmark.cs
+++ b/tools/PackageAssemblyQueryBenchmark.cs
@@ -166,6 +166,36 @@ static async Task<BenchmarkSample> RunCliAsync(
             json.SemanticProjection)
         ?? throw new InvalidOperationException(
             $"Package Query trial {trial} returned an empty document.");
+    ProjectionSummary validated = ValidateProjection(
+        projection,
+        expectedFingerprint,
+        manifest.Packages.Count,
+        trial,
+        json);
+    int requests = ParseRequestCount(measured.StandardError);
+
+    return new(
+        trial,
+        measured.ElapsedMilliseconds,
+        measured.CpuMilliseconds,
+        measured.PeakWorkingSetBytes,
+        validated.Candidates,
+        validated.Matches,
+        validated.SemanticMisses,
+        validated.NotApplicable,
+        validated.Failures,
+        requests,
+        validated.Candidates / (measured.ElapsedMilliseconds / 1000d),
+        validated.Fingerprint);
+}
+
+static ProjectionSummary ValidateProjection(
+    SemanticProjection projection,
+    string expectedFingerprint,
+    int expectedCandidates,
+    int trial,
+    BenchmarkJsonContext json)
+{
     string fingerprint = Fingerprint(
         JsonSerializer.Serialize(projection, json.SemanticProjection));
     if (fingerprint != expectedFingerprint)
@@ -183,26 +213,18 @@ static async Task<BenchmarkSample> RunCliAsync(
     int notApplicable = projection.Candidates.Count(
         static candidate => candidate.Outcome == "not-applicable");
     int failures = candidates - matched - misses - notApplicable;
-    int requests = ParseRequestCount(measured.StandardError);
-    if (candidates != manifest.Packages.Count || failures != 0)
+    if (candidates != expectedCandidates || failures != 0)
     {
         throw new InvalidOperationException(
             $"Package Query trial {trial} completed {candidates} of "
-            + $"{manifest.Packages.Count} candidates with {failures} failures.");
+            + $"{expectedCandidates} candidates with {failures} failures.");
     }
-
     return new(
-        trial,
-        measured.ElapsedMilliseconds,
-        measured.CpuMilliseconds,
-        measured.PeakWorkingSetBytes,
         candidates,
         matched,
         misses,
         notApplicable,
         failures,
-        requests,
-        candidates / (measured.ElapsedMilliseconds / 1000d),
         fingerprint);
 }
 
@@ -397,16 +419,51 @@ static async Task SelfTestAsync(BenchmarkJsonContext json)
                 measured.StandardOutput,
                 json.SemanticProjection)
             ?? throw new InvalidOperationException("The fake child returned no projection.");
+        string expectedFingerprint = Fingerprint(
+            JsonSerializer.Serialize(expected, json.SemanticProjection));
+        ProjectionSummary projection = ValidateProjection(
+            actual,
+            expectedFingerprint,
+            expectedCandidates: 1,
+            trial: 1,
+            json);
         if (measured.ElapsedMilliseconds <= 0
             || measured.CpuMilliseconds < 0
             || measured.PeakWorkingSetBytes <= 0
-            || Fingerprint(JsonSerializer.Serialize(actual, json.SemanticProjection))
-                != Fingerprint(
-                    JsonSerializer.Serialize(expected, json.SemanticProjection)))
+            || projection != new ProjectionSummary(
+                1,
+                0,
+                1,
+                0,
+                0,
+                expectedFingerprint))
         {
             throw new InvalidOperationException(
                 "The fake child process did not produce one complete measured projection.");
         }
+
+        bool mismatchRejected = false;
+        try
+        {
+            ValidateProjection(
+                actual with
+                {
+                    Candidates =
+                    [
+                        actual.Candidates[0] with { Detail = "different" },
+                    ],
+                },
+                expectedFingerprint,
+                expectedCandidates: 1,
+                trial: 2,
+                json);
+        }
+        catch (InvalidOperationException)
+        {
+            mismatchRejected = true;
+        }
+        if (!mismatchRejected)
+            throw new InvalidOperationException("A semantic mismatch was accepted.");
 
         MetricSummary summary = Statistics([3, 1, 2, 5, 4]);
         if (summary != new MetricSummary(3, 3, 1, 5, 5))
@@ -470,6 +527,14 @@ readonly record struct ChildMeasurement(
     double ElapsedMilliseconds,
     double CpuMilliseconds,
     long PeakWorkingSetBytes);
+
+readonly record struct ProjectionSummary(
+    int Candidates,
+    int Matches,
+    int SemanticMisses,
+    int NotApplicable,
+    int Failures,
+    string Fingerprint);
 
 sealed record BenchmarkSample(
     int Trial,

--- a/tools/PackageAssemblyQueryBenchmark.json
+++ b/tools/PackageAssemblyQueryBenchmark.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "decoded-literal-five-packages-v1",
+  "literal": "Unexpected end when reading JSON",
+  "targetFramework": "net6.0",
+  "packages": [
+    "Newtonsoft.Json@13.0.3",
+    "System.Text.Json@8.0.5",
+    "Serilog@4.3.0",
+    "Microsoft.Extensions.Logging@8.0.1",
+    "Microsoft.Extensions.Primitives@8.0.0"
+  ],
+  "limits": {
+    "maximumPackages": 5,
+    "maximumEntryBytes": 16777216,
+    "maximumRetainedImageBytes": 33554432,
+    "maximumMethods": 50000,
+    "maximumMethodBodyBytes": 1000000,
+    "maximumMethodBodyBytesVisited": 16000000,
+    "maximumInstructions": 4000000,
+    "maximumDecodedUserStringCharacters": 4000000,
+    "maximumOccurrences": 10000,
+    "maximumDurationSeconds": 60
+  },
+  "expected": {
+    "candidates": [
+      {
+        "package": "newtonsoft.json",
+        "version": "13.0.3",
+        "outcome": "matched",
+        "asset": "lib/net6.0/Newtonsoft.Json.dll",
+        "target_framework": "net6.0",
+        "detail": "3 literal uses; 0 sibling assemblies not evaluated."
+      },
+      {
+        "package": "system.text.json",
+        "version": "8.0.5",
+        "outcome": "no-match",
+        "asset": "lib/net6.0/System.Text.Json.dll",
+        "target_framework": "net6.0",
+        "detail": "The selected implementation assembly has no matching decoded ldstr use after 3525 method bodies."
+      },
+      {
+        "package": "serilog",
+        "version": "4.3.0",
+        "outcome": "no-match",
+        "asset": "lib/net6.0/Serilog.dll",
+        "target_framework": "net6.0",
+        "detail": "The selected implementation assembly has no matching decoded ldstr use after 1123 method bodies."
+      },
+      {
+        "package": "microsoft.extensions.logging",
+        "version": "8.0.1",
+        "outcome": "no-match",
+        "asset": "lib/net6.0/Microsoft.Extensions.Logging.dll",
+        "target_framework": "net6.0",
+        "detail": "The selected implementation assembly has no matching decoded ldstr use after 246 method bodies."
+      },
+      {
+        "package": "microsoft.extensions.primitives",
+        "version": "8.0.0",
+        "outcome": "no-match",
+        "asset": "lib/net6.0/Microsoft.Extensions.Primitives.dll",
+        "target_framework": "net6.0",
+        "detail": "The selected implementation assembly has no matching decoded ldstr use after 240 method bodies."
+      }
+    ],
+    "matches": [
+      {
+        "package": "newtonsoft.json",
+        "version": "13.0.3",
+        "assembly": "Newtonsoft.Json.dll",
+        "method": "0x0600010C",
+        "offset": "IL_0001",
+        "literal": "Unexpected end when reading JSON."
+      },
+      {
+        "package": "newtonsoft.json",
+        "version": "13.0.3",
+        "assembly": "Newtonsoft.Json.dll",
+        "method": "0x0600011B",
+        "offset": "IL_0009",
+        "literal": "Unexpected end when reading JSON."
+      },
+      {
+        "package": "newtonsoft.json",
+        "version": "13.0.3",
+        "assembly": "Newtonsoft.Json.dll",
+        "method": "0x0600011C",
+        "offset": "IL_000B",
+        "literal": "Unexpected end when reading JSON."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Build robust, capable Package Query features from measured production evidence rather than speculative optimization.

## Outcome

Establishes the first reproducible assembly-pattern Package Query throughput and peak-memory baseline required by milestone 11 of #5766. The evidence supports retaining the serial five-candidate limit and current conservative resource defaults; it does not justify a byte prefilter, concurrency, or larger limits.

The product-backed probe launches the exact built Release CLI over a pinned five-package corpus. Every sample must complete all candidates without failure and reproduce the expected candidate/match projection after excluding only opaque Root reopening tokens.

Closes #6350.

## Demo

```bash
"$DOTNET_ROOT/dotnet" build \
  src/dotnet-inspect/dotnet-inspect.csproj -c Release
"$DOTNET_ROOT/dotnet" run \
  tools/PackageAssemblyQueryBenchmark.cs -c Release -- \
  cf96f4e7be43e905a2bd1908ac1d8f42687cc095 \
  artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  warm 5 artifacts/package-assembly-query-warm.json
```

Pinned query: `Unexpected end when reading JSON` across five exact packages at `net6.0`.

| State | Median elapsed | Median CPU | Median peak working set | Median candidates/s | HTTP requests/sample |
| --- | ---: | ---: | ---: | ---: | ---: |
| Isolated private cache, 3 samples | 870 ms | 430 ms | 115.5 MiB | 5.75 | 5 |
| Shared private cache after warmup, 5 samples | 728 ms | 400 ms | 115.5 MiB | 6.87 | 5 |

All eight samples produced one matched candidate, four semantic misses, three matching literal occurrences, no failures, and the same semantic fingerprint. The raw reports preserve each sample, including the warm 663-837 ms range.

## Evidence and boundary

- Pins coordinates, operand, TFM, default product limits, and exact stable semantic projection in `tools/PackageAssemblyQueryBenchmark.json`.
- Records elapsed time, CPU, sampled peak process working set, HTTP requests, throughput, host/runtime identity, and raw samples.
- Separates isolated private-cache runs from post-warmup runs, while explicitly retaining that both states made five HTTP requests and remain network-sensitive.
- Adds only an offline fake-child self-test to CI; live timing remains descriptive non-CI evidence, not a deterministic threshold.
- Leaves Browser responsiveness with #5816 and makes no changes to production query semantics or resource defaults.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run tools/PackageAssemblyQueryBenchmark.cs -c Release -- --self-test`
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release --no-build`
- `npx markdownlint-cli docs/design/package-query-assembly-evaluation.md`