### PR TITLE
Adopt one central NuGet package-version registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,8 +38,9 @@ updates:
   # `/` expands dotnet-inspect.slnx, and 17 tracked projects are outside that
   # solution, so the two that matter are listed explicitly:
   #
-  #   eng/CiChangeDetection     opts out of central package management and pins
-  #                             YamlDotNet inline, so `/` governs nothing here.
+  #   eng/CiChangeDetection     the only referrer of the centrally managed
+  #                             YamlDotNet version; `/` does not discover this
+  #                             standalone project.
   #   inspect-web/msdl-proxy    the only referrer of the three
   #                             Microsoft.Azure.Functions.Worker* versions, and
   #                             it is deployed by the inspect-web workflows.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.5" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/eng/CiChangeDetection/CiChangeDetection.csproj
+++ b/eng/CiChangeDetection/CiChangeDetection.csproj
@@ -6,11 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="18.1.0" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Demo

`eng/CiChangeDetection` now consumes the repository's central package version
without changing the resolved dependency:

```text
Before:
  ManagePackageVersionsCentrally=false
  PackageReference YamlDotNet Version=18.1.0

After:
  Directory.Packages.props: PackageVersion YamlDotNet Version=18.1.0
  CiChangeDetection.csproj: PackageReference YamlDotNet

Resolved:
  requestedVersion: 18.1.0
  resolvedVersion:  18.1.0
```

What to notice: the version has one owner, while the standalone project remains
an explicit Dependabot discovery root because it is outside
`dotnet-inspect.slnx`.

## Summary

- Move the remaining inline NuGet version into `Directory.Packages.props`.
- Remove the `CiChangeDetection` Central Package Management opt-out.
- Update the existing Dependabot comment to distinguish version ownership from
  project discovery.

No package version, dependency, update cadence, or configured discovery root
changes.

## Design basis

`Directory.Packages.props` is the repository's normative NuGet version registry
through `ManagePackageVersionsCentrally=true`. `.github/dependabot.yml` remains
the supporting discovery map for package referrers outside the solution.

The current-tree inventory contains no inline `PackageReference Version=`
attributes or `ManagePackageVersionsCentrally=false` project overrides. This PR
does not add a bespoke repository scanner to prevent future exceptions; the
standard CPM restore/build path is the enforcing gate for participating
projects.

## Validation

- `dotnet run eng/test-ci-change-detection.cs`
- `dotnet build eng/CiChangeDetection/CiChangeDetection.csproj -c Release`
- `dotnet list eng/CiChangeDetection/CiChangeDetection.csproj package --format json --no-restore`
  reports requested and resolved `YamlDotNet` version `18.1.0`
- `.github/dependabot.yml` parsed with Ruby Psych

Closes #6351