### PR TITLE
Migrate Ecosystems consumer tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -214,6 +214,12 @@ These paths reuse the pinned outcome-level host gate without changing the
 suite's friend-only registry and catalog evidence or the separately compiled
 public-consumer evidence in `DotnetInspector.Ecosystems.Consumer.Tests`.
 
+`DotnetInspector.Ecosystems.Consumer.Tests` is the eleventh migrated adopter.
+Its required PR, Windows, Deep Inspect platform, and developer commands remain
+unfiltered. These paths reuse the pinned outcome-level host gate without
+changing the suite's separately compiled non-friend evidence or combining it
+with the dedicated catalog suite.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/DotnetInspector.Ecosystems.Consumer.Tests/DotnetInspector.Ecosystems.Consumer.Tests.csproj
+++ b/tests/DotnetInspector.Ecosystems.Consumer.Tests/DotnetInspector.Ecosystems.Consumer.Tests.csproj
@@ -10,6 +10,7 @@
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This keeps dotnet-inspect's test evidence conventionally sound: selector mistakes fail at the test host while suite semantics remain owned by their real contracts.

This is migration 11 of 30 under #5379.

## Demo

Before this change, a stale native xUnit selector executed zero tests and still
reported success:

```text
Test Pipeline:
  DotnetInspector.Ecosystems.Consumer.Tests.dll: Zero tests ran

Exit code: 0
```

After selecting Microsoft Testing Platform through xUnit's supported project
property, the equivalent unmatched filter is an aggregate test failure:

```text
Test run summary: Zero tests ran
  total: 0

Exit code: 8
```

The neighboring evidence remains intact:

```text
DotnetInspector.Ecosystems.Consumer.Tests: 5 passed
DotnetInspector.Ecosystems.Tests:          89 passed
```

## Change

- Select the Microsoft Testing Platform runner for
  `DotnetInspector.Ecosystems.Consumer.Tests`.
- Record the suite as the eleventh migrated adopter in the normative xUnit host
  design.
- Keep all supported PR, Windows, Deep Inspect platform, and developer
  invocations unfiltered.
- Preserve the separately compiled non-friend consumer boundary; the suite is
  not combined with the dedicated friend-only catalog suite.

No direct MTP package dependency, runner-internal dependency, repository-owned
selector parser, workflow change, or domain-test change is introduced.

## Validation

- Full Release solution build on .NET SDK `11.0.100-rc.1.26425.128`
- Unmatched MTP class filter: zero tests, exit `8`
- Focused consumer class: 5/5 passed
- Full consumer suite: 5/5 passed
- Dedicated Ecosystems suite: 89/89 passed
- `markdownlint` and `git diff --check`

Part of #5379.