### PR TITLE
Restore CoreCLR verifier cohort packages

### DIFF
--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -210,7 +210,11 @@ jobs:
                 <package pattern="Microsoft.NET.Sdk.WebAssembly.Pack" />
               </packageSource>
               <packageSource key="dotnet12">
+                <package pattern="Microsoft.AspNetCore.App.*" />
+                <package pattern="Microsoft.DotNet.ILCompiler" />
                 <package pattern="Microsoft.NET.ILLink.Tasks" />
+                <package pattern="Microsoft.NETCore.App.*" />
+                <package pattern="runtime.*.Microsoft.DotNet.ILCompiler" />
               </packageSource>
               <packageSource key="nuget.org">
                 <package pattern="*" />
@@ -246,12 +250,13 @@ jobs:
       - name: Verify runtime-async deployment
         shell: bash
         run: |
-          eng/verify-inspect-web-async-deployment.sh \
-            runtime \
-            prototypes/inspect-web/engine/bin/Release/net11.0/InspectWeb.Engine.dll \
-            artifacts/inspect-web-coreclr-publish/wwwroot \
-            artifacts/inspect-web-coreclr-publish/async-lowering.json \
-            artifacts/inspect-web-runtime-async-receipts
+          RestoreConfigFile="$RUNNER_TEMP/inspect-web-coreclr-NuGet.Config" \
+            eng/verify-inspect-web-async-deployment.sh \
+              runtime \
+              prototypes/inspect-web/engine/bin/Release/net11.0/InspectWeb.Engine.dll \
+              artifacts/inspect-web-coreclr-publish/wwwroot \
+              artifacts/inspect-web-coreclr-publish/async-lowering.json \
+              artifacts/inspect-web-runtime-async-receipts
 
       - name: Publish MSDL managed API
         run: >

--- a/docs/inspect-web-runtime-performance.md
+++ b/docs/inspect-web-runtime-performance.md
@@ -206,14 +206,15 @@ Inspect Web project graph retains that target framework while executing on the
 explicitly. Both workload installation and application publication restore use
 the pinned daily feed plus NuGet.org. Publication uses package-source mapping so
 the installed workload supplies `Microsoft.NET.Sdk.WebAssembly.Pack`, the daily
-feed supplies SDK-selected `Microsoft.NET.ILLink.Tasks`, and NuGet.org supplies
-ordinary project dependencies. Its artifact carries `dotnet --info`, `dotnet
-workload list`, and a machine-readable receipt that binds the SDK, runtime,
-workload manifest and packs, feeds, target framework, runtime-async lowering,
-and non-ReadyToRun configuration. It also records the pinned CoreCLR pack's
-native JavaScript and Wasm hashes, which must equal the published runtime
-assets. The same receipt is verified before artifact upload and again before
-deployment.
+feed supplies SDK-selected linker, NativeAOT compiler, and runtime packages,
+and NuGet.org supplies ordinary project dependencies. The same mapped
+configuration governs both publication and runtime-async verification. Its
+artifact carries `dotnet --info`, `dotnet workload list`, and a machine-readable
+receipt that binds the SDK, runtime, workload manifest and packs, feeds, target
+framework, runtime-async lowering, and non-ReadyToRun configuration. It also
+records the pinned CoreCLR pack's native JavaScript and Wasm hashes, which must
+equal the published runtime assets. The same receipt is verified before
+artifact upload and again before deployment.
 
 ReadyToRun publication must additionally record:
 

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -38,12 +38,13 @@ internal static class PromotionWorkflowContract
         """;
     private const string RuntimeAsyncDeploymentCheck =
         """
-        eng/verify-inspect-web-async-deployment.sh \
-          runtime \
-          prototypes/inspect-web/engine/bin/Release/net11.0/InspectWeb.Engine.dll \
-          artifacts/inspect-web-coreclr-publish/wwwroot \
-          artifacts/inspect-web-coreclr-publish/async-lowering.json \
-          artifacts/inspect-web-runtime-async-receipts
+        RestoreConfigFile="$RUNNER_TEMP/inspect-web-coreclr-NuGet.Config" \
+          eng/verify-inspect-web-async-deployment.sh \
+            runtime \
+            prototypes/inspect-web/engine/bin/Release/net11.0/InspectWeb.Engine.dll \
+            artifacts/inspect-web-coreclr-publish/wwwroot \
+            artifacts/inspect-web-coreclr-publish/async-lowering.json \
+            artifacts/inspect-web-runtime-async-receipts
         """;
     private const string PairedAsyncDeploymentCheck =
         """
@@ -307,6 +308,18 @@ internal static class PromotionWorkflowContract
             "",
             ValidateCoreClrStaging,
             "CoreCLR staging contract accepted publish restore without its mapped cohort feeds.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "                <package pattern=\"Microsoft.DotNet.ILCompiler\" />\n",
+            "",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted verifier restore without the daily NativeAOT compiler.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "          RestoreConfigFile=\"$RUNNER_TEMP/inspect-web-coreclr-NuGet.Config\" \\\n",
+            "",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted runtime verification without its mapped cohort feeds.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
             "            -p:PublishReadyToRun=false \\\n",
@@ -1465,7 +1478,11 @@ internal static class PromotionWorkflowContract
                   <package pattern="Microsoft.NET.Sdk.WebAssembly.Pack" />
                 </packageSource>
                 <packageSource key="dotnet12">
+                  <package pattern="Microsoft.AspNetCore.App.*" />
+                  <package pattern="Microsoft.DotNet.ILCompiler" />
                   <package pattern="Microsoft.NET.ILLink.Tasks" />
+                  <package pattern="Microsoft.NETCore.App.*" />
+                  <package pattern="runtime.*.Microsoft.DotNet.ILCompiler" />
                 </packageSource>
                 <packageSource key="nuget.org">
                   <package pattern="*" />


### PR DESCRIPTION
Build robust, capable deployment paths that keep the production and CoreCLR Inspect Web experiences advancing together.

## Summary

- apply the CoreCLR mapped NuGet configuration to runtime-async verification
- map the verifier's pinned NativeAOT compiler and runtime packages to the .NET 12 daily feed
- extend the executable workflow contract and runtime evidence documentation

## Demo

After #6343 fixed browser publication, recovery promotion run `34300881649` successfully promoted v0.25.0 production and published the CoreCLR browser app, then failed in `Verify runtime-async deployment`. The verifier's generated project requested the pinned `Microsoft.DotNet.ILCompiler`, `Microsoft.NETCore.App.Runtime.*`, `Microsoft.AspNetCore.App.Runtime.*`, and `runtime.*.Microsoft.DotNet.ILCompiler` packages, but searched only NuGet.org and the local workload library packs.

With this change, the verifier inherits the same mapped restore configuration as publication. A clean-package-cache production-equivalent run published the browser app and completed the full runtime-async verifier: 63 exports, 38 runtime-lowered async methods, seven facade assemblies, and all 38 repository projects. NuGet metadata confirmed every NativeAOT/runtime package came from the pinned .NET 12 daily feed. The neighboring compiler-async staging verifier remains unchanged on the repository SDK and ordinary package sources.

## Validation

- `dotnet run eng/test-ci-change-detection.cs`
- `npx markdownlint-cli docs/inspect-web-runtime-performance.md`
- clean-cache pinned SDK/workload install, CoreCLR browser publish, and complete `eng/verify-inspect-web-async-deployment.sh runtime ...` execution
- package-origin checks for linker, ILCompiler, CoreCLR, ASP.NET Core, NativeAOT, and runtime-specific ILCompiler packages
- `git diff --check origin/main...HEAD`

## Recovery

After merge, dispatch another `promote-inspect-web.yml` run with staging run `34135265082`; rerunning run `34300881649` would retain its original workflow revision.