### PR TITLE
Resolve deps asset locations before candidate capture

### DIFF
--- a/docs/design/assembly-dependency-candidate-inventory.md
+++ b/docs/design/assembly-dependency-candidate-inventory.md
@@ -27,6 +27,17 @@ target exclusion. It preserves repeated discovery entries and their
 provenance. Once a tier emits a candidate path, inability to acquire that
 candidate is evidence, not permission to remove its row.
 
+One `.deps.json` target asset is one logical candidate even when its manifest
+provides multiple physical locations. Services follows the .NET host's
+location order: a valid application-relative `localPath` first, then the
+valid package-root path. Capture validates every declared path, emits the
+first existing location, and emits one preferred unavailable location when
+none exists. The locations are not independent compiler candidates.
+This deliberately matches the hostpolicy behavior introduced by
+[dotnet/runtime#118297](https://github.com/dotnet/runtime/pull/118297);
+only its physical-location semantics transfer. Legacy `ResolveAll` and
+`Select` keep their existing behavior and effective location choice.
+
 This boundary inherits existing package-version, asset-directory, target-
 framework and optional-tier choices. It does not enumerate alternative
 package versions, every compatible TFM, or all framework installations.

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.ReferenceDiscovery.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.ReferenceDiscovery.cs
@@ -619,17 +619,22 @@ public sealed partial class AssemblyDependencyResolver
 
             if (strict && asset.Value.ValueKind != JsonValueKind.Object)
                 throw new JsonException("A dependency asset entry must be an object.");
+            string? resolvedLocalPath = null;
             if (asset.Value.ValueKind == JsonValueKind.Object
                 && asset.Value.TryGetProperty("localPath", out var localPathElement))
             {
                 if (localPathElement.ValueKind == JsonValueKind.String
                     && localPathElement.GetString() is { Length: > 0 } localPath
-                    && StorePath.TryResolveUnderRoot(targetDirectory, localPath, out string? resolvedLocalPath))
-                    addReference(resolvedLocalPath);
+                    && StorePath.TryResolveUnderRoot(targetDirectory, localPath, out resolvedLocalPath))
+                {
+                    if (!strict)
+                        addReference(resolvedLocalPath);
+                }
                 else if (strict)
                     throw new JsonException("A declared dependency local asset path was rejected.");
             }
 
+            string? resolvedAssetPath = null;
             if (libraryPaths.TryGetValue(library.Name, out var packagePath))
             {
                 if (StorePath.TryResolveUnderRoot(
@@ -639,10 +644,29 @@ public sealed partial class AssemblyDependencyResolver
                     && StorePath.TryResolveUnderRoot(
                     packageDirectory,
                     asset.Name,
-                    out string? resolvedAssetPath))
-                    addReference(resolvedAssetPath);
+                    out resolvedAssetPath))
+                {
+                    if (!strict)
+                        addReference(resolvedAssetPath);
+                }
                 else if (strict)
                     throw new JsonException("A declared dependency package asset path was rejected.");
+            }
+
+            if (strict)
+            {
+                string? selectedPath;
+                if (resolvedLocalPath is not null
+                    && DiscoveryFileExists(resolvedLocalPath, strict: true))
+                    selectedPath = resolvedLocalPath;
+                else if (resolvedAssetPath is not null
+                    && DiscoveryFileExists(resolvedAssetPath, strict: true))
+                    selectedPath = resolvedAssetPath;
+                else
+                    selectedPath = resolvedLocalPath ?? resolvedAssetPath;
+
+                if (selectedPath is not null)
+                    addReference(selectedPath);
             }
         }
     }

--- a/tests/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.DiscoveryInventory.cs
+++ b/tests/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.DiscoveryInventory.cs
@@ -182,6 +182,141 @@ public partial class AssemblyDependencyResolverTests
     }
 
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CaptureDiscoveryInventory_DepsAssetChoosesFirstAvailablePhysicalLocation(
+        bool localExists)
+    {
+        using var files = new DiscoveryFiles();
+        string packages = Path.Combine(files.Root, "packages");
+        string local = Path.Combine(files.Root, "P.dll");
+        string package = files.Write(
+            "packages/p/1.0.0/lib/net10.0/P.dll",
+            BuildAssembly("P", [], new Version(2, 0, 0, 0)));
+        if (localExists)
+            files.Write("P.dll", BuildAssembly("P", [], new Version(1, 0, 0, 0)));
+        files.WriteText("Target.deps.json", """
+            {"targets":{"net10.0":{"P/1.0.0":{"runtime":
+              {"lib/net10.0/P.dll":{"localPath":"P.dll"}}}}},
+             "libraries":{"P/1.0.0":{"path":"p/1.0.0"}}}
+            """);
+        string? oldPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", packages);
+            var resolver = new AssemblyDependencyResolver(files.Options with
+            {
+                IncludeDepsJsonAssets = true,
+            });
+
+            var inventory = Assert.IsType<AssemblyDependencyDiscoveryResult.Captured>(
+                resolver.CaptureDiscoveryInventory(TestContext.Current.CancellationToken));
+            var row = Assert.Single(inventory.Entries);
+            Assert.Equal(localExists ? local : package, row.Dependency.Path);
+            Assert.Equal(
+                localExists ? new Version(1, 0, 0, 0) : new Version(2, 0, 0, 0),
+                Acquired(row).Identity.Version);
+            Assert.Equal(row.Dependency.Path, Assert.Single(resolver.ResolveAll()).Path);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", oldPackages);
+        }
+    }
+
+    [Fact]
+    public void CaptureDiscoveryInventory_DepsAssetWithoutPhysicalLocationIsOneUnavailableRow()
+    {
+        using var files = new DiscoveryFiles();
+        string packages = Path.Combine(files.Root, "packages");
+        string local = Path.Combine(files.Root, "P.dll");
+        files.WriteText("Target.deps.json", """
+            {"targets":{"net10.0":{"P/1.0.0":{"runtime":
+              {"lib/net10.0/P.dll":{"localPath":"P.dll"}}}}},
+             "libraries":{"P/1.0.0":{"path":"p/1.0.0"}}}
+            """);
+        string? oldPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", packages);
+            var resolver = new AssemblyDependencyResolver(files.Options with
+            {
+                IncludeDepsJsonAssets = true,
+            });
+
+            var failure = Assert.IsType<AssemblyDependencyDiscoveryResult.Failed>(
+                resolver.CaptureDiscoveryInventory(TestContext.Current.CancellationToken));
+            var row = Assert.Single(failure.PartialEntries);
+            Assert.Equal(local, row.Dependency.Path);
+            Assert.Equal(CandidateOpenFailureKind.Unreadable,
+                Assert.IsType<AssemblyDependencyAcquisition.Unavailable>(row.Acquisition).Failure.Kind);
+            Assert.Empty(resolver.ResolveAll());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", oldPackages);
+        }
+    }
+
+    [Fact]
+    public void CaptureDiscoveryInventory_DepsAssetValidatesFallbackBeforeSelectingLocal()
+    {
+        using var files = new DiscoveryFiles();
+        files.Write("P.dll", BuildAssembly("P", []));
+        files.WriteText("Target.deps.json", """
+            {"targets":{"net10.0":{"P/1.0.0":{"runtime":
+              {"P.dll":{"localPath":"P.dll"}}}}},
+             "libraries":{"P/1.0.0":{"path":"../outside"}}}
+            """);
+        var resolver = new AssemblyDependencyResolver(files.Options with
+        {
+            IncludeDepsJsonAssets = true,
+        });
+
+        var failure = Assert.IsType<AssemblyDependencyDiscoveryResult.Failed>(
+            resolver.CaptureDiscoveryInventory(TestContext.Current.CancellationToken));
+        Assert.Empty(failure.PartialEntries);
+        Assert.Equal(AssemblyDependencyDiscoveryFailureKind.InvalidDocument,
+            Assert.Single(failure.DiscoveryFailures).Kind);
+        Assert.Equal(Path.Combine(files.Root, "P.dll"), Assert.Single(resolver.ResolveAll()).Path);
+    }
+
+    [Fact]
+    public void CaptureDiscoveryInventory_DepsAssetValidatesLocalBeforeSelectingFallback()
+    {
+        using var files = new DiscoveryFiles();
+        string packages = Path.Combine(files.Root, "packages");
+        string package = files.Write(
+            "packages/p/1.0.0/lib/net10.0/P.dll",
+            BuildAssembly("P", []));
+        files.WriteText("Target.deps.json", """
+            {"targets":{"net10.0":{"P/1.0.0":{"runtime":
+              {"lib/net10.0/P.dll":{"localPath":"../outside/P.dll"}}}}},
+             "libraries":{"P/1.0.0":{"path":"p/1.0.0"}}}
+            """);
+        string? oldPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", packages);
+            var resolver = new AssemblyDependencyResolver(files.Options with
+            {
+                IncludeDepsJsonAssets = true,
+            });
+
+            var failure = Assert.IsType<AssemblyDependencyDiscoveryResult.Failed>(
+                resolver.CaptureDiscoveryInventory(TestContext.Current.CancellationToken));
+            Assert.Empty(failure.PartialEntries);
+            Assert.Equal(AssemblyDependencyDiscoveryFailureKind.InvalidDocument,
+                Assert.Single(failure.DiscoveryFailures).Kind);
+            Assert.Equal(package, Assert.Single(resolver.ResolveAll()).Path);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", oldPackages);
+        }
+    }
+
+    [Theory]
     [InlineData("nuspec", false)]
     [InlineData("nuspec", true)]
     [InlineData("deps", false)]


### PR DESCRIPTION
Build robust, capable inspection foundations by making Services candidate
capture agree with the .NET host's physical asset selection before RTS relies
on the frozen inventory.

## Summary

- Treat a `.deps.json` target asset as one logical candidate with ordered
  application-relative and package-cache locations.
- Validate both declared locations, select the first existing location, and
  retain one preferred unavailable row when neither exists.
- Preserve legacy `ResolveAll` and `Select` behavior while correcting only the
  strict `CaptureDiscoveryInventory` contract.
- Record the hostpolicy-derived rule in the owning candidate-inventory design.

## Demo

An ordinary build-output-shaped dependency has both a local declaration and a
package-cache declaration, but the local copy is absent:

| Scenario | Before | After |
| --- | --- | --- |
| Local missing, package present | `Failed`; unavailable local row plus package row | `Captured`; one acquired package row |
| Local and package present | Two candidate locations | One acquired local row |
| Neither present | Multiple unavailable locations | One preferred unavailable local row |
| Either declaration invalid | `InvalidDocument` | `InvalidDocument` |

The focused contract run exercises both physical choices plus the missing and
invalid cases:

```text
Test run summary: Passed!
  total: 5
  failed: 0
  succeeded: 5
```

The neighboring legacy assertions also confirm that `ResolveAll` retains its
existing effective choice.

## Validation

```text
dotnet run --project tests/DotnetInspector.Services.Tests -c Release -- \
  --filter-class 'DotnetInspector.Services.Tests.AssemblyDependencyResolverTests' \
  --no-progress
```

146 tests passed.

```text
npx markdownlint-cli docs/design/assembly-dependency-candidate-inventory.md
git diff --check
```

## Scope

This is the focused Services prerequisite for #6103 in the six-step #6199 RTS
cutover. It does not change tools selection, compiler binding, package/TFM
policy, or RTS behavior.

Closes #6355.
