### PR TITLE
Window Package Query results in Inspect Web

### DIFF
--- a/docs/design/package-query-experience.md
+++ b/docs/design/package-query-experience.md
@@ -192,7 +192,17 @@ and
   visible without consuming package-row credit. Rows append to source-
   independent state, while Browser publication is frame-batched and patches
   only the live failure, cancellation, and result regions rather than replacing
-  the whole application DOM for every event. Product-issued progress
+  the whole application DOM for every event. The Browser retains every durable
+  row in query state but renders at most 30 package cards in the DOM. The
+  rendered range covers the visible rows plus 600 CSS pixels of overscan;
+  measured card heights and estimated heights for unseen cards drive inert top
+  and bottom spacers so ordinary scrolling can move through the full retained
+  result set. Each patch preserves the first visible row and its viewport
+  offset, so measurement correction or changing progress above the list does
+  not replace the user's logical reading position. Scrolling schedules the same
+  animation-frame-coalesced region patch used by stream publication. Query context, progress, assessments,
+  failures, and completion accounting remain outside the virtual row list and
+  continue to describe the complete retained outcome. Product-issued progress
   checkpoints distinguish source search, manifest evaluation, and explicit
   package-content evaluation, so filtered candidates remain perceptible
   without becoming result rows. Query-scoped source-selection context from the
@@ -532,7 +542,11 @@ and browser-history and focus-return outcomes are proved by
    replenishment resumes it, spent budget is not reset, and active-work expiry
    cannot publish an uncredited match.
 13. Confirm that streamed progress and rows produce at most one query-region
-   patch per animation frame and do not replace the application root.
+   patch per animation frame and do not replace the application root. With 100
+   durable rows retained in state, confirm that at most 30 package cards occupy
+   the DOM, scrolling changes the measured visible range with 600 CSS pixels of
+   overscan, top and bottom spacers preserve the full scroll extent, and the
+   footer still reports all 100 retained rows.
 14. Confirm assembly `NoMatch`, `NotApplicable`, and failures remain distinct,
    an empty match set states only selected-primary-implementation-assembly
    scope, assessments spend no match credit, and every assembly match opens
@@ -571,8 +585,10 @@ and browser-history and focus-return outcomes are proved by
    by #5816, removes the complete-search barrier in prefix-profile consumers.
    [#6070](https://github.com/richlander/dotnet-inspect/issues/6070) restored
    explicit package-ID and prefix selection on the website. Its separate
-   Gallery gesture is retired by #6341. DOM virtualization and Worker placement
-   remain separate follow-ups.
+   Gallery gesture is retired by #6341. The next #5816 Browser slice retains
+   durable rows outside the DOM and renders a measured window of at most 30
+   cards with 600 CSS pixels of overscan. Worker placement remains a separate
+   follow-up.
 9. [Package Query inspection evidence](package-query-inspection-evidence.md),
    tracked by #6071, transports typed package/query scope and count-plus-preview
    summaries to the website. Query context renders once per result set while

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -2746,6 +2746,252 @@ test("query header omits scope buttons and preserves navigation focus across wid
   await expect(page.locator("#package-query-product")).toBeVisible();
 });
 
+test("package query keeps 100 retained rows in a bounded scrolling DOM window", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 900, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html");
+
+  const result = await page.evaluate(async () => {
+    const {
+      appendFailure,
+      appendRows,
+      createQueryRequest,
+      emptyOutcome,
+    } = await import("../src/package-query.ts");
+    const {
+      bindPackageQueryView,
+      capturePackageQueryFocus,
+      capturePackageQueryScroll,
+      patchPackageQueryStream,
+      renderPackageQueryView,
+      restorePackageQueryFocus,
+      restorePackageQueryScroll,
+    } = await import("../src/package-query-view.ts");
+    const {
+      capturePackageQueryScrollAnchor,
+      createPackageQueryWindowState,
+      observePackageQueryRowHeights,
+      packageQueryResultWindowMatches,
+      preparePackageQueryResultWindow,
+      resetPackageQueryWindow,
+      restorePackageQueryScrollAnchor,
+    } = await import("../src/package-query-window.ts");
+    const app = document.querySelector<HTMLElement>("#app");
+    if (!app) throw new Error("The query window harness root is unavailable.");
+
+    const rows = Array.from({ length: 100 }, (_, index) => ({
+      packageId: `System.Windowed.${index.toString().padStart(3, "0")}`,
+      version: "1.0.0",
+      tier: "nuspec" as const,
+      evidence: [{
+        id: "test.query-window",
+        text: "windowed result",
+        scope: "package" as const,
+        summary: null,
+      }] as const,
+      totalDownloads: index,
+    }));
+    const state = {
+      request: createQueryRequest("System.*"),
+      outcome: appendRows(emptyOutcome(), rows),
+    };
+    const windowState = createPackageQueryWindowState();
+    let patches = 0;
+    let scheduled = false;
+    let patchRequired = false;
+    let viewportResizes = 0;
+    const schedulePatch = (source: "stream" | "viewport" = "viewport") => {
+      if (source === "stream") patchRequired = true;
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(() => {
+        scheduled = false;
+        const requirePatch = patchRequired;
+        patchRequired = false;
+        const focus = capturePackageQueryFocus(document);
+        const scrollTop = capturePackageQueryScroll(document);
+        const scrollAnchor = capturePackageQueryScrollAnchor(document);
+        const resultWindow = preparePackageQueryResultWindow(
+          document,
+          rows.length,
+          windowState,
+          scrollAnchor);
+        if (!requirePatch
+          && packageQueryResultWindowMatches(document, resultWindow)) return;
+        patches++;
+        patchPackageQueryStream(
+          document,
+          {
+            state,
+            resultWindow,
+            escapeHtml: value => String(value),
+          },
+          actions);
+        restorePackageQueryFocus(document, focus);
+        if (!restorePackageQueryScrollAnchor(document, scrollAnchor)) {
+          restorePackageQueryScroll(document, scrollTop);
+        }
+        if (observePackageQueryRowHeights(document, windowState)) {
+          schedulePatch();
+        }
+      });
+    };
+    const actions = {
+      onBack: () => {},
+      onCancel: () => {},
+      onFacetToggle: () => {},
+      onPrefixInput: () => {},
+      onResultPressure: () => {},
+      onViewportChange: schedulePatch,
+      onViewportResize: () => {
+        viewportResizes++;
+        resetPackageQueryWindow(windowState);
+        observePackageQueryRowHeights(document, windowState);
+        schedulePatch();
+      },
+      onRowOpen: () => {},
+      onRun: () => {},
+      onSourceChange: () => {},
+    };
+    app.innerHTML = renderPackageQueryView({
+      state,
+      availableFacets: [],
+      resultWindow: preparePackageQueryResultWindow(
+        document,
+        rows.length,
+        windowState),
+      escapeHtml: value => String(value),
+    });
+
+    const rowStyles = document.createElement("style");
+    const setRowStyles = (extraHeight: number) => {
+      rowStyles.textContent = rows.map((_, index) =>
+        `.query-row[data-query-row-index="${index}"]{min-height:${
+          (index < 30 ? 100 : index < 60 ? 260 : 160) + extraHeight
+        }px}`).join("");
+    };
+    setRowStyles(0);
+    document.head.append(rowStyles);
+    observePackageQueryRowHeights(document, windowState);
+    const binding = bindPackageQueryView(document, actions);
+    const waitFrames = async (count: number) => {
+      for (let frame = 0; frame < count; frame++) {
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+      }
+    };
+    const main = document.querySelector<HTMLElement>(".query-main");
+    if (!main) throw new Error("The query scroll container is unavailable.");
+    const visibleAnchor = () => {
+      const mainBounds = main.getBoundingClientRect();
+      const row = [...document.querySelectorAll<HTMLElement>(
+        "[data-query-row-index]")].find(element => {
+          const bounds = element.getBoundingClientRect();
+          return bounds.bottom > mainBounds.top
+            && bounds.top < mainBounds.bottom;
+        });
+      return row
+        ? {
+            index: Number(row.dataset.queryRowIndex),
+            offset: row.getBoundingClientRect().top - mainBounds.top,
+          }
+        : null;
+    };
+    await waitFrames(2);
+    const resizeBaseline = viewportResizes;
+    const estimatedHeightBeforeResize = windowState.estimatedRowHeight;
+    setRowStyles(200);
+    app.style.width = "700px";
+    await waitFrames(4);
+    const estimatedHeightAfterResize = windowState.estimatedRowHeight;
+    const measuredRowsAfterResize = windowState.rowHeights.size;
+
+    const initialRows = document.querySelectorAll(".query-row").length;
+    main.scrollTop = main.scrollHeight / 2;
+    main.dispatchEvent(new Event("scroll"));
+    await waitFrames(6);
+    const anchorBeforeProgress = visibleAnchor();
+    state.outcome = appendFailure(
+      state.outcome,
+      "A source failed after rows were retained; this banner changes geometry.");
+    schedulePatch("stream");
+    await waitFrames(4);
+    const anchorAfterProgress = visibleAnchor();
+
+    document.querySelector<HTMLElement>("[data-query-row-open]")?.focus();
+    main.scrollTop = main.scrollHeight;
+    main.dispatchEvent(new Event("scroll"));
+    await waitFrames(4);
+    const focusAfterEviction = document.activeElement?.id ?? "";
+    schedulePatch("stream");
+    await waitFrames(2);
+    const focusAfterRequiredPatch = document.activeElement?.id ?? "";
+    const settledPatches = patches;
+    await waitFrames(3);
+    binding.disconnect();
+    const resizesAtDisconnect = viewportResizes;
+    app.style.width = "650px";
+    await waitFrames(2);
+
+    const list = document.querySelector<HTMLElement>(".query-list");
+    const footer = document.querySelector<HTMLElement>(".query-footer");
+    const renderedRows = [
+      ...document.querySelectorAll<HTMLElement>("[data-query-row-index]"),
+    ];
+    return {
+      retainedRows: state.outcome.rows.length,
+      resizeBaseline,
+      viewportResizes,
+      resizesAtDisconnect,
+      estimatedHeightBeforeResize,
+      estimatedHeightAfterResize,
+      measuredRowsAfterResize,
+      initialRows,
+      finalRows: renderedRows.length,
+      finalStart: Number(list?.dataset.queryWindowStart),
+      finalEnd: Number(list?.dataset.queryWindowEnd),
+      firstRenderedIndex: Number(renderedRows[0]?.dataset.queryRowIndex),
+      lastRenderedIndex:
+        Number(renderedRows.at(-1)?.dataset.queryRowIndex),
+      topSpacerHeight: Number.parseFloat(
+        document.querySelector<HTMLElement>(".query-list-spacer")
+          ?.style.height ?? "0"),
+      footer: footer?.textContent ?? "",
+      anchorBeforeProgress,
+      anchorAfterProgress,
+      focusAfterEviction,
+      focusAfterRequiredPatch,
+      scrollTop: main.scrollTop,
+      patches,
+      settledPatches,
+    };
+  });
+
+  expect(result.retainedRows).toBe(100);
+  expect(result.resizesAtDisconnect).toBeGreaterThan(result.resizeBaseline);
+  expect(result.viewportResizes).toBe(result.resizesAtDisconnect);
+  expect(result.measuredRowsAfterResize).toBeGreaterThan(0);
+  expect(result.estimatedHeightAfterResize)
+    .toBeGreaterThan(result.estimatedHeightBeforeResize);
+  expect(result.initialRows).toBeLessThanOrEqual(30);
+  expect(result.finalRows).toBeLessThanOrEqual(30);
+  expect(result.finalStart).toBeGreaterThan(0);
+  expect(result.finalEnd).toBe(100);
+  expect(result.firstRenderedIndex).toBe(result.finalStart);
+  expect(result.lastRenderedIndex).toBe(99);
+  expect(result.topSpacerHeight).toBeGreaterThan(0);
+  expect(result.footer).toContain("100 packages");
+  expect(result.anchorAfterProgress?.index)
+    .toBe(result.anchorBeforeProgress?.index);
+  expect(result.anchorAfterProgress?.offset)
+    .toBeCloseTo(result.anchorBeforeProgress?.offset ?? 0, 0);
+  expect(result.focusAfterEviction).toBe("package-query-results");
+  expect(result.focusAfterRequiredPatch).toBe("package-query-results");
+  expect(result.scrollTop).toBeGreaterThan(0);
+  expect(result.patches).toBe(result.settledPatches);
+  expect(result.patches).toBeLessThanOrEqual(10);
+});
+
 test("Workspace retains its full split height at constrained widths", async ({
   page,
 }) => {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -465,6 +465,15 @@ import {
   type PackageQueryBindingActions,
 } from "./package-query-view.ts";
 import {
+  capturePackageQueryScrollAnchor,
+  createPackageQueryWindowState,
+  observePackageQueryRowHeights,
+  packageQueryResultWindowMatches,
+  preparePackageQueryResultWindow,
+  resetPackageQueryWindow,
+  restorePackageQueryScrollAnchor,
+} from "./package-query-window.ts";
+import {
   historyEntryId,
   isPackageQueryPath,
   isPackageQueryPredecessor,
@@ -1294,6 +1303,7 @@ const packageQueryController = createPackageQueryController(
   updateKind => {
     if (!state.packageQueryOpen) return;
     if (updateKind === "reset") {
+      resetPackageQueryWindow(packageQueryWindowState);
       render();
       return;
     }
@@ -1301,6 +1311,7 @@ const packageQueryController = createPackageQueryController(
   },
 );
 const packageQueryAnnouncements = createPackageQueryAnnouncementTracker();
+const packageQueryWindowState = createPackageQueryWindowState();
 const packageQueryLiveAnnouncer = createPackageQueryLiveAnnouncer(
   () => document.querySelector<HTMLElement>("#package-query-announcement"));
 
@@ -3471,6 +3482,8 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   scopeBarBinding?.disconnect();
   workbenchShellBinding?.disconnect();
   workbenchShellBinding = null;
+  packageQueryViewBinding?.disconnect();
+  packageQueryViewBinding = null;
 
   // The Metadata Explorer is a full-bleed "browse the database" view layered over the
   // package workbench. Like Settings it owns no URL and renders first, returning to the
@@ -9946,6 +9959,12 @@ const packageQueryActions: PackageQueryBindingActions = {
     packageQueryController.configure(configured);
   },
   onResultPressure: () => packageQueryController.requestMore(),
+  onViewportChange: () => schedulePackageQueryStreamRender("viewport"),
+  onViewportResize: () => {
+    resetPackageQueryWindow(packageQueryWindowState);
+    observePackageQueryRowHeights(document, packageQueryWindowState);
+    schedulePackageQueryStreamRender("viewport");
+  },
   onRowOpen: (packageId, version, rootRequest) => {
     observeAsync(
       openPackageQueryRow(packageId, version, rootRequest),
@@ -9955,30 +9974,49 @@ const packageQueryActions: PackageQueryBindingActions = {
 };
 
 let packageQueryStreamRenderFrame: number | null = null;
+let packageQueryStreamRenderRequired = false;
+let packageQueryViewBinding: { disconnect(): void } | null = null;
 
 function cancelPackageQueryStreamRender() {
-  if (packageQueryStreamRenderFrame === null) return;
-  cancelAnimationFrame(packageQueryStreamRenderFrame);
+  if (packageQueryStreamRenderFrame !== null) {
+    cancelAnimationFrame(packageQueryStreamRenderFrame);
+  }
   packageQueryStreamRenderFrame = null;
+  packageQueryStreamRenderRequired = false;
 }
 
-function schedulePackageQueryStreamRender() {
+function schedulePackageQueryStreamRender(
+  source: "stream" | "viewport" = "stream",
+) {
+  if (source === "stream") packageQueryStreamRenderRequired = true;
   if (packageQueryStreamRenderFrame !== null) return;
   packageQueryStreamRenderFrame = requestAnimationFrame(() => {
     packageQueryStreamRenderFrame = null;
-    if (state.packageQueryOpen) patchPackageQueryPage();
+    if (!state.packageQueryOpen) return;
+    const requirePatch = packageQueryStreamRenderRequired;
+    packageQueryStreamRenderRequired = false;
+    patchPackageQueryPage(requirePatch);
   });
 }
 
-function patchPackageQueryPage() {
+function patchPackageQueryPage(requirePatch = true) {
   const focus = capturePackageQueryFocus(document);
   const scrollTop = capturePackageQueryScroll(document);
+  const scrollAnchor = capturePackageQueryScrollAnchor(document);
   const announcement = takePackageQueryAnnouncement();
+  const resultWindow = preparePackageQueryResultWindow(
+    document,
+    state.packageQueryState.outcome.rows.length,
+    packageQueryWindowState,
+    scrollAnchor);
+  if (!requirePatch
+    && packageQueryResultWindowMatches(document, resultWindow)) return;
   const patched = patchPackageQueryStream(
     document,
     {
       state: state.packageQueryState,
       escapeHtml,
+      resultWindow,
     },
     packageQueryActions);
   if (!patched) {
@@ -9987,7 +10025,12 @@ function patchPackageQueryPage() {
   }
   const focusRestoration = restorePackageQueryFocus(document, focus);
   if (focusRestoration !== "fallback") {
-    restorePackageQueryScroll(document, scrollTop);
+    if (!restorePackageQueryScrollAnchor(document, scrollAnchor)) {
+      restorePackageQueryScroll(document, scrollTop);
+    }
+  }
+  if (observePackageQueryRowHeights(document, packageQueryWindowState)) {
+    schedulePackageQueryStreamRender("viewport");
   }
   packageQueryLiveAnnouncer.enqueue(announcement);
 }
@@ -9997,22 +10040,32 @@ function renderPackageQueryPage() {
   const focus = capturePackageQueryFocus(document);
   const scrollTop = capturePackageQueryScroll(document);
   const announcement = takePackageQueryAnnouncement();
+  const resultWindow = preparePackageQueryResultWindow(
+    document,
+    state.packageQueryState.outcome.rows.length,
+    packageQueryWindowState);
   document.title = "Package query · dotnet-inspect";
   app.innerHTML = renderPackageQueryView({
     state: state.packageQueryState,
     prefix: state.packageQueryPrefix,
     availableFacets: state.packageQueryFacets,
     availableAssemblyPatterns: state.packageQueryAssemblyPatterns,
+    resultWindow,
     navigationError: [
       state.packageQueryCatalogError,
       state.packageQueryNavigationError,
     ].filter(Boolean).join(" "),
     escapeHtml,
   });
-  bindPackageQueryView(document, packageQueryActions);
+  packageQueryViewBinding = bindPackageQueryView(
+    document,
+    packageQueryActions);
   const focusRestoration = restorePackageQueryFocus(document, focus);
   if (focusRestoration !== "fallback") {
     restorePackageQueryScroll(document, scrollTop);
+  }
+  if (observePackageQueryRowHeights(document, packageQueryWindowState)) {
+    schedulePackageQueryStreamRender("viewport");
   }
   packageQueryLiveAnnouncer.enqueue(announcement);
 }

--- a/prototypes/inspect-web/src/package-query-view.ts
+++ b/prototypes/inspect-web/src/package-query-view.ts
@@ -10,6 +10,7 @@ import {
   createAssemblyQueryRequest,
   createQueryRequest,
 } from "./package-query.ts";
+import type { PackageQueryResultWindow } from "./package-query-window.ts";
 import { renderBrand } from "./brand.ts";
 import { focusRenderedElement } from "./scope-bar.ts";
 
@@ -24,6 +25,8 @@ export interface PackageQueryBindingActions {
   onFacetToggle: (facetKey: string, prefix: string) => void;
   onPrefixInput: (prefix: string) => void;
   onResultPressure: () => void;
+  onViewportChange?: () => void;
+  onViewportResize?: () => void;
   onRowOpen: (
     packageId: string,
     version: string,
@@ -46,12 +49,18 @@ export type PackageQueryFocusSnapshot =
   | { kind: "back" }
   | { kind: "run" }
   | { kind: "prerelease" }
+  | { kind: "results" }
   | {
       kind: "assembly";
       control: "pattern" | "packages" | "operand" | "tfm" | "run";
     }
   | { kind: "facet"; facetKey: string }
-  | { kind: "row"; packageId: string; version: string }
+  | {
+      kind: "row";
+      packageId: string;
+      version: string;
+      rowIndex: number | null;
+    }
   | { kind: "cancel"; index: number }
   | { kind: "fallback" };
 
@@ -104,6 +113,7 @@ export function capturePackageQueryFocus(
   if (active.id === "package-query-back") return { kind: "back" };
   if (active.id === "package-query-run") return { kind: "run" };
   if (active.id === "package-query-prerelease") return { kind: "prerelease" };
+  if (active.id === "package-query-results") return { kind: "results" };
   const assemblyControl = assemblyControlName(active.id);
   if (assemblyControl) {
     return { kind: "assembly", control: assemblyControl };
@@ -112,10 +122,14 @@ export function capturePackageQueryFocus(
     return { kind: "facet", facetKey: active.dataset.queryFacet };
   }
   if (active.dataset.queryRowOpen && active.dataset.queryRowVersion) {
+    const rowIndex = Number.parseInt(
+      active.dataset.queryRowPosition ?? "",
+      10);
     return {
       kind: "row",
       packageId: active.dataset.queryRowOpen,
       version: active.dataset.queryRowVersion,
+      rowIndex: Number.isInteger(rowIndex) && rowIndex >= 0 ? rowIndex : null,
     };
   }
   const cancelButtons = [
@@ -149,6 +163,9 @@ export function restorePackageQueryFocus(
     case "prerelease":
       target = root.querySelector(`#package-query-${snapshot.kind}`);
       break;
+    case "results":
+      target = root.querySelector("#package-query-results");
+      break;
     case "assembly":
       target = root.querySelector(
         `#package-query-assembly-${snapshot.control}`);
@@ -162,8 +179,18 @@ export function restorePackageQueryFocus(
       target = [...root.querySelectorAll<HTMLElement>("[data-query-row-open]")]
         .find(element =>
           element.dataset.queryRowOpen === snapshot.packageId
-          && element.dataset.queryRowVersion === snapshot.version)
+          && element.dataset.queryRowVersion === snapshot.version
+          && (snapshot.rowIndex === null
+            || element.dataset.queryRowPosition === String(snapshot.rowIndex)))
         ?? null;
+      if (!target && snapshot.rowIndex !== null) {
+        const list = root.querySelector<HTMLElement>(".query-list");
+        const start = Number(list?.dataset.queryWindowStart);
+        const end = Number(list?.dataset.queryWindowEnd);
+        if (snapshot.rowIndex < start || snapshot.rowIndex >= end) {
+          target = root.querySelector("#package-query-results");
+        }
+      }
       break;
     case "cancel":
       target = [
@@ -175,12 +202,14 @@ export function restorePackageQueryFocus(
       break;
   }
   let usedFallback = false;
-  if (!isFocusableQueryElement(target) || !focusRenderedElement(target)) {
+  if (!isFocusableQueryElement(target)
+    || !focusRenderedElement(target, { preventScroll: true })) {
     target = root.querySelector("#package-query-prefix");
     usedFallback = true;
   }
   if (!isFocusableQueryElement(target)) return "none";
-  if (usedFallback && !focusRenderedElement(target)) return "none";
+  if (usedFallback
+    && !focusRenderedElement(target, { preventScroll: true })) return "none";
   if (snapshot.kind === "prefix"
     && supportsSelectionRange(target)
     && snapshot.selectionStart !== null
@@ -237,11 +266,22 @@ export function bindPackageQueryView(
       actions.onResultPressure();
     }
   };
-  queryMain?.addEventListener("scroll", reportResultPressure);
+  const handleScroll = () => {
+    actions.onViewportChange?.();
+    reportResultPressure();
+  };
+  queryMain?.addEventListener("scroll", handleScroll);
+  const resizeObserver = queryMain
+    && actions.onViewportResize
+    && typeof ResizeObserver !== "undefined"
+    ? new ResizeObserver(actions.onViewportResize)
+    : null;
+  if (queryMain) resizeObserver?.observe(queryMain);
   reportResultPressure();
   return {
     disconnect() {
-      queryMain?.removeEventListener("scroll", reportResultPressure);
+      queryMain?.removeEventListener("scroll", handleScroll);
+      resizeObserver?.disconnect();
     },
   };
 }
@@ -411,6 +451,8 @@ export function packageQueryNeedsMoreMatches(
 
 function renderRow(
   row: QueryResultRow,
+  index: number,
+  rowCount: number,
   escapeHtml: (value: unknown) => string,
 ): string {
   const evidence = row.evidence
@@ -420,11 +462,11 @@ function renderRow(
   const rootRequest = row.tier === "assembly" ? row.rootRequest : undefined;
   const openAction = row.tier === "assembly" && !rootRequest?.trim()
     ? `<span>Workspace opening request unavailable</span>`
-    : `<button type="button" data-query-row-open="${escapeHtml(row.packageId)}" data-query-row-version="${escapeHtml(row.version)}"${rootRequest
+    : `<button type="button" data-query-row-open="${escapeHtml(row.packageId)}" data-query-row-version="${escapeHtml(row.version)}" data-query-row-position="${index}"${rootRequest
         ? ` data-query-root-request="${escapeHtml(rootRequest)}"`
         : ""}>Open in workspace</button>`;
   return `
-    <article class="query-row">
+    <article class="query-row" role="listitem" aria-posinset="${index + 1}" aria-setsize="${rowCount}" data-query-row-index="${index}">
       <div class="query-row-head">
         <div>
           <h2>${escapeHtml(row.packageId)}</h2>
@@ -752,6 +794,7 @@ export interface RenderPackageQueryOptions {
   prefix?: string;
   availableFacets: readonly QueryFacetTerm[];
   availableAssemblyPatterns?: readonly QueryAssemblyPatternDescriptor[];
+  resultWindow?: PackageQueryResultWindow;
   navigationError?: string;
   escapeHtml: (value: unknown) => string;
 }
@@ -796,21 +839,58 @@ function renderAssessments(
 function renderResults(
   state: PackageQueryState,
   escapeHtml: (value: unknown) => string,
+  resultWindow?: PackageQueryResultWindow,
 ): string {
+  const window = normalizeResultWindow(
+    resultWindow,
+    state.outcome.rows.length);
   const rows = state.outcome.rows
-    .map(row => renderRow(row, escapeHtml))
+    .slice(window.start, window.end)
+    .map((row, index) =>
+      renderRow(row, window.start + index, state.outcome.rows.length, escapeHtml))
     .join("");
   const assessments = renderAssessments(state, escapeHtml);
   return rows
-    ? `${renderProgress(state.outcome, escapeHtml)}${assessments}${renderQueryContext(state.outcome.rows, escapeHtml)}<div class="query-list">${rows}</div>${renderCompletionFooter(state.request, state.outcome, escapeHtml)}`
+    ? `${renderProgress(state.outcome, escapeHtml)}${assessments}${renderQueryContext(state.outcome.rows, escapeHtml)}<div class="query-list" role="list" data-query-window-start="${window.start}" data-query-window-end="${window.end}" data-query-window-top="${Math.round(window.topSpacerHeight)}" data-query-window-bottom="${Math.round(window.bottomSpacerHeight)}">${renderResultSpacer(window.topSpacerHeight)}${rows}${renderResultSpacer(window.bottomSpacerHeight)}</div>${renderCompletionFooter(state.request, state.outcome, escapeHtml)}`
     : state.outcome.completion.kind === "streaming" && state.request
       ? `<section class="query-empty query-running"><span class="loader" aria-hidden="true"></span><h2>${state.request.assemblyPattern ? "Evaluating selected assemblies" : "Acquiring package input"}</h2><p>${state.request.assemblyPattern ? "Matches, semantic non-matches, and non-applicable selections will appear as the explicit packages are evaluated." : "Matches will appear as package candidates are evaluated."}</p></section>${renderProgress(state.outcome, escapeHtml)}${assessments}${renderCompletionFooter(state.request, state.outcome, escapeHtml)}`
       : `${assessments}${renderEmptyState(state, escapeHtml)}`;
 }
 
+function normalizeResultWindow(
+  resultWindow: PackageQueryResultWindow | undefined,
+  rowCount: number,
+): PackageQueryResultWindow {
+  if (!resultWindow) {
+    return {
+      start: 0,
+      end: rowCount,
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+    };
+  }
+  const start = Math.min(Math.max(0, resultWindow.start), rowCount);
+  const end = Math.min(Math.max(start, resultWindow.end), rowCount);
+  return {
+    start,
+    end,
+    topSpacerHeight: Math.max(0, resultWindow.topSpacerHeight),
+    bottomSpacerHeight: Math.max(0, resultWindow.bottomSpacerHeight),
+  };
+}
+
+function renderResultSpacer(height: number): string {
+  return height > 0
+    ? `<div class="query-list-spacer" aria-hidden="true" style="height:${Math.round(height)}px"></div>`
+    : "";
+}
+
 export function patchPackageQueryStream(
   root: ParentNode,
-  options: Pick<RenderPackageQueryOptions, "state" | "escapeHtml">,
+  options: Pick<
+    RenderPackageQueryOptions,
+    "state" | "escapeHtml" | "resultWindow"
+  >,
   actions: PackageQueryBindingActions,
 ): boolean {
   const failures = root.querySelector<HTMLElement>(
@@ -823,7 +903,10 @@ export function patchPackageQueryStream(
 
   failures.innerHTML = renderFailures(options.state, options.escapeHtml);
   cancel.innerHTML = renderStreamingCancel(options.state);
-  results.innerHTML = renderResults(options.state, options.escapeHtml);
+  results.innerHTML = renderResults(
+    options.state,
+    options.escapeHtml,
+    options.resultWindow);
   bindPackageQueryStreamControls(root, actions);
 
   const queryMain = root.querySelector<HTMLElement>(".query-main");
@@ -841,13 +924,14 @@ export function renderPackageQueryView(
     prefix = state.request?.scopeQuery ?? "",
     availableFacets,
     availableAssemblyPatterns = [],
+    resultWindow,
     navigationError = "",
     escapeHtml,
   } = options;
   const activeKeys = new Set(state.request?.facets.map(facet => facet.key) ?? []);
   const facets = renderFacets(availableFacets, activeKeys, escapeHtml);
   const failures = renderFailures(state, escapeHtml);
-  const results = renderResults(state, escapeHtml);
+  const results = renderResults(state, escapeHtml, resultWindow);
   const request = state.request ?? createQueryRequest("");
 
   return `
@@ -890,7 +974,7 @@ export function renderPackageQueryView(
             <p class="query-facet-disclosure">Candidate bound K: ${request.requestedLimit.toLocaleString()}; exact IDs use one candidate. Maximum matches N: ${request.requestedMatchLimit.toLocaleString()}. The match limit does not change prefix capacity.</p>
             <p class="query-facet-disclosure">Match counts and lifetime downloads describe a bounded response, not global top-N.</p>
           </aside>
-          <section id="package-query-results" class="query-results" aria-label="Package query results">
+          <section id="package-query-results" class="query-results" aria-label="Package query results" tabindex="-1">
             ${results}
           </section>
         </div>

--- a/prototypes/inspect-web/src/package-query-window.ts
+++ b/prototypes/inspect-web/src/package-query-window.ts
@@ -1,0 +1,231 @@
+const DEFAULT_ROW_HEIGHT_PX = 180;
+const ROW_GAP_PX = 10;
+const OVERSCAN_PX = 600;
+
+export const PACKAGE_QUERY_MAX_RENDERED_ROWS = 30;
+
+export interface PackageQueryResultWindow {
+  start: number;
+  end: number;
+  topSpacerHeight: number;
+  bottomSpacerHeight: number;
+}
+
+export interface PackageQueryWindowState {
+  readonly rowHeights: Map<number, number>;
+  estimatedRowHeight: number;
+}
+
+export interface PackageQueryScrollAnchor {
+  rowIndex: number;
+  viewportOffset: number;
+}
+
+interface PackageQueryViewport {
+  start: number;
+  height: number;
+}
+
+export function createPackageQueryWindowState(): PackageQueryWindowState {
+  return {
+    rowHeights: new Map<number, number>(),
+    estimatedRowHeight: DEFAULT_ROW_HEIGHT_PX,
+  };
+}
+
+export function resetPackageQueryWindow(
+  state: PackageQueryWindowState,
+): void {
+  state.rowHeights.clear();
+  state.estimatedRowHeight = DEFAULT_ROW_HEIGHT_PX;
+}
+
+export function preparePackageQueryResultWindow(
+  root: ParentNode,
+  rowCount: number,
+  state: PackageQueryWindowState,
+  anchor?: PackageQueryScrollAnchor | null,
+): PackageQueryResultWindow {
+  return calculatePackageQueryResultWindow(
+    rowCount,
+    readPackageQueryViewport(root),
+    state,
+    anchor);
+}
+
+export function packageQueryResultWindowMatches(
+  root: ParentNode,
+  window: PackageQueryResultWindow,
+): boolean {
+  const list = root.querySelector<HTMLElement>(".query-list");
+  if (!list) return false;
+  return Number(list.dataset.queryWindowStart) === window.start
+    && Number(list.dataset.queryWindowEnd) === window.end
+    && Number(list.dataset.queryWindowTop) ===
+      Math.round(window.topSpacerHeight)
+    && Number(list.dataset.queryWindowBottom) ===
+      Math.round(window.bottomSpacerHeight);
+}
+
+export function observePackageQueryRowHeights(
+  root: ParentNode,
+  state: PackageQueryWindowState,
+): boolean {
+  let changed = false;
+  root.querySelectorAll<HTMLElement>("[data-query-row-index]")
+    .forEach(element => {
+      const index = Number.parseInt(element.dataset.queryRowIndex ?? "", 10);
+      const height = element.getBoundingClientRect().height;
+      if (!Number.isInteger(index) || index < 0
+        || !Number.isFinite(height) || height <= 0) return;
+      const previous = state.rowHeights.get(index);
+      if (previous === undefined || Math.abs(previous - height) > 0.5) {
+        changed = true;
+      }
+      state.rowHeights.set(index, height);
+    });
+  if (!changed) return false;
+  const heights = [...state.rowHeights.values()];
+  state.estimatedRowHeight =
+    heights.reduce((sum, height) => sum + height, 0) / heights.length;
+  return true;
+}
+
+export function capturePackageQueryScrollAnchor(
+  root: ParentNode,
+): PackageQueryScrollAnchor | null {
+  const main = root.querySelector<HTMLElement>(".query-main");
+  if (!main) return null;
+  const mainBounds = main.getBoundingClientRect();
+  for (const element of root.querySelectorAll<HTMLElement>(
+    "[data-query-row-index]")) {
+    const rowIndex = Number.parseInt(
+      element.dataset.queryRowIndex ?? "",
+      10);
+    const bounds = element.getBoundingClientRect();
+    if (!Number.isInteger(rowIndex) || rowIndex < 0
+      || bounds.bottom <= mainBounds.top
+      || bounds.top >= mainBounds.bottom) continue;
+    return {
+      rowIndex,
+      viewportOffset: bounds.top - mainBounds.top,
+    };
+  }
+  return null;
+}
+
+export function restorePackageQueryScrollAnchor(
+  root: ParentNode,
+  anchor: PackageQueryScrollAnchor | null,
+): boolean {
+  if (!anchor) return false;
+  const main = root.querySelector<HTMLElement>(".query-main");
+  const row = [...root.querySelectorAll<HTMLElement>(
+    "[data-query-row-index]")].find(element =>
+      Number(element.dataset.queryRowIndex) === anchor.rowIndex);
+  if (!main || !row) return false;
+  const offset = row.getBoundingClientRect().top
+    - main.getBoundingClientRect().top;
+  main.scrollTop += offset - anchor.viewportOffset;
+  return true;
+}
+
+export function calculatePackageQueryResultWindow(
+  rowCount: number,
+  viewport: PackageQueryViewport | null,
+  state: PackageQueryWindowState,
+  anchor?: PackageQueryScrollAnchor | null,
+): PackageQueryResultWindow {
+  if (rowCount <= PACKAGE_QUERY_MAX_RENDERED_ROWS) {
+    return {
+      start: 0,
+      end: rowCount,
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+    };
+  }
+
+  const strides = Array.from(
+    { length: rowCount },
+    (_, index) =>
+      (state.rowHeights.get(index) ?? state.estimatedRowHeight)
+        + (index < rowCount - 1 ? ROW_GAP_PX : 0));
+  const totalHeight = strides.reduce((sum, height) => sum + height, 0);
+  if (!viewport || viewport.height <= 0) {
+    const end = PACKAGE_QUERY_MAX_RENDERED_ROWS;
+    const renderedHeight = sumRange(strides, 0, end);
+    return {
+      start: 0,
+      end,
+      topSpacerHeight: 0,
+      bottomSpacerHeight: totalHeight - renderedHeight,
+    };
+  }
+
+  const anchoredViewportStart = anchor
+    && anchor.rowIndex >= 0
+    && anchor.rowIndex < rowCount
+    ? Math.max(
+        0,
+        sumRange(strides, 0, anchor.rowIndex) - anchor.viewportOffset)
+    : viewport.start;
+  const targetStart = Math.max(0, anchoredViewportStart - OVERSCAN_PX);
+  const targetEnd = anchoredViewportStart + viewport.height + OVERSCAN_PX;
+  let start = 0;
+  let topSpacerHeight = 0;
+  while (start < rowCount
+    && topSpacerHeight + strides[start]! <= targetStart) {
+    topSpacerHeight += strides[start]!;
+    start++;
+  }
+
+  let end = start;
+  let renderedHeight = 0;
+  while (end < rowCount
+    && end - start < PACKAGE_QUERY_MAX_RENDERED_ROWS
+    && (topSpacerHeight + renderedHeight < targetEnd || end === start)) {
+    renderedHeight += strides[end]!;
+    end++;
+  }
+
+  if (end === rowCount && end - start < PACKAGE_QUERY_MAX_RENDERED_ROWS) {
+    const adjustedStart = Math.max(0, rowCount - PACKAGE_QUERY_MAX_RENDERED_ROWS);
+    if (adjustedStart < start) {
+      start = adjustedStart;
+      topSpacerHeight = sumRange(strides, 0, start);
+      renderedHeight = sumRange(strides, start, end);
+    }
+  }
+
+  return {
+    start,
+    end,
+    topSpacerHeight,
+    bottomSpacerHeight:
+      Math.max(0, totalHeight - topSpacerHeight - renderedHeight),
+  };
+}
+
+function readPackageQueryViewport(
+  root: ParentNode,
+): PackageQueryViewport | null {
+  const main = root.querySelector<HTMLElement>(".query-main");
+  const list = root.querySelector<HTMLElement>(".query-list");
+  if (!main || !list) return null;
+  const mainBounds = main.getBoundingClientRect();
+  const listBounds = list.getBoundingClientRect();
+  return {
+    start: Math.max(0, mainBounds.top - listBounds.top),
+    height: main.clientHeight,
+  };
+}
+
+function sumRange(
+  values: readonly number[],
+  start: number,
+  end: number,
+): number {
+  let sum = 0;
+  for (let index = start; index < end; index++) sum += values[index]!;
+  return sum;
+}

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -3167,13 +3167,19 @@ kbd {
   z-index: 1;
 }
 .query-results { min-width: 0; }
-.query-list { display: grid; gap: 10px; }
+.query-list { display: block; }
+.query-list-spacer {
+  width: 1px;
+  pointer-events: none;
+}
 .query-row {
+  margin-bottom: 10px;
   padding: 16px;
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--panel);
 }
+.query-row:last-child { margin-bottom: 0; }
 .query-row-head,
 .query-row-meta {
   display: flex;

--- a/prototypes/inspect-web/test/package-query-view.test.ts
+++ b/prototypes/inspect-web/test/package-query-view.test.ts
@@ -288,7 +288,7 @@ test("basic metadata rows show producer evidence and unavailable lifetime downlo
     assert.match(html, /Source selection and order from the producer/);
     assert.equal((html.match(/Source selection and order from the producer/g)
       ?? []).length, 1);
-    assert.equal((html.match(/<article class="query-row">/g) ?? []).length, 2);
+    assert.equal((html.match(/<article class="query-row"/g) ?? []).length, 2);
     assert.equal((html.match(/<ul class="query-evidence">/g) ?? []).length, 1);
     if (totalDownloads === null) {
       assert.match(html, /Lifetime downloads unavailable/);
@@ -350,13 +350,13 @@ test("query context renders once while package summaries remain on their cards",
   assert.equal((html.match(/Selected by producer ranking\./g) ?? []).length, 1);
   assert.match(
     html,
-    /<section class="query-context"[\s\S]*Selected by producer ranking\.[\s\S]*<div class="query-list">/);
+    /<section class="query-context"[\s\S]*Selected by producer ranking\.[\s\S]*<div class="query-list"/);
   assert.equal((html.match(/4 dependencies: A, B, C \(\+1 more\)\./g)
     ?? []).length, 1);
   assert.equal((html.match(/2 skill documents:/g) ?? []).length, 1);
   assert.doesNotMatch(
     html,
-    /<article class="query-row">[\s\S]*Selected by producer ranking\./);
+    /<article class="query-row"[\s\S]*Selected by producer ranking\./);
 });
 
 test("Gallery completion text retains the finite bound and estimate with or without rows", () => {
@@ -1095,6 +1095,45 @@ test("query cancel focus restores by rendered position", () => {
   assert.equal(replacement.focusCount, 1);
 });
 
+test("a virtualized focused row moves focus to the retained result surface", () => {
+  const active = new FakeElement({
+    queryRowOpen: "Contoso.Old",
+    queryRowVersion: "1.0.0",
+    queryRowPosition: "4",
+  });
+  const list = new FakeElement({
+    queryWindowStart: "40",
+    queryWindowEnd: "60",
+  });
+  const results = new FakeElement({}, "package-query-results");
+  const root = new FakeRoot(active);
+  root.add("[data-query-row-open]");
+  root.add(".query-list", list);
+  root.add("#package-query-results", results);
+  const documentRoot = fakeDom.document(root);
+
+  const snapshot = capturePackageQueryFocus(documentRoot);
+  const restoration = restorePackageQueryFocus(documentRoot, snapshot);
+
+  assert.equal(restoration, "restored");
+  assert.equal(results.focusCount, 1);
+});
+
+test("the retained result surface keeps focus across later query patches", () => {
+  const active = new FakeElement({}, "package-query-results");
+  const replacement = new FakeElement({}, "package-query-results");
+  const root = new FakeRoot(active);
+  root.add("#package-query-results", replacement);
+  const documentRoot = fakeDom.document(root);
+
+  const snapshot = capturePackageQueryFocus(documentRoot);
+  const restoration = restorePackageQueryFocus(documentRoot, snapshot);
+
+  assert.deepEqual(snapshot, { kind: "results" });
+  assert.equal(restoration, "restored");
+  assert.equal(replacement.focusCount, 1);
+});
+
 test("query scroll position survives streamed full renders", () => {
   const oldMain = new FakeElement();
   oldMain.scrollTop = 480;
@@ -1412,12 +1451,14 @@ test("bindPackageQueryView reports near-end scroll pressure and disconnects it",
   main.scrollHeight = 1800;
   root.add(".query-main", main);
   let pressure = 0;
+  let viewportChanges = 0;
   const binding = bindPackageQueryView(fakeDom.parentNode(root), {
     onBack: () => {},
     onCancel: () => {},
     onFacetToggle: () => {},
     onPrefixInput: () => {},
     onResultPressure: () => { pressure++; },
+    onViewportChange: () => { viewportChanges++; },
     onRowOpen: () => {},
     onRun: () => {},
     onSourceChange: () => {},
@@ -1426,10 +1467,44 @@ test("bindPackageQueryView reports near-end scroll pressure and disconnects it",
   main.scrollTop = 401;
   main.dispatch("scroll");
   assert.equal(pressure, 1);
+  assert.equal(viewportChanges, 1);
 
   binding.disconnect();
   main.dispatch("scroll");
   assert.equal(pressure, 1);
+  assert.equal(viewportChanges, 1);
+});
+
+test("result rendering keeps durable totals outside a bounded DOM window", () => {
+  const state: PackageQueryState = {
+    request: createQueryRequest("Contoso.*"),
+    outcome: appendRows(
+      emptyOutcome(),
+      Array.from({ length: 100 }, (_, index) => row(`Contoso.${index}`))),
+  };
+
+  const html = renderPackageQueryView({
+    state,
+    availableFacets: FACETS,
+    resultWindow: {
+      start: 40,
+      end: 50,
+      topSpacerHeight: 7200,
+      bottomSpacerHeight: 9000,
+    },
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /Contoso\.39</);
+  assert.match(html, /Contoso\.40</);
+  assert.match(html, /Contoso\.49</);
+  assert.doesNotMatch(html, /Contoso\.50</);
+  assert.match(html, /data-query-window-start="40"/);
+  assert.match(html, /data-query-window-end="50"/);
+  assert.match(html, /style="height:7200px"/);
+  assert.match(html, /style="height:9000px"/);
+  assert.match(html, /100 packages/);
+  assert.equal((html.match(/class="query-row"/g) ?? []).length, 10);
 });
 
 test("patchPackageQueryStream updates only dynamic query regions", () => {

--- a/prototypes/inspect-web/test/package-query-window.test.ts
+++ b/prototypes/inspect-web/test/package-query-window.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  calculatePackageQueryResultWindow,
+  createPackageQueryWindowState,
+  packageQueryResultWindowMatches,
+  PACKAGE_QUERY_MAX_RENDERED_ROWS,
+} from "../src/package-query-window.ts";
+import { fakeDom } from "./fake-dom.ts";
+
+test("small retained outcomes render without spacers", () => {
+  const state = createPackageQueryWindowState();
+
+  assert.deepEqual(
+    calculatePackageQueryResultWindow(20, { start: 0, height: 800 }, state),
+    {
+      start: 0,
+      end: 20,
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+    });
+});
+
+test("large outcomes render a measured visible range plus overscan", () => {
+  const state = createPackageQueryWindowState();
+  state.estimatedRowHeight = 100;
+
+  const window = calculatePackageQueryResultWindow(
+    100,
+    { start: 5500, height: 800 },
+    state);
+
+  assert.deepEqual(window, {
+    start: 44,
+    end: 63,
+    topSpacerHeight: 4840,
+    bottomSpacerHeight: 4060,
+  });
+  assert.ok(window.end - window.start <= PACKAGE_QUERY_MAX_RENDERED_ROWS);
+});
+
+test("the final viewport keeps a bounded tail and no bottom spacer", () => {
+  const state = createPackageQueryWindowState();
+  state.estimatedRowHeight = 100;
+
+  const window = calculatePackageQueryResultWindow(
+    100,
+    { start: 10200, height: 800 },
+    state);
+
+  assert.deepEqual(window, {
+    start: 70,
+    end: 100,
+    topSpacerHeight: 7700,
+    bottomSpacerHeight: 0,
+  });
+});
+
+test("a logical row anchor survives changed unseen-row estimates", () => {
+  const state = createPackageQueryWindowState();
+  state.estimatedRowHeight = 230;
+
+  const window = calculatePackageQueryResultWindow(
+    100,
+    { start: 5500, height: 800 },
+    state,
+    { rowIndex: 50, viewportOffset: 200 });
+
+  assert.ok(window.start <= 50);
+  assert.ok(window.end > 50);
+  const anchorTop = 50 * 240;
+  const anchoredViewportStart = anchorTop - 200;
+  assert.equal(
+    window.topSpacerHeight - anchoredViewportStart,
+    (window.start * 240) - anchoredViewportStart);
+  assert.ok(window.end - window.start <= PACKAGE_QUERY_MAX_RENDERED_ROWS);
+});
+
+test("a rendered window matches only the same range and rounded spacers", () => {
+  const list = {
+    dataset: {
+      queryWindowStart: "40",
+      queryWindowEnd: "50",
+      queryWindowTop: "7200",
+      queryWindowBottom: "9000",
+    },
+  };
+  const root = fakeDom.parentNode({
+    querySelector(selector: string) {
+      return selector === ".query-list" ? list : null;
+    },
+  });
+
+  assert.equal(packageQueryResultWindowMatches(root, {
+    start: 40,
+    end: 50,
+    topSpacerHeight: 7200.2,
+    bottomSpacerHeight: 8999.8,
+  }), true);
+  assert.equal(packageQueryResultWindowMatches(root, {
+    start: 41,
+    end: 51,
+    topSpacerHeight: 7380,
+    bottomSpacerHeight: 8820,
+  }), false);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3279,9 +3279,9 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /state\.packageQueryReturnFocusPending = true/);
   assert.match(
     appSource,
-    /function renderPackageQueryPage\(\) \{\s*cancelPackageQueryStreamRender\(\);\s*const focus = capturePackageQueryFocus\(document\);\s*const scrollTop = capturePackageQueryScroll\(document\);[\s\S]*app\.innerHTML = renderPackageQueryView\([\s\S]*bindPackageQueryView\(document, packageQueryActions\);\s*const focusRestoration = restorePackageQueryFocus\(document, focus\);\s*if \(focusRestoration !== "fallback"\) \{\s*restorePackageQueryScroll\(document, scrollTop\)/);
+    /function renderPackageQueryPage\(\) \{\s*cancelPackageQueryStreamRender\(\);\s*const focus = capturePackageQueryFocus\(document\);\s*const scrollTop = capturePackageQueryScroll\(document\);[\s\S]*app\.innerHTML = renderPackageQueryView\([\s\S]*packageQueryViewBinding = bindPackageQueryView\(\s*document,\s*packageQueryActions\);\s*const focusRestoration = restorePackageQueryFocus\(document, focus\);\s*if \(focusRestoration !== "fallback"\) \{\s*restorePackageQueryScroll\(document, scrollTop\)/);
   const streamPatch =
-    appSource.match(/function patchPackageQueryPage\(\) \{[\s\S]*?\n}\n/)?.[0]
+    appSource.match(/function patchPackageQueryPage\([^)]*\) \{[\s\S]*?\n}\n/)?.[0]
     ?? "";
   assert.match(
     streamPatch,
@@ -3289,7 +3289,10 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
   assert.doesNotMatch(streamPatch, /app\.innerHTML/);
   assert.match(
     appSource,
-    /function schedulePackageQueryStreamRender\(\) \{\s*if \(packageQueryStreamRenderFrame !== null\) return;\s*packageQueryStreamRenderFrame = requestAnimationFrame\(/);
+    /function schedulePackageQueryStreamRender\([\s\S]*source: "stream" \| "viewport"[\s\S]*packageQueryStreamRenderRequired = true;[\s\S]*requestAnimationFrame\([\s\S]*patchPackageQueryPage\(requirePatch\)/);
+  assert.match(
+    streamPatch,
+    /packageQueryResultWindowMatches\(document, resultWindow\)/);
   const popstate =
     appSource.match(/window\.addEventListener\("popstate",[\s\S]*?\n}\);/)?.[0]
     ?? "";


### PR DESCRIPTION
dotnet-inspect builds robust, capable inspection features that are conventionally sound, delightfully useful, or both. This change keeps streaming Package Query responsive as durable results grow.

## Demo

Run a Package Query that retains 100 durable package matches, then scroll from the initial rows to the tail:

```text
Durable query state:          100 package rows
Rendered package cards:       at most 30
Scrolling:                    measured window + 600px overscan
Full scroll extent:           inert top and bottom spacers
Footer:                       100 packages
Focused row leaves window:    focus moves to the results surface
Next required stream patch:   results-surface focus remains stable
Progress/failure grows above: first visible row keeps its viewport offset
```

The Firefox scenario also changes card heights during a real `ResizeObserver`
notification and confirms that measurements refresh, the observer disconnects,
and frame-coalesced patching settles.

## Summary

- retain every durable `QueryOutcome` row while rendering a maximum of 30 cards
- calculate a measured row window with 600 CSS pixels of overscan and inert
  spacers for omitted rows
- preserve a logical first-visible-row anchor across measurement correction and
  changing progress or failure content above the list
- preserve semantic focus when rows are virtualized and across later patches
- share one animation-frame slot for stream and viewport work while suppressing
  unchanged viewport-only patches
- invalidate and remeasure row geometry through the Package Query view
  binding's `ResizeObserver`

Worker placement remains separate follow-up work under #5816.

## Validation

- `npm test -- --test-reporter=spec`
- `npm run analyze`
- `npm run build`
- `npx playwright test browser/workspace-titlebar.spec.ts --project=firefox`
- `npx markdownlint-cli docs/design/package-query-experience.md`

Contributes to #5816.
