### PR TITLE
Clarify ReadyToRun format version labels

### DIFF
--- a/docs/design/readytorun-browser-projection.md
+++ b/docs/design/readytorun-browser-projection.md
@@ -63,10 +63,10 @@ root overview carries:
   and
 - the containing image's PE and CLI header facts.
 
-The ReadyToRun response carries role, advertisements, exact version, raw and
-named flags, header locations, manifest relationship, and every section entry
-with its numeric identity. TypeScript renders those fields but does not
-reclassify the image or discover the manifest section.
+The ReadyToRun response carries role, advertisements, exact ReadyToRun format
+version, raw and named flags, header locations, manifest relationship, and every
+section entry with its numeric identity. TypeScript renders those fields but
+does not reclassify the image or discover the manifest section.
 
 The facade may perform the CLI-root, manifest-root, and ReadyToRun queries
 independently against the same immutable, admitted workspace participant. This

--- a/docs/design/readytorun-cli-projection.md
+++ b/docs/design/readytorun-cli-projection.md
@@ -43,8 +43,8 @@ default suppression.
 members are:
 
 - `ReadyToRun: Image`, a fixed one-row summary containing role, discovery
-  evidence, exact version, raw-preserving flags, header location and size, and
-  manifest relationship; and
+  evidence, exact ReadyToRun format version, raw-preserving flags, header
+  location and size, and manifest relationship; and
 - `ReadyToRun: Sections`, one row per validated section-directory entry,
   including numeric type identity, RVA, size, and CLI-metadata aliasing.
 

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -730,9 +730,10 @@ function renderReadyToRun(
   return `<section class="meta-r2r">
     <div class="meta-r2r-title">
       <h3>ReadyToRun</h3>
-      <span>${escapeHtml(readyToRun.role)} · v${readyToRun.majorVersion}.${readyToRun.minorVersion}</span>
+      <span>${escapeHtml(readyToRun.role)}</span>
     </div>
     <div class="meta-r2r-facts">
+      <span><strong>R2R format version</strong>${readyToRun.majorVersion}.${readyToRun.minorVersion}</span>
       <span><strong>Advertisements</strong>${escapeHtml(readyToRun.advertisements)}</span>
       <span><strong>Flags</strong>0x${(readyToRun.flagsValue >>> 0).toString(16).padStart(8, "0")} (${escapeHtml(readyToRun.flags)})</span>
       <span><strong>Header</strong>RVA 0x${(readyToRun.headerRelativeVirtualAddress >>> 0).toString(16)} · ${fmtBytes(readyToRun.headerSize)}</span>

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -684,7 +684,8 @@ test("an assembly block reports an available managed ReadyToRun header", () => {
 
   assert.match(
     readyToRun,
-    /ReadyToRun[\s\S]*Component · v9\.1[\s\S]*PlatformNeutralSource[\s\S]*ManifestMetadata[\s\S]*RVA 0x5678/);
+    /ReadyToRun[\s\S]*Component[\s\S]*R2R format version<\/strong>9\.1[\s\S]*PlatformNeutralSource[\s\S]*ManifestMetadata[\s\S]*RVA 0x5678/);
+  assert.doesNotMatch(readyToRun, /Component · v9\.1/);
   assert.match(ilOnly, /ReadyToRun[\s\S]*No/);
 });
 

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -125,6 +125,8 @@ public partial class CommandExecutionTests
             output,
             StringComparison.Ordinal);
         Assert.Contains("| Role |", output, StringComparison.Ordinal);
+        Assert.Contains("| R2R Format Version |", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("| Version |", output, StringComparison.Ordinal);
         Assert.Contains("ManagedNativeHeader", output, StringComparison.Ordinal);
         Assert.Contains("separate at 0x", output, StringComparison.Ordinal);
     }

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -2020,7 +2020,10 @@ public sealed record ReadyToRunImageRow
 {
     public required string Role { get => field; init => field = LibraryViewText.Contain(value); }
     public required string Advertisements { get => field; init => field = LibraryViewText.Contain(value); }
+
+    [MarkoutPropertyName("R2R Format Version")]
     public required string Version { get => field; init => field = LibraryViewText.Contain(value); }
+
     public required string Flags { get => field; init => field = LibraryViewText.Contain(value); }
 
     [MarkoutPropertyName("Header RVA")]


### PR DESCRIPTION
dotnet-inspect builds robust, capable inspection features that provide
foundational capabilities and compelling experiences while remaining
conventionally sound and, where useful, delightfully unique.

The ReadyToRun header's major/minor pair is now labeled explicitly as its
binary-format version in both the CLI and Inspect Web. The typed
`majorVersion`/`minorVersion` transport and all parsing behavior remain
unchanged.

## Demo

Before, the CLI rendered an ambiguous column:

```text
| Role | Advertisements | Version | ... |
| Standalone | ManagedNativeHeader | 26.1 | ... |
```

After:

```console
$ dotnet-inspect library System.Private.CoreLib -S "ReadyToRun: Image"

| Role | Advertisements | R2R Format Version | Flags | ... |
| Standalone | ManagedNativeHeader | 26.1 | ... |
```

Inspect Web likewise moves `v26.1` out of the role subtitle and presents the
fact as `R2R format version 26.1`.

Neighboring non-ReadyToRun product assemblies remain inapplicable:

```console
$ dotnet-inspect library ILInspector.Metadata.dll -S "ReadyToRun: Image"
This section (ReadyToRun: Image) produced no output.
```

## Validation

- Release solution build
- focused CLI ReadyToRun image test
- complete Metadata Viewer unit suite: 44 passed
- Inspect Web typecheck and production build
- Markdown lint for both ReadyToRun projection owners
- `git diff --check`

Closes #6369