### PR TITLE
Preserve selected resolver context in match body comparison

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1564,6 +1564,44 @@ for that work bound. Existing physical-candidate forwarder-cycle detection
 and hop budgets remain unchanged. This effort does not widen support for
 revisiting a candidate through a different context on one forwarding path.
 
+##### CLI match body continuation
+
+Issue #6391 applies this contract to the CLI `match --body` handoff. API selection
+retains the terminal occurrence and its issuing policy with each selected type.
+The body query starts from that occurrence; it does not construct another
+resolver from the terminal assembly path.
+
+The query workspace remains sealed. Before creating it, the CLI walks the
+selected occurrence's assembly references through the retained policy and
+continuations, bounded by Metadata's existing candidate limit. The resulting
+participants are the exact selected descriptors and shadows returned by that
+policy. Directly selected platform participants are included but not
+recursively expanded; the platform resolver remains their closure owner.
+Missing, ambiguous, unavailable, or rejected references add no participant,
+and the query does not synthesize a fallback candidate for them.
+
+The occurrence-rooted participant adapter is a transforming policy. It owns a
+distinct outer version, translates the selected initial occurrence to the
+delegate, retains delegated continuations inside its own lineage, and rejects a
+different seed origin. The sealed group composes one such route for every
+selected occurrence under one routing-only source-relative policy version;
+shadow-only participants have no invented continuation. The existing Research
+publication guard validates the resulting policy version before body evidence
+escapes.
+
+The pathological gate uses a facade-forwarded implementation whose body calls
+a dependency selected by project policy. An unselected same-name dependency
+beside the implementation advertises an incompatible delegate shape. Re-seeding
+from the implementation path produces partial reconstructed C# through the
+decoy or an unavailable dependency; continuing the selected occurrence produces
+the same full-fidelity body with and without that neighbor.
+
+This adoption does not change `match --similar`, broaden navigation or
+reference-tree discovery, define a Browser transport, retire
+`IAssemblyReferenceResolver`, or change candidate-domain finalization. The
+existing resolver-lineage model covers the retained occurrence and
+reconstruction negative control; no new state transition is introduced.
+
 ##### Both production hosts and retirement
 
 The counted adoption path in #5274 has **four steps**, including this design.
@@ -1619,6 +1657,10 @@ delegate-version refresh, and the compiled two-context case.
 `AssemblySetResolutionSessionTests` retain the original forwarded-constraint
 oracle; CLI `CommandLine_ForwardedConstraint_ReportsDependencyCompleteness`
 exercises the real command and its missing-dependency neighbor.
+CLI `ExecuteAsync_ForwardedBodies_RetainSelectedProjectContext` exercises the
+Issue #6391's facade, selected dependency, and same-name neighbor through production
+`match --body`; `AssemblyContextParticipantTests` enforce seed translation,
+continuation translation, distinct outer versions, and foreign-seed rejection.
 Existing `MemberCallGraphSessionTests` provide query-level regression coverage,
 not Browser endpoint adoption. Browser's Release `BrowserEngineBoundaryTests`
 provide that endpoint evidence:

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -32,6 +32,10 @@
     <Project Path="fixtures/cli/DotnetInspector.CallerBinding.Facade/DotnetInspector.CallerBinding.Facade.csproj" />
     <Project Path="fixtures/cli/DotnetInspector.HostileNameFixtures/DotnetInspector.HostileNameFixtures.csproj" />
     <Project Path="fixtures/cli/DotnetInspector.InstallScriptFixture/DotnetInspector.InstallScriptFixture.csproj" />
+    <Project Path="fixtures/cli/DotnetInspector.MatchBinding.Decoy/DotnetInspector.MatchBinding.Decoy.csproj" />
+    <Project Path="fixtures/cli/DotnetInspector.MatchBinding.Dependency/DotnetInspector.MatchBinding.Dependency.csproj" />
+    <Project Path="fixtures/cli/DotnetInspector.MatchBinding.Facade/DotnetInspector.MatchBinding.Facade.csproj" />
+    <Project Path="fixtures/cli/DotnetInspector.MatchBinding.Implementation/DotnetInspector.MatchBinding.Implementation.csproj" />
     <Project Path="fixtures/decompiler/ILInspector.Decompiler.Fixtures.AuthoredRebuild/ILInspector.Decompiler.Fixtures.AuthoredRebuild.csproj" />
     <Project Path="fixtures/decompiler/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj" />
     <Project Path="fixtures/decompiler/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" />

--- a/fixtures/cli/DotnetInspector.MatchBinding.Decoy/DotnetInspector.MatchBinding.Decoy.csproj
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Decoy/DotnetInspector.MatchBinding.Decoy.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DotnetInspector.MatchBinding.Dependency</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/fixtures/cli/DotnetInspector.MatchBinding.Decoy/Payload.cs
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Decoy/Payload.cs
@@ -1,0 +1,10 @@
+namespace DotnetInspector.MatchBinding;
+
+public sealed class Payload
+{
+    public Payload(object? target, nint method)
+    {
+    }
+
+    public int Invoke(int value) => value;
+}

--- a/fixtures/cli/DotnetInspector.MatchBinding.Dependency/DotnetInspector.MatchBinding.Dependency.csproj
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Dependency/DotnetInspector.MatchBinding.Dependency.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/fixtures/cli/DotnetInspector.MatchBinding.Dependency/Payload.cs
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Dependency/Payload.cs
@@ -1,0 +1,3 @@
+namespace DotnetInspector.MatchBinding;
+
+public delegate int Payload(int value);

--- a/fixtures/cli/DotnetInspector.MatchBinding.Facade/DotnetInspector.MatchBinding.Facade.csproj
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Facade/DotnetInspector.MatchBinding.Facade.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../DotnetInspector.MatchBinding.Implementation/DotnetInspector.MatchBinding.Implementation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/fixtures/cli/DotnetInspector.MatchBinding.Facade/Forwarder.cs
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Facade/Forwarder.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+using DotnetInspector.MatchBinding;
+
+[assembly: TypeForwardedTo(typeof(ComparisonApi))]

--- a/fixtures/cli/DotnetInspector.MatchBinding.Implementation/ComparisonApi.cs
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Implementation/ComparisonApi.cs
@@ -1,0 +1,14 @@
+namespace DotnetInspector.MatchBinding;
+
+public static class ComparisonApi
+{
+    public static int InvokePayload(int value)
+    {
+        Payload payload = Identity;
+        return payload(value);
+    }
+
+    public static int ReturnZero(int value) => 0;
+
+    static int Identity(int value) => value;
+}

--- a/fixtures/cli/DotnetInspector.MatchBinding.Implementation/DotnetInspector.MatchBinding.Implementation.csproj
+++ b/fixtures/cli/DotnetInspector.MatchBinding.Implementation/DotnetInspector.MatchBinding.Implementation.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../DotnetInspector.MatchBinding.Dependency/DotnetInspector.MatchBinding.Dependency.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -23,8 +23,74 @@ public sealed class AssemblyContextParticipant
         BindingPolicy = bindingPolicy;
     }
 
+    /// <summary>
+    /// Creates a participant whose initial binding request continues from a
+    /// policy-issued occurrence rather than reconstructing a seed from its
+    /// assembly descriptor.
+    /// </summary>
+    public AssemblyContextParticipant(
+        AssemblyBindingOccurrence occurrence,
+        IAssemblyBindingPolicy bindingPolicy)
+        : this(
+            (occurrence
+                ?? throw new ArgumentNullException(nameof(occurrence)))
+                .Assembly,
+            new OccurrenceRootedBindingPolicy(
+                occurrence,
+                bindingPolicy
+                    ?? throw new ArgumentNullException(
+                        nameof(bindingPolicy))))
+    {
+    }
+
     public ResolvedAssemblyReference Assembly { get; }
     public IAssemblyBindingPolicy BindingPolicy { get; }
+
+    sealed class OccurrenceRootedBindingPolicy(
+        AssemblyBindingOccurrence root,
+        IAssemblyBindingPolicy inner)
+        : AssemblyBindingPolicyFacade(inner)
+    {
+        public override AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            if (request.Origin
+                    is AssemblyBindingOrigin.RequestingAssembly requesting
+                && (requesting.Lineage is null
+                    || requesting.Lineage == AssemblyBindingLineage.Seed)
+                && !ReferenceEquals(
+                    requesting.Registration,
+                    root.Assembly.Registration))
+            {
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    AssemblyBindingSelection.Invalid(
+                        new AssemblyBindingFailure(
+                            AssemblyBindingFailureKind
+                                .InvalidBindingOrigin)));
+            }
+
+            return base.Select(request);
+        }
+
+        protected override AssemblyBindingRequest SeedRequest(
+            AssemblyBindingRequest request) =>
+            request.Origin
+                    is AssemblyBindingOrigin.RequestingAssembly
+                        requesting
+                && ReferenceEquals(
+                    requesting.Registration,
+                    root.Assembly.Registration)
+                ? new AssemblyBindingRequest(
+                    request.Target,
+                    AssemblyBindingOrigin.FromOccurrence(root),
+                    request.Scope)
+                : request;
+
+        protected override AssemblyBindingSelection TransformSelection(
+            AssemblyBindingSelection selection) => selection;
+    }
 }
 
 /// <summary>Resource limits for one binding-consistent assembly context group.</summary>

--- a/src/dotnet-inspect.Tests/MatchCommandTests.cs
+++ b/src/dotnet-inspect.Tests/MatchCommandTests.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Text.Json;
 using DotnetInspector.CommandLine;
 using DotnetInspector.Commands;
+using DotnetInspector.Fixtures;
 using DotnetInspector.Options;
 
 namespace DotnetInspector.Tests;
@@ -352,6 +353,51 @@ public sealed class MatchCommandTests
             producer => Assert.Equal("Exact", producer.GetProperty("native_verdict").GetString()));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteAsync_ForwardedBodies_RetainSelectedProjectContext(
+        bool includeUnselectedNeighbor)
+    {
+        using var project = new MatchBindingProjectFixture(
+            includeUnselectedNeighbor);
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(
+            () => MatchCommand.ExecuteAsync(new MatchOptions
+            {
+                LeftSelector =
+                    "DotnetInspector.MatchBinding.ComparisonApi.InvokePayload",
+                RightSelector =
+                    "DotnetInspector.MatchBinding.ComparisonApi.ReturnZero",
+                AssemblyPath = project.FacadePath,
+                ProjectAssetsPath = project.AssetsPath,
+                Tfm = "net11.0",
+                IncludeAll = true,
+                IncludeBody = true,
+                JsonOutput = true,
+            }));
+
+        Assert.True(exitCode == 0, $"Exit {exitCode}: {error}\n{output}");
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        JsonElement body = document.RootElement.GetProperty("body");
+        Assert.False(body.GetProperty("has_failures").GetBoolean());
+        JsonElement csharp = Assert.Single(
+            body.GetProperty("producers").EnumerateArray(),
+            producer => producer.GetProperty("producer").GetString()
+                == "CSharp");
+        JsonElement removed = Assert.Single(
+            csharp.GetProperty("c_sharp")
+                .GetProperty("rows")
+                .EnumerateArray(),
+            row => row.GetProperty("kind").GetString() == "Remove");
+        Assert.Equal(
+            "return new Payload(ComparisonApi.Identity).Invoke(value);",
+            removed.GetProperty("text").GetString());
+        Assert.Equal(
+            "Full",
+            removed.GetProperty("fidelity").GetString());
+    }
+
     [Fact]
     public async Task ExecuteAsync_RawPrivateMethodToken_PreservesTheSelectedBody()
     {
@@ -552,4 +598,88 @@ public abstract class MatchSampleWithoutBody
 public static class MatchPrivateBodySample
 {
     private static int HiddenBody(int x) => x + 1;
+}
+
+sealed class MatchBindingProjectFixture : IDisposable
+{
+    readonly string _root = Directory.CreateTempSubdirectory(
+        "dotnet-inspect-match-binding-").FullName;
+    readonly string? _originalPackages;
+
+    internal MatchBindingProjectFixture(bool includeUnselectedNeighbor)
+    {
+        string packages = Path.Combine(_root, "packages");
+        FixtureDefinition[] fixtures =
+        [
+            FixtureCatalog.MatchBindingFacade,
+            FixtureCatalog.MatchBindingImplementation,
+            FixtureCatalog.MatchBindingDependency,
+        ];
+        string[] names = ["Facade", "Implementation", "Dependency"];
+        var targets = new Dictionary<string, object>();
+        var libraries = new Dictionary<string, object>();
+        for (int index = 0; index < fixtures.Length; index++)
+        {
+            FixtureDefinition fixture = fixtures[index];
+            string package = names[index];
+            string packagePath = $"{package.ToLowerInvariant()}/1.0.0";
+            string asset = $"lib/net11.0/{fixture.AssemblyFileName}";
+            string destination = Path.Combine(packages, packagePath, asset);
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            File.Copy(fixture.AssemblyPath(), destination);
+            var assets = new Dictionary<string, object>
+            {
+                [asset] = new { },
+            };
+            targets.Add(
+                $"{package}/1.0.0",
+                new { type = "package", compile = assets, runtime = assets });
+            libraries.Add(
+                $"{package}/1.0.0",
+                new { type = "package", path = packagePath });
+
+            if (package == "Facade")
+                FacadePath = destination;
+        }
+
+        if (includeUnselectedNeighbor)
+        {
+            File.Copy(
+                FixtureCatalog.MatchBindingDecoy.AssemblyPath(),
+                Path.Combine(
+                    packages,
+                    "implementation",
+                    "1.0.0",
+                    "lib",
+                    "net11.0",
+                    FixtureCatalog.MatchBindingDecoy.AssemblyFileName));
+        }
+
+        AssetsPath = Path.Combine(_root, "project.assets.json");
+        File.WriteAllText(
+            AssetsPath,
+            JsonSerializer.Serialize(new
+            {
+                version = 3,
+                targets = new Dictionary<string, object>
+                {
+                    ["net11.0"] = targets,
+                },
+                libraries,
+            }));
+        _originalPackages = Environment.GetEnvironmentVariable(
+            "NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", packages);
+    }
+
+    internal string AssetsPath { get; }
+    internal string FacadePath { get; } = null!;
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(
+            "NUGET_PACKAGES",
+            _originalPackages);
+        Directory.Delete(_root, recursive: true);
+    }
 }

--- a/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
@@ -1621,6 +1621,15 @@ public class SourceForwarderResolutionTests
             Assert.Equal("Target", supplier.Identity.Name);
             if (sourceKind == SourceKind.Library)
                 Assert.IsType<AssemblyResolutionProvenance.LocalAsset>(supplier.Provenance);
+            SelectedTypeBindingContext? bindingContext =
+                loaded.TryGetBindingContext(type);
+            Assert.Equal(summaryOnly, bindingContext is null);
+            if (bindingContext is not null)
+            {
+                Assert.Same(
+                    supplier.Registration,
+                    bindingContext.Occurrence.Assembly.Registration);
+            }
         }
         finally
         {

--- a/src/dotnet-inspect/Commands/MatchCommand.cs
+++ b/src/dotnet-inspect/Commands/MatchCommand.cs
@@ -102,14 +102,24 @@ public static class MatchCommand
                 return 1;
             }
 
-            var left = ResolveSelector(loaded.Api, loaded.ApiDllPath, options.LeftSelector);
+            var left = AttachBindingContext(
+                ResolveSelector(
+                    loaded.Api,
+                    loaded.ApiDllPath,
+                    options.LeftSelector),
+                loaded);
             if (left.Error is not null)
             {
                 CommandError.Write(left.Error);
                 return 1;
             }
 
-            var right = ResolveSelector(loaded.Api, loaded.ApiDllPath, options.RightSelector);
+            var right = AttachBindingContext(
+                ResolveSelector(
+                    loaded.Api,
+                    loaded.ApiDllPath,
+                    options.RightSelector),
+                loaded);
             if (right.Error is not null)
             {
                 CommandError.Write(right.Error);
@@ -127,6 +137,19 @@ public static class MatchCommand
                     $"'{options.LeftSelector}' and '{options.RightSelector}' resolve to different assemblies "
                         + $"({DistinguishingImageNames(left.OriginAssemblyPath, right.OriginAssemblyPath)}); "
                         + "match compares two methods within one retained assembly.");
+                return 1;
+            }
+
+            if (options.IncludeBody
+                && left.BindingContext is { } leftContext
+                && right.BindingContext is { } rightContext
+                && leftContext != rightContext)
+            {
+                CommandError.Write(
+                    $"'{options.LeftSelector}' and "
+                        + $"'{options.RightSelector}' resolve through "
+                        + "different binding contexts; match --body "
+                        + "requires one retained context.");
                 return 1;
             }
 
@@ -220,7 +243,18 @@ public static class MatchCommand
         string? Display,
         string? OriginAssemblyPath,
         string? Error,
-        ApiType? DeclaringType = null);
+        ApiType? DeclaringType = null,
+        SelectedTypeBindingContext? BindingContext = null);
+
+    static ResolvedSelector AttachBindingContext(
+        ResolvedSelector selector,
+        ApiServices.LoadedApiSurface loaded) =>
+        selector with
+        {
+            BindingContext = selector.DeclaringType is { } type
+                ? loaded.TryGetBindingContext(type)
+                : loaded.RootBindingContext,
+        };
 
     /// <summary>
     /// Canonicalizes an image path so two spellings of one file compare equal. A selector's origin
@@ -556,24 +590,86 @@ public static class MatchCommand
         MatchOptions options,
         CancellationToken cancellationToken)
     {
-        string image = left.OriginAssemblyPath!;
-        ResolvedAssemblyReference assembly =
-            (left.DeclaringType is { } type ? loaded.TryGetSourceAssembly(type) : null)
-            ?? ResolvedAssemblyReference.CreateFromPath(
-                image, AssemblyResolutionProvenance.Local("match --body"));
-        var policy = new AssemblyDependencyResolver(
-            new AssemblyDependencyResolutionOptions(image)
+        AssemblyContextParticipant participant;
+        IReadOnlyList<AssemblyContextParticipant> participants;
+        if (left.BindingContext is { } bindingContext)
+        {
+            IReadOnlyList<
+                SelectedTypeBindingContext.SelectedBindingParticipant>
+                selectedParticipants;
+            try
             {
-                ProjectAssetsPath = options.ProjectAssetsPath,
-                RootPackageDirectory = source.PackageExtractPath,
-                TargetFramework = options.Tfm ?? source.SelectedTfm,
-                PackageSourceOptions = options.SourceOptions,
-                UsePackageSourcePolicy = source.PackageExtractPath is not null,
-            });
+                selectedParticipants =
+                    bindingContext.DiscoverParticipants(
+                        cancellationToken);
+            }
+            catch (OperationCanceledException exception)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                return MethodBodyDiffFormatter.QueryFailure(
+                    left.Display!,
+                    right.Display!,
+                    "Cancelled",
+                    side: null,
+                    exception.Message);
+            }
+
+            AssemblyContextParticipant[] occurrenceParticipants =
+            [
+                .. selectedParticipants.Select(candidate =>
+                        candidate.Occurrence is { } occurrence
+                            ? new AssemblyContextParticipant(
+                                occurrence,
+                                bindingContext.Policy)
+                            : new AssemblyContextParticipant(
+                                candidate.Assembly,
+                                NoResolverAssemblyBindingPolicy.Instance)),
+            ];
+            var groupPolicy =
+                SourceRelativeAssemblyGroupBindingPolicy.CreateRoutingOnly(
+                    occurrenceParticipants.Select(candidate => (
+                        candidate.Assembly,
+                        candidate.BindingPolicy)));
+            participants =
+            [
+                .. occurrenceParticipants.Select(candidate =>
+                    new AssemblyContextParticipant(
+                        candidate.Assembly,
+                        groupPolicy)),
+            ];
+            participant = participants.Single(candidate =>
+                ReferenceEquals(
+                    candidate.Assembly.Registration,
+                    bindingContext.Occurrence.Assembly.Registration));
+        }
+        else
+        {
+            string image = left.OriginAssemblyPath!;
+            ResolvedAssemblyReference assembly =
+                (left.DeclaringType is { } type
+                    ? loaded.TryGetSourceAssembly(type)
+                    : null)
+                ?? ResolvedAssemblyReference.CreateFromPath(
+                    image,
+                    AssemblyResolutionProvenance.Local("match --body"));
+            var policy = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(image)
+                {
+                    ProjectAssetsPath = options.ProjectAssetsPath,
+                    RootPackageDirectory = source.PackageExtractPath,
+                    TargetFramework = options.Tfm ?? source.SelectedTfm,
+                    PackageSourceOptions = options.SourceOptions,
+                    UsePackageSourcePolicy =
+                        source.PackageExtractPath is not null,
+                });
+            participant = new AssemblyContextParticipant(
+                assembly,
+                policy);
+            participants = [participant];
+        }
         using var workspace = new InspectionWorkspace();
-        var participant = new AssemblyContextParticipant(assembly, policy);
         using AssemblyContextGroup group =
-            workspace.CreateAssemblyContextGroup([participant]);
+            workspace.CreateAssemblyContextGroup(participants);
 
         // The structural result retains the physical module identity and tokens selected above.
         // Carry those addresses, not names or a new token lookup, into the borrowed context.

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -23,7 +23,11 @@ internal static class ApiServices
         IReadOnlyDictionary<
             ApiType,
             ResolvedAssemblyReference> SourceAssemblies,
-        bool IsSummary = false)
+        bool IsSummary = false,
+        SelectedTypeBindingContext? RootBindingContext = null,
+        IReadOnlyDictionary<
+            ApiType,
+            SelectedTypeBindingContext>? BindingContexts = null)
     {
         internal string GetLibraryAssetPath(string? packageExtractPath) =>
             packageExtractPath is null
@@ -51,6 +55,16 @@ internal static class ApiServices
                 out var assembly)
                 ? assembly
                 : null;
+        }
+
+        internal SelectedTypeBindingContext? TryGetBindingContext(
+            ApiType type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+            return BindingContexts is not null
+                && BindingContexts.TryGetValue(type, out var context)
+                    ? context
+                    : null;
         }
     }
 
@@ -151,10 +165,23 @@ internal static class ApiServices
         var sourceAssemblies =
             new Dictionary<ApiType, ResolvedAssemblyReference>(
                 ReferenceEqualityComparer.Instance);
+        Dictionary<ApiType, SelectedTypeBindingContext>?
+            bindingContexts = resolution is null
+                ? null
+                : new(ReferenceEqualityComparer.Instance);
+        SelectedTypeBindingContext? rootBindingContext =
+            resolution is not null && rootAssembly is not null
+                ? resolution.BindingContext(
+                    AssemblyBindingOccurrence.Seed(rootAssembly))
+                : null;
         if (rootAssembly is not null)
         {
             foreach (ApiType type in api.Types)
+            {
                 sourceAssemblies.Add(type, rootAssembly);
+                if (rootBindingContext is not null)
+                    bindingContexts!.Add(type, rootBindingContext);
+            }
         }
 
         if (resolution is not null)
@@ -166,7 +193,8 @@ internal static class ApiServices
                 options.IncludeAll,
                 isPlatformAssembly,
                 resolution: resolution,
-                sourceAssemblies);
+                sourceAssemblies,
+                bindingContexts);
         }
 
         if (!string.IsNullOrEmpty(packagePath))
@@ -188,7 +216,9 @@ internal static class ApiServices
             api,
             apiDllPath,
             runtimeAssemblyPath ?? apiDllPath,
-            sourceAssemblies);
+            sourceAssemblies,
+            RootBindingContext: rootBindingContext,
+            BindingContexts: bindingContexts);
     }
 
     static ResolvedAssemblyReference? SelectRootAssembly(
@@ -525,13 +555,19 @@ internal static class ApiServices
         bool isPlatformAssembly,
         TypeDefinitionResolutionSession resolution,
         IDictionary<ApiType, ResolvedAssemblyReference>?
-            sourceAssemblies = null)
+            sourceAssemblies = null,
+        IDictionary<ApiType, SelectedTypeBindingContext>?
+            bindingContexts = null)
     {
         Dictionary<
             AssemblyAcquisitionRegistration,
             (ResolvedAssemblyReference Assembly,
                 HashSet<MetadataTypeDefinitionName> Types,
-                HashSet<int> TypeTokens)> byAssembly = [];
+                HashSet<int> TypeTokens,
+                Dictionary<
+                    MetadataTypeDefinitionName,
+                    SelectedTypeBindingContext> BindingContexts)>
+            byAssembly = [];
 
         foreach (TypeForwarder forwarder in api.TypeForwarders)
         {
@@ -563,12 +599,15 @@ internal static class ApiServices
                     assembly.Registration,
                     out var group))
             {
-                group = (assembly, [], []);
+                group = (assembly, [], [], []);
                 byAssembly.Add(assembly.Registration, group);
             }
             group.Types.Add(resolved.Definition.Type);
             group.TypeTokens.Add(
                 resolved.Definition.Address.Definition.Value);
+            group.BindingContexts[resolved.Definition.Type] =
+                resolution.BindingContext(
+                    resolved.Definition.Occurrence);
         }
 
         logger.Log(
@@ -604,7 +643,9 @@ internal static class ApiServices
                     group.Types,
                     group.Assembly,
                     group.TypeTokens,
-                    sourceAssemblies);
+                    sourceAssemblies,
+                    bindingContexts,
+                    group.BindingContexts);
             }
             catch (Exception ex) when (
                 ex is IOException
@@ -665,7 +706,13 @@ internal static class ApiServices
         ResolvedAssemblyReference targetAssembly,
         IReadOnlyCollection<int>? forwardedTypeTokens = null,
         IDictionary<ApiType, ResolvedAssemblyReference>?
-            sourceAssemblies = null)
+            sourceAssemblies = null,
+        IDictionary<ApiType, SelectedTypeBindingContext>?
+            bindingContexts = null,
+        IReadOnlyDictionary<
+            MetadataTypeDefinitionName,
+            SelectedTypeBindingContext>?
+            forwardedBindingContexts = null)
     {
         List<ApiType> copiedTypes =
         [
@@ -722,6 +769,15 @@ internal static class ApiServices
             type.IsForwarded = true;
             type.SourceAssemblyPath = targetAssembly.Path;
             sourceAssemblies?.Add(type, targetAssembly);
+            if (bindingContexts is not null
+                && type.DefinitionName is { } definitionName
+                && forwardedBindingContexts is not null
+                && forwardedBindingContexts.TryGetValue(
+                    definitionName,
+                    out SelectedTypeBindingContext? context))
+            {
+                bindingContexts.Add(type, context);
+            }
             api.Types.Add(type);
             api.PublicMethodCount +=
                 type.Members.Count(

--- a/src/dotnet-inspect/Inspectors/TypeDefinitionResolutionSession.cs
+++ b/src/dotnet-inspect/Inspectors/TypeDefinitionResolutionSession.cs
@@ -1,3 +1,5 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using DotnetInspector.Options;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
@@ -8,6 +10,136 @@ namespace DotnetInspector.Inspectors;
 internal sealed record TypeDefinitionApiSurfaceFailure(
     string Kind,
     string Detail);
+
+internal sealed record SelectedTypeBindingContext(
+    AssemblyBindingOccurrence Occurrence,
+    IAssemblyBindingPolicy Policy)
+{
+    internal sealed record SelectedBindingParticipant(
+        ResolvedAssemblyReference Assembly,
+        AssemblyBindingOccurrence? Occurrence);
+
+    internal IReadOnlyList<SelectedBindingParticipant>
+        DiscoverParticipants(
+            CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        AssemblyBindingPolicyVersion version = Policy.Version;
+        int maxCandidates =
+            new TypeResolutionContextOptions().MaxCandidates;
+        var participants = new Dictionary<
+            AssemblyAcquisitionRegistration,
+            SelectedBindingParticipant>(
+                ReferenceEqualityComparer.Instance);
+        var expanded = new HashSet<AssemblyBindingOccurrence>();
+        var pending = new Queue<AssemblyBindingOccurrence>();
+        pending.Enqueue(Occurrence);
+
+        while (pending.TryDequeue(out AssemblyBindingOccurrence? current))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!expanded.Add(current))
+                continue;
+            Retain(current.Assembly, current);
+
+            using Stream stream = current.Assembly.OpenRead();
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                throw new BadImageFormatException(
+                    $"The selected assembly "
+                    + $"'{current.Assembly.Identity.Name}' has no metadata.");
+            }
+
+            MetadataReader reader = peReader.GetMetadataReader();
+            foreach (AssemblyReferenceHandle handle
+                in reader.AssemblyReferences)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                AssemblyReferenceIdentity identity =
+                    AssemblyReferenceIdentity.From(reader, handle);
+                var request = new AssemblyBindingRequest(
+                    AssemblyBindingTarget.Reference(identity),
+                    AssemblyBindingOrigin.FromOccurrence(current),
+                    PlatformKeys.IsPlatform(identity.PublicKeyToken)
+                        ? AssemblyResolutionScope.Platform
+                        : AssemblyResolutionScope.Any);
+                AssemblyBindingSelectionSnapshot? snapshot =
+                    Policy.Select(request);
+                if (snapshot is null
+                    || !ReferenceEquals(snapshot.Version, version)
+                    || !ReferenceEquals(Policy.Version, version))
+                {
+                    throw new InvalidOperationException(
+                        "The binding-policy snapshot changed while "
+                        + "forming the match body context.");
+                }
+
+                AssemblyBindingSelection selection =
+                    AssemblyBindingSelection.ValidateForRequest(
+                        request,
+                        snapshot.Selection);
+                if (selection
+                    is not AssemblyBindingSelection.Selected selected)
+                {
+                    continue;
+                }
+
+                Retain(selected.Assembly, selected.Occurrence);
+                foreach (ResolvedAssemblyReference shadow
+                    in selected.ShadowedAssemblies)
+                {
+                    Retain(shadow, occurrence: null);
+                }
+
+                if (selected.Assembly.Provenance
+                        is not AssemblyResolutionProvenance.PlatformAsset)
+                {
+                    pending.Enqueue(selected.Occurrence);
+                }
+            }
+        }
+
+        if (!ReferenceEquals(Policy.Version, version))
+        {
+            throw new InvalidOperationException(
+                "The binding-policy snapshot changed while "
+                + "forming the match body context.");
+        }
+
+        return [.. participants.Values];
+
+        void Retain(
+            ResolvedAssemblyReference assembly,
+            AssemblyBindingOccurrence? occurrence)
+        {
+            if (participants.TryGetValue(
+                    assembly.Registration,
+                    out SelectedBindingParticipant? retained))
+            {
+                if (retained.Occurrence is null
+                    && occurrence is not null)
+                {
+                    participants[assembly.Registration] =
+                        new SelectedBindingParticipant(
+                            assembly,
+                            occurrence);
+                }
+                return;
+            }
+
+            participants.Add(
+                assembly.Registration,
+                new SelectedBindingParticipant(assembly, occurrence));
+            if (participants.Count > maxCandidates)
+            {
+                throw new InvalidOperationException(
+                    $"The match binding context exceeded its "
+                    + $"{maxCandidates}-assembly candidate bound.");
+            }
+        }
+    }
+}
 
 /// <summary>
 /// CLI inspection-lifetime owner for structured type resolution from one acquired
@@ -115,6 +247,10 @@ internal sealed class TypeDefinitionResolutionSession : IDisposable
             [request]);
         return context.Resolve(request);
     }
+
+    internal SelectedTypeBindingContext BindingContext(
+        AssemblyBindingOccurrence occurrence) =>
+        new(occurrence, _policy);
 
     public ApiSurface? ExtractApiSurface(
         bool includeAll = false,

--- a/src/dotnet-inspect/Inspectors/TypeDefinitionResolutionSession.cs
+++ b/src/dotnet-inspect/Inspectors/TypeDefinitionResolutionSession.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using DotnetInspector.Options;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
@@ -42,22 +40,19 @@ internal sealed record SelectedTypeBindingContext(
                 continue;
             Retain(current.Assembly, current);
 
-            using Stream stream = current.Assembly.OpenRead();
-            using var peReader = new PEReader(stream);
-            if (!peReader.HasMetadata)
+            using AssemblyInspectionSession inspection =
+                AssemblyInspectionSession.Open(current.Assembly);
+            if (!inspection.HasMetadata)
             {
                 throw new BadImageFormatException(
                     $"The selected assembly "
                     + $"'{current.Assembly.Identity.Name}' has no metadata.");
             }
 
-            MetadataReader reader = peReader.GetMetadataReader();
-            foreach (AssemblyReferenceHandle handle
-                in reader.AssemblyReferences)
+            foreach (AssemblyReferenceIdentity identity
+                in inspection.AssemblyReferenceIdentities())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                AssemblyReferenceIdentity identity =
-                    AssemblyReferenceIdentity.From(reader, handle);
                 var request = new AssemblyBindingRequest(
                     AssemblyBindingTarget.Reference(identity),
                     AssemblyBindingOrigin.FromOccurrence(current),

--- a/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
+++ b/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
@@ -76,6 +76,10 @@ public static class FixtureIds
     public const string CallerBindingCaller = "cli.caller-binding.caller";
     public const string CallerBindingContract = "cli.caller-binding.contract";
     public const string CallerBindingFacade = "cli.caller-binding.facade";
+    public const string MatchBindingDecoy = "cli.match-binding.decoy";
+    public const string MatchBindingDependency = "cli.match-binding.dependency";
+    public const string MatchBindingFacade = "cli.match-binding.facade";
+    public const string MatchBindingImplementation = "cli.match-binding.implementation";
     public const string AnalysisAsyncSiblingFriend = "analysis.async-sibling.friend";
     public const string AnalysisCallerLoop = "analysis.caller-loop";
     public const string AnalysisCrossAsmCollision = "analysis.cross-asm-collision";
@@ -827,6 +831,34 @@ public static class FixtureCatalog
         Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "cli", "caller-binding", "resolver-lineage");
 
+    public static readonly FixtureDefinition MatchBindingDecoy = Fixture(
+        FixtureIds.MatchBindingDecoy,
+        "DotnetInspector.MatchBinding.Decoy",
+        "DotnetInspector.MatchBinding.Dependency.dll",
+        Boundaries(FixtureBoundary.AssemblyName, FixtureBoundary.CrossAssemblyBoundary),
+        "cli", "match-binding", "resolver-lineage", "decoy");
+
+    public static readonly FixtureDefinition MatchBindingDependency = Fixture(
+        FixtureIds.MatchBindingDependency,
+        "DotnetInspector.MatchBinding.Dependency",
+        "DotnetInspector.MatchBinding.Dependency.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity, FixtureBoundary.CrossAssemblyBoundary),
+        "cli", "match-binding", "resolver-lineage", "selected");
+
+    public static readonly FixtureDefinition MatchBindingFacade = Fixture(
+        FixtureIds.MatchBindingFacade,
+        "DotnetInspector.MatchBinding.Facade",
+        "DotnetInspector.MatchBinding.Facade.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
+        "cli", "match-binding", "resolver-lineage", "facade");
+
+    public static readonly FixtureDefinition MatchBindingImplementation = Fixture(
+        FixtureIds.MatchBindingImplementation,
+        "DotnetInspector.MatchBinding.Implementation",
+        "DotnetInspector.MatchBinding.Implementation.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
+        "cli", "match-binding", "resolver-lineage", "implementation");
+
     public static readonly IReadOnlyList<FixtureDefinition> All =
     [
         JsExportUnions,
@@ -908,6 +940,10 @@ public static class FixtureCatalog
         CallerBindingCaller,
         CallerBindingContract,
         CallerBindingFacade,
+        MatchBindingDecoy,
+        MatchBindingDependency,
+        MatchBindingFacade,
+        MatchBindingImplementation,
         ResearchTargetSample,
         ResearchTargetCorrespondenceV1,
         ResearchTargetCorrespondenceV2,
@@ -1236,6 +1272,10 @@ public static class FixtureCatalog
             "DotnetInspector.CallerBinding.Caller" => "fixtures/cli/DotnetInspector.CallerBinding.Caller",
             "DotnetInspector.CallerBinding.Contract" => "fixtures/cli/DotnetInspector.CallerBinding.Contract",
             "DotnetInspector.CallerBinding.Facade" => "fixtures/cli/DotnetInspector.CallerBinding.Facade",
+            "DotnetInspector.MatchBinding.Decoy" => "fixtures/cli/DotnetInspector.MatchBinding.Decoy",
+            "DotnetInspector.MatchBinding.Dependency" => "fixtures/cli/DotnetInspector.MatchBinding.Dependency",
+            "DotnetInspector.MatchBinding.Facade" => "fixtures/cli/DotnetInspector.MatchBinding.Facade",
+            "DotnetInspector.MatchBinding.Implementation" => "fixtures/cli/DotnetInspector.MatchBinding.Implementation",
             "DotnetInspector.RestoredProjectFixtures" => "fixtures/queries/DotnetInspector.RestoredProjectFixtures",
             "DotnetInspector.SourceLinkMalformedFixtures" => "fixtures/sourcelink/DotnetInspector.SourceLinkMalformedFixtures",
             "DotnetInspector.SourceLinkNormalizedFixtures" => "fixtures/sourcelink/DotnetInspector.SourceLinkNormalizedFixtures",

--- a/tests/DotnetInspector.Queries.Tests/AssemblyContextParticipantTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/AssemblyContextParticipantTests.cs
@@ -1,0 +1,163 @@
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class AssemblyContextParticipantTests
+{
+    [Fact]
+    public void OccurrenceRootedParticipant_TranslatesSeedAndContinuation()
+    {
+        ResolvedAssemblyReference root = Descriptor("Root");
+        ResolvedAssemblyReference dependency = Descriptor("Dependency");
+        var inner = new RecordingPolicy();
+        AssemblyBindingOccurrence rootOccurrence =
+            new TestLineage(inner.Version).Issue(root);
+        AssemblyBindingOccurrence dependencyOccurrence =
+            new TestLineage(inner.Version).Issue(dependency);
+        inner.Selection = AssemblyBindingSelection.FoundOccurrence(
+            dependencyOccurrence);
+        var participant = new AssemblyContextParticipant(
+            rootOccurrence,
+            inner);
+
+        Assert.NotSame(inner.Version, participant.BindingPolicy.Version);
+        var first = Assert.IsType<AssemblyBindingSelection.Selected>(
+            participant.BindingPolicy.Select(
+                    Request(AssemblyBindingOrigin.FromAssembly(root)))
+                .Selection);
+        Assert.Same(
+            rootOccurrence,
+            Assert.IsType<AssemblyBindingOrigin.RequestingAssembly>(
+                    inner.LastRequest!.Origin)
+                .Occurrence);
+
+        participant.BindingPolicy.Select(
+            Request(
+                AssemblyBindingOrigin.FromOccurrence(
+                    first.Occurrence)));
+        Assert.Same(
+            dependencyOccurrence,
+            Assert.IsType<AssemblyBindingOrigin.RequestingAssembly>(
+                    inner.LastRequest!.Origin)
+                .Occurrence);
+    }
+
+    [Fact]
+    public void OccurrenceRootedParticipant_RejectsAnotherSeed()
+    {
+        ResolvedAssemblyReference root = Descriptor("Root");
+        ResolvedAssemblyReference other = Descriptor("Other");
+        var inner = new RecordingPolicy();
+        var participant = new AssemblyContextParticipant(
+            new TestLineage(inner.Version).Issue(root),
+            inner);
+
+        AssemblyBindingSelectionSnapshot snapshot =
+            participant.BindingPolicy.Select(
+                Request(AssemblyBindingOrigin.FromAssembly(other)));
+
+        var rejected =
+            Assert.IsType<AssemblyBindingSelection.Rejected>(
+                snapshot.Selection);
+        Assert.Equal(
+            AssemblyBindingFailureKind.InvalidBindingOrigin,
+            rejected.Failure.Kind);
+        Assert.Equal(0, inner.SelectionCount);
+    }
+
+    [Fact]
+    public void OccurrenceRootedParticipants_ComposeUnderOneRoutingVersion()
+    {
+        ResolvedAssemblyReference root = Descriptor("Root");
+        ResolvedAssemblyReference dependency = Descriptor("Dependency");
+        var inner = new RecordingPolicy();
+        var lineage = new TestLineage(inner.Version);
+        AssemblyBindingOccurrence rootOccurrence = lineage.Issue(root);
+        AssemblyBindingOccurrence dependencyOccurrence =
+            lineage.Issue(dependency);
+        inner.Selection = AssemblyBindingSelection.NotFound();
+        var rootRoute = new AssemblyContextParticipant(
+            rootOccurrence,
+            inner);
+        var dependencyRoute = new AssemblyContextParticipant(
+            dependencyOccurrence,
+            inner);
+        var policy =
+            SourceRelativeAssemblyGroupBindingPolicy.CreateRoutingOnly(
+                [
+                    (rootRoute.Assembly, rootRoute.BindingPolicy),
+                    (dependencyRoute.Assembly,
+                        dependencyRoute.BindingPolicy),
+                ]);
+        var rootParticipant = new AssemblyContextParticipant(
+            root,
+            policy);
+        var dependencyParticipant = new AssemblyContextParticipant(
+            dependency,
+            policy);
+
+        policy.Select(
+            Request(
+                AssemblyBindingOrigin.FromAssembly(dependency)));
+
+        Assert.Same(
+            dependencyOccurrence,
+            Assert.IsType<AssemblyBindingOrigin.RequestingAssembly>(
+                    inner.LastRequest!.Origin)
+                .Occurrence);
+        Assert.Same(
+            rootParticipant.BindingPolicy.Version,
+            dependencyParticipant.BindingPolicy.Version);
+    }
+
+    static AssemblyBindingRequest Request(
+        AssemblyBindingOrigin origin) =>
+        new(
+            AssemblyBindingTarget.Reference(
+                new AssemblyReferenceIdentity(
+                    "Dependency",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    null)),
+            origin,
+            AssemblyResolutionScope.Any);
+
+    static ResolvedAssemblyReference Descriptor(string name) =>
+        ResolvedAssemblyReference.Create(
+            new AssemblyReferenceIdentity(
+                name,
+                new Version(1, 0, 0, 0),
+                null,
+                null),
+            path: null,
+            static () => new MemoryStream(),
+            AssemblyResolutionProvenance.Local("test"));
+
+    sealed class RecordingPolicy : IAssemblyBindingPolicy
+    {
+        internal AssemblyBindingSelection Selection { get; set; } =
+            AssemblyBindingSelection.NotFound();
+        internal AssemblyBindingRequest? LastRequest { get; private set; }
+        internal int SelectionCount { get; private set; }
+
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            LastRequest = request;
+            SelectionCount++;
+            return new(Version, Selection);
+        }
+    }
+
+    sealed record TestLineage(
+        AssemblyBindingPolicyVersion Version)
+        : AssemblyBindingLineage(Version)
+    {
+        internal AssemblyBindingOccurrence Issue(
+            ResolvedAssemblyReference assembly) =>
+            CreateOccurrence(assembly);
+    }
+}


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational
capabilities or compelling user experiences while remaining conventionally
sound, delightfully new, or both.

## Summary

Preserve the resolver occurrence and policy that selected a forwarded API type
when `match --body` enters Research analysis. The CLI now provisions the
bounded selected dependency closure into the sealed query group and composes
per-occurrence routes under one source-relative policy version instead of
reconstructing context from the terminal assembly path.

This implements the focused
`type-forwarding-resolution.md#resolver-lineage-continuations` adoption for
#6391 under #5274. Acquisition identity remains separate from resolver context,
and existing path-rooted behavior remains the compatibility fallback when API
selection has no retained context.

## Demo

The fixture forwards `ComparisonApi` from a facade to an implementation whose
body constructs and invokes `Payload`. Project policy selects a dependency
where `Payload` is a delegate. A same-name assembly beside the implementation
defines `Payload` as an ordinary class with compatible constructor and
`Invoke` signatures.

Before this change, the body handoff re-rooted resolution at the implementation
path. The no-neighbor case could not supply the external dependency to the
sealed group, while the neighbor case selected the decoy. Both remained
partial, exposing stack temporaries, `new(null, &Identity)`, and explicit
`Invoke` calls.

After this change, both the no-neighbor and decoy-neighbor cases publish the
same full-fidelity C# row:

```csharp
return new Payload(ComparisonApi.Identity).Invoke(value);
```

The neighboring decoy no longer changes the selected dependency or the body
evidence.

## Design

- Retain the terminal `AssemblyBindingOccurrence` and issuing
  `IAssemblyBindingPolicy` with root and forwarded API type suppliers.
- Carry that context through named and raw-token selector resolution.
- Walk selected references through their retained continuations under
  Metadata's existing candidate bound.
- Provision exact selected descriptors and shadows before sealing the Research
  group; directly selected platform assemblies remain platform-closure owned.
- Give every selected occurrence its own transforming adapter, then route all
  participants through one routing-only `SourceRelativeAssemblyGroupBindingPolicy`.
- Reject mixed retained contexts for one body comparison instead of analyzing
  them under an arbitrary policy.

No new TLA+ transition is introduced. The existing resolver-lineage model owns
the retained-occurrence versus reconstructed-seed distinction.

## Validation

- Release solution build
- CLI raw-metadata-reader layering gate
- `AssemblyContextParticipantTests` and
  `AssemblyContextAnalysisSourceTests`: 23 passed
- `MatchCommandTests`: 25 passed
- Forwarded supplier retention tests: 3 passed
- Resolver-lineage TLA+: 7 exact outcomes, 0 unverified
- `markdownlint` on the changed design document

## Compatibility and scope

This does not change `match --similar`, navigation or reference-tree discovery,
candidate-domain finalization, Browser transport, source comparison, or
repository-wide `IAssemblyReferenceResolver` retirement. Missing, ambiguous,
unavailable, and rejected references do not gain synthesized fallback
candidates.

Closes #6391.
Part of #5274.
