### PR TITLE
Document platform asset entry paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ and repository-specific guidance.
 | Platform libraries | `library System.Private.CoreLib`, `library System.Text.Json --version 10.0.0`, `diff --platform System.Runtime@9.0.0..10.0.0` | Resolves installed SDK/runtime assemblies, including runtime-only implementation assemblies with no NuGet package. |
 | Local assets | `library ./artifacts/obj/ILInspector.Metadata/release/ILInspector.Metadata.dll`, `package ./artifacts/MyLib.nupkg` | Useful for auditing local builds before publishing. |
 
+Platform packs have distinct package, Platform, and direct-library views. For
+example, `package Microsoft.NETCore.App.Ref@10.0.0` inspects the targeting-pack
+container as an exact NuGet package, while
+`library ./packs/Microsoft.NETCore.App.Ref/10.0.0/ref/net10.0/System.Runtime.dll`
+inspects one manually downloaded or extracted DLL directly. A Platform
+selection unwraps authorized pack DLLs without publishing its source pack as a
+Package participant. These entry paths preserve different provenance and do
+not infer Platform identity from a package or file name.
+
 Windows Metadata (`.winmd`) is not a supported input format, and rejection is
 only partially enforced. Directory and package scans select `*.dll`, so a
 `.winmd` beside them is skipped without comment. A `.winmd` named explicitly —

--- a/docs/design/platform-house-reference-processing.md
+++ b/docs/design/platform-house-reference-processing.md
@@ -670,13 +670,16 @@ Forwarder-only facades require the same distinction. For platform population,
 type listing, and member traversal, a facade with only `ExportedType`
 forwarders contributes no independent type definitions: the
 [structured type-forwarding owner](type-forwarding-resolution.md) follows its
-metadata evidence to the physical implementation supplier. The facade does not
-become an additional implementation library merely because it was present in a
-runtime or reference pack. The artifact itself has not disappeared, however.
-Direct Library inspection may still select the facade, report that it is a
-facade, and show its forwarding evidence. "Collapse" means zero independent
-definition contribution after forwarding, not deletion or an inability to
-inspect the file.
+metadata evidence to the terminal definition authorized by the selected view.
+A reference-view terminal does not prove an implementation supplier;
+House-owned reference-to-implementation correspondence and a second Metadata
+resolution establish that bridge when implementation evidence is required.
+The facade does not become an additional implementation library merely because
+it was present in a runtime or reference pack. The artifact itself has not
+disappeared, however. Direct Library inspection may still select the facade,
+report that it is a facade, and show its forwarding evidence. "Collapse" means
+zero independent definition contribution after forwarding, not deletion or an
+inability to inspect the file.
 
 ### Workspace admission and platform skew
 

--- a/docs/design/platform-house-reference-processing.md
+++ b/docs/design/platform-house-reference-processing.md
@@ -641,6 +641,43 @@ Library inspection owner, not this document. Its focused design must preserve
 the evidence above before any PackageHouse, PlatformHouse, or direct-library
 adoption ships.
 
+### Platform asset handling map
+
+The physical container does not decide the product identity. Frameworks and
+targeting packs use NuGet package files as a distribution mechanism, but a
+Platform operation treats their package IDs and layouts as source coordinates,
+not as Package participants or assembly identities.
+
+| Asset | Platform treatment | Other explicit treatment |
+| --- | --- | --- |
+| Installed `Microsoft.NETCore.App` or `Microsoft.AspNetCore.App` shared framework | An implementation supplier for the selected platform target and family. There may be no corresponding package artifact on the machine. | An assembly path obtained independently enters direct Library inspection. |
+| `Microsoft.NETCore.App.Ref` or `Microsoft.AspNetCore.App.Ref` targeting pack | A reference-view source. `PlatformHouse` selects and unwraps the authorized DLLs without publishing the acquired pack as a Package participant. | An exact package coordinate or local `.nupkg` may be inspected separately as a package. That package inspection does not establish a Platform target or transfer package identity to its DLLs. |
+| Runtime implementation pack such as `Microsoft.NETCore.App.Runtime.<rid>` | An implementation-view source. Public implementations, facades, and private implementation libraries retain their platform roles and provenance after unwrapping. | Explicit package inspection may describe the distribution container; an extracted DLL enters direct Library inspection. Neither route implies Platform membership. |
+| `NETStandard.Library.Ref` or `NETStandard.Library` reference assets | A .NET Standard reference-contract contribution used during transparent forwarding; never a platform family or implementation population. | Explicit package inspection may describe the package. An extracted `netstandard.dll` is an ordinary direct library whose forwarding evidence remains visible. |
+| Any manually downloaded or extracted DLL | No Platform inference from its path, parent pack name, file name, or assembly name. | Direct Library inspection reads that one file with direct provenance. A caller must issue a separately typed Platform request to obtain platform target or view correspondence. |
+
+A Platform-backed Workspace therefore contains the Platform participant and
+the libraries selected from its sources, not `Microsoft.NETCore.App.Ref`,
+`Microsoft.AspNetCore.App.Ref`, runtime-pack, or .NET Standard source packages
+as ordinary package participants. Package discovery may also omit distribution
+packages that are not listed for browsing. This is not a global prohibition on
+package inspection: an exact package request or a local `.nupkg` request uses
+the generic Package path and inspects the container under package semantics.
+No result from that path can be reused as proof of Platform identity,
+selection, or compatibility.
+
+Forwarder-only facades require the same distinction. For platform population,
+type listing, and member traversal, a facade with only `ExportedType`
+forwarders contributes no independent type definitions: the
+[structured type-forwarding owner](type-forwarding-resolution.md) follows its
+metadata evidence to the physical implementation supplier. The facade does not
+become an additional implementation library merely because it was present in a
+runtime or reference pack. The artifact itself has not disappeared, however.
+Direct Library inspection may still select the facade, report that it is a
+facade, and show its forwarding evidence. "Collapse" means zero independent
+definition contribution after forwarding, not deletion or an inability to
+inspect the file.
+
 ### Workspace admission and platform skew
 
 Workspace admission and bare-library construction do not require compatibility


### PR DESCRIPTION
Build robust, capable platform inspection from explicit ownership boundaries: conventionally sound entry semantics, with a clear user experience across packages, Platform sources, and direct libraries.

## Summary

Document the product distinction between framework/reference/runtime pack distribution, Platform realization, explicit package inspection, and direct DLL inspection.

- add a platform-asset handling map to the PlatformHouse composition design;
- define facade collapse as zero independent definition contribution while preserving direct facade inspection;
- show exact pack-package and extracted-DLL CLI entry paths in the README; and
- align #6301 and #4592 issue bodies with the merged #6400 ownership and compatibility contracts.

## Demo

The documentation now explains three intentionally separate views of the same distributed assets:

```text
package Microsoft.NETCore.App.Ref@10.0.0
  -> inspect the exact NuGet package container

library ./packs/Microsoft.NETCore.App.Ref/10.0.0/ref/net10.0/System.Runtime.dll
  -> inspect one extracted DLL with direct-library provenance

Platform selection
  -> select and unwrap authorized pack DLLs without publishing the source pack
     as a Package participant
```

A forwarder-only facade contributes no independent type definitions after structured forwarding, but remains directly inspectable as a facade artifact with forwarding evidence.

## Validation

- `npx markdownlint-cli README.md docs/design/platform-house-reference-processing.md`
- `git diff --check origin/main...HEAD`

## Compatibility

Documentation only. This records current CLI behavior and the merged PlatformHouse contract; it does not change package acquisition, Platform realization, forwarding, or Workspace behavior.