### PR TITLE
Define CLI Workspace sharing as command projection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [Architecture](architecture.md) | Current host-neutral composition, logical layers, project regions, currencies, and code-navigation map. |
 | [Library Family Boundaries](design/library-family-boundaries.md) | Meaning of the `Inspector`, `ILInspector`, `DotnetInspector`, independent-domain, and host namespace families, independent of dependency altitude and component role. |
 | [CLI Host Architecture](cli-architecture.md) | CLI command-host responsibilities, request lifetime, selection, and presentation composition. |
+| [CLI Workspace Sharing](design/cli-workspace-sharing.md) | Common `--share` projection of an inspection command's effective resolved state to a canonical Workspace packet or Inspect Web URL, without a second Workspace-construction grammar. |
 | [Decompiler Architecture](decompiler-architecture.md) | Decompiler project boundaries, import/IR/pass/printer flow, host consumers, and testing/evidence infrastructure. |
 | [CLI Change Classification and Obsolete Inputs](design/cli-change-classification.md) | Published CLI surfaces, observable change classification, disclosure, invalid-input guards, and routing reservations. |
 | [CLI Option-Value Validation](design/cli-option-value-validation.md) | Shared zero-arity diagnostics that preserve positional ownership and command-owned capacity. |

--- a/docs/design/cli-workspace-sharing.md
+++ b/docs/design/cli-workspace-sharing.md
@@ -1,0 +1,323 @@
+# CLI Workspace sharing
+
+The **CLI Workspace Sharing** design is the normative owner for one public
+gesture: projecting the effective state of an already-resolved
+`dotnet-inspect` invocation into a portable Workspace scenario and emitting
+that scenario as a canonical packet or complete Inspect Web URL.
+
+The end-to-end adoption tracker is
+[#6150](https://github.com/richlander/dotnet-inspect/issues/6150). The producing
+consumer is the CLI command the user already chose; the receiving production
+consumer is Inspect Web. The complementary Browser-to-CLI replay direction is
+tracked by
+[#4647](https://github.com/richlander/dotnet-inspect/issues/4647).
+
+This is a proposed target contract. `member --share packet|url` is the first
+production adoption, but its current restrictions are narrower than the
+contract below. Further command adoption remains unverified until the gates in
+[Status and gates](#status-and-gates) land.
+
+## Ownership and boundaries
+
+CLI Workspace Sharing owns:
+
+- the common `--share` gesture and its packet-versus-URL selection;
+- the requirement to project the command's effective resolved state rather
+  than reconstructing it through another command;
+- classification of semantic command inputs, local execution policy, and
+  terminal CLI presentation when sharing;
+- CLI output, refusal, and exit behavior; and
+- the command-by-command adoption rule.
+
+[Workspace Definitions](workspace-definitions.md) remains the sole owner of
+portable scenario records, packet versions, canonical encoding, projection
+validity, capacity, and restoration. Each inspection command remains the owner
+of its source, focus, selector, query, traversal, and execution semantics.
+Inspect Web remains the owner of URL activation and presentation. This design
+composes those owner-issued contracts without redefining them.
+
+The repository convention is that a caller selects source, focus, operation,
+and lens on the command that performs the inspection, then chooses output
+through an option on that same command. `--share` follows that convention. It
+is a terminal projection, like selecting another output representation, not a
+new structural focus or operation arity under the
+[Command Transition Model](command-transition-model.md).
+
+Canonical packet and URL output deliberately bypass Markout. They are
+byte-sensitive interchange scalars owned by Workspace Definitions, not a
+human or tabular rendering of inspection results. The typed portable scenario
+remains intact until that canonical encoding boundary.
+
+## Decisions
+
+1. **The inspection command constructs the scenario.** The command's existing
+   arguments and options are the only CLI grammar for selecting source,
+   context, subject, lens, query, and traversal. Appending `--share` projects
+   that selection.
+2. **There is no `workspace create` command.** A user never restates a working
+   `package`, `library`, `type`, `member`, `depends`, `graph`, or other
+   invocation through a second Workspace-construction grammar merely to obtain
+   a link.
+3. **Sharing captures effective typed state, not argv.** Commands hand
+   owner-issued coordinates, identities, selectors, facets, and query payloads
+   to Workspace Definitions. A packet never persists command names, option
+   spellings, display text, or a shell command line.
+4. **A bare `--share` emits the complete URL.** URL sharing is the primary
+   agent-to-human handoff. `--share packet` explicitly requests only the
+   canonical base64url packet; `--share url` is the explicit spelling of the
+   default.
+5. **Sharing preserves semantic choices or refuses.** A command must carry
+   every projectable source, context, subject, facet, query, and traversal
+   choice that affects the receiving inspection. It never drops an unsupported
+   choice, substitutes a default view, or produces a less-specific link.
+6. **Sharing does not execute the selected inspection merely to encode it.**
+   The command performs only the normal resolution needed to establish exact
+   portable identity and projectability. Query, analysis, traversal, source,
+   or rendering work that the receiving host will perform is not run solely
+   because `--share` was selected.
+7. **The receiving host replays a recipe, not a result.** A packet contains no
+   rendered rows, analysis findings, graph edges, acquired payloads,
+   credentials, or frozen result snapshot. Inspect Web applies its own source
+   authorization and capabilities when opening the URL.
+
+## CLI contract
+
+### Append sharing to the working invocation
+
+The target gesture is:
+
+```console
+dotnet-inspect member JsonSerializer SerializeAsync \
+  --package System.Text.Json@10.0.0 \
+  --tfm net10.0 \
+  --share
+```
+
+The same invocation without `--share` performs the ordinary CLI inspection.
+Appending `--share` changes only the terminal projection. It must not require a
+second command such as:
+
+```console
+dotnet-inspect workspace create \
+  --package System.Text.Json@10.0.0 \
+  --tfm net10.0 \
+  --type System.Text.Json.JsonSerializer \
+  --member SerializeAsync
+```
+
+That duplicate construction path is prohibited even if it could be lowered to
+the same records. It would make users and agents translate between two
+grammars, allow the grammars to drift, and lose command-specific choices that
+the original invocation had already validated.
+
+### Output selection
+
+Commands that adopt sharing expose one common option:
+
+```text
+--share[=url|packet]
+```
+
+- `--share` and `--share url` write exactly one complete
+  `https://dotnet-inspect.net/?w=<packet>` URL plus the platform newline.
+- `--share packet` writes exactly the canonical packet plus the platform
+  newline.
+- Successful sharing writes no ordinary inspection report.
+- Diagnostics are written to stderr. Failure writes no packet, partial URL, or
+  success-shaped fallback.
+
+`--share` is mutually exclusive with terminal CLI representations and reducers
+such as Markdown, JSON, table, TSV, JSONL, plaintext, Mermaid, URL-list, path,
+print, count, row-window, field, and column output. Those gestures describe how
+the CLI presents an executed result; they do not describe the receiving
+Workspace.
+
+Source, focus, section, facet, query, filter, relationship, traversal, and
+other semantic options are not rejected merely because sharing was selected.
+When their owner provides a portable codec, they are part of the projected
+scenario. When the packet or receiving host cannot preserve them, the command
+returns a visible non-projectable failure naming the unsupported choice.
+
+Local host policy such as offline mode, source authorization, credentials,
+timeouts, cache selection, tracing, verbosity, and tips may govern resolution
+in the producing process but never enters the packet. The receiving host
+applies its own policy.
+
+### Effective state and exact identity
+
+Sharing consumes the command's effective state after ordinary parsing,
+normalization, source selection, and the minimum exact resolution needed for
+portable identity. This has four consequences:
+
+1. An input need not repeat information that the command already resolves
+   unambiguously. If normal command resolution selects one exact type, member,
+   library, context, or query payload, sharing uses that owner-issued identity.
+   It does not demand a second selector solely for packet production.
+2. A floating package or platform input may use the command's normal resolution
+   path. The packet records the resulting exact version and target, never the
+   floating spelling. If one exact portable coordinate cannot be established,
+   sharing fails.
+3. Product defaults that affect the receiving inspection are resolved before
+   projection and represented through owner-issued scenario state. A later
+   change to CLI or Browser defaults must not reinterpret an existing link.
+4. A command that intentionally selects a collection or query may share that
+   query when the portable contract represents it. Sharing never chooses the
+   first row or another arbitrary result to manufacture a singular subject.
+
+The handoff must use typed command results or plans. Serializing argv and
+re-parsing it, invoking another CLI command, recovering identity from rendered
+output, or rebuilding state from display strings are all prohibited.
+
+### Work and acquisition
+
+`--share` authorizes the minimum work required to produce an exact portable
+scenario; it does not authorize the observation merely because the ordinary
+command would have rendered it.
+
+For example, a package dependency invocation may resolve an unversioned package
+to one exact version, but it need not acquire the package or walk its dependency
+graph when the packet carries the exact coordinate and Dependencies facet. A
+member invocation may need package metadata and compile-surface resolution to
+mint an exact member identity, but it does not need documentation, PDB, source,
+decompiler, caller, or analysis enrichment solely to emit the link.
+
+If exact identity genuinely depends on work that the command normally performs,
+that owner may perform the bounded work and must retain its ordinary failure
+semantics. Sharing does not create a cheaper identity guess.
+
+### Projectability and refusal
+
+A valid CLI invocation is not necessarily URL-projectable. Workspace
+Definitions may refuse because the current packet version cannot preserve the
+scenario, the receiving host lacks the required portable query or restoration
+binding, the source cannot be reacquired without excluded authority, or the
+canonical packet exceeds its capacity.
+
+The command reports that typed refusal as a nonzero outcome with actionable
+stderr. It must identify the first unsupported semantic choice or owner-issued
+projection path. It must not:
+
+- omit state and emit a URL anyway;
+- fall back to a landing page, Overview, or another facet;
+- replace an exact subject with a textual search;
+- upload local content or credentials;
+- execute the query and serialize its rendered result; or
+- instruct the user to recreate the same invocation through `workspace`.
+
+Packet and URL output have identical projectability. URL wrapping cannot make a
+non-projectable packet valid.
+
+## The `workspace` and codec command boundaries
+
+The `workspace` command may eventually consume a packet or URL and replay it
+under the CLI host contract tracked by #4647. It may also expose inspection of
+an already-defined Workspace. Neither role makes it a generic construction
+proxy for other commands.
+
+`workspace-state encode` and `workspace-state decode` are low-level conversion
+utilities over the canonical packet JSON boundary. They are not the authoring
+workflow for a shareable inspection, and this design does not require users to
+construct their JSON input. Their eventual naming or retirement is a separate
+CLI-surface decision after direct command sharing and required diagnostics are
+available.
+
+## Adoption
+
+Adoption is command-by-command because each command owner must issue the typed
+state that sharing consumes, and Inspect Web must restore the corresponding
+facet or query. The common gesture and output contract do not permit one
+command adapter to infer another command's semantics.
+
+For each adopting command, #6150's path has three observable steps:
+
+1. the command projects its effective resolved state to canonical scenario
+   records without argv translation;
+2. Workspace Definitions either emits one canonical packet or returns its
+   typed projection refusal; and
+3. Inspect Web restores the packet to the same source coordinates, context,
+   subject, facet, query, and portable options.
+
+The exact-member adoption completes these steps for its supported package API
+Overview subset. Package Dependencies is the next focused adoption in #6394.
+Type, package, library, call-graph, and later operation/query adoptions remain
+separate slices under #6150; a command exposes `--share` only when its first
+useful scenario closes through the receiving host.
+
+## Pathological and neighboring cases
+
+The contract-defining pathological case is a rich invocation whose source,
+subject, and selected view are already correct:
+
+```console
+dotnet-inspect member JsonSerializer DeserializeAsync \
+  --package System.Text.Json \
+  --tfm net10.0 \
+  -S "Call Graph" \
+  --depth 3 \
+  --share
+```
+
+Once the Call Graph query has a portable packet codec and Browser restoration
+binding, this invocation resolves the package version and exact member once,
+pins them in the packet, preserves the Call Graph selection and depth, and
+emits the URL without running the graph in the CLI. Before that complete path
+exists, it fails visibly at the unsupported Call Graph projection. It never
+silently emits member Overview and never asks the user to restate the package,
+type, member, and graph options under `workspace`.
+
+Neighboring cases prove the boundary:
+
+- the equivalent exact package/member Overview invocation succeeds;
+- an ambiguous member selection fails without choosing an overload;
+- a local or private artifact that the public Browser cannot reacquire fails
+  without leaking a path or credential;
+- a floating package that resolves uniquely emits the resolved exact version;
+- a command with a competing CLI output format fails rather than producing two
+  outputs; and
+- packet-capacity overflow emits no URL.
+
+## Non-goals
+
+- A new Workspace construction language or serialized CLI grammar.
+- A snapshot of inspection results or guarantee that remote content remains
+  available.
+- Uploading artifacts, opening a browser, hosting shortened URLs, or storing
+  scenarios server-side.
+- Treating a packet as source authorization or embedding credentials.
+- Making every command projectable before its semantic state and Browser
+  consumer have a faithful portable contract.
+- Expanding packet schemas merely because a CLI option exists; unsupported
+  state remains a visible refusal until its owner designs a portable form.
+
+## Status and gates
+
+The common target contract is **unverified**. Current
+`member --share packet|url` proves canonical packet/URL production for one
+explicitly selected public NuGet member Overview, but it currently requires an
+explicit format and exact overload gesture and rejects all section selection.
+Those restrictions are implementation status, not the general sharing
+contract.
+
+Each adoption must add focused Release gates proving:
+
+- appending `--share` consumes the same normalized source, context, subject,
+  facet, query, and traversal state as the ordinary command plan;
+- no argv serialization, synthetic command invocation, rendered-text identity,
+  or duplicate source/focus grammar participates in the projection;
+- bare `--share`, explicit `url`, and `packet` produce the required scalar and
+  no ordinary report;
+- a uniquely resolved floating input is pinned to its exact portable
+  coordinate;
+- semantic selections are preserved when projectable and produce a typed
+  refusal when not;
+- work unnecessary for exact identity or projectability does not execute;
+- competing terminal output, ambiguous identity, unsupported source,
+  over-capacity state, and Browser-restoration gaps fail nonzero with empty
+  stdout; and
+- the real Inspect Web URL restores the same normalized coordinates, context,
+  subject, facet, query, and portable options.
+
+The existing `MemberShare_*` tests gate the narrower member subset.
+`WorkspaceSharePacketTransposerTests` and codec vectors remain authoritative
+for packet validity. An adoption is not complete with a decode-only test; its
+gate must exercise the command-to-Browser handoff described by #6150.

--- a/docs/design/cli-workspace-sharing.md
+++ b/docs/design/cli-workspace-sharing.md
@@ -87,7 +87,7 @@ remains intact until that canonical encoding boundary.
 The target gesture is:
 
 ```console
-dotnet-inspect member JsonSerializer SerializeAsync \
+dotnet-inspect member JsonSerializer SerializeAsync:1 \
   --package System.Text.Json@10.0.0 \
   --tfm net10.0 \
   --share
@@ -249,7 +249,7 @@ The contract-defining pathological case is a rich invocation whose source,
 subject, and selected view are already correct:
 
 ```console
-dotnet-inspect member JsonSerializer DeserializeAsync \
+dotnet-inspect member JsonSerializer DeserializeAsync:1 \
   --package System.Text.Json \
   --tfm net10.0 \
   -S "Call Graph" \

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -60,6 +60,12 @@ one complete restoration result.
 
 Adjacent owners remain independent:
 
+- [CLI Workspace Sharing](cli-workspace-sharing.md) owns the public
+  `--share` gesture, its use of an inspection command's already-resolved
+  semantic state, terminal packet/URL output, refusal behavior, and
+  command-by-command adoption. It consumes this owner's scenario records and
+  typed packet-projection outcome rather than defining another Workspace or
+  packet grammar.
 - [View Facet Registry](view-facet-registry.md) issues and resolves facet IDs,
   descriptors, applicability, and availability, and owns its private execution
   bindings.
@@ -104,9 +110,11 @@ authority and carries only owner-issued activation and Navigation authority.
    replace the pseudo-package; each group expression lowers to exactly one
    `AssemblyContextGroup`.
 5. **The URL share packet is a terse projection of one scenario
-   composition**, produced and consumed by the browser's transposition layer.
-   The visible query is a human-readable courtesy label; the peer definition
-   records are always canonical.
+   composition**, produced and consumed through the product transposition
+   layer. CLI inspection commands may request that projection through the
+   separately owned [`--share` contract](cli-workspace-sharing.md); Inspect Web
+   consumes it for restoration. The visible query is a human-readable courtesy
+   label; the peer definition records are always canonical.
 6. **Complete committed views begin at definition schema version 2 and packet
    format 2.** Version 1 remains an immutable legacy contract. Version 2 uses
    one canonical View Facet Registry ID field, one retained view state per

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,6 +36,11 @@ substrates, and inspection producers that will extend that space.
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options,
   output views, section descriptors, and inspectors. Its
+  [CLI Workspace Sharing](design/cli-workspace-sharing.md) owns the common
+  `--share` gesture that projects an inspection command's effective resolved
+  source, context, subject, facet, and query state to a canonical Workspace
+  packet or Inspect Web URL without a second construction grammar.
+  Its
   [CLI row-selection grammar](design/cli-row-selection.md) owns item, Window,
   Top, direction, rendered-line spelling, shorthand, capability, and typed
   operation-intent lowering at the L3 boundary. Its


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational
capabilities or compelling user experiences while remaining conventionally
sound and, where useful, delightfully new.

Define CLI Workspace sharing as a projection of the inspection invocation the
user already constructed. The specification prohibits a separate `workspace
create` grammar, makes bare `--share` produce the human-ready URL, and requires
semantic source, focus, facet, query, and traversal choices to be preserved or
refused visibly.

Part of #6150. The complementary Browser-to-CLI replay direction remains #4647.

## Demo

Target workflow:

```console
$ dotnet-inspect member JsonSerializer DeserializeAsync:1 \
    --package System.Text.Json \
    --tfm net10.0 \
    -S "Call Graph" \
    --depth 3 \
    --share
https://dotnet-inspect.net/?w=<canonical-packet>
```

The command resolves and pins its effective state once, emits the URL without
running the call graph in the CLI, and never asks the user to restate the
invocation under `workspace create`. Until the selected view has a faithful
packet codec and Browser restoration binding, the same invocation fails visibly
instead of silently falling back to member Overview.

The neighboring packet form is:

```console
$ dotnet-inspect member JsonSerializer SerializeAsync:1 \
    --package System.Text.Json@10.0.0 \
    --tfm net10.0 \
    --share packet
<canonical-packet>
```

## Design

- Adds `docs/design/cli-workspace-sharing.md` as the focused owner of the common
  CLI gesture and command-to-scenario handoff.
- Keeps Workspace Definitions authoritative for records, packet versions,
  canonical encoding, projectability, capacity, and restoration.
- Uses the command's typed effective state rather than argv serialization,
  rendered-text reconstruction, or a synthetic second command.
- Allows ordinary resolution to turn floating inputs into exact pinned packet
  coordinates.
- Treats current `member --share packet|url` restrictions and the package
  Dependencies work in #6394 as narrower staged adoptions, not the final common
  contract.
- Records packet/URL output as a byte-sensitive interchange scalar that
  deliberately bypasses Markout.

This is specification-only and changes no current CLI behavior or packet
format.

## Validation

- `npx markdownlint-cli docs/design/cli-workspace-sharing.md
  docs/design/workspace-definitions.md docs/README.md docs/overview.md`
- `git diff --check`
