### PR TITLE
Migrate Inspector artifact tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -220,6 +220,11 @@ unfiltered. These paths reuse the pinned outcome-level host gate without
 changing the suite's separately compiled non-friend evidence or combining it
 with the dedicated catalog suite.
 
+`Inspector.Artifacts.Tests` is the twelfth migrated adopter. Its required PR,
+Deep Inspect platform, and developer commands remain unfiltered. These paths
+reuse the pinned outcome-level host gate without changing the suite's artifact
+access, local admission, workspace-session, digest, or cleanup evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/Inspector.Artifacts.Tests/Inspector.Artifacts.Tests.csproj
+++ b/tests/Inspector.Artifacts.Tests/Inspector.Artifacts.Tests.csproj
@@ -10,6 +10,7 @@
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This keeps dotnet-inspect's test evidence conventionally sound: selector
mistakes fail at the standard test host while the renamed `Inspector.Artifacts`
suite retains ownership of its artifact contracts.

This is migration 12 of 30 under #5379.

## Demo

Before this change, a stale native xUnit selector executed zero tests and
reported success:

```text
Inspector.Artifacts.Tests  Total: 0

Exit code: 0
```

After selecting Microsoft Testing Platform through xUnit's supported project
property, the equivalent unmatched filter fails:

```text
Test run summary: Zero tests ran
  total: 0

Exit code: 8
```

Neighboring artifact evidence remains intact:

```text
ArtifactContractTests:      18 passed
Inspector.Artifacts.Tests: 111 passed, 6 Windows-only skipped
```

## Change

- Select the Microsoft Testing Platform runner for
  `Inspector.Artifacts.Tests`.
- Record the renamed suite as the twelfth migrated adopter in the normative
  xUnit host design.
- Keep required PR, Deep Inspect platform, and developer invocations
  unfiltered.
- Preserve the suite's artifact access, local admission, workspace-session,
  digest, and cleanup evidence.

No direct MTP package dependency, runner-internal dependency, repository-owned
selector parser, workflow change, developer-command change, or domain-test
change is introduced.

## Validation

- Full Release solution build on .NET SDK `11.0.100-rc.1.26425.128`
- Unmatched MTP class filter: zero tests, exit `8`
- Focused `ArtifactContractTests`: 18/18 passed
- Full `Inspector.Artifacts.Tests`: 117 total, 111 passed, 6 Windows-only
  skipped
- `markdownlint` and `git diff --check`

Part of #5379.