### PR TITLE
Redesign Package comparison targets

### DIFF
--- a/docs/design/inspect-web-diff-targets.md
+++ b/docs/design/inspect-web-diff-targets.md
@@ -76,6 +76,25 @@ This is deliberately host-specific rather than a Markout lowering: it edits
 typed interaction state, not comparison evidence. Actual diff presentation
 continues to consume the shared comparison and presentation owners.
 
+Package Overview composes the settings as one task-oriented **Comparison
+targets** work area, not as prose interrupted by a generic coordinate form.
+Diff baseline and Clone search scope each occupy one row that keeps its
+persistent task label, native selector, effective selection or failure state,
+and any recovery action together. A wide row gives the selector the available
+content width instead of inheriting the shell coordinate control's compact
+maximum. A narrow row stacks that same label, selector, and state without
+changing their DOM or focus order. Long selected values may elide only when
+the viewport cannot contain them; the native control retains the complete
+accessible option text.
+
+The work area has no introductory paragraph that restates its labels and no
+separate result-style paragraphs below the controls. One quiet policy line
+states the two facts shared by both rows: settings belong to the browser
+session, and choosing one neither executes a comparison nor changes a shared
+link. Loading, no-predecessor, partial-listing, unsupported-source, removed
+Clone target, and failed-inventory outcomes remain visible in their owning row
+rather than becoming general section prose.
+
 The initial target-settings slice does not advertise working result inspectors.
 Its Package controls identify that limitation. The immediate successor adds
 the shared presentation adapter, then the feature facade and Library API Diff

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -850,6 +850,12 @@ visibly unavailable. Settings are not included in shared links. The first
 version-selector adopter is the existing Gallery path, not custom sources or
 platform inputs.
 
+Package Overview presents the two settings as task rows: each row keeps its
+label, available-width native selector, effective state, and recovery action
+together. At narrow widths the row stacks without changing focus order. One
+shared note explains that target selection is session-local and does not run a
+comparison.
+
 These controls prepare targets only: the Library Diff/Clone result inspectors
 remain follow-on work under #5083. The owner is
 [Browser Diff targets](../../docs/design/inspect-web-diff-targets.md) for the

--- a/prototypes/inspect-web/browser/library-hierarchy.spec.ts
+++ b/prototypes/inspect-web/browser/library-hierarchy.spec.ts
@@ -512,7 +512,9 @@ test("Package comparison targets survive Library, Type, and Member navigation", 
   await installFacades(page);
   await page.goto(root);
   await expect(page.locator("#package-diff-target-status"))
-    .toHaveText("Compare against 0.9.0 (previous version).");
+    .toHaveText("Previous listed release");
+  await expect(page.locator("#package-diff-target option:checked"))
+    .toHaveText("Automatic: 0.9.0");
   await page.locator("#package-diff-target").focus();
   await page.locator("#package-diff-target").selectOption("exact:1.0.0");
   await expect(page.locator("#package-diff-target")).toBeFocused();
@@ -527,7 +529,7 @@ test("Package comparison targets survive Library, Type, and Member navigation", 
   await expect(page.locator("#package-clone-target")).toHaveValue("package:0");
   await page.locator("#package-diff-target").selectOption("previous");
   await expect(page.locator("#package-diff-target-status"))
-    .toHaveText("Compare against 0.9.0 (previous version).");
+    .toHaveText("Previous listed release");
 });
 
 for (const initialWidth of [1440, 390]) {
@@ -1318,9 +1320,34 @@ for (const width of [1440, 390]) {
     ]);
     await expect(overview.locator(".library-row")).toHaveCount(3);
     await expect(overview.locator('[data-lib-scope="asset:empty"]')).toContainText("0 types");
+    await expect(overview.locator(".comparison-target-row")).toHaveCount(2);
+    const diffTarget = overview.locator("#package-diff-target");
+    await expect(diffTarget.locator("option:checked")).toHaveText("Automatic: 0.9.0");
+    await expect(overview.locator(".comparison-target-policy"))
+      .toHaveText("Session only. Choosing a target does not run a comparison or change shared links.");
+    if (width === 1440) {
+      expect((await diffTarget.boundingBox())!.width).toBeGreaterThan(500);
+      expect(await diffTarget.evaluate(select => {
+        if (!(select instanceof HTMLSelectElement)) return false;
+        const canvas = document.createElement("canvas");
+        const context = canvas.getContext("2d");
+        if (!context) return false;
+        context.font = getComputedStyle(select).font;
+        return context.measureText(select.selectedOptions[0]?.text ?? "").width + 48
+          <= select.clientWidth;
+      })).toBe(true);
+    } else {
+      const row = await overview.locator(".comparison-target-row").first().boundingBox();
+      const heading = await overview.locator(".comparison-target-heading").first().boundingBox();
+      const selection = await overview.locator(".comparison-target-selection").first().boundingBox();
+      expect(row).not.toBeNull();
+      expect(heading).not.toBeNull();
+      expect(selection).not.toBeNull();
+      expect(Math.abs(selection!.x - heading!.x)).toBeLessThan(1);
+      expect(selection!.y).toBeGreaterThan(heading!.y + heading!.height);
+    }
     expect(await page.evaluate(() =>
       document.documentElement.scrollWidth - document.documentElement.clientWidth)).toBe(0);
-
     if (width === 390) {
       await page.getByRole("button", { name: "Libraries", exact: true }).click();
       await expect(page.locator(".library-subject-list")).toBeFocused();

--- a/prototypes/inspect-web/browser/library-hierarchy.spec.ts
+++ b/prototypes/inspect-web/browser/library-hierarchy.spec.ts
@@ -1300,7 +1300,7 @@ for (const [width, activation] of [[900, "click"], [480, "keyboard"]] as const) 
   });
 }
 
-for (const width of [1440, 390]) {
+for (const width of [1440, 800, 390]) {
   test(`production Package Overview fills its frame and opens Library at ${width}px`, async ({ page }) => {
     await page.setViewportSize({ width, height: 900 });
     await installFacades(page);
@@ -1346,6 +1346,8 @@ for (const width of [1440, 390]) {
       expect(Math.abs(selection!.x - heading!.x)).toBeLessThan(1);
       expect(selection!.y).toBeGreaterThan(heading!.y + heading!.height);
     }
+    expect(await overview.locator(".overview-scroll").evaluate(scroll =>
+      scroll.scrollWidth - scroll.clientWidth)).toBe(0);
     expect(await page.evaluate(() =>
       document.documentElement.scrollWidth - document.documentElement.clientWidth)).toBe(0);
     if (width === 390) {

--- a/prototypes/inspect-web/src/package-comparison-targets.ts
+++ b/prototypes/inspect-web/src/package-comparison-targets.ts
@@ -67,12 +67,12 @@ export function diffTargetDescription(
   versions: PackageVersionState,
 ): string {
   if (versions.status === "failed") return versions.message;
-  if (diff.kind === "exact") return `Compare against ${diff.version}.`;
+  if (diff.kind === "exact") return "Exact version";
   if (versions.status !== "available") return "Reading available versions...";
   const { previousVersion, previousVersionUnavailableReason } = versions.inventory;
   return previousVersionUnavailableReason
     ?? (previousVersion
-      ? `Compare against ${previousVersion} (previous version).`
+      ? "Previous listed release"
       : "No earlier listed version is available.");
 }
 
@@ -98,38 +98,60 @@ export function renderPackageComparisonTargets<T extends ComparisonPackage>(
   const unavailableClone = clone.kind === "package" && targetIndex < 0;
   const packageLabel = (item: T) => `${item.id} ${item.version} (${item.activeFramework})`;
   const cloneDescription = clone.kind === "workspace"
-    ? "All libraries in the current Workspace, including this library."
+    ? "All loaded Packages, including this one"
     : unavailableClone
       ? `${packageLabel(clone.package)} is no longer in this Workspace. Choose another target.`
-      : `All libraries in ${packageLabel(clone.package)}.`;
+      : "All libraries in the selected Package";
+  const automaticDiffLabel = versions.status === "available"
+    ? versions.inventory.previousVersionUnavailableReason
+      ? "Automatic: listing unavailable"
+      : versions.inventory.previousVersion
+        ? `Automatic: ${versions.inventory.previousVersion}`
+        : "Automatic: no earlier version"
+    : "Automatic: previous listed version";
+  const retry = supported && (versions.status === "failed"
+    || (versions.status === "available"
+      && versions.inventory.previousVersionUnavailableReason));
+  const diffStatusClass = versions.status === "failed"
+    ? " comparison-target-status-error" : "";
 
-  return `<div class="section-title"><h2>Comparison targets</h2><span>Browser session</span></div>
-    <p>These settings prepare targets for the forthcoming Diff and Clone inspectors.</p>
-    <div class="package-coordinate-fields">
-      <label class="version-select">
-        <span>Diff against</span>
-        <select id="package-diff-target" aria-describedby="package-diff-target-status"${supported ? "" : " disabled"}>
-          <option value="previous"${diff.kind === "previous" ? " selected" : ""}>Previous version (automatic)</option>
+  return `<div class="section-title comparison-targets-title"><h2>Comparison targets</h2><span>Target setup</span></div>
+    <div class="comparison-target-list">
+      <section class="comparison-target-row" aria-labelledby="package-diff-target-label">
+        <div class="comparison-target-heading">
+          <h3 id="package-diff-target-label">Diff baseline</h3>
+        </div>
+        <div class="comparison-target-selection">
+          <select id="package-diff-target" aria-labelledby="package-diff-target-label" aria-describedby="package-diff-target-status"${supported ? "" : " disabled"}>
+          <option value="previous"${diff.kind === "previous" ? " selected" : ""}>${escapeHtml(automaticDiffLabel)}</option>
           ${choices.map(version => `<option value="exact:${escapeHtml(version)}"${diff.kind === "exact" && diff.version === version ? " selected" : ""}>${escapeHtml(version)}</option>`).join("")}
-        </select>
-      </label>
-      <label class="version-select">
-        <span>Clone across</span>
-        <select id="package-clone-target" aria-describedby="package-clone-target-status">
-          <option value="workspace"${clone.kind === "workspace" ? " selected" : ""}>Workspace (including self)</option>
-          ${unavailableClone ? `<option value="unavailable" selected disabled>Unavailable: ${escapeHtml(packageLabel(clone.package))}</option>` : ""}
-          ${packages.map((item, index) => `<option value="package:${index}"${clone.kind === "package" && index === targetIndex ? " selected" : ""}>${escapeHtml(packageLabel(item))}</option>`).join("")}
-        </select>
-      </label>
+          </select>
+          <div class="comparison-target-status${diffStatusClass}">
+            <p id="package-diff-target-status" role="status">${escapeHtml(supported
+              ? diffTargetDescription(diff, versions)
+              : "Version targets are available only for Gallery packages.")}</p>
+            ${retry
+              ? '<button type="button" class="comparison-target-retry" id="package-comparison-retry">Retry versions</button>' : ""}
+          </div>
+        </div>
+      </section>
+      <section class="comparison-target-row" aria-labelledby="package-clone-target-label">
+        <div class="comparison-target-heading">
+          <h3 id="package-clone-target-label">Clone search scope</h3>
+        </div>
+        <div class="comparison-target-selection">
+          <select id="package-clone-target" aria-labelledby="package-clone-target-label" aria-describedby="package-clone-target-status">
+            <option value="workspace"${clone.kind === "workspace" ? " selected" : ""}>Workspace: all libraries</option>
+            ${unavailableClone ? `<option value="unavailable" selected disabled>Unavailable: ${escapeHtml(packageLabel(clone.package))}</option>` : ""}
+            ${packages.map((item, index) => `<option value="package:${index}"${clone.kind === "package" && index === targetIndex ? " selected" : ""}>${escapeHtml(packageLabel(item))}</option>`).join("")}
+          </select>
+          <div class="comparison-target-status">
+            <p id="package-clone-target-status" role="status">${escapeHtml(cloneDescription)}</p>
+          </div>
+        </div>
+      </section>
     </div>
-    <p id="package-diff-target-status" role="status">${escapeHtml(supported
-      ? diffTargetDescription(diff, versions)
-      : "Version comparison targets are currently available for Gallery packages.")}</p>
-    ${supported && (versions.status === "failed"
-      || (versions.status === "available" && versions.inventory.previousVersionUnavailableReason))
-      ? '<button type="button" id="package-comparison-retry">Retry versions</button>' : ""}
-    <p id="package-clone-target-status" role="status">${escapeHtml(cloneDescription)}</p>
-    <p>Automatic Diff uses listed stable releases; preview coordinates can also select earlier previews. Targets are not included in shared links.</p>`;
+    <p class="comparison-target-policy">Session only. Choosing a target does not run a comparison or change shared links.</p>`;
 }
 
 export function bindPackageComparisonTargets<T extends ComparisonPackage>(

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1183,6 +1183,67 @@ kbd {
 .overview-scroll .doc-chip,
 .overview-scroll .type-chip { max-width: 100%; white-space: normal; text-align: left; }
 .overview-scroll .doc-name { min-width: 0; }
+.comparison-targets-title { margin-bottom: 10px; }
+.comparison-target-list { border: 1px solid var(--line); background: var(--panel); }
+.comparison-target-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(170px, .55fr) minmax(320px, 1.45fr);
+  align-items: center;
+  gap: 24px;
+  padding: 14px 12px;
+}
+.comparison-target-row + .comparison-target-row { border-top: 1px solid var(--line); }
+.comparison-target-heading,
+.comparison-target-selection { min-width: 0; }
+.comparison-target-selection { max-width: 680px; }
+.comparison-target-heading h3 { margin: 0; color: var(--text); font-size: 13px; line-height: 1.35; }
+.comparison-target-selection select {
+  width: 100%;
+  height: 34px;
+  min-width: 0;
+  max-width: none;
+  padding: 0 32px 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 2px;
+  background: var(--panel-raised);
+  color: var(--text);
+  font: 11px var(--mono);
+}
+.comparison-target-selection select:hover:not(:disabled) { border-color: var(--muted); }
+.comparison-target-selection select:disabled { opacity: .55; cursor: default; }
+.comparison-target-status {
+  min-width: 0;
+  min-height: 26px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 5px;
+}
+.comparison-target-status p {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  font: 10px/1.5 var(--mono);
+}
+.comparison-target-status-error p { color: var(--red, #d97070); }
+.comparison-target-retry {
+  flex: none;
+  min-height: 26px;
+  padding: 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--muted);
+  font: 10px var(--mono);
+}
+.comparison-target-retry:hover { border-color: var(--line-strong); color: var(--text); }
+.comparison-target-policy {
+  margin: 9px 0 0;
+  color: var(--dim);
+  font: 10px/1.5 var(--mono);
+}
 .api-surface-controls { margin: 0; border: 0; border-bottom: 1px solid var(--line); }
 .api-surface-controls .member-filter-disclosure { border-top: 0; }
 .api-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
@@ -2100,6 +2161,13 @@ kbd {
   .package-dependencies-scroll > .document-section,
   .package-dependencies-scroll > [data-dependency-graph-surface] > .document-section,
   .package-metadata-scroll > .document-section { padding-inline: 12px; }
+  .comparison-target-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+    padding: 12px 10px;
+  }
+  .comparison-target-selection { max-width: none; }
+  .comparison-target-status { min-height: 0; }
   .member-surface-scroll { padding: 12px 12px 52px; }
   .member-overload-surface .member-surface-scroll { padding: 0 0 20px; }
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1128,7 +1128,7 @@ kbd {
 .metadata-surface-footer { justify-content: space-between; }
 .package-dependencies-surface,
 .package-metadata-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: 40px auto minmax(0, 1fr) 34px; background: var(--bg); }
-.overview-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: 40px minmax(0, 1fr) 34px; background: var(--bg); }
+.overview-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: 40px minmax(0, 1fr) 34px; container: overview-surface / inline-size; background: var(--bg); }
 .overview-with-controls { grid-template-rows: 40px auto minmax(0, 1fr) 34px; }
 .overview-surface-label { color: var(--muted); font: 10px var(--mono); letter-spacing: .12em; text-transform: uppercase; }
 .overview-identity { display: flex; align-items: flex-start; gap: 14px; padding: 24px 16px 0; }
@@ -2117,6 +2117,16 @@ kbd {
   .member-contract-list dd { padding-top: 0; }
 }
 
+@container overview-surface (max-width: 580px) {
+  .comparison-target-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+    padding: 12px 10px;
+  }
+  .comparison-target-selection { max-width: none; }
+  .comparison-target-status { min-height: 0; }
+}
+
 @media (max-width: 760px) {
   .brand { width: 48px; padding: 0 14px; }
   .brand span:last-child { display: none; }
@@ -2161,13 +2171,6 @@ kbd {
   .package-dependencies-scroll > .document-section,
   .package-dependencies-scroll > [data-dependency-graph-surface] > .document-section,
   .package-metadata-scroll > .document-section { padding-inline: 12px; }
-  .comparison-target-row {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 8px;
-    padding: 12px 10px;
-  }
-  .comparison-target-selection { max-width: none; }
-  .comparison-target-status { min-height: 0; }
   .member-surface-scroll { padding: 12px 12px 52px; }
   .member-overload-surface .member-surface-scroll { padding: 0 0 20px; }
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }

--- a/prototypes/inspect-web/test/package-comparison-targets.test.ts
+++ b/prototypes/inspect-web/test/package-comparison-targets.test.ts
@@ -32,7 +32,7 @@ test("new Packages default to the previous version and live Workspace including 
     diff: { kind: "previous" }, clone: { kind: "workspace" },
   });
   assert.equal(diffTargetDescription(targets.get(current).diff, versions),
-    "Compare against 1.0.0 (previous version).");
+    "Previous listed release");
 });
 
 test("Library, Type, and Member readers inherit the same Package selection", () => {
@@ -117,9 +117,15 @@ test("form renders escaped coordinates, explicit limitations, and a retry action
   }, escapeHtml);
   assert.match(html, /&lt;Package>/);
   assert.match(html, /&lt;offline>/);
-  assert.match(html, /forthcoming Diff and Clone/);
+  assert.match(html, /comparison-target-list/);
+  assert.match(html, /Diff baseline/);
+  assert.match(html, /Clone search scope/);
+  assert.match(html, /Automatic: previous listed version/);
   assert.match(html, /package-comparison-retry/);
-  assert.match(html, /Workspace \(including self\)/);
+  assert.match(html, /comparison-target-status-error/);
+  assert.match(html, /Workspace: all libraries/);
+  assert.match(html, /Choosing a target does not run a comparison/);
+  assert.doesNotMatch(html, /These settings prepare targets/);
 });
 
 test("failed inventory retry stays visible while preserving an exact selection", () => {
@@ -131,8 +137,18 @@ test("failed inventory retry stays visible while preserving an exact selection",
   }, escapeHtml);
   assert.match(html, /Network unavailable/);
   assert.match(html, /value="exact:1\.0\.0" selected/);
-  assert.doesNotMatch(html, /Compare against 1\.0\.0\./);
+  assert.doesNotMatch(html, /Exact version/);
   assert.match(html, /package-comparison-retry/);
+});
+
+test("available automatic Diff renders the effective version in the control", () => {
+  const current = pkg();
+  const html = renderPackageComparisonTargets({
+    package: current, packages: [current],
+    diff: { kind: "previous" }, clone: { kind: "workspace" }, versions,
+  }, escapeHtml);
+  assert.match(html, /<option value="previous" selected>Automatic: 1\.0\.0<\/option>/);
+  assert.match(html, /id="package-diff-target-status" role="status">Previous listed release/);
 });
 
 test("bindings dispatch exact versions and captured Package objects without eager selection", () => {


### PR DESCRIPTION
## Demo

Package Overview now treats target selection as a dedicated comparison setup task rather than prose interrupted by compact coordinate controls.

### Wide — 1440px

| Before | After |
| --- | --- |
| ![Package comparison targets before at 1440px](https://github.com/user-attachments/assets/d30a8bae-12c9-4251-ac58-4c9780787666) | ![Package comparison targets after at 1440px](https://github.com/user-attachments/assets/43f09195-65f7-4a09-b58f-04c9f8aaa1be) |

### Narrow — 390px

| Before | After |
| --- | --- |
| ![Package comparison targets before at 390px](https://github.com/user-attachments/assets/b099aedf-b0eb-40d8-a79a-22ed55452ef6) | ![Package comparison targets after at 390px](https://github.com/user-attachments/assets/24a917fa-2992-45d5-a6a6-3d48a792540e) |

## Claim

Diff baseline and Clone search scope now share one restrained work area. Each row keeps its persistent task label, native selector, effective state, and local recovery action together. Wide selectors receive enough available width for selected values; narrow rows stack the same elements without changing DOM or focus order.

The automatic Diff choice exposes its effective version directly. Repeated introductory and result-style prose is replaced by one shared policy note.

Comparison semantics, Package-scoped persistence, Gallery inventory behavior, Clone target behavior, and execution authority are unchanged. The current Package-specific Clone selector remains temporary under the existing Structural Clone Search Scope adoption plan.

The refinement applied Impeccable’s read-only Operate, Layout, Typeset, Distill, Polish, Adapt, and Harden guidance. No Impeccable tool, script, detector, browser integration, or installer was run.

## Validation

- `npm test -- --test-reporter=dot`
- `npm run analyze`
- `npm run build`
- Focused Firefox production tests for Package target persistence and Package Overview at 1440px, 800px, and 390px, including direct Overview-scroller overflow measurement
- `markdownlint` for `docs/design/inspect-web-diff-targets.md` and `prototypes/inspect-web/README.md`

Closes #6414
Parent: #5083