### PR TITLE
Fix Workspace root test artifact namespace

### DIFF
--- a/tests/DotnetInspector.Queries.Tests/WorkspaceRootQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceRootQueryTests.cs
@@ -1,6 +1,6 @@
 using System.IO.Compression;
 
-using DotnetInspector.Artifacts;
+using Inspector.Artifacts;
 using DotnetInspector.Packages;
 using DotnetInspector.Queries.EmbeddedFixtures;
 using DotnetInspector.QueriesConsumer;


### PR DESCRIPTION
dotnet-inspect builds robust, capable inspection features that provide foundational capabilities or compelling user experiences, with designs that are conventionally sound, delightfully new or unique, or both.

## Summary

Updates `WorkspaceRootQueryTests` to import the current `Inspector.Artifacts` namespace after the artifact project migration. This restores compilation of the Query test project and the repository-wide CI paths that consume it.

## Demo

Before:

```text
WorkspaceRootQueryTests.cs(3,23): error CS0234: The type or namespace name Artifacts does not exist in the namespace DotnetInspector
```

After:

```text
DotnetInspector.Queries.Tests -> .../DotnetInspector.Queries.Tests.dll
Build succeeded.
```

The neighboring Query tests already import `Inspector.Artifacts`; this change brings the newly landed Workspace root test into the same project-wide namespace.

## Validation

- `dotnet build tests/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj -c Release --nologo`

This is trivial: it changes one stale namespace import to the existing namespace exported by the referenced project, with no production behavior change.