### PR TITLE
Migrate CSharpText tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -225,6 +225,13 @@ Deep Inspect platform, and developer commands remain unfiltered. These paths
 reuse the pinned outcome-level host gate without changing the suite's artifact
 access, local admission, workspace-session, digest, or cleanup evidence.
 
+`CSharpText.Tests` is the thirteenth migrated adopter. Its required PR, Deep
+Inspect platform, and developer commands remain unfiltered. These paths reuse
+the pinned outcome-level host gate without changing the suite's identifier,
+signature, declaration, conditional-recovery, or layout evidence. Manual
+decompiler fixture probes continue to inspect the built test assembly rather
+than invoke its test host.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/CSharpText.Tests/CSharpText.Tests.csproj
+++ b/tests/CSharpText.Tests/CSharpText.Tests.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
This advances robust, conventional test evidence by making stale
`CSharpText.Tests` selectors fail through the test platform that owns
discovery and filtering.

## Demo

Before this change, the native xUnit host accepts an unmatched class selector
as successful evidence:

```text
CSharpText.Tests  Total: 0
exit=0
```

With Microsoft Testing Platform selected, the equivalent stale filter remains
visible as zero execution and fails:

```text
Test run summary: Zero tests ran
  total: 0
exit=8
```

A neighboring valid class filter still executes normally:

```text
Test run summary: Passed!
  total: 2
  failed: 0
exit=0
```

## Summary

- Select Microsoft Testing Platform for `CSharpText.Tests` through the
  `xunit.v3` integration already pinned by the repository.
- Record the suite as the thirteenth migrated adopter in the xUnit host owner.
- Preserve all supported PR, Deep Inspect, and developer invocations
  unchanged because they are unfiltered.
- Preserve manual decompiler fixture probes, which inspect the built test
  assembly rather than invoke its test host.

## Design basis

`docs/design/xunit-test-host.md` owns repository xUnit host selection and
aggregate zero-test behavior. MTP owns parsing, discovery, filtering,
execution, and exit code `8`; this slice adds no selector parser, runner
library dependency, workflow scan, or output parser.

The migration does not reinterpret the suite's identifier, signature,
declaration, conditional-recovery, or layout evidence.

## Validation

- Unmatched MTP class filter: 0 tests, exit `8`.
- `CSharpText.Tests.LayeringTests`: 2 passed.
- Full `CSharpText.Tests` suite: 755 passed.
- Full Release solution build.
- `markdownlint` and `git diff --check`.

Closes the thirteenth migration slice of #5379.
