### PR TITLE
Fix workspace root artifact namespace

### DIFF
--- a/tests/DotnetInspector.Queries.Tests/WorkspaceRootQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceRootQueryTests.cs
@@ -1,6 +1,6 @@
 using System.IO.Compression;
 
-using DotnetInspector.Artifacts;
+using Inspector.Artifacts;
 using DotnetInspector.Packages;
 using DotnetInspector.Queries.EmbeddedFixtures;
 using DotnetInspector.QueriesConsumer;


### PR DESCRIPTION
Restore the Queries test build after the artifact namespace migration by updating the one stale import left in `WorkspaceRootQueryTests`. This is a trivial compile-only correction with no behavior change.

## Demo

Before: `WorkspaceRootQueryTests.cs(3,23): CS0234` because `DotnetInspector.Artifacts` no longer exists.

After: the test project resolves `PackageRootBinding` through `Inspector.Artifacts` and builds successfully.

## Validation

- `dotnet build tests/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj -c Release --no-restore`