### PR TITLE
Retain package asset-selection correspondence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [Platform Composition and Overlays](design/platform-composition-and-overlays.md) | Platform library composition, overlays, and core-library entitlement. |
 | [Platform/Package Pruning](design/platform-package-pruning.md) | Which package identities a platform target subsumes, the subsumption comparison, and the staleness contract for the shipped prune inventory. |
 | [Platform Package Supply Policy](design/platform-package-supply-policy.md) | Host-neutral decision from a package coordinate and target-bound prune inventory to preserved supply evidence and conservative platform delegation. |
+| [Package Asset-selection Correspondence](design/package-asset-selection-correspondence.md) | Resource-free generation and request correspondence for runtime and compile asset-selection outcomes. |
 | [Type, Member, and API Representation](design/type-member-api-representation.md) | Canonical type, member, and API identity model. |
 | [Member Signature Shape and Transport](design/member-signature-shape.md) | Non-authoritative signature correspondence: loss-policy rationale, caller obligations, alternatives, canonical `mss1` grammar, and evolution. |
 | [C# Type-Declaration Identifier Admission](design/csharp-type-declaration-identifier-admission.md) | Compiler-characterized model-free admission from exact identity text to a legal C# declared-type identifier spelling or typed refusal. |

--- a/docs/design/package-asset-selection-correspondence.md
+++ b/docs/design/package-asset-selection-correspondence.md
@@ -1,0 +1,83 @@
+# Package asset-selection correspondence
+
+## Status
+
+Implemented as a focused prerequisite for the PackageHouse resource-free
+contract slice in #6433.
+
+## Authority and exact claim
+
+The existing runtime and compile asset selectors own one additional result
+contract:
+
+> A selector evaluation retains the exact package-content generation and
+> request arguments that produced its existing typed selection outcome,
+> without retaining package content.
+
+This owner does not change framework compatibility, runtime-identifier
+selection, compile/reference preference, default-asset selection, or
+compile-to-implementation correspondence. Those remain properties of
+`PackageAssetSelection` and `PackageCompileAssetSelection`.
+
+## Receipts
+
+`PackageAssetSelector.Evaluate` returns `PackageAssetSelectionReceipt` with:
+
+- the `PackageContentGenerationIdentity` read from the input content;
+- the exact requested target-framework string;
+- the exact optional requested runtime identifier; and
+- the existing `PackageAssetSelection` outcome.
+
+`PackageCompileAssetSelector.Evaluate` returns
+`PackageCompileAssetSelectionReceipt` with the same generation and request
+evidence plus the exact package ID used for default-asset selection and the
+existing `PackageCompileAssetSelection` outcome.
+
+The receipts are resource-free. They do not retain `IPackageContent`, streams,
+filesystem paths outside the existing package-relative asset outcomes, package
+source clients, or leases.
+
+The existing `Select` methods remain convenience projections returning
+`Evaluate(...).Selection`. Existing consumers therefore keep their current
+result and behavior while consumers that join selection with acquisition can
+retain owner-issued correspondence.
+
+## Composition and adoption
+
+[#6426](https://github.com/richlander/dotnet-inspect/issues/6426) is the
+eleven-step PackageHouse production-adoption tracker. The immediate consumer is
+the resource-free PackageHouse contract slice in #6433.
+
+PackageHouse may compare a selector receipt's generation and exact request
+arguments with its acquisition and target-context receipts. It does not
+construct selector correspondence around an independently supplied selection
+outcome.
+
+This slice does not implement PackageHouse, Workspace admission, package
+acquisition, dependency traversal, CLI or browser/Wasm behavior, rendering, or
+content lifetime.
+
+## Gates
+
+The focused gates run with:
+
+```text
+dotnet run --project tests/DotnetInspector.Services.Tests -c Release -- \
+  --filter-class '*PackageAssetSelectorTests' \
+  '*PackageCompileAssetSelectorTests'
+```
+
+| Property | Gate |
+| --- | --- |
+| Runtime evaluation retains generation, request, and outcome | `Evaluate_RetainsGenerationRequestAndSelection` |
+| Compile evaluation retains generation, request, and outcome | `Evaluate_RetainsGenerationRequestAndSelection` |
+| A null runtime framework remains a typed invalid outcome | `Evaluate_PreservesNullTargetAsTypedInvalidSelection` |
+| Receipt instance type graphs retain no content or disposable resource | `SelectionReceiptsAreResourceFree` |
+| Existing runtime selection remains the evaluation projection | Existing `PackageAssetSelectorTests` |
+| Existing compile selection remains the evaluation projection | Existing `PackageCompileAssetSelectorTests` |
+
+## Non-claims
+
+The receipts do not prove package coordinate, source, producer, authority,
+operation, dependency edge, or platform correspondence. Those associations
+require their respective owner-issued evidence at a composition boundary.

--- a/src/DotnetInspector.Packages/PackageAssetSelector.cs
+++ b/src/DotnetInspector.Packages/PackageAssetSelector.cs
@@ -103,6 +103,35 @@ public abstract record PackageAssetSelection
 }
 
 /// <summary>
+/// Resource-free evidence binding one runtime asset-selection outcome to the
+/// content generation and exact request that produced it.
+/// </summary>
+public sealed class PackageAssetSelectionReceipt
+{
+    internal PackageAssetSelectionReceipt(
+        PackageContentGenerationIdentity generation,
+        string? requestedTargetFramework,
+        string? requestedRuntimeIdentifier,
+        PackageAssetSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(generation);
+        ArgumentNullException.ThrowIfNull(selection);
+        Generation = generation;
+        RequestedTargetFramework = requestedTargetFramework;
+        RequestedRuntimeIdentifier = requestedRuntimeIdentifier;
+        Selection = selection;
+    }
+
+    public PackageContentGenerationIdentity Generation { get; }
+
+    public string? RequestedTargetFramework { get; }
+
+    public string? RequestedRuntimeIdentifier { get; }
+
+    public PackageAssetSelection Selection { get; }
+}
+
+/// <summary>
 /// Selects one effective assembly asset universe from package content, over
 /// <see cref="IPackageContent.EnumerateEntries"/> only, so a host without a
 /// filesystem uses the same selection as the desktop cache.
@@ -197,6 +226,29 @@ public static class PackageAssetSelector
     /// <paramref name="runtimeIdentifier"/>.
     /// </summary>
     public static PackageAssetSelection Select(
+        IPackageContent content,
+        string targetFramework,
+        string? runtimeIdentifier = null) =>
+        Evaluate(content, targetFramework, runtimeIdentifier).Selection;
+
+    /// <summary>
+    /// Selects the effective asset universe and retains its exact invocation
+    /// correspondence without retaining package content.
+    /// </summary>
+    public static PackageAssetSelectionReceipt Evaluate(
+        IPackageContent content,
+        string targetFramework,
+        string? runtimeIdentifier = null)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return new PackageAssetSelectionReceipt(
+            content.GenerationIdentity,
+            targetFramework,
+            runtimeIdentifier,
+            SelectCore(content, targetFramework, runtimeIdentifier));
+    }
+
+    private static PackageAssetSelection SelectCore(
         IPackageContent content,
         string targetFramework,
         string? runtimeIdentifier = null)

--- a/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
+++ b/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
@@ -130,6 +130,40 @@ public sealed record PackageCompileAssetSelection(
 }
 
 /// <summary>
+/// Resource-free evidence binding one compile asset-selection outcome to the
+/// content generation and exact request that produced it.
+/// </summary>
+public sealed class PackageCompileAssetSelectionReceipt
+{
+    internal PackageCompileAssetSelectionReceipt(
+        PackageContentGenerationIdentity generation,
+        string packageId,
+        string? requestedTargetFramework,
+        string? requestedRuntimeIdentifier,
+        PackageCompileAssetSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(generation);
+        ArgumentNullException.ThrowIfNull(packageId);
+        ArgumentNullException.ThrowIfNull(selection);
+        Generation = generation;
+        PackageId = packageId;
+        RequestedTargetFramework = requestedTargetFramework;
+        RequestedRuntimeIdentifier = requestedRuntimeIdentifier;
+        Selection = selection;
+    }
+
+    public PackageContentGenerationIdentity Generation { get; }
+
+    public string PackageId { get; }
+
+    public string? RequestedTargetFramework { get; }
+
+    public string? RequestedRuntimeIdentifier { get; }
+
+    public PackageCompileAssetSelection Selection { get; }
+}
+
+/// <summary>
 /// Adds reference-assembly and explicit-empty-group semantics to the implementation universe
 /// selected by <see cref="PackageAssetSelector"/>, without requiring a filesystem.
 /// </summary>
@@ -141,6 +175,40 @@ public static class PackageCompileAssetSelector
     const string EmptyGroupMarker = "_._";
 
     public static PackageCompileAssetSelection Select(
+        IPackageContent content,
+        string packageId,
+        string? targetFramework = null,
+        string? runtimeIdentifier = null) =>
+        Evaluate(
+            content,
+            packageId,
+            targetFramework,
+            runtimeIdentifier).Selection;
+
+    /// <summary>
+    /// Selects compile assets and retains the exact invocation correspondence
+    /// without retaining package content.
+    /// </summary>
+    public static PackageCompileAssetSelectionReceipt Evaluate(
+        IPackageContent content,
+        string packageId,
+        string? targetFramework = null,
+        string? runtimeIdentifier = null)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return new PackageCompileAssetSelectionReceipt(
+            content.GenerationIdentity,
+            packageId,
+            targetFramework,
+            runtimeIdentifier,
+            SelectCore(
+                content,
+                packageId,
+                targetFramework,
+                runtimeIdentifier));
+    }
+
+    private static PackageCompileAssetSelection SelectCore(
         IPackageContent content,
         string packageId,
         string? targetFramework = null,

--- a/tests/DotnetInspector.Services.Tests/PackageAssetSelectorTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageAssetSelectorTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Services.Tests;
@@ -9,6 +10,75 @@ namespace DotnetInspector.Services.Tests;
 /// </summary>
 public sealed class PackageAssetSelectorTests
 {
+    [Fact]
+    public void Evaluate_RetainsGenerationRequestAndSelection()
+    {
+        var content = new InMemoryPackageContent(
+            TestPackageArchive.Create(
+                "lib/net8.0/Sample.dll"),
+            fromCache: true,
+            "test-source");
+
+        PackageAssetSelectionReceipt receipt =
+            PackageAssetSelector.Evaluate(
+                content,
+                "net10.0",
+                "linux-x64");
+
+        Assert.Same(content.GenerationIdentity, receipt.Generation);
+        Assert.Equal("net10.0", receipt.RequestedTargetFramework);
+        Assert.Equal("linux-x64", receipt.RequestedRuntimeIdentifier);
+        Assert.Equal(
+            "net8.0",
+            Selected(receipt.Selection).TargetFramework);
+    }
+
+    [Fact]
+    public void Evaluate_PreservesNullTargetAsTypedInvalidSelection()
+    {
+        var content = new InMemoryPackageContent(
+            TestPackageArchive.Create(
+                "lib/net8.0/Sample.dll"),
+            fromCache: true,
+            "test-source");
+
+        PackageAssetSelectionReceipt receipt =
+            PackageAssetSelector.Evaluate(content, null!);
+
+        Assert.Null(receipt.RequestedTargetFramework);
+        Assert.IsType<PackageAssetSelection.Invalid>(receipt.Selection);
+        Assert.IsType<PackageAssetSelection.Invalid>(
+            PackageAssetSelector.Select(content, null!));
+    }
+
+    [Fact]
+    public void SelectionReceiptsAreResourceFree()
+    {
+        Type[] graph =
+        [
+            .. InstanceTypeGraph(typeof(PackageAssetSelectionReceipt)),
+            .. InstanceTypeGraph(typeof(PackageAssetSelection)),
+            .. typeof(PackageAssetSelection)
+                .GetNestedTypes(BindingFlags.Public)
+                .SelectMany(InstanceTypeGraph),
+            .. InstanceTypeGraph(typeof(PackageAssetUniverse)),
+            .. InstanceTypeGraph(typeof(PackageAssetEntry)),
+            .. InstanceTypeGraph(
+                typeof(PackageCompileAssetSelectionReceipt)),
+            .. InstanceTypeGraph(typeof(PackageCompileAssetSelection)),
+            .. InstanceTypeGraph(typeof(PackageCompileAsset)),
+        ];
+
+        Assert.DoesNotContain(
+            graph,
+            type =>
+                typeof(Stream).IsAssignableFrom(type)
+                || typeof(IPackageContent).IsAssignableFrom(type)
+                || typeof(IDisposable).IsAssignableFrom(type)
+                || typeof(IAsyncDisposable).IsAssignableFrom(type)
+                || typeof(Delegate).IsAssignableFrom(type));
+    }
+
     [Fact]
     public void Select_TakesHighestApplicableFrameworkFolder()
     {
@@ -603,4 +673,42 @@ public sealed class PackageAssetSelectorTests
                 "test-source"),
             targetFramework,
             runtimeIdentifier);
+
+    static IEnumerable<Type> InstanceTypeGraph(Type root)
+    {
+        var pending = new Stack<Type>([root]);
+        var seen = new HashSet<Type>();
+        while (pending.TryPop(out Type? current))
+        {
+            if (!seen.Add(current))
+                continue;
+
+            yield return current;
+            foreach (FieldInfo field in current.GetFields(
+                BindingFlags.Instance
+                | BindingFlags.Public
+                | BindingFlags.NonPublic))
+            {
+                Add(field.FieldType);
+            }
+        }
+
+        void Add(Type type)
+        {
+            if (type.IsArray)
+                Add(type.GetElementType()!);
+            foreach (Type argument in type.GetGenericArguments())
+                Add(argument);
+
+            if (type.IsPrimitive
+                || type.IsEnum
+                || type == typeof(string)
+                || type == typeof(decimal))
+            {
+                return;
+            }
+
+            pending.Push(type);
+        }
+    }
 }

--- a/tests/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
@@ -15,6 +15,27 @@ public class PackageCompileAssetSelectorTests : IDisposable
     }
 
     [Fact]
+    public void Evaluate_RetainsGenerationRequestAndSelection()
+    {
+        IPackageContent content = InMemory(
+            "lib/net8.0/Example.dll",
+            "ref/net8.0/Example.dll");
+
+        PackageCompileAssetSelectionReceipt receipt =
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "Example",
+                "net8.0",
+                "linux-x64");
+
+        Assert.Same(content.GenerationIdentity, receipt.Generation);
+        Assert.Equal("Example", receipt.PackageId);
+        Assert.Equal("net8.0", receipt.RequestedTargetFramework);
+        Assert.Equal("linux-x64", receipt.RequestedRuntimeIdentifier);
+        Assert.True(receipt.Selection.IsSelected);
+    }
+
+    [Fact]
     public void InMemorySelection_PrefersReferenceAssetsAndPackageNamedDefault()
     {
         IPackageContent content = InMemory(


### PR DESCRIPTION
This advances dotnet-inspect's package architecture toward a robust
PackageHouse facade by letting the existing asset-selection owners issue the
correspondence needed to join selection with acquisition.

## Demo

Before, callers received a typed selection but no owner-issued association
with the content generation or exact request:

```csharp
PackageCompileAssetSelection selection =
    PackageCompileAssetSelector.Select(
        content,
        "Example",
        "net10.0",
        "linux-x64");
```

Callers can now retain that correspondence without retaining content:

```csharp
PackageCompileAssetSelectionReceipt receipt =
    PackageCompileAssetSelector.Evaluate(
        content,
        "Example",
        "net10.0",
        "linux-x64");

Assert.Same(content.GenerationIdentity, receipt.Generation);
Assert.Same(selectionOwnerOutcome, receipt.Selection);
```

The runtime selector exposes the same shape through
`PackageAssetSelector.Evaluate`. Existing `Select` methods remain projections
of the new evaluation APIs.

## Summary

- add resource-free runtime and compile selection receipts retaining content
  generation, exact request arguments, and existing owner outcomes;
- preserve all current selector semantics and `Select` APIs;
- retain null runtime target requests as the existing typed `Invalid` outcome;
- gate receipt type graphs against content, streams, sync/async disposable
  resources, and delegates; and
- document the focused selector-owner contract and PackageHouse adoption
  boundary.

This slice does not implement PackageHouse, acquisition, Workspace admission,
dependency traversal, rendering, or CLI/browser behavior.

## Stack

This is slice 2 of the current PackageHouse prerequisite stack.

- parent: #6448
- target branch: `feature/platform-supply-receipt`
- next: #6433 consumes both owner-issued receipt families

## Validation

```text
dotnet run --project tests/DotnetInspector.Services.Tests -c Release -- \
  --filter-class '*PackageAssetSelectorTests' \
  '*PackageCompileAssetSelectorTests'
```

80 passed.

```text
npx markdownlint-cli \
  docs/design/package-asset-selection-correspondence.md \
  docs/README.md
```

Passed.
