### PR TITLE
Define resource-free PackageHouse contracts

### DIFF
--- a/docs/design/package-house.md
+++ b/docs/design/package-house.md
@@ -53,7 +53,7 @@ The owner defines:
 - composition of owner-issued package source, version, pruning, payload,
   asset-selection, and dependency capabilities;
 - the House result envelope and terminal outcome;
-- the package decision and realization receipts;
+- the package decision, acquisition, and realization receipts;
 - typed package-to-platform delegation;
 - package-to-library unwrapping with retained provenance;
 - target-aware dependency-edge realization handoff;
@@ -129,7 +129,7 @@ PackageHouse is above these roles by composition, not by ownership transfer.
 | Version policy | Exact, latest, wildcard, range, listing, and prerelease decisions from [Version Resolution](version-resolution.md) |
 | Pruning | Exact target-bound package supply decisions from [Platform Package Supply Policy](platform-package-supply-policy.md) |
 | Dependency expansion | Exact candidate and immutable graph evidence from [Package Dependency Traversal](package-dependency-traversal.md) |
-| Asset selection | Package content and typed selected asset outcomes from `PackageAssetSelector` and `PackageCompileAssetSelector` |
+| Asset selection | Generation- and request-bound outcomes from [Package Asset-selection Correspondence](package-asset-selection-correspondence.md) |
 | Artifact lifetime | Generation-scoped content, contributions, and sessions from [Artifact Acquisition and Workspaces](artifact-acquisition-and-workspaces.md) |
 
 PackageHouse does not accept transport URLs, rendered dependency rows, asset
@@ -152,6 +152,13 @@ prefix or search row is not itself a House package identity.
 An unresolved version demand retains its original constraint beside every
 selection observation. Resolution issues one exact coordinate or a typed
 non-success; it does not replace the request with a display version.
+
+The initial resource-free contract floor in #6433 deliberately exposes only
+the exact-coordinate demand. The selecting and resolved-edge arms remain
+architectural requirements, but they do not enter the public contract until
+their owners issue a version-selection request and resolution receipt, or an
+edge correspondence, that PackageHouse can consume without interpreting
+selector text.
 
 ## Package target context
 
@@ -274,12 +281,27 @@ Every terminal House result retains:
 - completion and every typed failure; and
 - one owner-issued settlement identity that consumers retain opaquely.
 
-The result contains two separable receipts when the corresponding work ran:
+The result contains three separable receipts when the corresponding work ran:
 
 - a **package decision receipt** records coordinate settlement, authority,
   pruning, and the decision to acquire, delegate, or stop; and
-- a **package realization receipt** records the acquired generation, requested
-  target context, selected asset universe, and library-focused handoff.
+- a **package acquisition receipt** binds the retained decision and candidate
+  to the selected configured authority, source result and producer, payload
+  origin, and package-content generation; and
+- a **package realization receipt** binds that acquisition to an
+  asset-selection-owner receipt and any library-focused handoffs.
+
+Every terminal arm retains one common immutable evidence envelope containing
+the settlement identity, every completed receipt, and every typed failure.
+A later no-match, rejection, incompleteness, or failure does not rewrite or
+discard an earlier package-retention decision or successful acquisition.
+Recovered request-scoped failures may accompany `Settled`; operation timeout
+is terminal and cannot. House failure adaptation retains an owner-issued
+authority failure and associates it with the House operation; an owner
+`PackageSourceTimeoutKind.Operation` remains terminal through that adaptation.
+Operation timeout takes precedence over an otherwise successful selection:
+`Failed` retains the completed acquisition and realization receipts, including
+selected assets or an explicit empty compile group.
 
 Consumers may retain the decision without retaining payload bytes. A disposed
 payload or expired artifact session does not erase the historical decision
@@ -316,6 +338,20 @@ deadline identity.
 A `Settled` package may contain zero, one, or many selected libraries.
 Package-shaped inspection remains available when its acquired content and
 lifetime remain available.
+
+For a completed realization, the asset-selection owner outcome determines the
+House terminal family:
+
+- selected runtime or compile assets produce `Settled`;
+- an explicit empty compile group produces `Settled` with zero library
+  handoffs;
+- no assets or no matching target produce `NoMatch`;
+- runtime ambiguity produces `Ambiguous`; and
+- invalid runtime or implementation-asset evidence produces `Rejected`.
+
+Every non-success mapping retains the completed acquisition and realization
+receipts. Constructing a realization receipt is evidence that selection ran;
+it does not by itself make the operation successful.
 
 ## Target-aware dependency-edge realization
 
@@ -361,6 +397,12 @@ selected identity remains distinct from the `net10.0` request.
 The package owner invokes the focused platform package supply policy before
 payload acquisition when the request has complete comparable target and
 package version evidence.
+
+PackageHouse consumes the policy-issued `PlatformSupplyReceipt`; it does not
+attach an independently supplied `PlatformSupply` to package and target
+labels. Delegation additionally requires the actual supplying shared-framework
+family and exact inventory family version to match the retained
+`PlatformFamilyTarget`.
 
 Only `Subsumed` authorizes delegation. The package decision receipt retains:
 
@@ -492,8 +534,10 @@ The first implementation may keep host-neutral PackageHouse source settlement
 inside `DotnetInspector.Packages`, replacing the
 `DesktopPackageSourceComposition` identity. Query adapters that require both
 `DotnetInspector.Packages` and `DotnetInspector.Queries` belong in
-`DotnetInspector.PackageQueries` or another separately justified package
-composition project.
+`DotnetInspector.PackageQueries` only when the boundary investigation in
+[#6432](https://github.com/richlander/dotnet-inspect/issues/6432) confirms that
+ownership; this design does not pre-decide whether that project remains,
+merges, or decomposes.
 
 `DotnetInspector.Queries` does not depend on a higher project merely to keep
 its evidence and traversal algorithms usable. PackageHouse does not introduce
@@ -654,10 +698,15 @@ every supported host that uses it.
 
 | Claim | Required Release evidence |
 | --- | --- |
+| Exact implementation floor | The public demand family exposes only the exact-coordinate arm until a version-owner request and resolution receipt exist. |
 | Request association | A result retains the exact demand, operation, target context, and owner-issued settlement identity without reconstructing them from display values. |
+| Terminal evidence | Every terminal arm retains the same immutable evidence envelope, completed receipts, and typed failures; direct and owner-adapted operation timeouts cannot produce success. |
 | Source completeness | Partial authority evidence cannot settle latest, wildcard, range, or authoritative absence. |
 | Pruning order | `Subsumed` skips payload acquisition and every other pruning state cannot issue platform delegation. |
+| Pruning correspondence | Platform delegation consumes the policy-issued inventory/coordinate/supply receipt and matches the actual supplier family and exact target version. |
 | Payload authority | Discovered payload comes only from a reporting authority; pinned payload follows the Package Source Model's eligible-authority rule. |
+| Selection correspondence | Realization consumes a selector-issued generation/request/outcome receipt matching the exact acquisition and target context. |
+| Selection completion | Selected assets and explicit empty compile groups settle; no-match, ambiguity, and invalid outcomes map to their corresponding terminal arms without losing receipts. |
 | Target-aware realization | A `net10.0` dependency with `net10.0` and `net11.0` folders selects `net10.0` and retains requested-versus-selected evidence. |
 | Context separation | The same coordinate realized under two target contexts retains two realization receipts and cannot share one selected asset universe. |
 | Package shape | Zero, one, and many selected library outcomes preserve package-shaped inspection and typed asset status. |

--- a/docs/design/package-house.md
+++ b/docs/design/package-house.md
@@ -703,7 +703,7 @@ every supported host that uses it.
 | Terminal evidence | Every terminal arm retains the same immutable evidence envelope, completed receipts, and typed failures; direct and owner-adapted operation timeouts cannot produce success. |
 | Source completeness | Partial authority evidence cannot settle latest, wildcard, range, or authoritative absence. |
 | Pruning order | `Subsumed` skips payload acquisition and every other pruning state cannot issue platform delegation. |
-| Pruning correspondence | Platform delegation consumes the policy-issued inventory/coordinate/supply receipt and matches the actual supplier family and exact target version. |
+| Pruning correspondence | Platform delegation consumes the policy-issued inventory/coordinate/supply receipt, compares the coordinate through the package owner's normalization, and matches the actual supplier family and exact target version. |
 | Payload authority | Discovered payload comes only from a reporting authority; pinned payload follows the Package Source Model's eligible-authority rule. |
 | Selection correspondence | Realization consumes a selector-issued generation/request/outcome receipt matching the exact acquisition and target context. |
 | Selection completion | Selected assets and explicit empty compile groups settle; no-match, ambiguity, and invalid outcomes map to their corresponding terminal arms without losing receipts. |

--- a/eng/decompiler-gate-skip-projects.txt
+++ b/eng/decompiler-gate-skip-projects.txt
@@ -85,7 +85,6 @@ fixtures/sourcelink/DotnetInspector.SourceLinkVisualBasicFixtures
 src/DotnetInspector.Ecosystems
 src/DotnetInspector.MetadataRendering
 src/DotnetInspector.PackageQueries
-src/DotnetInspector.Platforms
 src/DotnetInspector.Presentation
 src/DotnetInspector.Sections
 src/DotnetInspector.SourceDelegation

--- a/eng/inspect-web-gate-projects.txt
+++ b/eng/inspect-web-gate-projects.txt
@@ -7,6 +7,7 @@ src/DotnetInspector.Core
 src/DotnetInspector.Ecosystems
 src/DotnetInspector.PackageQueries
 src/DotnetInspector.Packages
+src/DotnetInspector.Platforms
 src/DotnetInspector.Presentation
 src/DotnetInspector.Queries
 src/DotnetInspector.ResearchQueries

--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
+    <ProjectReference Include="..\DotnetInspector.Platforms\DotnetInspector.Platforms.csproj" />
     <ProjectReference Include="..\NuGetFetch\NuGetFetch.csproj" />
     <PackageReference Include="NuGet.Versioning" />
     <InternalsVisibleTo Include="DotnetInspector.Queries.Tests" />

--- a/src/DotnetInspector.Packages/PackageHouseRequest.cs
+++ b/src/DotnetInspector.Packages/PackageHouseRequest.cs
@@ -1,0 +1,275 @@
+using DotnetInspector.Platforms;
+using NuGetFetch;
+
+namespace DotnetInspector.Packages;
+
+/// <summary>The maximum work one PackageHouse request authorizes.</summary>
+public enum PackageHouseOperationProfile
+{
+    Settle,
+    Acquire,
+    Realize,
+}
+
+/// <summary>The existing package-owner selection result one realization requests.</summary>
+public enum PackageHouseAssetSelectionKind
+{
+    Compile,
+    Runtime,
+}
+
+/// <summary>Whether a realization remains package-shaped or also unwraps libraries.</summary>
+public enum PackageHouseLibraryHandoffMode
+{
+    PackageOnly,
+    SelectedLibraries,
+}
+
+/// <summary>How the package target framework is selected.</summary>
+public enum PackageHouseTargetSelectionMode
+{
+    Exact,
+    OwnerDefault,
+}
+
+/// <summary>Opaque identity for one PackageHouse operation declaration.</summary>
+public sealed class PackageHouseOperationIdentity
+{
+    internal PackageHouseOperationIdentity()
+    {
+    }
+
+    public override string ToString() => nameof(PackageHouseOperationIdentity);
+}
+
+/// <summary>Opaque caller-owned association with the request's originating fact.</summary>
+public sealed class PackageHouseRequestAssociation
+{
+    private PackageHouseRequestAssociation()
+    {
+    }
+
+    public static PackageHouseRequestAssociation Create() => new();
+
+    public override string ToString() => nameof(PackageHouseRequestAssociation);
+}
+
+/// <summary>One resource-free PackageHouse operation declaration.</summary>
+public sealed class PackageHouseOperation
+{
+    private PackageHouseOperation(
+        PackageHouseOperationProfile profile,
+        TimeSpan requestTimeout,
+        TimeSpan operationTimeout)
+    {
+        if (!Enum.IsDefined(profile))
+            throw new ArgumentOutOfRangeException(nameof(profile));
+
+        ValidateTimeout(requestTimeout, nameof(requestTimeout));
+        ValidateTimeout(operationTimeout, nameof(operationTimeout));
+
+        Identity = new PackageHouseOperationIdentity();
+        Profile = profile;
+        RequestTimeout = requestTimeout;
+        OperationTimeout = operationTimeout;
+    }
+
+    public PackageHouseOperationIdentity Identity { get; }
+
+    public PackageHouseOperationProfile Profile { get; }
+
+    public TimeSpan RequestTimeout { get; }
+
+    public TimeSpan OperationTimeout { get; }
+
+    public static PackageHouseOperation Create(
+        PackageHouseOperationProfile profile,
+        TimeSpan? requestTimeout = null,
+        TimeSpan? operationTimeout = null) =>
+        new(
+            profile,
+            requestTimeout ?? NuGetFetchOptions.DefaultRequestTimeout,
+            operationTimeout ?? NuGetFetchOptions.DefaultOperationTimeout);
+
+    private static void ValidateTimeout(TimeSpan timeout, string parameterName)
+    {
+        if (timeout <= TimeSpan.Zero || timeout == Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                timeout,
+                "A PackageHouse timeout must be finite and positive.");
+        }
+    }
+}
+
+/// <summary>One PackageHouse demand form supported by this contract floor.</summary>
+public abstract class PackageHouseDemand
+{
+    private PackageHouseDemand()
+    {
+    }
+
+    /// <summary>One already normalized exact package coordinate.</summary>
+    public sealed class Exact : PackageHouseDemand
+    {
+        public Exact(PackageSourceCoordinate coordinate)
+        {
+            ArgumentNullException.ThrowIfNull(coordinate);
+            Coordinate = coordinate;
+        }
+
+        public PackageSourceCoordinate Coordinate { get; }
+    }
+}
+
+/// <summary>One package-owned target-selection context.</summary>
+public sealed class PackageHouseTargetContext
+{
+    private PackageHouseTargetContext(
+        PackageHouseTargetSelectionMode mode,
+        string? requestedFramework,
+        string? runtimeIdentifier,
+        PlatformFamilyTarget? platformTarget)
+    {
+        Mode = mode;
+        RequestedFramework = requestedFramework;
+        RuntimeIdentifier = runtimeIdentifier;
+        PlatformTarget = platformTarget;
+    }
+
+    public PackageHouseTargetSelectionMode Mode { get; }
+
+    public string? RequestedFramework { get; }
+
+    public string? RuntimeIdentifier { get; }
+
+    public PlatformFamilyTarget? PlatformTarget { get; }
+
+    public static PackageHouseTargetContext Exact(
+        string requestedFramework,
+        string? runtimeIdentifier = null,
+        PlatformFamilyTarget? platformTarget = null)
+    {
+        string framework = NormalizeFramework(
+            requestedFramework,
+            nameof(requestedFramework));
+        string? runtime = ValidateRuntimeIdentifier(
+            runtimeIdentifier,
+            nameof(runtimeIdentifier));
+
+        if (platformTarget is not null
+            && !framework.Equals(
+                platformTarget.TargetFramework.ToString(),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                "The platform correspondence must describe the requested package framework.",
+                nameof(platformTarget));
+        }
+
+        return new PackageHouseTargetContext(
+            PackageHouseTargetSelectionMode.Exact,
+            framework,
+            runtime,
+            platformTarget);
+    }
+
+    public static PackageHouseTargetContext OwnerDefault(
+        string? runtimeIdentifier = null) =>
+        new(
+            PackageHouseTargetSelectionMode.OwnerDefault,
+            requestedFramework: null,
+            ValidateRuntimeIdentifier(
+                runtimeIdentifier,
+                nameof(runtimeIdentifier)),
+            platformTarget: null);
+
+    internal static string NormalizeFramework(
+        string value,
+        string parameterName)
+    {
+        if (!PackageCoordinateResolver.IsAcquisitionTargetText(value))
+        {
+            throw new ArgumentException(
+                "A package target framework must be a bounded ASCII target moniker.",
+                parameterName);
+        }
+
+        return value.ToLowerInvariant();
+    }
+
+    internal static string? ValidateRuntimeIdentifier(
+        string? value,
+        string parameterName)
+    {
+        if (value is null)
+            return null;
+
+        if (!PackageCoordinateResolver.IsCanonicalRuntimeIdentifier(value))
+        {
+            throw new ArgumentException(
+                "A package runtime identifier must use its canonical lowercase spelling.",
+                parameterName);
+        }
+
+        return value;
+    }
+}
+
+/// <summary>The immutable resource-free input to one PackageHouse operation.</summary>
+public sealed class PackageHouseRequest
+{
+    public PackageHouseRequest(
+        PackageHouseDemand demand,
+        PackageHouseOperation operation,
+        PackageHouseTargetContext? targetContext = null,
+        PackageHouseAssetSelectionKind? assetSelection = null,
+        PackageHouseLibraryHandoffMode libraryHandoff =
+            PackageHouseLibraryHandoffMode.PackageOnly,
+        PackageHouseRequestAssociation? association = null)
+    {
+        ArgumentNullException.ThrowIfNull(demand);
+        ArgumentNullException.ThrowIfNull(operation);
+        if (!Enum.IsDefined(libraryHandoff))
+            throw new ArgumentOutOfRangeException(nameof(libraryHandoff));
+        if (assetSelection is { } selection && !Enum.IsDefined(selection))
+            throw new ArgumentOutOfRangeException(nameof(assetSelection));
+
+        bool realizes =
+            operation.Profile == PackageHouseOperationProfile.Realize;
+        if (realizes != assetSelection.HasValue)
+        {
+            throw new ArgumentException(
+                "Only a Realize operation declares an asset-selection kind.",
+                nameof(assetSelection));
+        }
+
+        if (!realizes
+            && libraryHandoff != PackageHouseLibraryHandoffMode.PackageOnly)
+        {
+            throw new ArgumentException(
+                "Only a Realize operation can request library handoffs.",
+                nameof(libraryHandoff));
+        }
+
+        Demand = demand;
+        Operation = operation;
+        TargetContext = targetContext;
+        AssetSelection = assetSelection;
+        LibraryHandoff = libraryHandoff;
+        Association = association;
+    }
+
+    public PackageHouseDemand Demand { get; }
+
+    public PackageHouseOperation Operation { get; }
+
+    public PackageHouseTargetContext? TargetContext { get; }
+
+    public PackageHouseAssetSelectionKind? AssetSelection { get; }
+
+    public PackageHouseLibraryHandoffMode LibraryHandoff { get; }
+
+    public PackageHouseRequestAssociation? Association { get; }
+}

--- a/src/DotnetInspector.Packages/PackageHouseResults.cs
+++ b/src/DotnetInspector.Packages/PackageHouseResults.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using DotnetInspector.Platforms;
 using InertText;
-using NuGet.Versioning;
 using NuGetFetch;
 
 namespace DotnetInspector.Packages;
@@ -95,16 +94,10 @@ public sealed class PackageHousePruningReceipt
         PackageSourceCoordinate exact,
         PackageHouseTargetContext? target)
     {
-        if (!policy.PackageId.Equals(
-                exact.PackageId,
-                StringComparison.OrdinalIgnoreCase)
-            || policy.Version is null
-            || !NuGetVersion.TryParse(
-                policy.Version,
-                out NuGetVersion? policyVersion)
-            || !policyVersion.ToNormalizedString().Equals(
-                exact.Version,
-                StringComparison.Ordinal))
+        if (policy.Version is null
+            || PackageSourceCoordinate.Create(
+                policy.PackageId,
+                policy.Version) != exact)
         {
             return false;
         }

--- a/src/DotnetInspector.Packages/PackageHouseResults.cs
+++ b/src/DotnetInspector.Packages/PackageHouseResults.cs
@@ -1,0 +1,1138 @@
+using System.Collections.Immutable;
+using DotnetInspector.Platforms;
+using InertText;
+using NuGet.Versioning;
+using NuGetFetch;
+
+namespace DotnetInspector.Packages;
+
+/// <summary>Opaque identity associating one terminal PackageHouse result.</summary>
+public sealed class PackageHouseSettlementIdentity
+{
+    internal PackageHouseSettlementIdentity()
+    {
+    }
+
+    public override string ToString() => nameof(PackageHouseSettlementIdentity);
+}
+
+/// <summary>
+/// Package-owned evidence binding one policy-issued platform-supply receipt to
+/// the exact House request, package coordinate, and platform target.
+/// </summary>
+public sealed class PackageHousePruningReceipt
+{
+    internal PackageHousePruningReceipt(
+        PackageHouseRequest request,
+        PlatformFamilyTarget target,
+        PlatformSupplyReceipt policy)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(policy);
+        if (request.Demand is not PackageHouseDemand.Exact exact)
+        {
+            throw new ArgumentException(
+                "This PackageHouse contract floor prunes only exact package demands.",
+                nameof(request));
+        }
+        if (request.TargetContext?.PlatformTarget != target)
+        {
+            throw new ArgumentException(
+                "A pruning receipt must use the request's exact platform correspondence.",
+                nameof(target));
+        }
+        if (!PolicyCoordinateMatches(
+                policy.Coordinate,
+                exact.Coordinate,
+                request.TargetContext)
+            || !policy.Inventory.TargetFramework.Equals(
+                target.TargetFramework.ToString(),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                "The policy receipt must describe the request's exact package and framework comparison.",
+                nameof(policy));
+        }
+
+        PlatformPruneFamily? family =
+            policy.Inventory.Families.FirstOrDefault(candidate =>
+                candidate.Name.Equals(
+                    SharedFrameworkName(target.Family),
+                    StringComparison.OrdinalIgnoreCase));
+        if (family is null
+            || !family.TargetPackVersion.ToNormalizedString().Equals(
+                target.Version.Value,
+                StringComparison.Ordinal)
+            || (policy.Supply.DelegatesToPlatform
+                && !SharedFrameworkName(target.Family).Equals(
+                    policy.Supply.Family,
+                    StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException(
+                "The policy inventory and any delegating supplier must match the exact platform family version.",
+                nameof(policy));
+        }
+
+        Request = request;
+        Coordinate = exact.Coordinate;
+        Target = target;
+        Policy = policy;
+    }
+
+    public PackageHouseRequest Request { get; }
+
+    public PackageSourceCoordinate Coordinate { get; }
+
+    public PlatformFamilyTarget Target { get; }
+
+    public PlatformSupplyReceipt Policy { get; }
+
+    public PlatformSupply Supply => Policy.Supply;
+
+    private static bool PolicyCoordinateMatches(
+        PackageCoordinate policy,
+        PackageSourceCoordinate exact,
+        PackageHouseTargetContext? target)
+    {
+        if (!policy.PackageId.Equals(
+                exact.PackageId,
+                StringComparison.OrdinalIgnoreCase)
+            || policy.Version is null
+            || !NuGetVersion.TryParse(
+                policy.Version,
+                out NuGetVersion? policyVersion)
+            || !policyVersion.ToNormalizedString().Equals(
+                exact.Version,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return target?.RequestedFramework is not { } framework
+            ? policy.Framework is null
+            : framework.Equals(
+                policy.Framework,
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string SharedFrameworkName(PlatformFamily family) =>
+        family switch
+        {
+            PlatformFamily.DotNetRuntime => "Microsoft.NETCore.App",
+            PlatformFamily.AspNetCore => "Microsoft.AspNetCore.App",
+            _ => throw new ArgumentOutOfRangeException(nameof(family)),
+        };
+}
+
+/// <summary>How PackageHouse disposed the package side of one operation.</summary>
+public enum PackageHouseDecision
+{
+    RetainPackage,
+    DelegateToPlatform,
+    Stop,
+}
+
+/// <summary>Resource-free evidence for one package settlement decision.</summary>
+public sealed class PackageHouseDecisionReceipt
+{
+    private PackageHouseDecisionReceipt(
+        PackageHouseRequest request,
+        PackageHouseDecision decision,
+        PackageSourceCoordinate? coordinate,
+        PackageAcquisitionCandidate? candidate,
+        PackageHousePruningReceipt? pruning)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (!Enum.IsDefined(decision))
+            throw new ArgumentOutOfRangeException(nameof(decision));
+        if (coordinate is not null)
+        {
+            PackageHouseContractValidation.RequireCoordinateMatchesDemand(
+                request.Demand,
+                coordinate);
+        }
+        if (candidate is not null
+            && candidate.Coordinate != coordinate)
+        {
+            throw new ArgumentException(
+                "The acquisition candidate must describe the settled coordinate.",
+                nameof(candidate));
+        }
+        if (pruning is not null
+            && (!ReferenceEquals(pruning.Request, request)
+                || pruning.Coordinate != coordinate))
+        {
+            throw new ArgumentException(
+                "The pruning receipt must describe the same request and coordinate.",
+                nameof(pruning));
+        }
+
+        bool delegates =
+            decision == PackageHouseDecision.DelegateToPlatform;
+        if (delegates
+            != (coordinate is not null
+                && pruning?.Supply.DelegatesToPlatform is true))
+        {
+            throw new ArgumentException(
+                "A platform decision requires one exact Subsumed pruning receipt.",
+                nameof(pruning));
+        }
+        if (decision == PackageHouseDecision.RetainPackage
+            && coordinate is null)
+        {
+            throw new ArgumentException(
+                "A retained package decision requires one settled coordinate.",
+                nameof(coordinate));
+        }
+        if (decision != PackageHouseDecision.DelegateToPlatform
+            && pruning?.Supply.DelegatesToPlatform is true)
+        {
+            throw new ArgumentException(
+                "A Subsumed pruning receipt can only produce platform delegation.",
+                nameof(pruning));
+        }
+
+        Request = request;
+        Decision = decision;
+        Coordinate = coordinate;
+        Candidate = candidate;
+        Pruning = pruning;
+    }
+
+    public PackageHouseRequest Request { get; }
+
+    public PackageHouseDecision Decision { get; }
+
+    public PackageSourceCoordinate? Coordinate { get; }
+
+    public PackageAcquisitionCandidate? Candidate { get; }
+
+    public PackageHousePruningReceipt? Pruning { get; }
+
+    internal static PackageHouseDecisionReceipt RetainPackage(
+        PackageHouseRequest request,
+        PackageSourceCoordinate coordinate,
+        PackageAcquisitionCandidate? candidate = null,
+        PackageHousePruningReceipt? pruning = null) =>
+        new(
+            request,
+            PackageHouseDecision.RetainPackage,
+            coordinate,
+            candidate,
+            pruning);
+
+    internal static PackageHouseDecisionReceipt DelegateToPlatform(
+        PackageHouseRequest request,
+        PackageSourceCoordinate coordinate,
+        PackageAcquisitionCandidate? candidate,
+        PackageHousePruningReceipt pruning) =>
+        new(
+            request,
+            PackageHouseDecision.DelegateToPlatform,
+            coordinate,
+            candidate,
+            pruning);
+
+    internal static PackageHouseDecisionReceipt Stop(
+        PackageHouseRequest request,
+        PackageSourceCoordinate? coordinate = null,
+        PackageAcquisitionCandidate? candidate = null,
+        PackageHousePruningReceipt? pruning = null) =>
+        new(
+            request,
+            PackageHouseDecision.Stop,
+            coordinate,
+            candidate,
+            pruning);
+}
+
+/// <summary>
+/// Resource-free evidence binding an authorized payload generation to its
+/// decision, candidate, authority, source result, producer, and origin.
+/// </summary>
+public sealed class PackageHouseAcquisitionReceipt
+{
+    internal PackageHouseAcquisitionReceipt(
+        PackageHouseDecisionReceipt decision,
+        PackageAcquisitionCandidate candidate,
+        ConfiguredPackageAuthority authority,
+        PackageSourceResultIdentity source,
+        PackagePayloadOrigin origin,
+        PackageContentGenerationIdentity generation)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(authority);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(generation);
+        if (!Enum.IsDefined(origin))
+            throw new ArgumentOutOfRangeException(nameof(origin));
+        if (decision.Request.Operation.Profile
+            == PackageHouseOperationProfile.Settle)
+        {
+            throw new ArgumentException(
+                "A Settle operation does not authorize payload acquisition.",
+                nameof(decision));
+        }
+        if (decision.Decision != PackageHouseDecision.RetainPackage
+            || !ReferenceEquals(decision.Candidate, candidate)
+            || decision.Coordinate != candidate.Coordinate)
+        {
+            throw new ArgumentException(
+                "Acquisition requires the decision's exact retained candidate.",
+                nameof(candidate));
+        }
+        if (!candidate.Authorities.Any(evidence =>
+                ReferenceEquals(evidence.Authority, authority)))
+        {
+            throw new ArgumentException(
+                "The payload authority must belong to the acquisition candidate.",
+                nameof(authority));
+        }
+        if (!ReferenceEquals(source.Association, authority.Association))
+        {
+            throw new ArgumentException(
+                "The payload source result must belong to the selected authority.",
+                nameof(source));
+        }
+
+        Decision = decision;
+        Candidate = candidate;
+        Authority = authority;
+        Source = source;
+        Origin = origin;
+        Generation = generation;
+    }
+
+    public PackageHouseDecisionReceipt Decision { get; }
+
+    public PackageAcquisitionCandidate Candidate { get; }
+
+    public ConfiguredPackageAuthority Authority { get; }
+
+    public PackageSourceResultIdentity Source { get; }
+
+    public PackageProducerIdentity Producer => Source.Producer;
+
+    public PackagePayloadOrigin Origin { get; }
+
+    public PackageContentGenerationIdentity Generation { get; }
+}
+
+/// <summary>
+/// Resource-free evidence binding one existing package-owner asset-selection
+/// outcome to the exact acquisition and request that produced it.
+/// </summary>
+public abstract class PackageHouseAssetSelectionReceipt
+{
+    private PackageHouseAssetSelectionReceipt(
+        PackageHouseAcquisitionReceipt acquisition)
+    {
+        ArgumentNullException.ThrowIfNull(acquisition);
+        if (acquisition.Decision.Request.Operation.Profile
+            != PackageHouseOperationProfile.Realize)
+        {
+            throw new ArgumentException(
+                "Only a Realize operation can produce asset-selection evidence.",
+                nameof(acquisition));
+        }
+
+        Acquisition = acquisition;
+    }
+
+    public PackageHouseAcquisitionReceipt Acquisition { get; }
+
+    public sealed class Compile : PackageHouseAssetSelectionReceipt
+    {
+        internal Compile(
+            PackageHouseAcquisitionReceipt acquisition,
+            PackageCompileAssetSelectionReceipt receipt)
+            : base(acquisition)
+        {
+            ArgumentNullException.ThrowIfNull(receipt);
+            if (acquisition.Decision.Request.AssetSelection
+                != PackageHouseAssetSelectionKind.Compile)
+            {
+                throw new ArgumentException(
+                    "A compile selection requires a compile realization request.",
+                    nameof(acquisition));
+            }
+            PackageHouseRequest request = acquisition.Decision.Request;
+            if (!ReferenceEquals(
+                    receipt.Generation,
+                    acquisition.Generation)
+                || !receipt.PackageId.Equals(
+                    acquisition.Decision.Coordinate!.PackageId,
+                    StringComparison.OrdinalIgnoreCase)
+                || !RequestMatches(
+                    request.TargetContext,
+                    receipt.RequestedTargetFramework,
+                    receipt.RequestedRuntimeIdentifier))
+            {
+                throw new ArgumentException(
+                    "The compile selection receipt must describe the acquired generation and exact House selection request.",
+                    nameof(receipt));
+            }
+            if (receipt.Selection.Status
+                    == PackageCompileAssetSelectionStatus.Selected
+                && !receipt.Selection.IsSelected)
+            {
+                throw new ArgumentException(
+                    "A selected compile outcome must carry its selected assets and default asset.",
+                    nameof(receipt));
+            }
+
+            Receipt = receipt;
+        }
+
+        public PackageCompileAssetSelectionReceipt Receipt { get; }
+
+        public PackageCompileAssetSelection Selection => Receipt.Selection;
+    }
+
+    public sealed class Runtime : PackageHouseAssetSelectionReceipt
+    {
+        internal Runtime(
+            PackageHouseAcquisitionReceipt acquisition,
+            PackageAssetSelectionReceipt receipt)
+            : base(acquisition)
+        {
+            ArgumentNullException.ThrowIfNull(receipt);
+            if (acquisition.Decision.Request.AssetSelection
+                != PackageHouseAssetSelectionKind.Runtime)
+            {
+                throw new ArgumentException(
+                    "A runtime selection requires a runtime realization request.",
+                    nameof(acquisition));
+            }
+            if (!ReferenceEquals(
+                    receipt.Generation,
+                    acquisition.Generation)
+                || !RequestMatches(
+                    acquisition.Decision.Request.TargetContext,
+                    receipt.RequestedTargetFramework,
+                    receipt.RequestedRuntimeIdentifier))
+            {
+                throw new ArgumentException(
+                    "The runtime selection receipt must describe the acquired generation and exact House selection request.",
+                    nameof(receipt));
+            }
+
+            Receipt = receipt;
+        }
+
+        public PackageAssetSelectionReceipt Receipt { get; }
+
+        public PackageAssetSelection Selection => Receipt.Selection;
+    }
+
+    private static bool RequestMatches(
+        PackageHouseTargetContext? target,
+        string? framework,
+        string? runtimeIdentifier)
+    {
+        bool frameworkMatches = target?.Mode switch
+        {
+            PackageHouseTargetSelectionMode.Exact =>
+                target.RequestedFramework!.Equals(
+                    framework,
+                    StringComparison.OrdinalIgnoreCase),
+            PackageHouseTargetSelectionMode.OwnerDefault =>
+                framework is null,
+            null => framework is null,
+            _ => false,
+        };
+        return frameworkMatches
+            && string.Equals(
+                target?.RuntimeIdentifier,
+                runtimeIdentifier,
+                StringComparison.Ordinal);
+    }
+}
+
+/// <summary>Opaque identity for one library handoff occurrence.</summary>
+public sealed class PackageHouseLibraryHandoffIdentity
+{
+    internal PackageHouseLibraryHandoffIdentity()
+    {
+    }
+
+    public override string ToString() =>
+        nameof(PackageHouseLibraryHandoffIdentity);
+}
+
+/// <summary>
+/// Resource-free package-to-library evidence retaining the complete
+/// acquisition and selection chain.
+/// </summary>
+public abstract class PackageHouseLibraryHandoff
+{
+    private PackageHouseLibraryHandoff(
+        PackageHouseAssetSelectionReceipt selection)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        Identity = new PackageHouseLibraryHandoffIdentity();
+        Selection = selection;
+    }
+
+    public PackageHouseLibraryHandoffIdentity Identity { get; }
+
+    public PackageHouseAssetSelectionReceipt Selection { get; }
+
+    public PackageHouseAcquisitionReceipt Acquisition =>
+        Selection.Acquisition;
+
+    public PackageHouseDecisionReceipt Decision => Acquisition.Decision;
+
+    public PackageSourceCoordinate Coordinate => Decision.Coordinate!;
+
+    public PackageHouseTargetContext? TargetContext =>
+        Decision.Request.TargetContext;
+
+    public sealed class Compile : PackageHouseLibraryHandoff
+    {
+        internal Compile(
+            PackageHouseAssetSelectionReceipt.Compile selection,
+            PackageCompileAsset asset,
+            PackageCompileAsset? implementationAsset)
+            : base(selection)
+        {
+            ArgumentNullException.ThrowIfNull(asset);
+            Asset = asset;
+            ImplementationAsset = implementationAsset;
+        }
+
+        public PackageCompileAsset Asset { get; }
+
+        public PackageCompileAsset? ImplementationAsset { get; }
+    }
+
+    public sealed class Runtime : PackageHouseLibraryHandoff
+    {
+        internal Runtime(
+            PackageHouseAssetSelectionReceipt.Runtime selection,
+            PackageAssetEntry asset)
+            : base(selection)
+        {
+            ArgumentNullException.ThrowIfNull(asset);
+            Asset = asset;
+        }
+
+        public PackageAssetEntry Asset { get; }
+    }
+}
+
+/// <summary>One package materialization plus typed asset-selection evidence.</summary>
+public sealed class PackageHouseRealizationReceipt
+{
+    internal PackageHouseRealizationReceipt(
+        PackageHouseAssetSelectionReceipt selection)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        Selection = selection;
+        Completion = GetCompletion(selection);
+        LibraryHandoffs = CreateLibraryHandoffs(selection);
+    }
+
+    public PackageHouseAssetSelectionReceipt Selection { get; }
+
+    public PackageHouseAcquisitionReceipt Acquisition =>
+        Selection.Acquisition;
+
+    internal PackageHouseRealizationCompletion Completion { get; }
+
+    public ImmutableArray<PackageHouseLibraryHandoff> LibraryHandoffs { get; }
+
+    private static PackageHouseRealizationCompletion GetCompletion(
+        PackageHouseAssetSelectionReceipt selection) =>
+        selection switch
+        {
+            PackageHouseAssetSelectionReceipt.Compile
+                {
+                    Selection.Status:
+                        PackageCompileAssetSelectionStatus.Selected
+                        or PackageCompileAssetSelectionStatus.EmptyCompileGroup,
+                } => PackageHouseRealizationCompletion.Settled,
+            PackageHouseAssetSelectionReceipt.Compile
+                {
+                    Selection.Status:
+                        PackageCompileAssetSelectionStatus.NoCompileAssets
+                        or PackageCompileAssetSelectionStatus
+                            .NoMatchingTargetFramework,
+                } => PackageHouseRealizationCompletion.NoMatch,
+            PackageHouseAssetSelectionReceipt.Compile =>
+                PackageHouseRealizationCompletion.Rejected,
+            PackageHouseAssetSelectionReceipt.Runtime
+                {
+                    Selection: PackageAssetSelection.Selected,
+                } => PackageHouseRealizationCompletion.Settled,
+            PackageHouseAssetSelectionReceipt.Runtime
+                {
+                    Selection: PackageAssetSelection.NoMatch,
+                } => PackageHouseRealizationCompletion.NoMatch,
+            PackageHouseAssetSelectionReceipt.Runtime
+                {
+                    Selection: PackageAssetSelection.Ambiguous,
+                } => PackageHouseRealizationCompletion.Ambiguous,
+            PackageHouseAssetSelectionReceipt.Runtime =>
+                PackageHouseRealizationCompletion.Rejected,
+            _ => throw new ArgumentOutOfRangeException(nameof(selection)),
+        };
+
+    private static ImmutableArray<PackageHouseLibraryHandoff>
+        CreateLibraryHandoffs(PackageHouseAssetSelectionReceipt selection)
+    {
+        if (selection.Acquisition.Decision.Request.LibraryHandoff
+            == PackageHouseLibraryHandoffMode.PackageOnly)
+        {
+            return [];
+        }
+
+        return selection switch
+        {
+            PackageHouseAssetSelectionReceipt.Compile compile
+                when compile.Selection.IsSelected =>
+            [
+                .. compile.Selection.Assets.Select(asset =>
+                    new PackageHouseLibraryHandoff.Compile(
+                        compile,
+                        asset,
+                        compile.Selection.FindImplementationAsset(asset))),
+            ],
+            PackageHouseAssetSelectionReceipt.Runtime
+                {
+                    Selection: PackageAssetSelection.Selected selected,
+                } runtime =>
+            [
+                .. selected.Universe.Assets.Select(asset =>
+                    new PackageHouseLibraryHandoff.Runtime(runtime, asset)),
+            ],
+            _ => [],
+        };
+    }
+}
+
+internal enum PackageHouseRealizationCompletion
+{
+    Settled,
+    NoMatch,
+    Ambiguous,
+    Rejected,
+}
+
+/// <summary>The PackageHouse stage that reported a typed failure.</summary>
+public enum PackageHouseFailureStage
+{
+    Settlement,
+    Pruning,
+    Acquisition,
+    Selection,
+    Handoff,
+    Operation,
+}
+
+/// <summary>The deadline that ended a PackageHouse operation.</summary>
+public enum PackageHouseTimeoutKind
+{
+    Request,
+    Operation,
+}
+
+/// <summary>One resource-free typed failure retained by a House result.</summary>
+public abstract class PackageHouseFailure
+{
+    private PackageHouseFailure()
+    {
+    }
+
+    public sealed class Source : PackageHouseFailure
+    {
+        internal Source(PackageSourceFailure failure)
+        {
+            ArgumentNullException.ThrowIfNull(failure);
+            Failure = failure;
+        }
+
+        public PackageSourceFailure Failure { get; }
+    }
+
+    public sealed class Authority : PackageHouseFailure
+    {
+        internal Authority(
+            PackageHouseOperationIdentity operation,
+            PackageAuthorityFailure failure)
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            ArgumentNullException.ThrowIfNull(failure);
+            Operation = operation;
+            Failure = failure;
+        }
+
+        public PackageHouseOperationIdentity Operation { get; }
+
+        public PackageAuthorityFailure Failure { get; }
+    }
+
+    public sealed class Timeout : PackageHouseFailure
+    {
+        internal Timeout(
+            PackageHouseOperationIdentity operation,
+            PackageHouseTimeoutKind kind,
+            TimeSpan duration)
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            if (!Enum.IsDefined(kind))
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            if (duration <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(duration),
+                    duration,
+                    "A retained timeout duration must be positive.");
+            }
+
+            Operation = operation;
+            Kind = kind;
+            Duration = duration;
+        }
+
+        public PackageHouseOperationIdentity Operation { get; }
+
+        public PackageHouseTimeoutKind Kind { get; }
+
+        public TimeSpan Duration { get; }
+    }
+
+    public sealed class Stage : PackageHouseFailure
+    {
+        internal Stage(
+            PackageHouseFailureStage stage,
+            InertString reason)
+        {
+            if (!Enum.IsDefined(stage))
+                throw new ArgumentOutOfRangeException(nameof(stage));
+            StageKind = stage;
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public PackageHouseFailureStage StageKind { get; }
+
+        public InertString Reason { get; }
+    }
+}
+
+/// <summary>
+/// The immutable evidence envelope retained by every terminal House result.
+/// </summary>
+public sealed class PackageHouseEvidence
+{
+    internal PackageHouseEvidence(
+        PackageHouseRequest request,
+        PackageHouseDecisionReceipt? decision = null,
+        PackageHouseAcquisitionReceipt? acquisition = null,
+        PackageHouseRealizationReceipt? realization = null,
+        IEnumerable<PackageHouseFailure>? failures = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (decision is not null
+            && !ReferenceEquals(decision.Request, request))
+        {
+            throw new ArgumentException(
+                "The decision receipt must retain the evidence request.",
+                nameof(decision));
+        }
+        if (acquisition is not null
+            && !ReferenceEquals(acquisition.Decision, decision))
+        {
+            throw new ArgumentException(
+                "The acquisition receipt must retain the evidence decision.",
+                nameof(acquisition));
+        }
+        if (realization is not null
+            && !ReferenceEquals(realization.Acquisition, acquisition))
+        {
+            throw new ArgumentException(
+                "The realization receipt must retain the evidence acquisition.",
+                nameof(realization));
+        }
+        if (request.Operation.Profile == PackageHouseOperationProfile.Settle
+            && (acquisition is not null || realization is not null))
+        {
+            throw new ArgumentException(
+                "A Settle operation cannot retain acquisition or realization evidence.",
+                nameof(acquisition));
+        }
+        if (request.Operation.Profile != PackageHouseOperationProfile.Realize
+            && realization is not null)
+        {
+            throw new ArgumentException(
+                "Only a Realize operation can retain realization evidence.",
+                nameof(realization));
+        }
+
+        Request = request;
+        Identity = new PackageHouseSettlementIdentity();
+        Decision = decision;
+        Acquisition = acquisition;
+        Realization = realization;
+        Failures = failures is null
+            ? []
+            : [.. failures];
+        if (Failures.Any(failure => failure is null))
+        {
+            throw new ArgumentException(
+                "A House evidence envelope cannot retain a null failure.",
+                nameof(failures));
+        }
+        foreach (PackageHouseFailure.Timeout timeout
+            in Failures.OfType<PackageHouseFailure.Timeout>())
+        {
+            TimeSpan expected = timeout.Kind switch
+            {
+                PackageHouseTimeoutKind.Request =>
+                    request.Operation.RequestTimeout,
+                PackageHouseTimeoutKind.Operation =>
+                    request.Operation.OperationTimeout,
+                _ => throw new ArgumentOutOfRangeException(nameof(failures)),
+            };
+            if (!ReferenceEquals(
+                    timeout.Operation,
+                    request.Operation.Identity)
+                || timeout.Duration != expected)
+            {
+                throw new ArgumentException(
+                    "A retained timeout must match the request's operation identity and configured duration.",
+                    nameof(failures));
+            }
+        }
+        foreach (PackageHouseFailure.Authority authority
+            in Failures.OfType<PackageHouseFailure.Authority>())
+        {
+            if (!ReferenceEquals(
+                        authority.Operation,
+                        request.Operation.Identity))
+            {
+                    throw new ArgumentException(
+                        "A retained authority failure must match the request's operation identity.",
+                        nameof(failures));
+            }
+            if (authority.Failure.Timeout is { } timeout)
+            {
+                    TimeSpan expected = timeout.Kind switch
+                    {
+                        PackageSourceTimeoutKind.Request
+                            or PackageSourceTimeoutKind.MetadataBody =>
+                            request.Operation.RequestTimeout,
+                        PackageSourceTimeoutKind.Operation =>
+                            request.Operation.OperationTimeout,
+                        _ => throw new ArgumentOutOfRangeException(
+                            nameof(failures)),
+                    };
+                    if (timeout.Duration != expected)
+                    {
+                        throw new ArgumentException(
+                            "A retained authority timeout must match the request's configured duration.",
+                            nameof(failures));
+                    }
+            }
+        }
+    }
+
+    public PackageHouseRequest Request { get; }
+
+    public PackageHouseSettlementIdentity Identity { get; }
+
+    public PackageHouseDecisionReceipt? Decision { get; }
+
+    public PackageHouseAcquisitionReceipt? Acquisition { get; }
+
+    public PackageHouseRealizationReceipt? Realization { get; }
+
+    public ImmutableArray<PackageHouseFailure> Failures { get; }
+
+    internal bool HasOperationTimeout =>
+        Failures.OfType<PackageHouseFailure.Timeout>().Any(timeout =>
+            timeout.Kind == PackageHouseTimeoutKind.Operation)
+        || Failures.OfType<PackageHouseFailure.Authority>().Any(authority =>
+            authority.Failure.Timeout?.Kind
+                == PackageSourceTimeoutKind.Operation);
+}
+
+/// <summary>
+/// A package-owned request for application orchestration to settle one
+/// corresponding platform target.
+/// </summary>
+public sealed class PlatformDelegation
+{
+    internal PlatformDelegation(PackageHouseDecisionReceipt decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        if (decision.Decision != PackageHouseDecision.DelegateToPlatform
+            || decision.Coordinate is null
+            || decision.Pruning is not
+                { Supply.DelegatesToPlatform: true } pruning)
+        {
+            throw new ArgumentException(
+                "Platform delegation requires one complete PackageHouse pruning decision.",
+                nameof(decision));
+        }
+
+        Decision = decision;
+        Coordinate = decision.Coordinate;
+        Pruning = pruning;
+    }
+
+    public PackageHouseDecisionReceipt Decision { get; }
+
+    public PackageSourceCoordinate Coordinate { get; }
+
+    public PackageHousePruningReceipt Pruning { get; }
+
+    public PlatformFamilyTarget Target => Pruning.Target;
+
+    public PlatformSupplyReceipt Policy => Pruning.Policy;
+
+    public PlatformSupply Supply => Pruning.Supply;
+}
+
+/// <summary>The closed resource-free result of one PackageHouse operation.</summary>
+public abstract class PackageHouseResult
+{
+    private PackageHouseResult(PackageHouseEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        Evidence = evidence;
+    }
+
+    public PackageHouseEvidence Evidence { get; }
+
+    public PackageHouseRequest Request => Evidence.Request;
+
+    public PackageHouseDecisionReceipt? Decision => Evidence.Decision;
+
+    public sealed class Settled : PackageHouseResult
+    {
+        internal Settled(PackageHouseEvidence evidence)
+            : base(evidence)
+        {
+            if (evidence.Decision?.Decision
+                != PackageHouseDecision.RetainPackage)
+            {
+                throw new ArgumentException(
+                    "A settled package result requires a retained package decision.",
+                    nameof(evidence));
+            }
+            if (evidence.HasOperationTimeout)
+            {
+                throw new ArgumentException(
+                    "An operation timeout is terminal and cannot produce a settled result.",
+                    nameof(evidence));
+            }
+
+            bool valid = evidence.Request.Operation.Profile switch
+            {
+                PackageHouseOperationProfile.Settle =>
+                    evidence.Acquisition is null
+                    && evidence.Realization is null,
+                PackageHouseOperationProfile.Acquire =>
+                    evidence.Acquisition is not null
+                    && evidence.Realization is null,
+                PackageHouseOperationProfile.Realize =>
+                    evidence.Acquisition is not null
+                    && evidence.Realization?.Completion
+                        == PackageHouseRealizationCompletion.Settled,
+                _ => false,
+            };
+            if (!valid)
+            {
+                throw new ArgumentException(
+                    "Decision, acquisition, and realization evidence must match the operation profile.",
+                    nameof(evidence));
+            }
+        }
+    }
+
+    public sealed class Delegated : PackageHouseResult
+    {
+        internal Delegated(
+            PackageHouseEvidence evidence,
+            PlatformDelegation delegation)
+            : base(evidence)
+        {
+            ArgumentNullException.ThrowIfNull(delegation);
+            if (!ReferenceEquals(evidence.Decision, delegation.Decision)
+                || evidence.Acquisition is not null
+                || evidence.Realization is not null
+                || evidence.HasOperationTimeout)
+            {
+                throw new ArgumentException(
+                    "A delegated result must retain only its matching package decision.",
+                    nameof(evidence));
+            }
+
+            Delegation = delegation;
+        }
+
+        public PlatformDelegation Delegation { get; }
+    }
+
+    public sealed class NotFound : PackageHouseResult
+    {
+        internal NotFound(PackageHouseEvidence evidence, InertString reason)
+            : base(evidence)
+        {
+            RequireNoCompletedRealization(evidence, nameof(evidence));
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public InertString Reason { get; }
+    }
+
+    public sealed class NoMatch : PackageHouseResult
+    {
+        internal NoMatch(PackageHouseEvidence evidence, InertString reason)
+            : base(evidence)
+        {
+            RequireRealizationCompletionWhenPresent(
+                evidence,
+                PackageHouseRealizationCompletion.NoMatch,
+                nameof(evidence));
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public InertString Reason { get; }
+    }
+
+    public sealed class Ambiguous : PackageHouseResult
+    {
+        internal Ambiguous(PackageHouseEvidence evidence, InertString reason)
+            : base(evidence)
+        {
+            RequireRealizationCompletionWhenPresent(
+                evidence,
+                PackageHouseRealizationCompletion.Ambiguous,
+                nameof(evidence));
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public InertString Reason { get; }
+    }
+
+    public sealed class Rejected : PackageHouseResult
+    {
+        internal Rejected(PackageHouseEvidence evidence, InertString reason)
+            : base(evidence)
+        {
+            RequireRealizationCompletionWhenPresent(
+                evidence,
+                PackageHouseRealizationCompletion.Rejected,
+                nameof(evidence));
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public InertString Reason { get; }
+    }
+
+    public sealed class Unavailable : PackageHouseResult
+    {
+        internal Unavailable(
+            PackageHouseEvidence evidence,
+            InertString reason)
+            : base(evidence)
+        {
+            RequireNoCompletedRealization(evidence, nameof(evidence));
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public InertString Reason { get; }
+    }
+
+    public sealed class Incomplete : PackageHouseResult
+    {
+        internal Incomplete(
+            PackageHouseEvidence evidence,
+            InertString reason)
+            : base(evidence)
+        {
+            RequireNoCompletedRealization(evidence, nameof(evidence));
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public InertString Reason { get; }
+    }
+
+    public sealed class Failed : PackageHouseResult
+    {
+        internal Failed(PackageHouseEvidence evidence, InertString reason)
+            : base(evidence)
+        {
+            if (evidence.Realization is not null
+                && !evidence.HasOperationTimeout)
+            {
+                throw new ArgumentException(
+                    "A completed asset-selection outcome requires its corresponding House terminal result unless operation timeout takes precedence.",
+                    nameof(evidence));
+            }
+            Reason = PackageHouseContractValidation.RequireReason(reason);
+        }
+
+        public InertString Reason { get; }
+    }
+
+    private static void RequireRealizationCompletionWhenPresent(
+        PackageHouseEvidence evidence,
+        PackageHouseRealizationCompletion expected,
+        string parameterName)
+    {
+        if (evidence.Realization is { Completion: var actual }
+            && actual != expected)
+        {
+            throw new ArgumentException(
+                "The terminal result must match the retained asset-selection outcome.",
+                parameterName);
+        }
+    }
+
+    private static void RequireNoCompletedRealization(
+        PackageHouseEvidence evidence,
+        string parameterName)
+    {
+        if (evidence.Realization is not null)
+        {
+            throw new ArgumentException(
+                "A completed asset-selection outcome requires its corresponding House terminal result.",
+                parameterName);
+        }
+    }
+}
+
+internal static class PackageHouseContractValidation
+{
+    internal static void RequireCoordinateMatchesDemand(
+        PackageHouseDemand demand,
+        PackageSourceCoordinate coordinate)
+    {
+        ArgumentNullException.ThrowIfNull(demand);
+        ArgumentNullException.ThrowIfNull(coordinate);
+        if (demand is not PackageHouseDemand.Exact exact
+            || exact.Coordinate != coordinate)
+        {
+            throw new ArgumentException(
+                "The settled coordinate must be the exact package demand.",
+                nameof(coordinate));
+        }
+    }
+
+    internal static InertString RequireReason(InertString reason)
+    {
+        if (reason.IsEmpty)
+        {
+            throw new ArgumentException(
+                "A PackageHouse non-success requires a visible reason.",
+                nameof(reason));
+        }
+
+        return reason;
+    }
+}

--- a/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
@@ -1,0 +1,1050 @@
+using System.Reflection;
+using DotnetInspector.Packages;
+using DotnetInspector.Platforms;
+using InertText;
+using NuGet.Versioning;
+using NuGetFetch;
+
+namespace DotnetInspector.Services.Tests;
+
+public sealed class PackageHouseContractTests
+{
+    private static readonly PackageSourceCoordinate Coordinate =
+        PackageSourceCoordinate.Create("contoso.json", "4.0.0");
+
+    [Fact]
+    public void RequestFloorAcceptsOnlyAnExactDemand()
+    {
+        var demand = new PackageHouseDemand.Exact(Coordinate);
+        PackageHouseTargetContext target =
+            PackageHouseTargetContext.Exact("NET10.0", "linux-x64");
+        PackageHouseRequestAssociation association =
+            PackageHouseRequestAssociation.Create();
+
+        var request = new PackageHouseRequest(
+            demand,
+            PackageHouseOperation.Create(
+                PackageHouseOperationProfile.Realize),
+            target,
+            PackageHouseAssetSelectionKind.Compile,
+            PackageHouseLibraryHandoffMode.SelectedLibraries,
+            association);
+
+        Assert.Same(Coordinate, demand.Coordinate);
+        Assert.Equal("net10.0", request.TargetContext!.RequestedFramework);
+        Assert.Equal("linux-x64", request.TargetContext.RuntimeIdentifier);
+        Assert.Same(association, request.Association);
+        Assert.Equal(
+            ["Exact"],
+            typeof(PackageHouseDemand)
+                .GetNestedTypes(BindingFlags.Public)
+                .Select(type => type.Name)
+                .ToArray());
+    }
+
+    [Fact]
+    public void DecisionBindsSettlementToTheExactDemand()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Settle);
+
+        Assert.Throws<ArgumentException>(
+            () => PackageHouseDecisionReceipt.RetainPackage(
+                request,
+                PackageSourceCoordinate.Create("other", "4.0.0")));
+        Assert.Throws<ArgumentException>(
+            () => PackageHouseDecisionReceipt.RetainPackage(
+                request,
+                PackageSourceCoordinate.Create(
+                    "contoso.json",
+                    "5.0.0")));
+
+        PackageHouseDecisionReceipt decision =
+            PackageHouseDecisionReceipt.RetainPackage(request, Coordinate);
+        Assert.Same(Coordinate, decision.Coordinate);
+    }
+
+    [Fact]
+    public void RequestRequiresRealizeForSelectionAndLibraryHandoff()
+    {
+        PackageHouseDemand demand = new PackageHouseDemand.Exact(Coordinate);
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseRequest(
+                demand,
+                PackageHouseOperation.Create(
+                    PackageHouseOperationProfile.Acquire),
+                assetSelection: PackageHouseAssetSelectionKind.Compile));
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseRequest(
+                demand,
+                PackageHouseOperation.Create(
+                    PackageHouseOperationProfile.Realize)));
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseRequest(
+                demand,
+                PackageHouseOperation.Create(
+                    PackageHouseOperationProfile.Settle),
+                libraryHandoff:
+                    PackageHouseLibraryHandoffMode.SelectedLibraries));
+    }
+
+    [Fact]
+    public void OperationPreservesIdentityAndDeadlineDurations()
+    {
+        PackageHouseOperation operation = PackageHouseOperation.Create(
+            PackageHouseOperationProfile.Acquire,
+            TimeSpan.FromSeconds(7),
+            TimeSpan.FromSeconds(31));
+
+        Assert.Equal(PackageHouseOperationProfile.Acquire, operation.Profile);
+        Assert.Equal(TimeSpan.FromSeconds(7), operation.RequestTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(31), operation.OperationTimeout);
+        Assert.NotSame(
+            operation.Identity,
+            PackageHouseOperation.Create(
+                PackageHouseOperationProfile.Acquire).Identity);
+    }
+
+    [Fact]
+    public void AcquireRequiresAuthorityBoundAcquisitionReceipt()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire);
+        AcquisitionBundle bundle = Acquisition(request);
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Settled(
+                new PackageHouseEvidence(request, bundle.Decision)));
+
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition);
+        var result = new PackageHouseResult.Settled(evidence);
+
+        Assert.Same(bundle.Candidate, evidence.Acquisition!.Candidate);
+        Assert.Same(bundle.Authority, evidence.Acquisition.Authority);
+        Assert.Same(bundle.Source.Producer, evidence.Acquisition.Producer);
+        Assert.Same(bundle.Generation, evidence.Acquisition.Generation);
+        Assert.Null(evidence.Realization);
+        Assert.Same(evidence, result.Evidence);
+    }
+
+    [Fact]
+    public void AcquisitionRejectsSourceFromAnotherAuthority()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire);
+        var authority = new ConfiguredPackageAuthority(PackageSource.NuGetOrg);
+        var otherAuthority = new ConfiguredPackageAuthority(
+            new PackageSource(
+                "other",
+                "https://packages.example.test/v3/index.json"));
+        PackageAcquisitionCandidate candidate =
+            PackageAcquisitionCandidate.CreatePinned(
+                new object(),
+                Coordinate,
+                [authority]);
+        PackageHouseDecisionReceipt decision =
+            PackageHouseDecisionReceipt.RetainPackage(
+                request,
+                Coordinate,
+                candidate);
+        PackageSourceResultIdentity otherSource;
+        using (IPackageSourceClient client =
+            PackageSourceClientFactory.Create(
+                otherAuthority.Source,
+                otherAuthority.Association))
+        {
+            otherSource = client.Source;
+        }
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseAcquisitionReceipt(
+                decision,
+                candidate,
+                authority,
+                otherSource,
+                PackagePayloadOrigin.Cache,
+                new PackageContentGenerationIdentity()));
+    }
+
+    [Fact]
+    public void AcquisitionRejectsASettleOperation()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Settle);
+
+        Assert.Throws<ArgumentException>(() => Acquisition(request));
+    }
+
+    [Fact]
+    public void TerminalFailureRetainsCompletedAcquisitionAndTypedFailure()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize);
+        AcquisitionBundle bundle = Acquisition(request);
+        var failure = new PackageHouseFailure.Stage(
+            PackageHouseFailureStage.Selection,
+            Reason("No compatible compile assets."));
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            failures: [failure]);
+
+        var result = new PackageHouseResult.NoMatch(
+            evidence,
+            Reason("Package acquisition completed but selection did not."));
+
+        Assert.Same(bundle.Decision, result.Decision);
+        Assert.Same(bundle.Acquisition, result.Evidence.Acquisition);
+        Assert.Same(failure, Assert.Single(result.Evidence.Failures));
+        Assert.NotNull(result.Evidence.Identity);
+    }
+
+    [Fact]
+    public void SettledResultRetainsEarlierFallbackFailures()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire);
+        AcquisitionBundle bundle = Acquisition(request);
+        var timeout = new PackageHouseFailure.Timeout(
+            request.Operation.Identity,
+            PackageHouseTimeoutKind.Request,
+            request.Operation.RequestTimeout);
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            failures: [timeout]);
+
+        var result = new PackageHouseResult.Settled(evidence);
+
+        Assert.Same(timeout, Assert.Single(result.Evidence.Failures));
+        Assert.Same(
+            request.Operation.Identity,
+            timeout.Operation);
+    }
+
+    [Fact]
+    public void TimeoutEvidenceMustMatchOperationAndRemainTerminal()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire);
+        AcquisitionBundle bundle = Acquisition(request);
+        PackageHouseRequest other = Request(
+            PackageHouseOperationProfile.Acquire);
+        var wrongOperation = new PackageHouseFailure.Timeout(
+            other.Operation.Identity,
+            PackageHouseTimeoutKind.Request,
+            request.Operation.RequestTimeout);
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseEvidence(
+                request,
+                bundle.Decision,
+                bundle.Acquisition,
+                failures: [wrongOperation]));
+
+        var operationTimeout = new PackageHouseFailure.Timeout(
+            request.Operation.Identity,
+            PackageHouseTimeoutKind.Operation,
+            request.Operation.OperationTimeout);
+        var timedOut = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            failures: [operationTimeout]);
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Settled(timedOut));
+        var failed = new PackageHouseResult.Failed(
+            timedOut,
+            Reason("The PackageHouse operation timed out."));
+        Assert.Same(operationTimeout, Assert.Single(failed.Evidence.Failures));
+    }
+
+    [Fact]
+    public void OwnerOperationTimeoutRemainsTerminalAfterHouseAdaptation()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire);
+        AcquisitionBundle bundle = Acquisition(request);
+        var ownerFailure = new PackageAuthorityFailure(
+            Reason("nuget.org"),
+            PackageAuthorityFailureKind.Timeout,
+            "The package source operation timed out.")
+        {
+            Timeout = new PackageSourceTimeout(
+                PackageSourceTimeoutKind.Operation,
+                request.Operation.OperationTimeout),
+        };
+        var adapted = new PackageHouseFailure.Authority(
+            request.Operation.Identity,
+            ownerFailure);
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            failures: [adapted]);
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Settled(evidence));
+        var failed = new PackageHouseResult.Failed(
+            evidence,
+            Reason("The PackageHouse operation timed out."));
+        Assert.Same(ownerFailure, adapted.Failure);
+        Assert.Same(adapted, Assert.Single(failed.Evidence.Failures));
+    }
+
+    [Fact]
+    public void DirectOperationTimeoutRetainsCompletedSelectedRealization()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize);
+        IPackageContent content = Content(
+            "ref/net10.0/Contoso.Json.dll",
+            "lib/net10.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        var selection = new PackageHouseAssetSelectionReceipt.Compile(
+            bundle.Acquisition,
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "contoso.json",
+                "net10.0"));
+        var realization = new PackageHouseRealizationReceipt(selection);
+        var timeout = new PackageHouseFailure.Timeout(
+            request.Operation.Identity,
+            PackageHouseTimeoutKind.Operation,
+            request.Operation.OperationTimeout);
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            realization,
+            [timeout]);
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Settled(evidence));
+        var failed = new PackageHouseResult.Failed(
+            evidence,
+            Reason("The PackageHouse operation timed out."));
+        Assert.Same(realization, failed.Evidence.Realization);
+        Assert.Same(timeout, Assert.Single(failed.Evidence.Failures));
+    }
+
+    [Fact]
+    public void OwnerOperationTimeoutRetainsCompletedEmptyRealization()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize);
+        IPackageContent content = Content(
+            "lib/net8.0/Contoso.Json.dll",
+            "ref/net10.0/_._");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        var selection = new PackageHouseAssetSelectionReceipt.Compile(
+            bundle.Acquisition,
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "contoso.json",
+                "net10.0"));
+        var realization = new PackageHouseRealizationReceipt(selection);
+        var ownerFailure = new PackageAuthorityFailure(
+            Reason("nuget.org"),
+            PackageAuthorityFailureKind.Timeout,
+            "The package source operation timed out.")
+        {
+            Timeout = new PackageSourceTimeout(
+                PackageSourceTimeoutKind.Operation,
+                request.Operation.OperationTimeout),
+        };
+        var adapted = new PackageHouseFailure.Authority(
+            request.Operation.Identity,
+            ownerFailure);
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            realization,
+            [adapted]);
+
+        var failed = new PackageHouseResult.Failed(
+            evidence,
+            Reason("The PackageHouse operation timed out."));
+
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.EmptyCompileGroup,
+            selection.Selection.Status);
+        Assert.Same(realization, failed.Evidence.Realization);
+        Assert.Same(adapted, Assert.Single(failed.Evidence.Failures));
+    }
+
+    [Fact]
+    public void SettleRejectsAcquisitionAndRealizeRequiresSelection()
+    {
+        PackageHouseRequest settle = Request(
+            PackageHouseOperationProfile.Settle);
+        PackageHouseDecisionReceipt settleDecision =
+            PackageHouseDecisionReceipt.RetainPackage(settle, Coordinate);
+        PackageHouseRequest realize = Request(
+            PackageHouseOperationProfile.Realize);
+        AcquisitionBundle realization = Acquisition(realize);
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Settled(
+                new PackageHouseEvidence(
+                    settle,
+                    settleDecision,
+                    realization.Acquisition)));
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Settled(
+                new PackageHouseEvidence(
+                    realize,
+                    realization.Decision,
+                    realization.Acquisition)));
+    }
+
+    [Fact]
+    public void SelectionReceiptRejectsAnotherRequestedKind()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize,
+            selection: PackageHouseAssetSelectionKind.Runtime);
+        IPackageContent content = Content(
+            "ref/net10.0/Contoso.Json.dll",
+            "lib/net10.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        PackageCompileAssetSelectionReceipt receipt =
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "contoso.json",
+                "net10.0");
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseAssetSelectionReceipt.Compile(
+                bundle.Acquisition,
+                receipt));
+    }
+
+    [Fact]
+    public void RealizeKeepsRequestedAndSelectedFrameworksDistinct()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize,
+            requestedFramework: "net10.0",
+            selection: PackageHouseAssetSelectionKind.Runtime);
+        IPackageContent content = Content(
+            "lib/net8.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        PackageAssetSelectionReceipt ownerReceipt =
+            PackageAssetSelector.Evaluate(content, "net10.0");
+        var selection = new PackageHouseAssetSelectionReceipt.Runtime(
+            bundle.Acquisition,
+            ownerReceipt);
+        var realization = new PackageHouseRealizationReceipt(selection);
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            realization);
+        var result = new PackageHouseResult.Settled(evidence);
+
+        Assert.Equal("net10.0", request.TargetContext!.RequestedFramework);
+        Assert.Equal(
+            "net8.0",
+            Assert.IsType<PackageAssetSelection.Selected>(
+                selection.Selection).Universe.TargetFramework);
+        Assert.Same(ownerReceipt, selection.Receipt);
+        Assert.Same(realization, result.Evidence.Realization);
+    }
+
+    [Fact]
+    public void SelectionReceiptRejectsAnotherContentGeneration()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize);
+        IPackageContent acquired = Content(
+            "ref/net10.0/Contoso.Json.dll");
+        IPackageContent other = Content(
+            "ref/net10.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            acquired.GenerationIdentity);
+        PackageCompileAssetSelectionReceipt receipt =
+            PackageCompileAssetSelector.Evaluate(
+                other,
+                "contoso.json",
+                "net10.0");
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseAssetSelectionReceipt.Compile(
+                bundle.Acquisition,
+                receipt));
+    }
+
+    [Fact]
+    public void SameCoordinateWithDifferentTargetsHasDistinctSettlements()
+    {
+        AcquisitionBundle netEight = Acquisition(
+            Request(
+                PackageHouseOperationProfile.Realize,
+                "net8.0"));
+        AcquisitionBundle netTen = Acquisition(
+            Request(
+                PackageHouseOperationProfile.Realize,
+                "net10.0"));
+        var first = new PackageHouseEvidence(
+            netEight.Decision.Request,
+            netEight.Decision,
+            netEight.Acquisition);
+        var second = new PackageHouseEvidence(
+            netTen.Decision.Request,
+            netTen.Decision,
+            netTen.Acquisition);
+
+        Assert.NotSame(first.Identity, second.Identity);
+        Assert.NotSame(netEight.Generation, netTen.Generation);
+        Assert.Same(Coordinate, netEight.Decision.Coordinate);
+        Assert.Same(Coordinate, netTen.Decision.Coordinate);
+    }
+
+    [Fact]
+    public void CompileHandoffRetainsSelectionAcquisitionAndCounterpart()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize,
+            handoff: PackageHouseLibraryHandoffMode.SelectedLibraries);
+        IPackageContent content = Content(
+            "ref/net10.0/Contoso.Json.dll",
+            "lib/net10.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        PackageCompileAssetSelectionReceipt ownerReceipt =
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "contoso.json",
+                "net10.0");
+        var selection = new PackageHouseAssetSelectionReceipt.Compile(
+            bundle.Acquisition,
+            ownerReceipt);
+        var realization = new PackageHouseRealizationReceipt(selection);
+
+        PackageHouseLibraryHandoff.Compile handoff =
+            Assert.IsType<PackageHouseLibraryHandoff.Compile>(
+                Assert.Single(realization.LibraryHandoffs));
+        Assert.Same(selection, handoff.Selection);
+        Assert.Same(bundle.Acquisition, handoff.Acquisition);
+        Assert.Same(bundle.Decision, handoff.Decision);
+        Assert.Same(Coordinate, handoff.Coordinate);
+        Assert.Same(ownerReceipt.Selection.Assets[0], handoff.Asset);
+        Assert.Same(
+            ownerReceipt.Selection.ImplementationAssets[0],
+            handoff.ImplementationAsset);
+        Assert.Same(bundle.Authority, handoff.Acquisition.Authority);
+        Assert.Same(bundle.Source, handoff.Acquisition.Source);
+        Assert.Same(bundle.Generation, handoff.Acquisition.Generation);
+    }
+
+    [Fact]
+    public void PackageOnlyRealizationDoesNotUnwrapSelectedLibraries()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize);
+        IPackageContent content = Content(
+            "ref/net10.0/Contoso.Json.dll",
+            "lib/net10.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        var selection = new PackageHouseAssetSelectionReceipt.Compile(
+            bundle.Acquisition,
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "contoso.json",
+                "net10.0"));
+        var realization = new PackageHouseRealizationReceipt(selection);
+
+        Assert.True(selection.Selection.IsSelected);
+        Assert.Empty(realization.LibraryHandoffs);
+    }
+
+    [Fact]
+    public void RuntimeHandoffWrapsOwnerSelectedAsset()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize,
+            runtimeIdentifier: "linux-x64",
+            handoff: PackageHouseLibraryHandoffMode.SelectedLibraries,
+            selection: PackageHouseAssetSelectionKind.Runtime);
+        IPackageContent content = Content(
+            "runtimes/linux-x64/lib/net10.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        PackageAssetSelectionReceipt ownerReceipt =
+            PackageAssetSelector.Evaluate(
+                content,
+                "net10.0",
+                "linux-x64");
+        var selection = new PackageHouseAssetSelectionReceipt.Runtime(
+            bundle.Acquisition,
+            ownerReceipt);
+        var realization = new PackageHouseRealizationReceipt(selection);
+
+        PackageHouseLibraryHandoff.Runtime handoff =
+            Assert.IsType<PackageHouseLibraryHandoff.Runtime>(
+                Assert.Single(realization.LibraryHandoffs));
+        Assert.Same(ownerReceipt, selection.Receipt);
+        Assert.Same(
+            Assert.IsType<PackageAssetSelection.Selected>(
+                ownerReceipt.Selection).Universe.Assets[0],
+            handoff.Asset);
+        Assert.Same(selection, handoff.Selection);
+    }
+
+    [Fact]
+    public void OwnerNoMatchSelectionProducesNoLibraryHandoffs()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize,
+            handoff: PackageHouseLibraryHandoffMode.SelectedLibraries);
+        IPackageContent content = Content(
+            "ref/net8.0/Contoso.Json.dll");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        PackageCompileAssetSelectionReceipt ownerReceipt =
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "contoso.json",
+                "net10.0");
+        var selection = new PackageHouseAssetSelectionReceipt.Compile(
+            bundle.Acquisition,
+            ownerReceipt);
+
+        var realization = new PackageHouseRealizationReceipt(selection);
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            realization);
+
+        Assert.Same(ownerReceipt, selection.Receipt);
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.NoMatchingTargetFramework,
+            selection.Selection.Status);
+        Assert.Empty(realization.LibraryHandoffs);
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Settled(evidence));
+        var result = new PackageHouseResult.NoMatch(
+            evidence,
+            Reason("No compile assets match the requested framework."));
+        Assert.Same(realization, result.Evidence.Realization);
+    }
+
+    [Fact]
+    public void ExplicitEmptyCompileGroupIsASettledZeroLibraryOutcome()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Realize,
+            handoff: PackageHouseLibraryHandoffMode.SelectedLibraries);
+        IPackageContent content = Content(
+            "lib/net8.0/Contoso.Json.dll",
+            "ref/net10.0/_._");
+        AcquisitionBundle bundle = Acquisition(
+            request,
+            content.GenerationIdentity);
+        PackageCompileAssetSelectionReceipt ownerReceipt =
+            PackageCompileAssetSelector.Evaluate(
+                content,
+                "contoso.json",
+                "net10.0");
+        var selection = new PackageHouseAssetSelectionReceipt.Compile(
+            bundle.Acquisition,
+            ownerReceipt);
+        var realization = new PackageHouseRealizationReceipt(selection);
+        var evidence = new PackageHouseEvidence(
+            request,
+            bundle.Decision,
+            bundle.Acquisition,
+            realization);
+
+        var result = new PackageHouseResult.Settled(evidence);
+
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.EmptyCompileGroup,
+            selection.Selection.Status);
+        Assert.Empty(result.Evidence.Realization!.LibraryHandoffs);
+    }
+
+    [Fact]
+    public void PlatformDelegationConsumesPolicyIssuedCorrespondence()
+    {
+        PlatformFamilyTarget target = PlatformTarget("net11.0", "11.0.0");
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire,
+            requestedFramework: "net11.0",
+            platformTarget: target);
+        PlatformPruneInventory inventory = PlatformInventory(
+            "net11.0",
+            "11.0.0");
+        PackageCoordinate policyCoordinate = new(
+            "contoso.json",
+            "4.0.0",
+            "net11.0");
+        PlatformSupplyReceipt policy =
+            PlatformPrunePolicy.Evaluate(inventory, policyCoordinate);
+        var pruning = new PackageHousePruningReceipt(
+            request,
+            target,
+            policy);
+        PackageHouseDecisionReceipt decision =
+            PackageHouseDecisionReceipt.DelegateToPlatform(
+                request,
+                Coordinate,
+                candidate: null,
+                pruning);
+        var delegation = new PlatformDelegation(decision);
+        var evidence = new PackageHouseEvidence(request, decision);
+        var result = new PackageHouseResult.Delegated(
+            evidence,
+            delegation);
+
+        Assert.Same(policy, delegation.Policy);
+        Assert.Same(inventory, delegation.Policy.Inventory);
+        Assert.Same(policyCoordinate, delegation.Policy.Coordinate);
+        Assert.Same(target, delegation.Target);
+        Assert.Same(Coordinate, delegation.Coordinate);
+        Assert.True(delegation.Supply.DelegatesToPlatform);
+        Assert.Same(evidence, result.Evidence);
+    }
+
+    [Fact]
+    public void PruningRejectsAnotherPolicyCoordinateOrPlatformVersion()
+    {
+        PlatformFamilyTarget target = PlatformTarget("net11.0", "11.0.0");
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire,
+            requestedFramework: "net11.0",
+            platformTarget: target);
+        PlatformPruneInventory inventory = PlatformInventory(
+            "net11.0",
+            "11.0.0");
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHousePruningReceipt(
+                request,
+                target,
+                PlatformPrunePolicy.Evaluate(
+                    inventory,
+                    new PackageCoordinate(
+                        "contoso.json",
+                        "5.0.0",
+                        "net11.0"))));
+        Assert.Throws<ArgumentException>(
+            () => new PackageHousePruningReceipt(
+                request,
+                target,
+                PlatformPrunePolicy.Evaluate(
+                    PlatformInventory("net11.0", "11.0.1"),
+                    new PackageCoordinate(
+                        "contoso.json",
+                        "4.0.0",
+                        "net11.0"))));
+    }
+
+    [Fact]
+    public void PruningRejectsADelegatingSupplyFromAnotherFamily()
+    {
+        PlatformFamilyTarget target = PlatformTarget("net11.0", "11.0.0");
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire,
+            requestedFramework: "net11.0",
+            platformTarget: target);
+        PlatformPruneInventory runtime = PlatformPruneInventory.FromExactFamily(
+            new PlatformPruneTarget(
+                "Microsoft.NETCore.App",
+                "net11.0",
+                NuGetVersion.Parse("11.0.0")),
+            ["system.runtime|11.0.0"]);
+        PlatformPruneInventory aspnet = PlatformPruneInventory.FromExactFamily(
+            new PlatformPruneTarget(
+                "Microsoft.AspNetCore.App",
+                "net11.0",
+                NuGetVersion.Parse("11.0.0")),
+            ["contoso.json|11.0.0"]);
+        PlatformSupplyReceipt policy = PlatformPrunePolicy.Evaluate(
+            PlatformPruneInventory.Compose([runtime, aspnet]),
+            new PackageCoordinate(
+                "contoso.json",
+                "4.0.0",
+                "net11.0"));
+
+        Assert.True(policy.Supply.DelegatesToPlatform);
+        Assert.Equal("Microsoft.AspNetCore.App", policy.Supply.Family);
+        Assert.Throws<ArgumentException>(
+            () => new PackageHousePruningReceipt(
+                request,
+                target,
+                policy));
+    }
+
+    [Fact]
+    public void PlatformDelegationRejectsNonSubsumedPruning()
+    {
+        PlatformFamilyTarget target = PlatformTarget("net11.0", "11.0.0");
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Acquire,
+            requestedFramework: "net11.0",
+            platformTarget: target);
+        PlatformPruneInventory inventory =
+            PlatformPruneInventory.FromExactFamily(
+                new PlatformPruneTarget(
+                    "Microsoft.NETCore.App",
+                    "net11.0",
+                    NuGetVersion.Parse("11.0.0")),
+                ["other|11.0.0"]);
+        PlatformSupplyReceipt policy = PlatformPrunePolicy.Evaluate(
+            inventory,
+            new PackageCoordinate(
+                "contoso.json",
+                "4.0.0",
+                "net11.0"));
+        var pruning = new PackageHousePruningReceipt(
+            request,
+            target,
+            policy);
+
+        Assert.Throws<ArgumentException>(
+            () => PackageHouseDecisionReceipt.DelegateToPlatform(
+                request,
+                Coordinate,
+                candidate: null,
+                pruning));
+    }
+
+    [Fact]
+    public void ContractFamiliesAreClosedClasses()
+    {
+        Type[] closedFamilies =
+        [
+            typeof(PackageHouseDemand),
+            typeof(PackageHouseAssetSelectionReceipt),
+            typeof(PackageHouseLibraryHandoff),
+            typeof(PackageHouseFailure),
+            typeof(PackageHouseResult),
+        ];
+
+        Assert.All(
+            closedFamilies,
+            family => Assert.All(
+                family.GetConstructors(
+                    BindingFlags.Instance | BindingFlags.NonPublic),
+                constructor => Assert.True(constructor.IsPrivate)));
+        Assert.All(
+            closedFamilies.SelectMany(family =>
+                family.GetNestedTypes(BindingFlags.Public)),
+            arm => Assert.True(arm.IsSealed));
+    }
+
+    [Fact]
+    public void NonSuccessRejectsAnEmptyReason()
+    {
+        var evidence = new PackageHouseEvidence(
+            Request(PackageHouseOperationProfile.Settle));
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageHouseResult.Failed(evidence, default));
+    }
+
+    [Fact]
+    public void TerminalResultFamilyIsClosedAndResourceFree()
+    {
+        Type result = typeof(PackageHouseResult);
+        string[] expected =
+        [
+            "Ambiguous",
+            "Delegated",
+            "Failed",
+            "Incomplete",
+            "NoMatch",
+            "NotFound",
+            "Rejected",
+            "Settled",
+            "Unavailable",
+        ];
+
+        Assert.Equal(
+            expected,
+            result.GetNestedTypes(BindingFlags.Public)
+                .Select(type => type.Name)
+                .Order(StringComparer.Ordinal)
+                .ToArray());
+
+        Type[] contractTypes =
+        [
+            typeof(PackageHouseRequest),
+            typeof(PackageHouseOperation),
+            typeof(PackageHouseDecisionReceipt),
+            typeof(PackageHousePruningReceipt),
+            typeof(PackageHouseAcquisitionReceipt),
+            typeof(PackageHouseAssetSelectionReceipt),
+            typeof(PackageAssetSelectionReceipt),
+            typeof(PackageCompileAssetSelectionReceipt),
+            typeof(PackageHouseRealizationReceipt),
+            typeof(PackageHouseLibraryHandoff),
+            typeof(PackageHouseFailure),
+            typeof(PackageHouseEvidence),
+            typeof(PlatformDelegation),
+            .. result.GetNestedTypes(BindingFlags.Public),
+        ];
+        Assert.DoesNotContain(
+            contractTypes.SelectMany(type => type.GetProperties()),
+            property =>
+                typeof(Stream).IsAssignableFrom(property.PropertyType)
+                || typeof(IPackageContent).IsAssignableFrom(
+                    property.PropertyType)
+                || property.PropertyType.Name.Contains(
+                    "Workspace",
+                    StringComparison.Ordinal)
+                || property.PropertyType.Namespace
+                    ?.Equals(
+                        "DotnetInspector.Queries",
+                        StringComparison.Ordinal)
+                    is true);
+    }
+
+    [Fact]
+    public void EveryTerminalArmRetainsTheExactEvidenceEnvelope()
+    {
+        PackageHouseRequest request = Request(
+            PackageHouseOperationProfile.Settle);
+        var evidence = new PackageHouseEvidence(request);
+        InertString reason = Reason("Terminal outcome.");
+        PackageHouseResult[] results =
+        [
+            new PackageHouseResult.NotFound(evidence, reason),
+            new PackageHouseResult.NoMatch(evidence, reason),
+            new PackageHouseResult.Ambiguous(evidence, reason),
+            new PackageHouseResult.Rejected(evidence, reason),
+            new PackageHouseResult.Unavailable(evidence, reason),
+            new PackageHouseResult.Incomplete(evidence, reason),
+            new PackageHouseResult.Failed(evidence, reason),
+        ];
+
+        Assert.All(results, result => Assert.Same(evidence, result.Evidence));
+        Assert.All(results, result => Assert.Same(request, result.Request));
+    }
+
+    private static PackageHouseRequest Request(
+        PackageHouseOperationProfile profile,
+        string? requestedFramework = "net10.0",
+        string? runtimeIdentifier = null,
+        PackageHouseLibraryHandoffMode handoff =
+            PackageHouseLibraryHandoffMode.PackageOnly,
+        PlatformFamilyTarget? platformTarget = null,
+        PackageHouseAssetSelectionKind selection =
+            PackageHouseAssetSelectionKind.Compile) =>
+        new(
+            new PackageHouseDemand.Exact(Coordinate),
+            PackageHouseOperation.Create(profile),
+            requestedFramework is null
+                ? null
+                : PackageHouseTargetContext.Exact(
+                    requestedFramework,
+                    runtimeIdentifier,
+                    platformTarget),
+            profile == PackageHouseOperationProfile.Realize
+                ? selection
+                : null,
+            handoff);
+
+    private static AcquisitionBundle Acquisition(
+        PackageHouseRequest request,
+        PackageContentGenerationIdentity? generation = null)
+    {
+        var authority = new ConfiguredPackageAuthority(PackageSource.NuGetOrg);
+        PackageAcquisitionCandidate candidate =
+            PackageAcquisitionCandidate.CreatePinned(
+                new object(),
+                Coordinate,
+                [authority]);
+        PackageHouseDecisionReceipt decision =
+            PackageHouseDecisionReceipt.RetainPackage(
+                request,
+                Coordinate,
+                candidate);
+        PackageSourceResultIdentity source;
+        using (IPackageSourceClient client =
+            PackageSourceClientFactory.Create(
+                authority.Source,
+                authority.Association))
+        {
+            source = client.Source;
+        }
+
+        generation ??= new PackageContentGenerationIdentity();
+        var acquisition = new PackageHouseAcquisitionReceipt(
+            decision,
+            candidate,
+            authority,
+            source,
+            PackagePayloadOrigin.Cache,
+            generation);
+        return new AcquisitionBundle(
+            decision,
+            candidate,
+            authority,
+            source,
+            generation,
+            acquisition);
+    }
+
+    private static IPackageContent Content(params string[] entries) =>
+        new InMemoryPackageContent(
+            TestPackageArchive.Create(entries),
+            fromCache: true,
+            producerKey: "test-source");
+
+    private static PlatformPruneInventory PlatformInventory(
+        string framework,
+        string version) =>
+        PlatformPruneInventory.FromExactFamily(
+            new PlatformPruneTarget(
+                "Microsoft.NETCore.App",
+                framework,
+                NuGetVersion.Parse(version)),
+            ["contoso.json|11.0.0"]);
+
+    private static PlatformFamilyTarget PlatformTarget(
+        string framework,
+        string version) =>
+        new(
+            PlatformFamily.DotNetRuntime,
+            PlatformTargetFramework.Parse(framework),
+            PlatformVersion.Parse(version));
+
+    private static InertString Reason(string text) =>
+        new(TextPolicy.Field, text);
+
+    private sealed record AcquisitionBundle(
+        PackageHouseDecisionReceipt Decision,
+        PackageAcquisitionCandidate Candidate,
+        ConfiguredPackageAuthority Authority,
+        PackageSourceResultIdentity Source,
+        PackageContentGenerationIdentity Generation,
+        PackageHouseAcquisitionReceipt Acquisition);
+}

--- a/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
@@ -733,6 +733,39 @@ public sealed class PackageHouseContractTests
     }
 
     [Fact]
+    public void PruningUsesPackageOwnerExactCoordinateNormalization()
+    {
+        PackageSourceCoordinate coordinate =
+            PackageSourceCoordinate.Create(
+                "contoso.json",
+                "4.0.0-RC.1");
+        PlatformFamilyTarget target = PlatformTarget(
+            "net11.0",
+            "11.0.0");
+        var request = new PackageHouseRequest(
+            new PackageHouseDemand.Exact(coordinate),
+            PackageHouseOperation.Create(
+                PackageHouseOperationProfile.Acquire),
+            PackageHouseTargetContext.Exact(
+                "net11.0",
+                platformTarget: target));
+        PlatformSupplyReceipt policy = PlatformPrunePolicy.Evaluate(
+            PlatformInventory("net11.0", "11.0.0"),
+            new PackageCoordinate(
+                "contoso.json",
+                "4.0.0-RC.1",
+                "net11.0"));
+
+        var pruning = new PackageHousePruningReceipt(
+            request,
+            target,
+            policy);
+
+        Assert.Equal("4.0.0-rc.1", coordinate.Version);
+        Assert.Same(policy, pruning.Policy);
+    }
+
+    [Fact]
     public void PruningRejectsAnotherPolicyCoordinateOrPlatformVersion()
     {
         PlatformFamilyTarget target = PlatformTarget("net11.0", "11.0.0");


### PR DESCRIPTION
This establishes the first resource-free PackageHouse contract floor: a
host-neutral package settlement boundary that preserves exact request,
authority, pruning, acquisition, selection, failure, and handoff evidence
without retaining package bytes.

## Demo

An exact target-aware package realization now keeps every owner-issued join
currency associated:

```csharp
PackageHouseRequest request = new(
    new PackageHouseDemand.Exact(coordinate),
    PackageHouseOperation.Create(PackageHouseOperationProfile.Realize),
    PackageHouseTargetContext.Exact("net10.0"),
    PackageHouseAssetSelectionKind.Compile,
    PackageHouseLibraryHandoffMode.SelectedLibraries);

PackageHouseEvidence evidence = new(
    request,
    decision,
    acquisition,
    new PackageHouseRealizationReceipt(
        new PackageHouseAssetSelectionReceipt.Compile(
            acquisition,
            compileSelectionReceipt)));

PackageHouseResult result = new PackageHouseResult.Settled(evidence);
```

The same exact coordinate under another target context receives a distinct
settlement and content generation. A selection no-match retains completed
acquisition and realization evidence in `PackageHouseResult.NoMatch` rather
than becoming an empty success.

## Summary

- define exact-demand PackageHouse requests with finite Settle, Acquire, and
  Realize work profiles;
- define closed resource-free terminal results with one immutable evidence
  envelope, settlement identity, completed receipts, and typed failures;
- bind acquisition to the exact candidate, configured authority, source
  result, producer, payload origin, and content generation;
- consume the policy-issued pruning receipt and require the actual supplying
  family, package-owner-normalized coordinate, and exact target version before
  platform delegation;
- consume runtime and compile selector receipts matching the acquired
  generation and exact target request;
- preserve owner-selected assets and compile/implementation pairing through
  package-to-library handoffs;
- map selection outcomes to Settled, NoMatch, Ambiguous, or Rejected while
  treating explicit empty compile groups as settled zero-library outcomes;
- preserve direct and owner-adapted operation timeouts as terminal failures,
  including after selection completed; and
- update the Inspect Web and decompiler CI project inventories for the new
  `DotnetInspector.Packages` to `DotnetInspector.Platforms` dependency; and
- update the PackageHouse design with the implemented floor and the
  `DotnetInspector.Queries`/`DotnetInspector.PackageQueries` investigation
  boundary from #6432.

The initial public demand family is intentionally exact-only. Latest,
wildcard, range, and resolved-edge demand arms wait for owner-issued request
and resolution correspondence rather than treating `PackageCoordinate` as a
universal selector.

## Stack

This is slice 3 of the current PackageHouse contract stack and implements
#6433.

- slice 1: #6448, platform-supply comparison correspondence
- slice 2: #6450, asset-selection generation/request correspondence
- slice 3: this PR, PackageHouse composition contracts
- target branch: `feature/package-selection-receipts`

## Validation

```text
dotnet run --project tests/DotnetInspector.Services.Tests -c Release \
  --no-build -- \
  --filter-class '*PackageHouseContractTests' \
  '*PlatformPrunePolicyTests' \
  '*PackageAssetSelectorTests' \
  '*PackageCompileAssetSelectorTests'
```

123 passed.

```text
npx markdownlint-cli docs/design/package-house.md
```

Passed.

```text
dotnet build dotnet-inspect.slnx -c Release
dotnet run eng/test-ci-change-detection.cs
dotnet run --project eng/DependencyPolicy.Tests -c Release --no-build
dotnet run --project eng/DependencyPolicy -c Release --no-build
```

Passed. Dependency policy evaluated 25 rules, 202 projects, and 43
assemblies.
