### PR TITLE
Clarify prohibited model result handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,10 +64,11 @@ development model and rationale. The binding summary:
   an established oracle, a TLA+ model, or a closely developed specification
   should bound the contract before implementation.
 - **Use only approved OpenAI GPT configurations.** In agent harnesses that
-  advertise GPT models, all other models, every `Fast` model or mode, and
-  extra-high (`xhigh`) reasoning are prohibited. Default to GPT-5.6 Sol for both
-  coding and review. Use GPT-6 Astra for complex reviews, or GPT-5.6 Terra or
-  Luna for relatively simple changes that still require review.
+  advertise GPT models, never start non-GPT, `Fast`, or extra-high (`xhigh`)
+  configurations. This launch prohibition does not invalidate work: observe and
+  use results from agents mistakenly started with a prohibited configuration.
+  Default to GPT-5.6 Sol; use GPT-6 Astra for complex reviews, or GPT-5.6 Terra
+  or Luna for relatively simple reviews.
 - **Hot-start requested work through PR and review.** Agents may branch,
   commit, push, open the PR, and dispatch eligible rounds without separate
   approval; merge remains separately authorized.

--- a/docs/agent-models.md
+++ b/docs/agent-models.md
@@ -28,6 +28,12 @@ changes that still require review. Another advertised non-Fast GPT model may be
 selected when the agent judges it sufficient for the task. Historical review
 attributions keep their original model names.
 
+These prohibitions govern dispatch only. If an agent is mistakenly started with
+a prohibited configuration, continue observing it and assess and use its
+returned work normally. Do not cancel, discard, or duplicate otherwise useful
+work solely because its launch violated model policy; use an approved
+configuration for subsequent dispatches.
+
 ## Resolving a dispatch
 
 Use the exact ID accepted by the active dispatch tool. Confirm a mapped ID

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -296,8 +296,9 @@ require review. If the selected model is unavailable, choose another non-Fast
 GPT model sufficient for the change's complexity, report the substitution and
 its reasoning on the PR, and proceed without approval. Non-GPT models, Fast
 models or modes, and extra-high (`xhigh`) reasoning are prohibited when the
-harness advertises GPT models. One round evaluates one settled head with its
-required reviewer.
+harness advertises GPT models. This prohibition governs dispatch only; observe
+and use otherwise valid work returned by a mistakenly prohibited launch. One
+round evaluates one settled head with its required reviewer.
 
 ### Dispatch
 


### PR DESCRIPTION
Build robust, capable agent workflows that preserve useful evidence while enforcing conventionally sound model-selection policy.

## Demo

Before: an agent that accidentally launched a prohibited Fast model could interpret the prohibition as requiring it to ignore the returned work.

After: guidance explicitly limits the prohibition to starting or dispatching the configuration. Agents continue observing the work and assess and use otherwise valid results instead of cancelling, discarding, or duplicating them.

## Summary

- Clarify the cross-cutting `AGENTS.md` rule without exceeding its 600-line cap.
- Add the operational handling rule to the model mapping owner.
- Repeat the dispatch-only distinction in reviewer orchestration guidance.

## Validation

- `npx markdownlint-cli AGENTS.md docs/agent-models.md docs/round-orchestration.md`
- `git diff --check`

This is a trivial documentation-only clarification with no product behavior or implementation change, so no adversarial reviewer is required.