### PR TITLE
Add peer skill release checkpoint

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -81,6 +81,15 @@ moving a skill into or out of it, is a product-surface change and needs the
 repository owner's explicit approval before landing — do not add or relocate a
 shipped skill unilaterally while doing routine release reconciliation.
 
+Reconcile the bootstrap skill in the peer `richlander/dotnet-skills` repository
+against the release's `VersionPrefix` and generated `dotnet-inspect skill list`.
+Keep it at or below 60 lines: explain the basic command UX and advertise every
+embedded focused skill, while deferring detailed guidance to the version-matched
+tool. When content or version changes, set every peer skill and plugin manifest
+version to the release version and publish that repository's update. If the
+peer repository is already current and no files change, do not make a no-op
+peer release.
+
 ## Publish package and site together
 
 Open `release.yml` and `promote-inspect-web.yml` together:

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -182,6 +182,17 @@ both before dispatching, and expect to update them:
 - Record the outcome either way. If neither needed a change, say so; silence
   reads the same as an unchecked box.
 
+The thin bootstrap skill distributed from the peer
+[`richlander/dotnet-skills`](https://github.com/richlander/dotnet-skills)
+marketplace is a release checkpoint too. Compare it with the selected
+`VersionPrefix` and the generated `dotnet-inspect skill list`. It must stay at
+or below 60 lines, teach the basic command UX, enumerate every embedded focused
+skill, and defer details to the version-matched guide in the tool. When the
+content or version changes, align every peer skill and plugin manifest version
+with the dotnet-inspect release and publish the peer update. When the peer is
+already current and the reconciliation produces no diff, do not make a no-op
+peer release.
+
 ## Dispatching
 
 1. Open the selected successful `main` CI run and copy its run ID.


### PR DESCRIPTION
dotnet-inspect's release rigor serves robust, capable features that are
foundational or compelling, conventionally sound or delightfully new.

## Demo

Before, a release reconciled the package README and embedded skills but could
leave the external marketplace bootstrap and its version manifests stale.

After, the release checkpoint compares `richlander/dotnet-skills` with the
selected `VersionPrefix` and generated skill inventory, keeps the bootstrap at
or below 60 lines, aligns all peer versions when an update is needed, and
explicitly skips no-op peer releases.

## Summary

- add the peer marketplace bootstrap to shipped-documentation reconciliation
- define its thin UX-and-skill-inventory contract
- require version alignment only when reconciliation produces a change

## Validation

- `npx markdownlint-cli .github/skills/release/SKILL.md
  docs/release-workflow.md`
