### PR TITLE
Migrate row selection tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -232,6 +232,12 @@ signature, declaration, conditional-recovery, or layout evidence. Manual
 decompiler fixture probes continue to inspect the built test assembly rather
 than invoke its test host.
 
+`DotnetInspector.RowSelection.Tests` is the fourteenth migrated adopter. Its
+required PR and developer commands remain unfiltered. These paths reuse the
+pinned outcome-level host gate without changing the suite's typed-language,
+reference-evaluator, failure, or separately compiled non-friend consumer
+evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/DotnetInspector.RowSelection.Tests/DotnetInspector.RowSelection.Tests.csproj
+++ b/tests/DotnetInspector.RowSelection.Tests/DotnetInspector.RowSelection.Tests.csproj
@@ -9,6 +9,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
This advances robust, conventional test evidence by making stale
`DotnetInspector.RowSelection.Tests` selectors fail through the test platform
that owns discovery and filtering.

## Demo

Before this change, the native xUnit host accepts an unmatched class selector
as successful evidence:

```text
DotnetInspector.RowSelection.Tests  Total: 0
exit=0
```

With Microsoft Testing Platform selected, the equivalent stale filter fails:

```text
Test run summary: Zero tests ran
  total: 0
exit=8
```

Both neighboring owner classes still execute normally:

```text
RowSelectionBoundaryTests  total: 2  exit=0
RowSelectionContractTests  total: 6  exit=0
```

## Summary

- Select Microsoft Testing Platform for
  `DotnetInspector.RowSelection.Tests` through the `xunit.v3` integration
  already pinned by the repository.
- Record the suite as the fourteenth migrated adopter in the xUnit host owner.
- Preserve the unfiltered required-CI and contributor commands unchanged.
- Preserve typed-language, reference-evaluator, failure, and separately
  compiled non-friend consumer evidence.

## Design basis

`docs/design/xunit-test-host.md` owns repository xUnit host selection and
aggregate zero-test behavior. MTP owns parsing, discovery, filtering,
execution, and exit code `8`; this slice adds no selector parser, runner
library dependency, workflow scan, or output parser.

`docs/design/semantic-row-selection.md` continues to own row-selection
semantics. This migration changes neither that contract nor product friendship.

## Validation

- Unmatched MTP class filter: 0 tests, exit `8`.
- `RowSelectionBoundaryTests`: 2 passed.
- `RowSelectionContractTests`: 6 passed.
- Full `DotnetInspector.RowSelection.Tests` suite: 8 passed.
- Full Release solution build.
- `markdownlint` and `git diff --check`.

Closes the fourteenth migration slice of #5379.
