### PR TITLE
Migrate sections tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -238,6 +238,11 @@ pinned outcome-level host gate without changing the suite's typed-language,
 reference-evaluator, failure, or separately compiled non-friend consumer
 evidence.
 
+`DotnetInspector.Sections.Tests` is the fifteenth migrated adopter. Its
+required PR and developer commands remain unfiltered. These paths reuse the
+pinned outcome-level host gate without changing the suite's unresolved-intent,
+cohort-binding, owner-identity, selection, or structured-failure evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/DotnetInspector.Sections.Tests/DotnetInspector.Sections.Tests.csproj
+++ b/tests/DotnetInspector.Sections.Tests/DotnetInspector.Sections.Tests.csproj
@@ -9,6 +9,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
This advances robust, conventional test evidence by making stale
`DotnetInspector.Sections.Tests` selectors fail through the test platform that
owns discovery and filtering.

## Demo

Before this change, the native xUnit host accepts an unmatched class selector
as successful evidence:

```text
DotnetInspector.Sections.Tests  Total: 0
exit=0
```

With Microsoft Testing Platform selected, the equivalent stale filter fails:

```text
Test run summary: Zero tests ran
  total: 0
exit=8
```

Both neighboring owner classes still execute normally:

```text
RowsCohortContractTests          total: 5  exit=0
RowSelectionIntentContractTests total: 3  exit=0
```

## Summary

- Select Microsoft Testing Platform for `DotnetInspector.Sections.Tests`
  through the `xunit.v3` integration already pinned by the repository.
- Record the suite as the fifteenth migrated adopter in the xUnit host owner.
- Preserve the unfiltered required-CI and contributor commands unchanged.
- Preserve unresolved-intent, cohort-binding, owner-identity, selection, and
  structured-failure evidence.

## Design basis

`docs/design/xunit-test-host.md` owns repository xUnit host selection and
aggregate zero-test behavior. MTP owns parsing, discovery, filtering,
execution, and exit code `8`; this slice adds no selector parser, runner
library dependency, workflow scan, or output parser.

`docs/design/section-row-shaping.md` continues to own the partial implemented
L2 section-row contract. This migration neither expands those verified subsets
nor changes product behavior.

## Validation

- Unmatched MTP class filter: 0 tests, exit `8`.
- `RowsCohortContractTests`: 5 passed.
- `RowSelectionIntentContractTests`: 3 passed.
- Full `DotnetInspector.Sections.Tests` suite: 8 passed.
- Full Release solution build.
- `markdownlint` and `git diff --check`.

Closes the fifteenth migration slice of #5379.
