### PR TITLE
Route pinned package searches through Workspace Roots

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -111,7 +111,8 @@ existing `find`, member-find, `implements`, `extensions`, and reachable
 extension implementations through one invocation-owned asynchronous
 `InspectionWorkspace` for a deliberately bounded source shape:
 
-- normalized source intent contains exactly one explicit package reference;
+- normalized source intent contains exactly one explicitly versioned package
+  reference whose version is an exact NuGet version;
 - the resolved request contains that package and no assembly, platform,
   project, or directory sources;
 - the request has one explicit target framework other than `all`; and
@@ -125,13 +126,14 @@ project library and source provenance from `PackageRootIdentity` and
 `PackageCompileAsset`; the CLI does not manufacture host filesystem paths for
 package-relative assets.
 
-Package archives, package groups and prefixes, multiple or mixed sources,
-implicit and `all` target frameworks, and limited searches retain the
-`AssemblySetResolver` and `AssemblySetInspectionWorkspace` path. In particular,
-the legacy path preserves streaming limit behavior that can stop before later
-sources are acquired. Type-mode `depends` remains outside this slice: its
-group-scoped dependency query and production caller land together rather than
-adding another caller-free query surface.
+Floating, `@latest`, and wildcard package versions; package archives, package
+groups and prefixes; multiple or mixed sources; implicit and `all` target
+frameworks; and limited searches retain the `AssemblySetResolver` and
+`AssemblySetInspectionWorkspace` path. That boundary preserves the CLI's
+existing version-selection and streaming-limit behavior rather than making
+Workspace acquisition redefine either contract. Type-mode `depends` remains
+outside this slice: its group-scoped dependency query and production caller
+land together rather than adding another caller-free query surface.
 
 This cutover consumes the package Root's reference-preferred compile surface.
 An explicit empty compile group therefore remains an empty configured Root and

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -103,6 +103,41 @@ Commands may have specialized acquisition and projection steps, but those
 steps retain the same ownership boundary: the host composes the request;
 reusable owners produce the facts.
 
+### Configured package search Roots
+
+The first production adoption in
+[#6170](https://github.com/richlander/dotnet-inspect/issues/6170) routes the
+existing `find`, member-find, `implements`, `extensions`, and reachable
+extension implementations through one invocation-owned asynchronous
+`InspectionWorkspace` for a deliberately bounded source shape:
+
+- normalized source intent contains exactly one explicit package reference;
+- the resolved request contains that package and no assembly, platform,
+  project, or directory sources;
+- the request has one explicit target framework other than `all`; and
+- `find` and member-find have no numeric result limit.
+
+The host acquires one package Root, commits it with `ReplaceScopeAsync`, retains
+the committed correspondence and generation, and executes the existing typed
+group queries through `ExecutePackageRootQueryAsync`. Type search reuses that
+same committed Root for its direct and fallback census passes. Package results
+project library and source provenance from `PackageRootIdentity` and
+`PackageCompileAsset`; the CLI does not manufacture host filesystem paths for
+package-relative assets.
+
+Package archives, package groups and prefixes, multiple or mixed sources,
+implicit and `all` target frameworks, and limited searches retain the
+`AssemblySetResolver` and `AssemblySetInspectionWorkspace` path. In particular,
+the legacy path preserves streaming limit behavior that can stop before later
+sources are acquired. Type-mode `depends` remains outside this slice: its
+group-scoped dependency query and production caller land together rather than
+adding another caller-free query surface.
+
+This cutover consumes the package Root's reference-preferred compile surface.
+An explicit empty compile group therefore remains an empty configured Root and
+does not reactivate platform defaults, package fallback, or an implementation
+assembly.
+
 ### Library inspection subject
 
 After a `library` source resolver identifies a physical participant, the

--- a/docs/design/find-search-service.md
+++ b/docs/design/find-search-service.md
@@ -66,14 +66,16 @@ described under [Implementation and validation status](#implementation-and-valid
 5. projects; and
 6. binary directories.
 
-For one normalized explicit package reference, one explicit target framework
-other than `all`, no other source, and no numeric result limit, the service owns
-an asynchronous `InspectionWorkspace`. It acquires and commits one package
-Root, then executes `AssemblyContextTypeInventoryQuery` against the Root's
-surface group. Direct and fallback census passes reuse that committed Root.
-Package candidates project library, source, and version from typed Root and
-asset provenance; a package-relative asset is not represented as a host
-filesystem path.
+For one normalized package reference with an exact NuGet version, one explicit
+target framework other than `all`, no other source, and no numeric result
+limit, the service owns an asynchronous `InspectionWorkspace`. It acquires and
+commits one package Root, then executes `AssemblyContextTypeInventoryQuery`
+against the Root's surface group. Direct and fallback census passes reuse that
+committed Root. Floating, `@latest`, and wildcard version selectors remain on
+the legacy route so this adoption does not redefine their version-selection
+semantics. Package candidates project library, source, and version from typed
+Root and asset provenance; a package-relative asset is not represented as a
+host filesystem path.
 
 All other source shapes retain an ephemeral
 `AssemblySetInspectionWorkspace`. Each admitted assembly executes the same

--- a/docs/design/find-search-service.md
+++ b/docs/design/find-search-service.md
@@ -66,14 +66,23 @@ described under [Implementation and validation status](#implementation-and-valid
 5. projects; and
 6. binary directories.
 
-The service owns an ephemeral `AssemblySetInspectionWorkspace` for one
-invocation. Each admitted assembly executes
-`AssemblyContextTypeInventoryQuery`; the service projects its type name,
-namespace, full name, kind, library file base name, source, and source version
-into the internal `TypeSearchResult` currency. The library value is path
-provenance, not metadata assembly identity. The service does not reopen
-assemblies, infer metadata facts from display text, or replace a typed query
-failure with a candidate.
+For one normalized explicit package reference, one explicit target framework
+other than `all`, no other source, and no numeric result limit, the service owns
+an asynchronous `InspectionWorkspace`. It acquires and commits one package
+Root, then executes `AssemblyContextTypeInventoryQuery` against the Root's
+surface group. Direct and fallback census passes reuse that committed Root.
+Package candidates project library, source, and version from typed Root and
+asset provenance; a package-relative asset is not represented as a host
+filesystem path.
+
+All other source shapes retain an ephemeral
+`AssemblySetInspectionWorkspace`. Each admitted assembly executes the same
+query, and the service projects its type name, namespace, full name, kind,
+library file base name, source, and source version into the internal
+`TypeSearchResult` currency. The library value on this route is path
+provenance, not metadata assembly identity. Neither route reopens assemblies,
+infers metadata facts from display text, or replaces a typed query failure with
+a candidate.
 
 A non-null collection pattern may be pushed into each inventory scan. With a
 non-tabular single pattern and an active result limit, `FindTypesAsync` selects
@@ -145,19 +154,22 @@ established.
 ## Failure and lifetime
 
 The invocation workspace and every resolved assembly set are disposed within
-the service call. Per-assembly rejection, query failure, and skipped metadata
-rows produce visible CLI warnings while healthy assemblies continue to
-contribute candidates. Verbose diagnostics retain the failed metadata
-operation, token, failure kind, and detail. An operation-wide exception
-propagates to `FindCommand`, which owns the hard error and exit status.
+the service call. The configured package route also observes artifact-session
+cleanup failures when the Workspace closes. Per-assembly rejection, query
+failure, and skipped metadata rows produce visible CLI warnings while healthy
+assemblies continue to contribute candidates. Typed package acquisition,
+publication, and Root-query admission failures are likewise visible. Verbose
+diagnostics retain the failed metadata operation, token, failure kind, and
+detail. An operation-wide exception propagates to `FindCommand`, which owns
+the hard error and exit status.
 
 An empty result is therefore not proof that every source succeeded; the stderr
 diagnostic stream is part of the CLI operation outcome. Structured completion
 evidence is not part of this CLI compatibility result.
 
-`FindTypesAsync` does not currently accept the command cancellation token.
-Cancellation ownership is therefore not fully adopted at this boundary and
-must not be inferred from the command signature.
+`FindTypesAsync` accepts the command cancellation token and carries it through
+package Root acquisition, publication, query admission, and the boundaries
+around each synchronous typed query execution.
 
 ## Implementation and validation status
 
@@ -187,8 +199,7 @@ particular, the following properties are unverified or known gaps:
 - partial suggestions are selected by similarity but emitted in collected
   candidate order and are not additionally capped by `Limit`;
 - mixed-pattern result order is grouped by outcome dictionaries rather than
-  explicitly preserving request order; and
-- the command cancellation token does not reach collection or classification.
+  explicitly preserving request order.
 
 The minimum pathological fixture for future adoption is one non-wildcard
 pattern with no direct, namespace-prefix, or similarity match, exercised

--- a/src/DotnetInspect.Cli/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/DotnetInspect.Cli/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -338,7 +338,7 @@ public static class SearchCommandDefinitions
                 SourceOptions = sourceOptions
             };
 
-            return await ImplementsCommand.ExecuteAsync(options);
+            return await ImplementsCommand.ExecuteAsync(options, ct);
         });
 
         return implCommand;
@@ -478,7 +478,7 @@ public static class SearchCommandDefinitions
                 SourceOptions = sourceOptions
             };
 
-            return await ExtensionsCommand.ExecuteAsync(options);
+            return await ExtensionsCommand.ExecuteAsync(options, ct);
         });
 
         return extCommand;

--- a/src/DotnetInspect.Cli/Commands/ExtensionsCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/ExtensionsCommand.cs
@@ -19,7 +19,9 @@ namespace DotnetInspect.Cli.Commands;
 /// </summary>
 public class ExtensionsCommand
 {
-    public static async Task<int> ExecuteAsync(ExtensionsOptions options)
+    public static async Task<int> ExecuteAsync(
+        ExtensionsOptions options,
+        CancellationToken cancellationToken = default)
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
@@ -37,7 +39,12 @@ public class ExtensionsCommand
                 };
             }
 
-            var results = await ScanExtensionsAsync(options, context, logger, targetType);
+            var results = await ScanExtensionsAsync(
+                options,
+                context,
+                logger,
+                targetType,
+                cancellationToken);
 
             // Apply limit
             if (options.Limit.HasValue && results.Count > options.Limit.Value)
@@ -89,87 +96,126 @@ public class ExtensionsCommand
         ExtensionsOptions options,
         CommandContext context,
         VerboseLogger logger,
-        string targetType)
+        string targetType,
+        CancellationToken cancellationToken)
     {
-        using var assemblySet = await AssemblySetResolver.CollectAsync(
-            context.HttpClient,
-            options.ToAssemblySetRequest("inspect-ext"),
-            logger.Log);
-        AssemblySetDiagnosticWriter.Write(assemblySet);
-
         List<ExtensionMethodResult> results = [];
-        var censuses = new List<ExtensionAssemblyCensus>(
-            assemblySet.Assemblies.Count);
+        var censuses = new List<ExtensionAssemblyCensus>();
         ImmutableArray<ExtensionReachableTypePath> reachableTypes = [];
-        using var workspace = new AssemblySetInspectionWorkspace();
-        if (options.Reachable)
+        AssemblySetRequest request =
+            options.ToAssemblySetRequest("inspect-ext");
+        if (ConfiguredPackageSearchWorkspace.IsEligible(
+                options.SourceSelection,
+                request,
+                options.Tfm))
         {
-            workspace.RunGroup(
-                assemblySet,
-                (group, entries) =>
+            await using ConfiguredPackageSearchWorkspace? configured =
+                await ConfiguredPackageSearchWorkspace.OpenAsync(
+                    context.HttpClient,
+                    request,
+                    options.Tfm!,
+                    logger.Log,
+                    cancellationToken);
+            if (configured is not null)
+            {
+                ConfiguredPackageSearchQueryResult<
+                    ExtensionSearchQueryResult>? execution =
+                        await configured.QuerySurfaceAsync(
+                            queryContext =>
+                                ExecuteQueries(
+                                    queryContext.Group,
+                                    options,
+                                    targetType),
+                            cancellationToken);
+                if (execution?.Sources is { } sources
+                    && execution.Result is { } queryResult)
                 {
-                    var registry =
-                        new InspectionQueryRegistry<AssemblyContextGroup>()
-                            .Add(
-                                AssemblyContextExtensionMethodsQuery.Definition,
-                                contextGroup =>
-                                    AssemblyContextExtensionMethodsQuery.Execute(
-                                        contextGroup,
-                                        options.IncludeAll))
-                            .Add(
-                                AssemblyContextExtensionReachabilityQuery.Definition,
-                                contextGroup =>
-                                    AssemblyContextExtensionReachabilityQuery.Execute(
-                                        contextGroup,
-                                        targetType,
-                                        options.Depth));
-                    InspectionQueryResults queryResults = registry.Run(
-                        [
-                            AssemblyContextExtensionMethodsQuery.Definition,
-                            AssemblyContextExtensionReachabilityQuery.Definition,
-                        ],
-                        group);
-                    AssemblyContextResult<
-                        ImmutableArray<ExtensionMethodInfo>> extensionMethods =
-                        queryResults.Get(
-                            AssemblyContextExtensionMethodsQuery.Definition);
                     foreach (AssemblyContextEntry<
-                        ImmutableArray<ExtensionMethodInfo>> entry
-                        in extensionMethods.Assemblies)
+                        ImmutableArray<ExtensionMethodInfo>> extensionMethods
+                        in queryResult.ExtensionMethods.Assemblies)
                     {
                         censuses.Add(
                             CreateExtensionCensus(
-                                entries.EntryFor(entry.Subject),
-                                entry));
+                                sources.SourceFor(
+                                    extensionMethods.Subject),
+                                extensionMethods));
                     }
-
-                    AssemblyContextExtensionReachabilityResult reachability =
-                        queryResults.Get(
-                            AssemblyContextExtensionReachabilityQuery.Definition);
-                    WriteReachabilityFailures(reachability, entries);
-                    reachableTypes = reachability.ReachableTypes;
-                },
-                (assembly, failure) =>
-                    censuses.Add(
-                        FailedExtensionCensus(
-                            assembly,
-                            failure)));
+                    if (queryResult.Reachability is { } reachability)
+                    {
+                        WriteReachabilityFailures(
+                            reachability,
+                            sources.SourceFor);
+                        reachableTypes = reachability.ReachableTypes;
+                    }
+                }
+            }
         }
         else
         {
-            workspace.RunPerAssembly(
-                assemblySet,
-                AssemblyContextExtensionMethodsQuery.Definition,
-                group => AssemblyContextExtensionMethodsQuery.Execute(
-                    group,
-                    options.IncludeAll),
-                (assembly, entry) =>
-                    censuses.Add(CreateExtensionCensus(assembly, entry)),
-                (assembly, failure) =>
-                    censuses.Add(
-                        FailedExtensionCensus(
-                            assembly,
-                            failure)));
+            using var assemblySet =
+                await AssemblySetResolver.CollectAsync(
+                    context.HttpClient,
+                    request,
+                    logger.Log);
+            AssemblySetDiagnosticWriter.Write(assemblySet);
+
+            using var workspace =
+                new AssemblySetInspectionWorkspace();
+            if (options.Reachable)
+            {
+                workspace.RunGroup(
+                    assemblySet,
+                    (group, entries) =>
+                    {
+                        ExtensionSearchQueryResult queryResult =
+                            ExecuteQueries(group, options, targetType);
+                        foreach (AssemblyContextEntry<
+                            ImmutableArray<ExtensionMethodInfo>> entry
+                            in queryResult.ExtensionMethods.Assemblies)
+                        {
+                            censuses.Add(
+                                CreateExtensionCensus(
+                                    SearchAssemblySource.FromAssemblySet(
+                                        entries.EntryFor(entry.Subject)),
+                                    entry));
+                        }
+
+                        WriteReachabilityFailures(
+                            queryResult.Reachability!,
+                            subject =>
+                                SearchAssemblySource.FromAssemblySet(
+                                    entries.EntryFor(subject)));
+                        reachableTypes =
+                            queryResult.Reachability!.ReachableTypes;
+                    },
+                    (assembly, failure) =>
+                        censuses.Add(
+                            FailedExtensionCensus(
+                                SearchAssemblySource.FromAssemblySet(
+                                    assembly),
+                                failure)));
+            }
+            else
+            {
+                workspace.RunPerAssembly(
+                    assemblySet,
+                    AssemblyContextExtensionMethodsQuery.Definition,
+                    group => AssemblyContextExtensionMethodsQuery.Execute(
+                        group,
+                        options.IncludeAll),
+                    (assembly, entry) =>
+                        censuses.Add(
+                            CreateExtensionCensus(
+                                SearchAssemblySource.FromAssemblySet(
+                                    assembly),
+                                entry)),
+                    (assembly, failure) =>
+                        censuses.Add(
+                            FailedExtensionCensus(
+                                SearchAssemblySource.FromAssemblySet(
+                                    assembly),
+                                failure)));
+            }
         }
 
         var availableCensuses = new List<ExtensionAssemblyCensus>(censuses.Count);
@@ -203,9 +249,51 @@ public class ExtensionsCommand
         return results;
     }
 
+    private static ExtensionSearchQueryResult ExecuteQueries(
+        AssemblyContextGroup group,
+        ExtensionsOptions options,
+        string targetType)
+    {
+        if (!options.Reachable)
+        {
+            return new(
+                AssemblyContextExtensionMethodsQuery.Execute(
+                    group,
+                    options.IncludeAll),
+                Reachability: null);
+        }
+
+        var registry =
+            new InspectionQueryRegistry<AssemblyContextGroup>()
+                .Add(
+                    AssemblyContextExtensionMethodsQuery.Definition,
+                    contextGroup =>
+                        AssemblyContextExtensionMethodsQuery.Execute(
+                            contextGroup,
+                            options.IncludeAll))
+                .Add(
+                    AssemblyContextExtensionReachabilityQuery.Definition,
+                    contextGroup =>
+                        AssemblyContextExtensionReachabilityQuery.Execute(
+                            contextGroup,
+                            targetType,
+                            options.Depth));
+        InspectionQueryResults queryResults = registry.Run(
+            [
+                AssemblyContextExtensionMethodsQuery.Definition,
+                AssemblyContextExtensionReachabilityQuery.Definition,
+            ],
+            group);
+        return new(
+            queryResults.Get(
+                AssemblyContextExtensionMethodsQuery.Definition),
+            queryResults.Get(
+                AssemblyContextExtensionReachabilityQuery.Definition));
+    }
+
     internal static void WriteReachabilityFailures(
         AssemblyContextExtensionReachabilityResult reachability,
-        AssemblyContextEntryMap entries)
+        Func<AssemblyContextSubject, SearchAssemblySource> sourceFor)
     {
         foreach (AssemblyContextEntry<
             ImmutableArray<ExtensionReachabilityType>> entry
@@ -218,7 +306,7 @@ public class ExtensionsCommand
                         ExtensionReachabilityType>>.Rejected rejected:
                     CommandError.WriteWarning(
                         $"Extension reachability inspection failed for "
-                        + $"{entries.EntryFor(entry.Subject).Path}: "
+                        + $"{sourceFor(entry.Subject).DiagnosticSubject}: "
                         + rejected.Failure.Detail);
                     break;
                 case AssemblyContextEntry<
@@ -226,15 +314,24 @@ public class ExtensionsCommand
                         ExtensionReachabilityType>>.Failed failed:
                     CommandError.WriteWarning(
                         $"Extension reachability inspection failed for "
-                        + $"{entries.EntryFor(entry.Subject).Path}: "
+                        + $"{sourceFor(entry.Subject).DiagnosticSubject}: "
                         + failed.Error.Message);
                     break;
             }
         }
     }
 
+    internal static void WriteReachabilityFailures(
+        AssemblyContextExtensionReachabilityResult reachability,
+        AssemblyContextEntryMap entries) =>
+        WriteReachabilityFailures(
+            reachability,
+            subject =>
+                SearchAssemblySource.FromAssemblySet(
+                    entries.EntryFor(subject)));
+
     private static ExtensionAssemblyCensus CreateExtensionCensus(
-        AssemblySetEntry assembly,
+        SearchAssemblySource assembly,
         AssemblyContextEntry<ImmutableArray<ExtensionMethodInfo>> entry)
         => entry switch
         {
@@ -256,36 +353,43 @@ public class ExtensionsCommand
         };
 
     private static ExtensionAssemblyCensus AvailableExtensionCensus(
-        AssemblySetEntry assembly,
+        SearchAssemblySource assembly,
         IReadOnlyList<ExtensionMethodInfo> members)
         => new(
             assembly,
             members,
             MetadataFindings.InspectExtensionMembers(
                 members,
-                ExtensionSubject(assembly.Path)));
+                assembly.FindingSubject));
 
     private static ExtensionAssemblyCensus FailedExtensionCensus(
-        AssemblySetEntry assembly,
+        SearchAssemblySource assembly,
         string reason)
         => new(
             assembly,
             [],
             new FindingInspection<ExtensionMemberObservation>.Failed(
                 new InspectionError(
-                    ExtensionSubject(assembly.Path),
+                    assembly.FindingSubject,
                     MetadataFindings.ExtensionMemberDescriptor,
                     reason)));
 
-    private static FindingSubject ExtensionSubject(string path)
-        => new(
-            Path.GetFullPath(path),
-            Path.GetFileName(path));
-
     internal sealed record ExtensionAssemblyCensus(
-        AssemblySetEntry Assembly,
+        SearchAssemblySource Assembly,
         IReadOnlyList<ExtensionMethodInfo> Members,
-        FindingInspection<ExtensionMemberObservation> Inspection);
+        FindingInspection<ExtensionMemberObservation> Inspection)
+    {
+        internal ExtensionAssemblyCensus(
+            AssemblySetEntry assembly,
+            IReadOnlyList<ExtensionMethodInfo> members,
+            FindingInspection<ExtensionMemberObservation> inspection)
+            : this(
+                SearchAssemblySource.FromAssemblySet(assembly),
+                members,
+                inspection)
+        {
+        }
+    }
 
     internal static ExtensionAssemblyCensus InspectExtensionAssembly(
         AssemblySetEntry assembly,
@@ -295,11 +399,15 @@ public class ExtensionsCommand
         {
             using var session = AssemblyInspectionSession.Open(assembly.Path);
             var members = session.ExtensionMethods(includeAll).ToList();
-            return AvailableExtensionCensus(assembly, members);
+            return AvailableExtensionCensus(
+                SearchAssemblySource.FromAssemblySet(assembly),
+                members);
         }
         catch (Exception ex)
         {
-            return FailedExtensionCensus(assembly, ex.Message);
+            return FailedExtensionCensus(
+                SearchAssemblySource.FromAssemblySet(assembly),
+                ex.Message);
         }
     }
 
@@ -340,7 +448,9 @@ public class ExtensionsCommand
             if (observation is null)
             {
                 throw new InvalidOperationException(
-                    $"Extension member census for {census.Assembly.Path} does not correspond to its scanner inventory.");
+                    $"Extension member census for "
+                    + $"{census.Assembly.DiagnosticSubject} does not "
+                    + "correspond to its scanner inventory.");
             }
 
             if (!TypeMatcher.Matches(
@@ -355,11 +465,11 @@ public class ExtensionsCommand
                 MethodName = member.MethodName,
                 ExtensionClass = member.ExtensionClass,
                 ExtendedType = member.ExtendedType,
-                Assembly = Path.GetFileNameWithoutExtension(census.Assembly.Path),
+                Assembly = census.Assembly.Library,
                 Signature = member.Signature,
                 Kind = observation.Kind == ExtensionMemberKind.Method ? "method" : "property",
                 Source = census.Assembly.Source,
-                SourceVersion = census.Assembly.Version,
+                SourceVersion = census.Assembly.SourceVersion,
                 ReachablePath = reachablePath,
                 ReachableFromType = reachableFromType,
             });
@@ -430,4 +540,9 @@ public class ExtensionsCommand
             })
             .ToList();
     }
+
+    private sealed record ExtensionSearchQueryResult(
+        AssemblyContextResult<ImmutableArray<ExtensionMethodInfo>>
+            ExtensionMethods,
+        AssemblyContextExtensionReachabilityResult? Reachability);
 }

--- a/src/DotnetInspect.Cli/Commands/FindCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/FindCommand.cs
@@ -134,10 +134,20 @@ public class FindCommand
 
             if (options.Members)
             {
-                return await ExecuteMemberSearchAsync(options, patterns, logger, context.HttpClient);
+                return await ExecuteMemberSearchAsync(
+                    options,
+                    patterns,
+                    logger,
+                    context.HttpClient,
+                    cancellationToken);
             }
 
-            var results = await TypeSearchService.FindTypesAsync(options, patterns, logger, context.HttpClient);
+            var results = await TypeSearchService.FindTypesAsync(
+                options,
+                patterns,
+                logger,
+                context.HttpClient,
+                cancellationToken);
             var title = patterns.Length == 1 ? $"Find: {patterns[0]}" : "Find Results";
 
             // --count reduces the payload, so it is resolved before the format flags that
@@ -609,7 +619,8 @@ public class FindCommand
         FindOptions options,
         string[] patterns,
         VerboseLogger logger,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        CancellationToken cancellationToken)
     {
         // Strip the leading '.' sentinel from each segment so ".Serialize" and "Serialize" both search
         // the member named "Serialize". ".ctor"/".cctor" are preserved (they are real member names).
@@ -624,7 +635,12 @@ public class FindCommand
             return 1;
         }
 
-        var results = await MemberSearchService.FindMembersAsync(options, memberPatterns, logger, httpClient);
+        var results = await MemberSearchService.FindMembersAsync(
+            options,
+            memberPatterns,
+            logger,
+            httpClient,
+            cancellationToken);
         var title = memberPatterns.Length == 1 ? $"Find member: {memberPatterns[0]}" : "Find Members";
 
         if (options.Count)

--- a/src/DotnetInspect.Cli/Commands/ImplementsCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/ImplementsCommand.cs
@@ -18,7 +18,9 @@ namespace DotnetInspect.Cli.Commands;
 /// </summary>
 public class ImplementsCommand
 {
-    public static async Task<int> ExecuteAsync(ImplementsOptions options)
+    public static async Task<int> ExecuteAsync(
+        ImplementsOptions options,
+        CancellationToken cancellationToken = default)
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
@@ -46,27 +48,81 @@ public class ImplementsCommand
                 };
             }
 
-            using var assemblySet = await AssemblySetResolver.CollectAsync(
-                context.HttpClient,
-                options.ToAssemblySetRequest("inspect-impl"),
-                logger.Log);
-            AssemblySetDiagnosticWriter.Write(assemblySet);
-            logger.Log($"Scanning {assemblySet.Assemblies.Count} libraries for types implementing {targetType}");
-
             var results = new List<ImplementerResult>();
-            using var workspace = new AssemblySetInspectionWorkspace();
-            workspace.RunPerAssembly(
-                assemblySet,
-                AssemblyContextImplementersQuery.Definition,
-                group => AssemblyContextImplementersQuery.Execute(
-                    group,
-                    targetType,
-                    options.IncludeAll),
-                (assembly, entry) =>
-                    AddImplementers(results, assembly, entry),
-                (assembly, failure) =>
-                    CommandError.WriteWarning(
-                        $"Error scanning {assembly.Path}: {failure}"));
+            AssemblySetRequest request =
+                options.ToAssemblySetRequest("inspect-impl");
+            if (ConfiguredPackageSearchWorkspace.IsEligible(
+                    options.SourceSelection,
+                    request,
+                    options.Tfm))
+            {
+                await using ConfiguredPackageSearchWorkspace? configured =
+                    await ConfiguredPackageSearchWorkspace.OpenAsync(
+                        context.HttpClient,
+                        request,
+                        options.Tfm!,
+                        logger.Log,
+                        cancellationToken);
+                if (configured is not null)
+                {
+                    ConfiguredPackageSearchQueryResult<
+                        AssemblyContextResult<
+                            ImmutableArray<TypeRelationship>>>? execution =
+                            await configured.QuerySurfaceAsync(
+                                queryContext =>
+                                    AssemblyContextImplementersQuery.Execute(
+                                        queryContext.Group,
+                                        targetType,
+                                        options.IncludeAll),
+                                cancellationToken);
+                    if (execution?.Sources is { } sources
+                        && execution.Result is { } queryResult)
+                    {
+                        logger.Log(
+                            $"Scanning {sources.AssemblyCount} "
+                            + $"libraries for types implementing {targetType}");
+                        foreach (AssemblyContextEntry<
+                            ImmutableArray<TypeRelationship>> entry
+                            in queryResult.Assemblies)
+                        {
+                            AddImplementers(
+                                results,
+                                sources.SourceFor(entry.Subject),
+                                entry);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                using var assemblySet =
+                    await AssemblySetResolver.CollectAsync(
+                        context.HttpClient,
+                        request,
+                        logger.Log);
+                AssemblySetDiagnosticWriter.Write(assemblySet);
+                logger.Log(
+                    $"Scanning {assemblySet.Assemblies.Count} libraries "
+                    + $"for types implementing {targetType}");
+
+                using var workspace =
+                    new AssemblySetInspectionWorkspace();
+                workspace.RunPerAssembly(
+                    assemblySet,
+                    AssemblyContextImplementersQuery.Definition,
+                    group => AssemblyContextImplementersQuery.Execute(
+                        group,
+                        targetType,
+                        options.IncludeAll),
+                    (assembly, entry) =>
+                        AddImplementers(
+                            results,
+                            SearchAssemblySource.FromAssemblySet(assembly),
+                            entry),
+                    (assembly, failure) =>
+                        CommandError.WriteWarning(
+                            $"Error scanning {assembly.Path}: {failure}"));
+            }
 
             // Deduplicate by type name + source (same type from multiple TFM folders)
             results = results
@@ -115,15 +171,13 @@ public class ImplementsCommand
 
     private static void AddImplementers(
         List<ImplementerResult> results,
-        AssemblySetEntry assembly,
+        SearchAssemblySource assembly,
         AssemblyContextEntry<ImmutableArray<TypeRelationship>> entry)
     {
         switch (entry)
         {
             case AssemblyContextEntry<
                 ImmutableArray<TypeRelationship>>.Available available:
-                string assemblyName =
-                    Path.GetFileNameWithoutExtension(assembly.Path);
                 foreach (TypeRelationship relationship
                     in available.Value)
                 {
@@ -135,21 +189,23 @@ public class ImplementsCommand
                         Relationship = relationship.RelationshipKind
                             .ToString()
                             .ToLowerInvariant(),
-                        Assembly = assemblyName,
+                        Assembly = assembly.Library,
                         Source = assembly.Source,
-                        SourceVersion = assembly.Version,
+                        SourceVersion = assembly.SourceVersion,
                     });
                 }
                 break;
             case AssemblyContextEntry<
                 ImmutableArray<TypeRelationship>>.Rejected rejected:
                 CommandError.WriteWarning(
-                    $"Error scanning {assembly.Path}: {rejected.Failure.Detail}");
+                    $"Error scanning {assembly.DiagnosticSubject}: "
+                    + rejected.Failure.Detail);
                 break;
             case AssemblyContextEntry<
                 ImmutableArray<TypeRelationship>>.Failed failed:
                 CommandError.WriteWarning(
-                    $"Error scanning {assembly.Path}: {failed.Error.Message}");
+                    $"Error scanning {assembly.DiagnosticSubject}: "
+                    + failed.Error.Message);
                 break;
         }
     }

--- a/src/DotnetInspect.Cli/Inspectors/ConfiguredPackageSearchWorkspace.cs
+++ b/src/DotnetInspect.Cli/Inspectors/ConfiguredPackageSearchWorkspace.cs
@@ -42,22 +42,29 @@ internal sealed class ConfiguredPackageSearchWorkspace : IAsyncDisposable
         int? resultLimit = null)
     {
         ArgumentNullException.ThrowIfNull(request);
-        return resultLimit is null
-            && !string.IsNullOrWhiteSpace(targetFramework)
-            && !string.Equals(targetFramework, "all", StringComparison.OrdinalIgnoreCase)
-            && selection is
+        if (resultLimit is not null
+            || string.IsNullOrWhiteSpace(targetFramework)
+            || string.Equals(targetFramework, "all", StringComparison.OrdinalIgnoreCase)
+            || selection is not
             {
                 UsesImplicitPlatform: false,
                 Frameworks.Count: 0,
                 OtherSources.Count: 0,
-                Packages: [SourceSelector.PackageReference],
+                Packages: [SourceSelector.PackageReference package],
             }
-            && request.Packages.Count == 1
-            && request.Assemblies.Count == 0
-            && request.PlatformAssemblies.Count == 0
-            && request.PlatformFrameworks.Count == 0
-            && request.Projects.Count == 0
-            && request.Directories.Count == 0;
+            || request.Packages.Count != 1
+            || request.Assemblies.Count != 0
+            || request.PlatformAssemblies.Count != 0
+            || request.PlatformFrameworks.Count != 0
+            || request.Projects.Count != 0
+            || request.Directories.Count != 0
+            || package.Version is null)
+        {
+            return false;
+        }
+
+        return PackageCoordinateResolver.Validate(
+            new PackageCoordinate(package.PackageId, package.Version)) is null;
     }
 
     internal static async ValueTask<ConfiguredPackageSearchWorkspace?>
@@ -104,7 +111,7 @@ internal sealed class ConfiguredPackageSearchWorkspace : IAsyncDisposable
                             new SourcePolicyPackageSourceAuthorization(
                                 request.SourceOptions),
                         PackageStore = new FileSystemPackageStore(),
-                        UseVersionCache = true,
+                        UseVersionCache = false,
                         Log = log,
                     },
                     cancellationToken).ConfigureAwait(false);

--- a/src/DotnetInspect.Cli/Inspectors/ConfiguredPackageSearchWorkspace.cs
+++ b/src/DotnetInspect.Cli/Inspectors/ConfiguredPackageSearchWorkspace.cs
@@ -1,15 +1,15 @@
 using System.Collections.Immutable;
 
-using DotnetInspector.Commands;
-using DotnetInspector.Options;
-using DotnetInspector.Output;
+using DotnetInspect.Cli.Commands;
+using DotnetInspect.Cli.Options;
+using DotnetInspect.Cli.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Queries;
 using DotnetInspector.Services;
 using DotnetInspector.SourceSelection;
 using ILInspector.Metadata;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspect.Cli.Inspectors;
 
 /// <summary>
 /// CLI-owned execution over one explicit package Root committed to an

--- a/src/DotnetInspect.Cli/Inspectors/ConfiguredPackageSearchWorkspace.cs
+++ b/src/DotnetInspect.Cli/Inspectors/ConfiguredPackageSearchWorkspace.cs
@@ -1,0 +1,346 @@
+using System.Collections.Immutable;
+
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using DotnetInspector.Queries;
+using DotnetInspector.Services;
+using DotnetInspector.SourceSelection;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// CLI-owned execution over one explicit package Root committed to an
+/// invocation-scoped Workspace.
+/// </summary>
+internal sealed class ConfiguredPackageSearchWorkspace : IAsyncDisposable
+{
+    readonly InspectionWorkspace _workspace;
+    readonly PackageArtifactRootCorrespondence _correspondence;
+    readonly ArtifactRootGenerationReference _generation;
+    readonly string _packageDisplay;
+    bool _closed;
+
+    ConfiguredPackageSearchWorkspace(
+        InspectionWorkspace workspace,
+        PackageArtifactRootCorrespondence correspondence,
+        ArtifactRootGenerationReference generation,
+        string packageDisplay)
+    {
+        _workspace = workspace;
+        _correspondence = correspondence;
+        _generation = generation;
+        _packageDisplay = packageDisplay;
+    }
+
+    internal static bool IsEligible(
+        SearchSourceSelection? selection,
+        AssemblySetRequest request,
+        string? targetFramework,
+        int? resultLimit = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return resultLimit is null
+            && !string.IsNullOrWhiteSpace(targetFramework)
+            && !string.Equals(targetFramework, "all", StringComparison.OrdinalIgnoreCase)
+            && selection is
+            {
+                UsesImplicitPlatform: false,
+                Frameworks.Count: 0,
+                OtherSources.Count: 0,
+                Packages: [SourceSelector.PackageReference],
+            }
+            && request.Packages.Count == 1
+            && request.Assemblies.Count == 0
+            && request.PlatformAssemblies.Count == 0
+            && request.PlatformFrameworks.Count == 0
+            && request.Projects.Count == 0
+            && request.Directories.Count == 0;
+    }
+
+    internal static async ValueTask<ConfiguredPackageSearchWorkspace?>
+        OpenAsync(
+            HttpClient httpClient,
+            AssemblySetRequest request,
+            string targetFramework,
+            Action<string>? log,
+            CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetFramework);
+        if (request.Packages is not [string packageSpec])
+        {
+            throw new ArgumentException(
+                "Configured package search requires exactly one package.",
+                nameof(request));
+        }
+
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        try
+        {
+            if (!InspectionGraphCommand.TryCreateMembers(
+                    [packageSpec],
+                    out WorkspaceMemberCoordinate[] members))
+            {
+                await CloseAsync(workspace).ConfigureAwait(false);
+                return null;
+            }
+
+            WorkspacePackageRootAcquisitionOutcome acquisition =
+                await WorkspaceContextLoader.AcquirePackageRootAsync(
+                    new WorkspaceContextInput
+                    {
+                        Framework = targetFramework,
+                        Members = members,
+                    },
+                    new WorkspaceContextLoadOptions
+                    {
+                        HttpClient = httpClient,
+                        SourceAuthorization =
+                            new SourcePolicyPackageSourceAuthorization(
+                                request.SourceOptions),
+                        PackageStore = new FileSystemPackageStore(),
+                        UseVersionCache = true,
+                        Log = log,
+                    },
+                    cancellationToken).ConfigureAwait(false);
+            if (acquisition
+                is WorkspacePackageRootAcquisitionOutcome.Failed failed)
+            {
+                foreach (WorkspaceContextLoadFailure failure
+                    in failed.Failures)
+                {
+                    CommandError.WriteWarning(
+                        $"Could not load package Root '{packageSpec}': "
+                        + $"{failure.Kind}: {failure.Message}");
+                }
+                await CloseAsync(workspace).ConfigureAwait(false);
+                return null;
+            }
+
+            PackageRootBinding binding =
+                ((WorkspacePackageRootAcquisitionOutcome.Acquired)acquisition)
+                    .Root;
+            WorkspaceScopeReadResult read =
+                await workspace.GetScopeSnapshotAsync().ConfigureAwait(false);
+            if (read is WorkspaceScopeReadResult.Unavailable unavailable)
+            {
+                CommandError.WriteWarning(
+                    $"Could not open package Root '{packageSpec}': "
+                    + unavailable.RuntimeFailure);
+                await CloseAsync(workspace).ConfigureAwait(false);
+                return null;
+            }
+
+            WorkspaceScopeOperationResult replacement =
+                await workspace.ReplaceScopeAsync(
+                    ((WorkspaceScopeReadResult.Available)read)
+                        .Snapshot.Revision,
+                    [binding],
+                    DateTimeOffset.UtcNow.AddMinutes(5),
+                    cancellationToken).ConfigureAwait(false);
+            if (replacement
+                is not WorkspaceScopeOperationResult.Committed committed)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CommandError.WriteWarning(
+                    $"Could not commit package Root '{packageSpec}': "
+                    + Describe(replacement));
+                await CloseAsync(workspace).ConfigureAwait(false);
+                return null;
+            }
+
+            WorkspacePackageOccurrenceDescriptor root =
+                committed.Snapshot.Packages.Single();
+            if (root.Occurrence.Correspondence
+                    is not PackageArtifactRootCorrespondence correspondence
+                || root.Realization.Status
+                    is not ArtifactRootRealizationStatus.Ready ready)
+            {
+                throw new InvalidOperationException(
+                    "The committed package Root did not publish query admission.");
+            }
+
+            log?.Invoke(
+                $"Using committed package Root for search: "
+                + $"{binding.Root.PackageId}@{binding.Root.PackageVersion} "
+                + $"({binding.Root.AssetSelection.Status}).");
+            return new(
+                workspace,
+                correspondence,
+                ready.Generation,
+                $"{binding.Root.PackageId}@{binding.Root.PackageVersion}");
+        }
+        catch (Exception failure)
+        {
+            await CloseAfterFailureAsync(workspace, failure)
+                .ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    internal async ValueTask<
+        ConfiguredPackageSearchQueryResult<TResult>?> QuerySurfaceAsync<TResult>(
+        Func<PackageSearchQueryContext, TResult> query,
+        CancellationToken cancellationToken = default)
+        where TResult : class
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArtifactRootResult<ConfiguredPackageSearchQueryResult<TResult>>
+            execution =
+                await _workspace.ExecutePackageRootQueryAsync(
+                    _correspondence,
+                    _generation,
+                    (realization, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        if (!realization.HasAssemblyContexts)
+                        {
+                            return ValueTask.FromResult(
+                                new ConfiguredPackageSearchQueryResult<TResult>(
+                                    Sources: null,
+                                    Result: null));
+                        }
+
+                        var sources = new PackageSearchQuerySources(
+                            realization.SurfaceParticipants);
+                        var context = new PackageSearchQueryContext(
+                            realization.SurfaceGroup,
+                            sources);
+                        TResult result = query(context);
+                        token.ThrowIfCancellationRequested();
+                        return ValueTask.FromResult(
+                            new ConfiguredPackageSearchQueryResult<TResult>(
+                                sources,
+                                result));
+                    },
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        if (execution
+            is ArtifactRootResult<
+                ConfiguredPackageSearchQueryResult<TResult>>.Available available)
+        {
+            return available.Value;
+        }
+
+        var rejected =
+            (ArtifactRootResult<
+                ConfiguredPackageSearchQueryResult<TResult>>.Rejected)execution;
+        CommandError.WriteWarning(
+            $"Could not query package Root '{_packageDisplay}': "
+            + rejected.Failure);
+        return null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_closed)
+            return;
+        _closed = true;
+        await CloseAsync(_workspace).ConfigureAwait(false);
+    }
+
+    static string Describe(WorkspaceScopeOperationResult result) =>
+        result switch
+        {
+            WorkspaceScopeOperationResult.Rejected rejected =>
+                $"Rejected: {rejected.Reason}",
+            WorkspaceScopeOperationResult.Failed failed =>
+                $"Failed: {failed.Failure}",
+            WorkspaceScopeOperationResult.Cancelled =>
+                "Cancelled",
+            WorkspaceScopeOperationResult.Superseded =>
+                "Superseded",
+            WorkspaceScopeOperationResult.Unavailable unavailable =>
+                $"Unavailable: {unavailable.RuntimeFailure}",
+            WorkspaceScopeOperationResult.NoEffect =>
+                "No effect",
+            _ => throw new InvalidOperationException(
+                "Unsupported Workspace Scope result."),
+        };
+
+    static async Task CloseAsync(InspectionWorkspace workspace)
+    {
+        InspectionWorkspaceCloseReport report =
+            await workspace.CloseAsync().ConfigureAwait(false);
+        if (!report.ArtifactSessionCleanupFailures.IsEmpty)
+        {
+            throw new AggregateException(
+                report.ArtifactSessionCleanupFailures);
+        }
+    }
+
+    static async Task CloseAfterFailureAsync(
+        InspectionWorkspace workspace,
+        Exception failure)
+    {
+        try
+        {
+            InspectionWorkspaceCloseReport report =
+                await workspace.CloseAsync().ConfigureAwait(false);
+            if (!report.ArtifactSessionCleanupFailures.IsEmpty)
+            {
+                failure.Data[
+                    "Inspector.Artifacts.Workspaces.CleanupFailures"] =
+                    report.ArtifactSessionCleanupFailures;
+            }
+        }
+        catch (Exception cleanupFailure)
+        {
+            failure.Data[
+                "DotnetInspector.Queries.WorkspaceCleanupFailure"] =
+                cleanupFailure;
+        }
+    }
+}
+
+internal sealed record ConfiguredPackageSearchQueryResult<TResult>(
+    PackageSearchQuerySources? Sources,
+    TResult? Result)
+    where TResult : class;
+
+internal sealed record PackageSearchQueryContext(
+    AssemblyContextGroup Group,
+    PackageSearchQuerySources Sources)
+{
+}
+
+internal sealed class PackageSearchQuerySources
+{
+    readonly Dictionary<
+        AssemblyAcquisitionRegistration,
+        SearchAssemblySource> _sources;
+
+    internal PackageSearchQuerySources(
+        ImmutableArray<PackageAssemblyRoleParticipant> participants)
+    {
+        _sources = new(
+            participants.Length,
+            ReferenceEqualityComparer.Instance);
+        foreach (PackageAssemblyRoleParticipant participant
+            in participants)
+        {
+            _sources.Add(
+                participant.Participant.Assembly.Registration,
+                SearchAssemblySource.FromPackage(
+                    participant.Package,
+                    participant.Asset));
+        }
+    }
+
+    internal int AssemblyCount => _sources.Count;
+
+    internal SearchAssemblySource SourceFor(
+        AssemblyContextSubject subject) =>
+        _sources.TryGetValue(
+            subject.Registration,
+            out SearchAssemblySource? source)
+            ? source
+            : throw new InspectionQueryException(
+                $"No committed package asset corresponds to "
+                + $"'{subject.Identity.Name}'.");
+}

--- a/src/DotnetInspect.Cli/Inspectors/MemberSearchService.cs
+++ b/src/DotnetInspect.Cli/Inspectors/MemberSearchService.cs
@@ -27,8 +27,34 @@ internal static class MemberSearchService
         FindOptions options,
         IReadOnlyList<string> patterns,
         VerboseLogger logger,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        CancellationToken cancellationToken = default)
     {
+        AssemblySetRequest request =
+            FindSourceCollector.BuildFindRequest(options);
+        if (ConfiguredPackageSearchWorkspace.IsEligible(
+                options.SourceSelection,
+                request,
+                options.Tfm,
+                options.Limit))
+        {
+            await using ConfiguredPackageSearchWorkspace? configured =
+                await ConfiguredPackageSearchWorkspace.OpenAsync(
+                    httpClient,
+                    request,
+                    options.Tfm!,
+                    logger.Log,
+                    cancellationToken);
+            return configured is null
+                ? []
+                : await CollectMembersAsync(
+                    options,
+                    patterns,
+                    logger,
+                    configured,
+                    cancellationToken);
+        }
+
         using var workspace = new AssemblySetInspectionWorkspace();
         return await CollectMembersAsync(
             options,
@@ -69,52 +95,11 @@ internal static class MemberSearchService
                     options.Limit.HasValue
                         ? options.Limit.Value - results.Count
                         : null),
-                (assembly, entry) =>
-                {
-                    switch (entry)
-                    {
-                        case AssemblyContextEntry<
-                            AssemblyMemberMatches>.Available available:
-                            foreach (MemberSearchResult member
-                                in available.Value.Members)
-                            {
-                                results.Add(new MemberFindResult
-                                {
-                                    Pattern = member.Pattern,
-                                    Match = member.IsGlob
-                                        ? MatchKind.Glob
-                                        : MatchKind.Exact,
-                                    Member = member.MemberName,
-                                    Kind = member.Kind,
-                                    DeclaringType = member.DeclaringType,
-                                    Namespace =
-                                        member.DeclaringNamespace ?? "",
-                                    Signature = member.Signature,
-                                    ReturnType = member.ReturnType,
-                                    Library =
-                                        Path.GetFileNameWithoutExtension(
-                                            assembly.Path),
-                                    Source = assembly.Source,
-                                    SourceVersion = assembly.Version,
-                                });
-                            }
-                            WriteInspectionFailures(
-                                assembly,
-                                available.Value.InspectionFailures,
-                                logger);
-                            break;
-                        case AssemblyContextEntry<
-                            AssemblyMemberMatches>.Rejected rejected:
-                            CommandError.WriteWarning(
-                                $"Could not read {assembly.Path}: {rejected.Failure.Detail}");
-                            break;
-                        case AssemblyContextEntry<
-                            AssemblyMemberMatches>.Failed failed:
-                            CommandError.WriteWarning(
-                                $"Could not read {assembly.Path}: {failed.Error.Message}");
-                            break;
-                    }
-                },
+                (assembly, entry) => AddMembers(
+                    results,
+                    SearchAssemblySource.FromAssemblySet(assembly),
+                    entry,
+                    logger),
                 (assembly, failure) =>
                     CommandError.WriteWarning(
                         $"Could not read {assembly.Path}: {failure}"),
@@ -131,8 +116,94 @@ internal static class MemberSearchService
         return results;
     }
 
+    private static async Task<List<MemberFindResult>> CollectMembersAsync(
+        FindOptions options,
+        IReadOnlyList<string> patterns,
+        VerboseLogger logger,
+        ConfiguredPackageSearchWorkspace workspace,
+        CancellationToken cancellationToken)
+    {
+        List<MemberFindResult> results = [];
+        ConfiguredPackageSearchQueryResult<
+            AssemblyContextResult<AssemblyMemberMatches>>? execution =
+                await workspace.QuerySurfaceAsync(
+                    context =>
+                        AssemblyContextMemberMatchesQuery.Execute(
+                            context.Group,
+                            patterns,
+                            options.IncludeAll),
+                    cancellationToken);
+        if (execution?.Sources is not { } sources
+            || execution.Result is not { } queryResult)
+        {
+            return results;
+        }
+
+        foreach (AssemblyContextEntry<AssemblyMemberMatches> entry
+            in queryResult.Assemblies)
+        {
+            AddMembers(
+                results,
+                sources.SourceFor(entry.Subject),
+                entry,
+                logger);
+        }
+        return results;
+    }
+
+    private static void AddMembers(
+        List<MemberFindResult> results,
+        SearchAssemblySource assembly,
+        AssemblyContextEntry<AssemblyMemberMatches> entry,
+        VerboseLogger logger)
+    {
+        switch (entry)
+        {
+            case AssemblyContextEntry<
+                AssemblyMemberMatches>.Available available:
+                foreach (MemberSearchResult member
+                    in available.Value.Members)
+                {
+                    results.Add(new MemberFindResult
+                    {
+                        Pattern = member.Pattern,
+                        Match = member.IsGlob
+                            ? MatchKind.Glob
+                            : MatchKind.Exact,
+                        Member = member.MemberName,
+                        Kind = member.Kind,
+                        DeclaringType = member.DeclaringType,
+                        Namespace =
+                            member.DeclaringNamespace ?? "",
+                        Signature = member.Signature,
+                        ReturnType = member.ReturnType,
+                        Library = assembly.Library,
+                        Source = assembly.Source,
+                        SourceVersion = assembly.SourceVersion,
+                    });
+                }
+                WriteInspectionFailures(
+                    assembly,
+                    available.Value.InspectionFailures,
+                    logger);
+                break;
+            case AssemblyContextEntry<
+                AssemblyMemberMatches>.Rejected rejected:
+                CommandError.WriteWarning(
+                    $"Could not read {assembly.DiagnosticSubject}: "
+                    + rejected.Failure.Detail);
+                break;
+            case AssemblyContextEntry<
+                AssemblyMemberMatches>.Failed failed:
+                CommandError.WriteWarning(
+                    $"Could not read {assembly.DiagnosticSubject}: "
+                    + failed.Error.Message);
+                break;
+        }
+    }
+
     private static void WriteInspectionFailures(
-        AssemblySetEntry assembly,
+        SearchAssemblySource assembly,
         ImmutableArray<ApiSurfaceInspectionFailure> failures,
         VerboseLogger logger)
     {
@@ -140,7 +211,8 @@ internal static class MemberSearchService
             return;
 
         CommandError.WriteWarning(
-            $"Member search in {assembly.Path} skipped {failures.Length} metadata row(s).");
+            $"Member search in {assembly.DiagnosticSubject} skipped "
+            + $"{failures.Length} metadata row(s).");
         foreach (ApiSurfaceInspectionFailure failure in failures)
         {
             logger.LogWarning(

--- a/src/DotnetInspect.Cli/Inspectors/SearchAssemblySource.cs
+++ b/src/DotnetInspect.Cli/Inspectors/SearchAssemblySource.cs
@@ -1,0 +1,43 @@
+using DotnetInspector.Packages;
+using DotnetInspector.Queries;
+using DotnetInspector.Services;
+using Inspector.Findings;
+
+namespace DotnetInspector.Inspectors;
+
+internal sealed record SearchAssemblySource(
+    string Library,
+    string Source,
+    string? SourceVersion,
+    string DiagnosticSubject,
+    FindingSubject FindingSubject)
+{
+    internal static SearchAssemblySource FromAssemblySet(
+        AssemblySetEntry assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        string fullPath = Path.GetFullPath(assembly.Path);
+        return new(
+            Path.GetFileNameWithoutExtension(assembly.Path),
+            assembly.Source,
+            assembly.Version,
+            assembly.Path,
+            new FindingSubject(fullPath, Path.GetFileName(assembly.Path)));
+    }
+
+    internal static SearchAssemblySource FromPackage(
+        PackageRootIdentity package,
+        PackageCompileAsset asset)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        ArgumentNullException.ThrowIfNull(asset);
+        string root = $"{package.PackageId}@{package.PackageVersion}";
+        string display = $"{root}/{asset.Path}";
+        return new(
+            Path.GetFileNameWithoutExtension(asset.AssemblyName),
+            package.PackageId,
+            package.PackageVersion,
+            display,
+            new FindingSubject($"{root}/{asset.Id}", display));
+    }
+}

--- a/src/DotnetInspect.Cli/Inspectors/SearchAssemblySource.cs
+++ b/src/DotnetInspect.Cli/Inspectors/SearchAssemblySource.cs
@@ -3,7 +3,7 @@ using DotnetInspector.Queries;
 using DotnetInspector.Services;
 using Inspector.Findings;
 
-namespace DotnetInspector.Inspectors;
+namespace DotnetInspect.Cli.Inspectors;
 
 internal sealed record SearchAssemblySource(
     string Library,

--- a/src/DotnetInspect.Cli/Inspectors/TypeSearchService.cs
+++ b/src/DotnetInspect.Cli/Inspectors/TypeSearchService.cs
@@ -24,9 +24,56 @@ internal static class TypeSearchService
         FindOptions options,
         string[] patterns,
         VerboseLogger logger,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        CancellationToken cancellationToken = default)
     {
+        AssemblySetRequest request =
+            FindSourceCollector.BuildFindRequest(options);
+        if (ConfiguredPackageSearchWorkspace.IsEligible(
+                options.SourceSelection,
+                request,
+                options.Tfm,
+                options.Limit))
+        {
+            await using ConfiguredPackageSearchWorkspace? configured =
+                await ConfiguredPackageSearchWorkspace.OpenAsync(
+                    httpClient,
+                    request,
+                    options.Tfm!,
+                    logger.Log,
+                    cancellationToken);
+            if (configured is null)
+                return [];
+
+            return patterns.Length == 1 && !options.Tabular
+                ? await FindSinglePatternAsync(
+                    patterns[0],
+                    options,
+                    pattern => CollectTypesAsync(
+                        options,
+                        pattern,
+                        logger,
+                        configured,
+                        cancellationToken))
+                : await FindMultiPatternAsync(
+                    patterns,
+                    options,
+                    pattern => CollectTypesAsync(
+                        options,
+                        pattern,
+                        logger,
+                        configured,
+                        cancellationToken));
+        }
+
         using var workspace = new AssemblySetInspectionWorkspace();
+        Task<List<TypeSearchResult>> Collect(string? pattern) =>
+            CollectTypesAsync(
+                options,
+                pattern,
+                logger,
+                httpClient,
+                workspace);
 
         // Optimized single-pattern path: collect with filtering, then partial match if empty
         if (patterns.Length == 1 && !options.Tabular)
@@ -34,33 +81,22 @@ internal static class TypeSearchService
             return await FindSinglePatternAsync(
                 patterns[0],
                 options,
-                logger,
-                httpClient,
-                workspace);
+                Collect);
         }
 
         // Multi-pattern or tabular output: collect all types, then match each pattern
         return await FindMultiPatternAsync(
             patterns,
             options,
-            logger,
-            httpClient,
-            workspace);
+            Collect);
     }
 
     private static async Task<List<TypeFindResult>> FindMultiPatternAsync(
         string[] patterns,
         FindOptions options,
-        VerboseLogger logger,
-        HttpClient httpClient,
-        AssemblySetInspectionWorkspace workspace)
+        Func<string?, Task<List<TypeSearchResult>>> collect)
     {
-        var allTypes = await CollectTypesAsync(
-            options,
-            null,
-            logger,
-            httpClient,
-            workspace);
+        var allTypes = await collect(null);
         var typeNames = allTypes.Select(t => t.FullName).Distinct().ToList();
 
         Dictionary<string, List<TypeSearchResult>> resultsByPattern = [];
@@ -151,27 +187,15 @@ internal static class TypeSearchService
     private static async Task<List<TypeFindResult>> FindSinglePatternAsync(
         string pattern,
         FindOptions options,
-        VerboseLogger logger,
-        HttpClient httpClient,
-        AssemblySetInspectionWorkspace workspace)
+        Func<string?, Task<List<TypeSearchResult>>> collect)
     {
-        var results = await CollectTypesAsync(
-            options,
-            pattern,
-            logger,
-            httpClient,
-            workspace);
+        var results = await collect(pattern);
 
         List<TypeSearchResult>? partialMatches = null;
         Dictionary<string, double>? partialSimilarities = null;
         if (results.Count == 0 && !pattern.Contains('*') && !pattern.Contains('?'))
         {
-            var allTypes = await CollectTypesAsync(
-                options,
-                null,
-                logger,
-                httpClient,
-                workspace);
+            var allTypes = await collect(null);
             var typeNames = allTypes.Select(t => t.FullName).Distinct().ToList();
 
             if (TryGetNamespacePrefixMatches(pattern, allTypes, options, out var prefixPattern, out var prefixResults))
@@ -329,54 +353,13 @@ internal static class TypeSearchService
                 group => AssemblyContextTypeInventoryQuery.Execute(
                     group,
                     options.IncludeAll),
-                (assembly, entry) =>
-                {
-                    switch (entry)
-                    {
-                        case AssemblyContextEntry<
-                            AssemblyTypeInventory>.Available available:
-                            foreach (AssemblyTypeInventoryEntry type
-                                in available.Value.Types)
-                            {
-                                if (!searchPatterns.Any(searchPattern =>
-                                        TypeMatcher.MatchesTypeFilter(
-                                            type.FullName,
-                                            searchPattern)))
-                                {
-                                    continue;
-                                }
-
-                                results.Add(new TypeSearchResult
-                                {
-                                    TypeName = type.TypeName,
-                                    Namespace = type.Namespace,
-                                    FullName = type.FullName,
-                                    Kind = type.Kind,
-                                    Assembly = Path.GetFileNameWithoutExtension(
-                                        assembly.Path),
-                                    Source = assembly.Source,
-                                    SourceVersion = assembly.Version,
-                                });
-                                if (ReachedLimit())
-                                    break;
-                            }
-                            WriteInspectionFailures(
-                                assembly,
-                                available.Value.InspectionFailures,
-                                logger);
-                            break;
-                        case AssemblyContextEntry<
-                            AssemblyTypeInventory>.Rejected rejected:
-                            CommandError.WriteWarning(
-                                $"Could not read {assembly.Path}: {rejected.Failure.Detail}");
-                            break;
-                        case AssemblyContextEntry<
-                            AssemblyTypeInventory>.Failed failed:
-                            CommandError.WriteWarning(
-                                $"Could not read {assembly.Path}: {failed.Error.Message}");
-                            break;
-                    }
-                },
+                (assembly, entry) => AddTypes(
+                    results,
+                    searchPatterns,
+                    SearchAssemblySource.FromAssemblySet(assembly),
+                    entry,
+                    logger,
+                    ReachedLimit),
                 (assembly, failure) =>
                     CommandError.WriteWarning(
                         $"Could not read {assembly.Path}: {failure}"),
@@ -393,8 +376,102 @@ internal static class TypeSearchService
         return results;
     }
 
+    private static async Task<List<TypeSearchResult>> CollectTypesAsync(
+        FindOptions options,
+        string? pattern,
+        VerboseLogger logger,
+        ConfiguredPackageSearchWorkspace workspace,
+        CancellationToken cancellationToken)
+    {
+        List<TypeSearchResult> results = [];
+        IReadOnlyList<string> searchPatterns =
+            pattern is null ? ["*"] : [pattern];
+        ConfiguredPackageSearchQueryResult<
+            AssemblyContextResult<AssemblyTypeInventory>>? execution =
+                await workspace.QuerySurfaceAsync(
+                    context =>
+                        AssemblyContextTypeInventoryQuery.Execute(
+                            context.Group,
+                            options.IncludeAll),
+                    cancellationToken);
+        if (execution?.Sources is not { } sources
+            || execution.Result is not { } queryResult)
+        {
+            return results;
+        }
+
+        foreach (AssemblyContextEntry<AssemblyTypeInventory> entry
+            in queryResult.Assemblies)
+        {
+            AddTypes(
+                results,
+                searchPatterns,
+                sources.SourceFor(entry.Subject),
+                entry,
+                logger,
+                static () => false);
+        }
+        return results;
+    }
+
+    private static void AddTypes(
+        List<TypeSearchResult> results,
+        IReadOnlyList<string> searchPatterns,
+        SearchAssemblySource assembly,
+        AssemblyContextEntry<AssemblyTypeInventory> entry,
+        VerboseLogger logger,
+        Func<bool> reachedLimit)
+    {
+        switch (entry)
+        {
+            case AssemblyContextEntry<
+                AssemblyTypeInventory>.Available available:
+                foreach (AssemblyTypeInventoryEntry type
+                    in available.Value.Types)
+                {
+                    if (!searchPatterns.Any(searchPattern =>
+                            TypeMatcher.MatchesTypeFilter(
+                                type.FullName,
+                                searchPattern)))
+                    {
+                        continue;
+                    }
+
+                    results.Add(new TypeSearchResult
+                    {
+                        TypeName = type.TypeName,
+                        Namespace = type.Namespace,
+                        FullName = type.FullName,
+                        Kind = type.Kind,
+                        Assembly = assembly.Library,
+                        Source = assembly.Source,
+                        SourceVersion = assembly.SourceVersion,
+                    });
+                    if (reachedLimit())
+                        break;
+                }
+                WriteInspectionFailures(
+                    assembly,
+                    available.Value.InspectionFailures,
+                    logger);
+                break;
+            case AssemblyContextEntry<
+                AssemblyTypeInventory>.Rejected rejected:
+                CommandError.WriteWarning(
+                    $"Could not read {assembly.DiagnosticSubject}: "
+                    + rejected.Failure.Detail);
+                break;
+            case AssemblyContextEntry<
+                AssemblyTypeInventory>.Failed failed:
+                CommandError.WriteWarning(
+                    $"Could not read {assembly.DiagnosticSubject}: "
+                    + failed.Error.Message);
+                break;
+        }
+    }
+
     private static void WriteInspectionFailures(
-        AssemblySetEntry assembly,
+        SearchAssemblySource assembly,
         ImmutableArray<ApiSurfaceInspectionFailure> failures,
         VerboseLogger logger)
     {
@@ -402,7 +479,8 @@ internal static class TypeSearchService
             return;
 
         CommandError.WriteWarning(
-            $"Type search in {assembly.Path} skipped {failures.Length} metadata row(s).");
+            $"Type search in {assembly.DiagnosticSubject} skipped "
+            + $"{failures.Length} metadata row(s).");
         foreach (ApiSurfaceInspectionFailure failure in failures)
         {
             logger.LogWarning(

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPackageSearchWorkspaceTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPackageSearchWorkspaceTests.cs
@@ -60,6 +60,42 @@ public sealed class ConfiguredPackageSearchWorkspaceTests
     }
 
     [Fact]
+    public void Eligibility_RejectsFloatingAndSelectorVersions()
+    {
+        var request = new AssemblySetRequest
+        {
+            Packages = ["Example.Package"],
+        };
+
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                Normalize(new SourceSelector.PackageReference(
+                    "Example.Package")),
+                request,
+                "net11.0"));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                Normalize(new SourceSelector.PackageReference(
+                    "Example.Package",
+                    "latest")),
+                request with
+                {
+                    Packages = ["Example.Package@latest"],
+                },
+                "net11.0"));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                Normalize(new SourceSelector.PackageReference(
+                    "Example.Package",
+                    "2.*")),
+                request with
+                {
+                    Packages = ["Example.Package@2.*"],
+                },
+                "net11.0"));
+    }
+
+    [Fact]
     public void Eligibility_RejectsArchiveGroupAndPrefixSources()
     {
         var request = new AssemblySetRequest

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPackageSearchWorkspaceTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPackageSearchWorkspaceTests.cs
@@ -1,0 +1,99 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+using DotnetInspector.SourceSelection;
+
+namespace DotnetInspector.Tests;
+
+public sealed class ConfiguredPackageSearchWorkspaceTests
+{
+    [Fact]
+    public void Eligibility_IsLimitedToOneExplicitPackageAndTfm()
+    {
+        SearchSourceSelection selection =
+            SearchSourceNormalizer.Normalize(
+                SourceIntent.Create(
+                    [new SourceSelector.PackageReference(
+                        "Example.Package",
+                        "1.0.0")]));
+        var request = new AssemblySetRequest
+        {
+            Packages = ["Example.Package@1.0.0"],
+        };
+
+        Assert.True(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                selection,
+                request,
+                "net11.0"));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                selection,
+                request,
+                targetFramework: null));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                selection,
+                request,
+                "net11.0",
+                resultLimit: 1));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                selection,
+                request with
+                {
+                    Packages =
+                    [
+                        "Example.Package@1.0.0",
+                        "Other.Package@1.0.0",
+                    ],
+                },
+                "net11.0"));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                selection,
+                request with
+                {
+                    Assemblies = ["Example.dll"],
+                },
+                "net11.0"));
+    }
+
+    [Fact]
+    public void Eligibility_RejectsArchiveGroupAndPrefixSources()
+    {
+        var request = new AssemblySetRequest
+        {
+            Packages = ["Example.Package@1.0.0"],
+        };
+
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                Normalize(
+                    new SourceSelector.PackageArchive(
+                        "Example.Package.1.0.0.nupkg")),
+                request,
+                "net11.0"));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                Normalize(
+                    new SourceSelector.PackageGroup(
+                        [new PackageCoordinate(
+                            "Example.Package",
+                            "1.0.0")])),
+                request,
+                "net11.0"));
+        Assert.False(
+            ConfiguredPackageSearchWorkspace.IsEligible(
+                Normalize(
+                    new SourceSelector.PackagePrefix(
+                        new PackagePrefixRequest("Example", 10))),
+                request,
+                "net11.0"));
+    }
+
+    private static SearchSourceSelection Normalize(
+        SourceSelector selector) =>
+        SearchSourceNormalizer.Normalize(
+            SourceIntent.Create([selector]));
+}

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPackageSearchWorkspaceTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPackageSearchWorkspaceTests.cs
@@ -1,9 +1,9 @@
-using DotnetInspector.Inspectors;
+using DotnetInspect.Cli.Inspectors;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using DotnetInspector.SourceSelection;
 
-namespace DotnetInspector.Tests;
+namespace DotnetInspect.Cli.Tests;
 
 public sealed class ConfiguredPackageSearchWorkspaceTests
 {

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.SearchWorkspace.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.SearchWorkspace.cs
@@ -4,7 +4,7 @@ using DotnetInspector.Services;
 
 using CoreHttpClientFactory = DotnetInspector.Core.HttpClientFactory;
 
-namespace DotnetInspector.Tests;
+namespace DotnetInspect.Cli.Tests;
 
 public sealed partial class ConfiguredPayloadAcquisitionTests
 {

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.SearchWorkspace.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.SearchWorkspace.cs
@@ -1,0 +1,264 @@
+using System.Collections.Concurrent;
+
+using DotnetInspector.Services;
+
+using CoreHttpClientFactory = DotnetInspector.Core.HttpClientFactory;
+
+namespace DotnetInspector.Tests;
+
+public sealed partial class ConfiguredPayloadAcquisitionTests
+{
+    [Theory]
+    [InlineData("type")]
+    [InlineData("member")]
+    [InlineData("implements")]
+    [InlineData("extensions")]
+    public async Task SearchCommands_QueryCommittedPackageRoot(
+        string operation)
+    {
+        string id = $"Workspace.Search.{operation}.{Guid.NewGuid():N}";
+        byte[] assembly = await File.ReadAllBytesAsync(
+            typeof(ConfiguredPayloadAcquisitionTests).Assembly.Location,
+            TestContext.Current.CancellationToken);
+        byte[] package = CreatePackage(
+            id,
+            "selected search package",
+            library: assembly,
+            libraryName: "Workspace.Search.dll");
+        var requests = new ConcurrentQueue<string>();
+        ConfigureCommandFeed(id, package, requests);
+
+        string[] arguments = operation switch
+        {
+            "type" =>
+            [
+                "find",
+                typeof(WorkspaceImplementation).FullName!,
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--all",
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ],
+            "member" =>
+            [
+                "find",
+                $".{MemberSearchServiceTests.SearchTargetMemberName}",
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--all",
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ],
+            "implements" =>
+            [
+                "implements",
+                typeof(IWorkspaceImplementationMarker).FullName!,
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--all",
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ],
+            "extensions" =>
+            [
+                "extensions",
+                typeof(ExtensionWorkspaceRoot).FullName!,
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--all",
+                "--reachable",
+                "--depth", "1",
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ],
+            _ => throw new InvalidOperationException(
+                $"Unknown search operation '{operation}'."),
+        };
+
+        var result = await RunCommandAsync(arguments);
+
+        Assert.True(result.Exit == 0, result.Error);
+        Assert.Contains(
+            "Using committed package Root for search:",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"\"source\": \"{id}\"",
+            result.Output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"\"source_version\": \"{Version}\"",
+            result.Output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            requests,
+            request => request.EndsWith(
+                ".nupkg",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            operation switch
+            {
+                "type" => nameof(WorkspaceImplementation),
+                "member" =>
+                    MemberSearchServiceTests.SearchTargetMemberName,
+                "implements" => nameof(WorkspaceImplementation),
+                "extensions" =>
+                    nameof(
+                        ExtensionWorkspaceMethods.WorkspaceExtension),
+                _ => throw new InvalidOperationException(),
+            },
+            result.Output,
+            StringComparison.Ordinal);
+        if (operation == "extensions")
+        {
+            Assert.Contains(
+                "\"reachable_path\": \".Reachable\"",
+                result.Output,
+                StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("README.md", "NoCompileAssets")]
+    [InlineData("ref/net11.0/_._", "EmptyCompileGroup")]
+    public async Task Find_PackageWithoutSurfaceRemainsQueryableRoot(
+        string packageEntry,
+        string expectedStatus)
+    {
+        string id =
+            $"Workspace.Search.Empty.{Guid.NewGuid():N}";
+        byte[] package;
+        if (expectedStatus == "EmptyCompileGroup")
+        {
+            byte[] fallbackAssembly = await File.ReadAllBytesAsync(
+                typeof(ConfiguredPayloadAcquisitionTests).Assembly.Location,
+                TestContext.Current.CancellationToken);
+            package = SnupkgPdbReaderTests.MakeSnupkg(
+                ($"{id}.nuspec", "<package />"u8.ToArray()),
+                (packageEntry, []),
+                ("lib/net8.0/Fallback.dll", fallbackAssembly));
+        }
+        else
+        {
+            package = SnupkgPdbReaderTests.MakeSnupkg(
+                ($"{id}.nuspec", "<package />"u8.ToArray()),
+                (packageEntry, []));
+        }
+        ConfigureCommandFeed(id, package);
+
+        var result = await RunCommandAsync(
+            [
+                "find", "No.Such.Type",
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ]);
+
+        Assert.Equal(0, result.Exit);
+        Assert.Contains(
+            "Using committed package Root for search:",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            expectedStatus,
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Equal("[]", result.Output.Trim());
+    }
+
+    [Fact]
+    public async Task Find_PackageRootPreparationFailureIsVisible()
+    {
+        string id =
+            $"Workspace.Search.Invalid.{Guid.NewGuid():N}";
+        byte[] package = SnupkgPdbReaderTests.MakeSnupkg(
+            ($"{id}.nuspec", "<package />"u8.ToArray()),
+            ("lib/net11.0/Invalid.dll", [1, 2, 3]));
+        ConfigureCommandFeed(id, package);
+
+        var result = await RunCommandAsync(
+            [
+                "find", "No.Such.Type",
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ]);
+
+        Assert.Equal(0, result.Exit);
+        Assert.Equal("[]", result.Output.Trim());
+        Assert.Contains(
+            $"Could not commit package Root '{id}@{Version}'",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Find_PackageRootUsesReferencePreferredCompileSurface()
+    {
+        string id =
+            $"Workspace.Search.Reference.{Guid.NewGuid():N}";
+        byte[] referenceAssembly = await File.ReadAllBytesAsync(
+            typeof(AssemblySetResolver).Assembly.Location,
+            TestContext.Current.CancellationToken);
+        byte[] package = SnupkgPdbReaderTests.MakeSnupkg(
+            ($"{id}.nuspec", "<package />"u8.ToArray()),
+            ("ref/net11.0/Workspace.Search.dll", referenceAssembly),
+            ("lib/net11.0/Implementation.dll", referenceAssembly));
+        ConfigureCommandFeed(id, package);
+
+        var referenceResult = await RunCommandAsync(
+            [
+                "find",
+                typeof(AssemblySetResolver).FullName!,
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--all",
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ]);
+        Assert.Equal(0, referenceResult.Exit);
+        Assert.Contains(
+            nameof(AssemblySetResolver),
+            referenceResult.Output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"library\": \"Workspace.Search\"",
+            referenceResult.Output,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "\"library\": \"Implementation\"",
+            referenceResult.Output,
+            StringComparison.Ordinal);
+    }
+
+    private static void ConfigureCommandFeed(
+        string packageId,
+        byte[] package,
+        ConcurrentQueue<string>? requests = null)
+    {
+        CoreHttpClientFactory.SetAuthenticationDecorator(
+            _ => new PayloadFeedHandler(
+                FirstFeed,
+                packageId,
+                () => new ByteArrayContent(package),
+                requests ?? new()));
+        CoreHttpClientFactory.ResetSharedForTesting();
+    }
+}

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.cs
@@ -736,13 +736,21 @@ public sealed partial class ConfiguredPayloadAcquisitionTests : IDisposable
 
     private static void WriteLocalPackage(
         string root, string id, string readme, bool hierarchical = false,
-        string? redirectId = null, string version = Version)
+        string? redirectId = null, string version = Version,
+        byte[]? library = null,
+        string libraryName = "Npgsql.dll")
     {
         string directory = hierarchical ? Path.Combine(root, id.ToLowerInvariant(), version) : root;
         Directory.CreateDirectory(directory);
         File.WriteAllBytes(
             Path.Combine(directory, $"{id.ToLowerInvariant()}.{version}.nupkg"),
-            CreatePackage(id, readme, redirectId, version));
+            CreatePackage(
+                id,
+                readme,
+                redirectId,
+                version,
+                library,
+                libraryName));
     }
 
     private static HttpContent PackageContent(string id, string readme) =>
@@ -750,7 +758,8 @@ public sealed partial class ConfiguredPayloadAcquisitionTests : IDisposable
 
     private static byte[] CreatePackage(
         string id, string readme, string? redirectId = null,
-        string version = Version, byte[]? library = null)
+        string version = Version, byte[]? library = null,
+        string libraryName = "Npgsql.dll")
     {
         using var buffer = new MemoryStream();
         using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
@@ -765,7 +774,8 @@ public sealed partial class ConfiguredPayloadAcquisitionTests : IDisposable
             WriteEntry(archive, "README.md", readme);
             if (library is not null)
             {
-                using Stream entry = archive.CreateEntry("lib/net11.0/Npgsql.dll").Open();
+                using Stream entry = archive.CreateEntry(
+                    $"lib/net11.0/{libraryName}").Open();
                 entry.Write(library);
             }
             if (redirectId is not null)

--- a/tests/DotnetInspect.Cli.Tests/ExtensionsCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/ExtensionsCommandTests.cs
@@ -225,7 +225,9 @@ public class ExtensionsCommandTests
 
         var (exitCode, output, error) =
             await ConsoleCapture.RunAsync(
-                () => ExtensionsCommand.ExecuteAsync(options));
+                () => ExtensionsCommand.ExecuteAsync(
+                    options,
+                    TestContext.Current.CancellationToken));
 
         Assert.Equal(0, exitCode);
         Assert.Empty(error);

--- a/tests/DotnetInspect.Cli.Tests/ImplementsCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/ImplementsCommandTests.cs
@@ -19,7 +19,9 @@ public sealed class ImplementsCommandTests
 
         var (exitCode, output, error) =
             await ConsoleCapture.RunAsync(
-                () => ImplementsCommand.ExecuteAsync(options));
+                () => ImplementsCommand.ExecuteAsync(
+                    options,
+                    TestContext.Current.CancellationToken));
 
         Assert.Equal(0, exitCode);
         Assert.Empty(error);
@@ -50,7 +52,9 @@ public sealed class ImplementsCommandTests
 
             var (exitCode, output, error) =
                 await ConsoleCapture.RunAsync(
-                    () => ImplementsCommand.ExecuteAsync(options));
+                    () => ImplementsCommand.ExecuteAsync(
+                        options,
+                        TestContext.Current.CancellationToken));
 
             Assert.Equal(0, exitCode);
             Assert.Equal("[]", output.Trim());

--- a/tests/DotnetInspect.Cli.Tests/MemberSearchServiceTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/MemberSearchServiceTests.cs
@@ -33,7 +33,8 @@ public class MemberSearchServiceTests
                 },
                 [SearchTargetMemberName],
                 new VerboseLogger(enabled: false),
-                httpClient);
+                httpClient,
+                TestContext.Current.CancellationToken);
 
             var result = Assert.Single(results, r => r.Member == SearchTargetMemberName && r.Library == "CopiedMemberAssembly");
             Assert.Equal("method", result.Kind);
@@ -68,7 +69,8 @@ public class MemberSearchServiceTests
                 },
                 ["FindMembersAsync_*"],
                 new VerboseLogger(enabled: false),
-                httpClient);
+                httpClient,
+                TestContext.Current.CancellationToken);
 
             Assert.NotEmpty(results);
             Assert.All(results, r => Assert.Equal(MatchKind.Glob, r.Match));
@@ -103,7 +105,8 @@ public class MemberSearchServiceTests
                         },
                         ["NoSuchMember"],
                         new VerboseLogger(enabled: false),
-                        httpClient);
+                        httpClient,
+                        TestContext.Current.CancellationToken);
                 Assert.Empty(results);
                 return 0;
             });
@@ -137,7 +140,8 @@ public class MemberSearchServiceTests
                 },
                 [SearchTargetMemberName],
                 new VerboseLogger(enabled: false),
-                httpClient);
+                httpClient,
+                TestContext.Current.CancellationToken);
             return 0;
         });
 

--- a/tests/DotnetInspect.Cli.Tests/SearchSourceAdapterTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/SearchSourceAdapterTests.cs
@@ -129,14 +129,22 @@ public class SearchSourceAdapterTests
             {
                 Pattern = "System.String", SourceSelection = selection, Count = true,
             }),
-            "implements" => await ImplementsCommand.ExecuteAsync(new ImplementsOptions
-            {
-                TargetType = "IDisposable", SourceSelection = selection, Count = true,
-            }),
-            "extensions" => await ExtensionsCommand.ExecuteAsync(new ExtensionsOptions
-            {
-                TargetType = "IEnumerable<T>", SourceSelection = selection, Count = true,
-            }),
+            "implements" => await ImplementsCommand.ExecuteAsync(
+                new ImplementsOptions
+                {
+                    TargetType = "IDisposable",
+                    SourceSelection = selection,
+                    Count = true,
+                },
+                TestContext.Current.CancellationToken),
+            "extensions" => await ExtensionsCommand.ExecuteAsync(
+                new ExtensionsOptions
+                {
+                    TargetType = "IEnumerable<T>",
+                    SourceSelection = selection,
+                    Count = true,
+                },
+                TestContext.Current.CancellationToken),
             "depends" => (await DependsCommand.ExecuteTypeDependsAsync(new DependsOptions
             {
                 TargetType = "System.String", SourceSelection = selection, Count = true,


### PR DESCRIPTION
This turns the package Root query substrate into robust production CLI behavior instead of extending caller-free typing: pinned package searches now execute against one committed Workspace Root while existing selector semantics remain intact.

## Demo

An exact package pin now enters the committed Root route:

```console
$ dotnet-inspect find Newtonsoft.Json.JsonConvert \
    --package Newtonsoft.Json@13.0.3 \
    --tfm netstandard2.0 \
    --source https://api.nuget.org/v3/index.json \
    --json --verbose --tips q
Using cached package: .../newtonsoft.json/13.0.3/...
Using committed package Root for search: Newtonsoft.Json@13.0.3 (Selected).
[
  {
    "pattern": "Newtonsoft.Json.JsonConvert",
    "match": "Exact",
    "similarity": 1,
    "type": "JsonConvert",
    "namespace": "Newtonsoft.Json",
    "full_name": "Newtonsoft.Json.JsonConvert",
    "kind": "class",
    "library": "Newtonsoft.Json",
    "source": "Newtonsoft.Json",
    "source_version": "13.0.3"
  }
]
```

The neighboring `@latest` selector intentionally retains the legacy route and
its cache-bypass/version-selection behavior:

```console
$ dotnet-inspect find Newtonsoft.Json.JsonConvert \
    --package Newtonsoft.Json@latest \
    --tfm netstandard2.0 \
    --source https://api.nuget.org/v3/index.json \
    --json --verbose --tips q
Fetching latest version from: https://azuresearch-usnc.nuget.org/query?REDACTED
Using cached package: .../newtonsoft.json/13.0.4
[
  {
    "full_name": "Newtonsoft.Json.JsonConvert",
    "source_version": "13.0.4"
  }
]
```

## Summary

- Route `find`, member-find, `implements`, and `extensions --reachable`
  through `InspectionWorkspace.ExecutePackageRootQueryAsync` for one exact
  package pin, one explicit non-`all` TFM, no mixed sources, and no numeric
  find limit.
- Materialize query results and registration-to-provenance mappings before the
  borrowed Root realization lease ends.
- Project package provenance from typed package and compile-asset identities
  without fabricating host filesystem paths.
- Preserve the legacy route for floating, `@latest`, wildcard, archive,
  group/prefix, multiple/mixed-source, implicit/`all` TFM, and limited-search
  requests.
- Surface acquisition, publication, query-admission, participant-query, and
  Workspace cleanup failures.

## Compatibility

The configured Root uses the reference-preferred compile surface. An explicit
`ref/<tfm>/_._` remains empty and does not fall back to `lib`; runtime-only and
tools-only assets do not become compile participants. Type-mode `depends`
(#6169) remains pending so its typed query and production caller can land
together rather than creating another caller-free surface.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --no-build -- --filter-method '*SearchCommands_QueryCommittedPackageRoot' '*Find_PackageWithoutSurfaceRemainsQueryableRoot' '*Find_PackageRootPreparationFailureIsVisible' '*Find_PackageRootUsesReferencePreferredCompileSurface'`
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --no-build -- --filter-class '*ConfiguredPackageSearchWorkspaceTests' '*TypeSearchServiceTests' '*MemberSearchServiceTests' '*ImplementsCommandTests' '*ExtensionsCommandTests' '*SearchSourceAdapterTests'`
- `npx markdownlint-cli docs/cli-architecture.md docs/design/find-search-service.md`
- `git diff --check`

Part of #6170.
