### PR TITLE
Bind package version discovery to its package ID

### DIFF
--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -818,3 +818,12 @@ authorization plus the remaining consumer migrations remain later slices of
 [#5400](https://github.com/richlander/dotnet-inspect/issues/5400). The legacy
 `Sources` projection remains available during those migrations; it is not an
 alternative authority identity.
+
+Every `PackageVersionDiscoveryResult` produced after package-ID validation
+retains the canonical package ID whose configured-authority operation produced
+it, including authoritative empty, filtered-empty, partial, and failed
+results. A failure produced before a valid package ID exists retains no
+package ID. Candidate evidence is validated against the retained ID during
+construction. Consumers use this owner-issued identity for request
+correspondence rather than inferring the package from candidate presence, feed
+labels, or failure text.

--- a/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
+++ b/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
@@ -77,6 +77,7 @@ internal sealed class ConfiguredPackageCandidateObservation
 public sealed class PackageVersionDiscoveryResult
 {
     internal PackageVersionDiscoveryResult(
+        string? packageId,
         PackageVersionDiscoveryState state,
         IReadOnlyList<PackageVersionSourceInfo> sourceListings,
         IReadOnlyList<PackageAuthorityFailure> failures,
@@ -85,6 +86,41 @@ public sealed class PackageVersionDiscoveryResult
         PackageVersionDiscoveryContract? contract = null,
         object? candidateIssuer = null)
     {
+        if (packageId is not null
+            && !PackageCoordinateResolver.IsCanonicalPackageId(packageId))
+        {
+            throw new ArgumentException(
+                "Version discovery requires a valid package ID.",
+                nameof(packageId));
+        }
+        ConfiguredPackageCandidateObservation[] candidateSnapshot =
+            candidates is null ? [] : [.. candidates];
+        if (packageId is null
+            && (state != PackageVersionDiscoveryState.Failed
+                || sourceListings.Count != 0
+                || failures.Count == 0
+                || failures.Any(failure =>
+                    failure.Kind != PackageAuthorityFailureKind.Input)
+                || hasAnyCandidate
+                || candidateSnapshot.Length != 0))
+        {
+            throw new ArgumentException(
+                "Missing package identity is reserved for package-ID input failure.",
+                nameof(packageId));
+        }
+        if (candidateSnapshot.Length > 0
+            && (packageId is null
+                || candidateSnapshot.Any(candidate =>
+                    !candidate.Observation.Coordinate.PackageId.Equals(
+                        packageId,
+                        StringComparison.OrdinalIgnoreCase))))
+        {
+            throw new ArgumentException(
+                "Version discovery candidates must belong to the requested package.",
+                nameof(candidates));
+        }
+
+        PackageId = packageId?.ToLowerInvariant();
         State = state;
         SourceListings = new ReadOnlyCollection<PackageVersionSourceInfo>([.. sourceListings]);
         Listings = new ReadOnlyCollection<PackageVersionInfo>(
@@ -96,11 +132,17 @@ public sealed class PackageVersionDiscoveryResult
             new ReadOnlyCollection<PackageAuthorityFailure>([.. failures]);
         HasAnyCandidate = hasAnyCandidate;
         Candidates = new ReadOnlyCollection<ConfiguredPackageCandidateObservation>(
-            candidates is null ? [] : [.. candidates]);
+            candidateSnapshot);
         Contract = contract ?? PackageVersionDiscoveryContract.Unspecified;
         CandidateIssuer = candidateIssuer ?? new object();
     }
 
+    /// <summary>
+    /// The canonical package ID whose source operation produced this result,
+    /// or <see langword="null"/> when input validation rejected the ID before
+    /// source discovery began.
+    /// </summary>
+    public string? PackageId { get; }
     public PackageVersionDiscoveryState State { get; }
     public IReadOnlyList<string> Versions { get; }
     public IReadOnlyList<PackageVersionInfo> Listings { get; }
@@ -130,9 +172,9 @@ public sealed class PackageVersionDiscoveryResult
         }
 
         string normalized = PackageSourceCoordinate.Create(
-            Candidates.FirstOrDefault()?.Observation.Coordinate.PackageId
+            PackageId
                 ?? throw new InvalidOperationException(
-                    "The discovery result contains no candidate observations."),
+                    "Version discovery rejected its package ID before candidate selection."),
             version).Version;
         var reporters = new List<ConfiguredPackageCandidateObservation>();
         var seen = new HashSet<ConfiguredPackageAuthority>(
@@ -249,6 +291,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
         if (!PackageExtractor.IsValidPackageId(packageId))
         {
             return Failed(
+                null,
                 new PackageAuthorityFailure(
                     InertString.Empty,
                     PackageAuthorityFailureKind.Input,
@@ -259,6 +302,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
         if (limit <= 0)
         {
             return Failed(
+                packageId,
                 new PackageAuthorityFailure(
                     InertString.Empty,
                     PackageAuthorityFailureKind.Input,
@@ -272,6 +316,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
         if (sources.Count == 0)
         {
             return new PackageVersionDiscoveryResult(
+                packageId,
                 PackageVersionDiscoveryState.Failed,
                 [],
                 failures,
@@ -451,6 +496,7 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
             _ => PackageVersionDiscoveryState.Failed,
         };
         return new PackageVersionDiscoveryResult(
+            packageId,
             state,
             ordered,
             failures,
@@ -786,9 +832,11 @@ public sealed partial class DesktopPackageSourceComposition : IAsyncDisposable
     }
 
     private static PackageVersionDiscoveryResult Failed(
+        string? packageId,
         PackageAuthorityFailure failure,
         PackageVersionDiscoveryContract contract) =>
         new(
+            packageId,
             PackageVersionDiscoveryState.Failed,
             [],
             [failure],

--- a/src/DotnetInspector.Packages/PackageAcquisitionCandidateIssuer.cs
+++ b/src/DotnetInspector.Packages/PackageAcquisitionCandidateIssuer.cs
@@ -142,6 +142,7 @@ public sealed class PackageAcquisitionCandidateIssuer
         }
 
         return new PackageVersionDiscoveryResult(
+            discovery.PackageId,
             PackageVersionDiscoveryState.Failed,
             discovery.SourceListings,
             [.. discovery.Failures, .. terminalFailures],
@@ -185,6 +186,7 @@ public sealed class PackageAcquisitionCandidateIssuer
                     ]
                     : terminalFailures;
             return new PackageVersionDiscoveryResult(
+                packageId,
                 PackageVersionDiscoveryState.Failed,
                 [],
                 emptyFailures,
@@ -294,6 +296,7 @@ public sealed class PackageAcquisitionCandidateIssuer
             _ => PackageVersionDiscoveryState.Failed,
         };
         return new PackageVersionDiscoveryResult(
+            packageId,
             state,
             orderedListings,
             failures,

--- a/tests/DotnetInspect.Cli.Tests/DependencyEvidenceCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/DependencyEvidenceCommandTests.cs
@@ -2306,8 +2306,8 @@ public sealed class DependencyEvidenceCommandTests
                 Nuspecs = [NuspecFixture],
             },
             authorization: new UniformPackageSourceAuthorization([StubFeed]),
-            discoverVersions: (_, _, _) => Task.FromResult(
-                DiscoveryResult(state, version)));
+            discoverVersions: (packageId, _, _) => Task.FromResult(
+                DiscoveryResult(packageId, state, version)));
 
         Assert.Single(projection.Roots);
         DependencyEvidenceFailureRow failure = Assert.Single(projection.Failures);
@@ -2352,6 +2352,7 @@ public sealed class DependencyEvidenceCommandTests
                     calls++;
                     return Task.FromResult(
                         DiscoveryResult(
+                            StubFeedHandler.PackageId,
                             PackageVersionDiscoveryState.Authoritative,
                             "3.0.0"));
                 },
@@ -2611,9 +2612,11 @@ public sealed class DependencyEvidenceCommandTests
     /// what this command did with a partial, failed, or authoritatively empty aggregate.
     /// </summary>
     private static PackageVersionDiscoveryResult DiscoveryResult(
+        string packageId,
         PackageVersionDiscoveryState state,
         string? version) =>
         new(
+            packageId,
             state,
             version is null
                 ? []

--- a/tests/DotnetInspector.Queries.Tests/PackageDependencyCandidateQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/PackageDependencyCandidateQueryTests.cs
@@ -648,6 +648,7 @@ public sealed class PackageDependencyCandidateQueryTests
                         "The configured authority did not answer."),
                 ];
         return new PackageVersionDiscoveryResult(
+            PackageId,
             state,
             [
                 .. versions.Select(version =>

--- a/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
@@ -300,6 +300,86 @@ public sealed class PackageHouseContractTests
     }
 
     [Fact]
+    public void VersionDiscoveryRetainsPackageIdentityWithoutCandidates()
+    {
+        PackageVersionDiscoveryResult absent = VersionDiscovery(
+            PackageVersionDiscoveryState.Authoritative,
+            includePrerelease: false,
+            hasAnyCandidate: false);
+        PackageVersionDiscoveryResult failed = VersionDiscovery(
+            PackageVersionDiscoveryState.Failed,
+            includePrerelease: false,
+            hasAnyCandidate: false);
+
+        Assert.Equal("contoso.json", absent.PackageId);
+        Assert.Equal("contoso.json", failed.PackageId);
+    }
+
+    [Fact]
+    public void VersionDiscoveryReservesMissingIdentityForInputFailure()
+    {
+        var inputFailure = new PackageVersionDiscoveryResult(
+            packageId: null,
+            PackageVersionDiscoveryState.Failed,
+            sourceListings: [],
+            failures:
+            [
+                new PackageAuthorityFailure(
+                    InertString.Empty,
+                    PackageAuthorityFailureKind.Input,
+                    "The package ID is invalid."),
+            ],
+            hasAnyCandidate: false);
+
+        Assert.Null(inputFailure.PackageId);
+        Assert.Throws<ArgumentException>(
+            () => new PackageVersionDiscoveryResult(
+                packageId: null,
+                PackageVersionDiscoveryState.Authoritative,
+                sourceListings: [],
+                failures: [],
+                hasAnyCandidate: false));
+    }
+
+    [Fact]
+    public void VersionDiscoveryRejectsCandidateForAnotherPackage()
+    {
+        var authority = new ConfiguredPackageAuthority(
+            new PackageSource(
+                "version-selection",
+                "https://versions.example/v3/index.json"));
+        PackageSourceResultFactory factory = ResultFactory(
+            authority.Association);
+        var candidate = new ConfiguredPackageCandidateObservation(
+            authority,
+            factory.Candidate(
+                PackageSourceCoordinate.Create(
+                    "other.package",
+                    "4.0.0"),
+                PackageDiscoveryContract.CompleteVersionEnumeration,
+                PackageListingState.Listed));
+
+        Assert.Throws<ArgumentException>(
+            () => new PackageVersionDiscoveryResult(
+                "contoso.json",
+                PackageVersionDiscoveryState.Authoritative,
+                [
+                    new PackageVersionSourceInfo(
+                        "4.0.0",
+                        "version-selection",
+                        Listed: true),
+                ],
+                failures: [],
+                hasAnyCandidate: true,
+                candidates: [candidate],
+                contract: PackageVersionDiscoveryContract.Create(
+                    includePrerelease: false,
+                    includeUnlisted: false,
+                    limit: null),
+                candidateIssuer: new object()));
+    }
+
+    [Fact]
     public void PartialDiscoveryCannotProduceASelectedCoordinate()
     {
         var request = new PackageVersionSelectionRequest.LatestStable(
@@ -1673,6 +1753,7 @@ public sealed class PackageHouseContractTests
                 ];
 
         return new PackageVersionDiscoveryResult(
+            "contoso.json",
             state,
             [
                 .. versions.Select(version =>


### PR DESCRIPTION
PackageHouse is the package-processing clearing house where source leases are
issued and owner receipts are settled. This slice strengthens that foundation
by giving all post-validation version-discovery evidence an explicit package
identity.

## Summary

- retain the canonical requested package ID on authoritative empty,
  filtered-empty, partial, and failed version-discovery results
- reserve absent package identity for typed package-ID validation failure
  before source discovery begins
- reject candidate evidence for a different package and preserve identity
  through dependency discovery and timeout conversion
- update query and CLI test adapters to construct identity-bearing evidence

Closes #6510.
Prerequisite for #6509 under the #6508 PackageHouse settlement stack.

## Demo

Before this change, an authoritative empty result had no candidate from which a
consumer could infer which package was queried. The result now retains its
owner-issued identity directly:

```csharp
PackageVersionDiscoveryResult absent = VersionDiscovery(
    PackageVersionDiscoveryState.Authoritative,
    includePrerelease: false,
    hasAnyCandidate: false);

Assert.Equal("contoso.json", absent.PackageId);
```

A request rejected before package-ID validation has no invented identity:

```csharp
Assert.Null(inputFailure.PackageId);
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.Services.Tests -c Release --no-build -- --filter-class '*PackageHouseContractTests'`
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release --no-build -- --filter-class '*PackageDependencyCandidateQueryTests'`
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --no-build -- --filter-class '*DependencyEvidenceCommandTests'`
- `npx markdownlint-cli docs/design/package-source-model.md`
