### PR TITLE
Migrate instructions tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -243,6 +243,12 @@ required PR and developer commands remain unfiltered. These paths reuse the
 pinned outcome-level host gate without changing the suite's unresolved-intent,
 cohort-binding, owner-identity, selection, or structured-failure evidence.
 
+`ILInspector.Instructions.Tests` is the sixteenth migrated adopter. Its
+required PR and developer commands remain unfiltered. These paths reuse the
+pinned outcome-level host gate without changing the suite's instruction
+decoding, block graph, typed-stack, metadata resolution, fidelity, comparison,
+analysis-diff, Finding value-equality, or review-fix evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj
+++ b/tests/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj
@@ -10,6 +10,7 @@
     <IsAotCompatible>false</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This advances robust, conventional test evidence by making stale
`ILInspector.Instructions.Tests` selectors fail through the test platform that
owns discovery and filtering.

## Demo

Before this change, the native xUnit host accepts an unmatched class selector
as successful evidence:

```text
ILInspector.Instructions.Tests  Total: 0
exit=0
```

With Microsoft Testing Platform selected, the equivalent stale filter fails:

```text
Test run summary: Zero tests ran
  total: 0
exit=8
```

Neighboring evidence continues to execute normally:

```text
InstructionDecoderTests      total: 14  exit=0
AnalysisDiffTests            total: 12  exit=0
FindingValueEqualityTests    total: 10  exit=0
full suite                  total: 111  exit=0
```

## Summary

- Select Microsoft Testing Platform for `ILInspector.Instructions.Tests`
  through the `xunit.v3` integration already pinned by the repository.
- Record the suite as the sixteenth migrated adopter in the xUnit host owner.
- Preserve the unfiltered required-CI and contributor commands unchanged.
- Preserve instruction decoding, block graph, typed-stack, metadata
  resolution, fidelity, comparison, analysis-diff, Finding value-equality,
  and review-fix evidence.

## Design basis

`docs/design/xunit-test-host.md` owns repository xUnit host selection and
aggregate zero-test behavior. MTP owns parsing, discovery, filtering,
execution, and exit code `8`; this slice adds no selector parser, runner
library dependency, workflow scan, or output parser.

The instruction substrate README and focused analysis-diff and Finding
value-equality designs continue to own their existing domain claims. This
migration changes only the executable host and does not broaden product
behavior.

## Validation

- Unmatched MTP class filter: 0 tests, exit `8`.
- `InstructionDecoderTests`: 14 passed.
- `AnalysisDiffTests`: 12 passed.
- `FindingValueEqualityTests`: 10 passed.
- Full `ILInspector.Instructions.Tests` suite: 111 passed.
- Full Release solution build.
- `markdownlint` and `git diff --check`.

Closes the sixteenth migration slice of #5379.
