### PR TITLE
Define subject-scoped Compare facets

### DIFF
--- a/docs/design/inspect-web-compare-experience.md
+++ b/docs/design/inspect-web-compare-experience.md
@@ -88,11 +88,20 @@ Compare consumes, without redefining:
 - optional owner-issued immersive destinations whose viewer interaction is
   separately owned.
 
-Compare first requires subject-scoped Library, Type, and Member facet
-descriptors from
-[#6494](https://github.com/richlander/dotnet-inspect/issues/6494). Drill-down
-then requires one product-owned atomic descendant-subject and exact-lens
-activation. That prerequisite is tracked by
+The subject-scoped `library.compare`, `type.compare`, and `member.compare`
+descriptor contract is owned by
+[View Facet Registry](view-facet-registry.md#compare-facet-extension) and
+tracked by
+[#6494](https://github.com/richlander/dotnet-inspect/issues/6494). Its runtime
+registrations remain unverified until exact occurrence-bound subjects from
+[#5518](https://github.com/richlander/dotnet-inspect/issues/5518), the
+Registry's Workspace/Package grammar from
+[#5509](https://github.com/richlander/dotnet-inspect/issues/5509), and the
+public execution handoff from
+[#6519](https://github.com/richlander/dotnet-inspect/issues/6519) are
+available. The active registrations then land with the first Browser adapter
+for that handoff. Drill-down also requires one product-owned atomic
+descendant-subject and exact-lens activation. That prerequisite is tracked by
 [#6490](https://github.com/richlander/dotnet-inspect/issues/6490).
 The Browser must not emulate it by coordinating a subject request and a later
 lens request through local mutable state. Until #6490 lands, sticky Compare
@@ -366,9 +375,10 @@ This design does not claim:
 The staged path is:
 
 1. this Browser Compare contract and its Surface Composition placement;
-2. Registry-owned Library, Type, and Member Compare facets in #6494;
+2. Registry-owned Library, Type, and Member Compare facet contract in #6494;
 3. Navigation-owned atomic descendant subject and lens activation in #6490;
-4. a bounded managed/browser projection for the Compare drill-down rows;
+4. the host-neutral facet execution handoff, consumer-paired runtime
+   registration, and bounded managed/browser projection in #6519;
 5. Library Diff adoption and retirement of the transient authored-source
    comparison interaction;
 6. Library and Type Clone drill-down adoption;

--- a/docs/design/view-facet-registry.md
+++ b/docs/design/view-facet-registry.md
@@ -314,6 +314,121 @@ These entries have no external compatibility obligation. Their implemented
 purposes and the current manifest remain exact baseline evidence until the
 consumer-paired cutover replaces them.
 
+## Compare facet extension
+
+Issue [#6494](https://github.com/richlander/dotnet-inspect/issues/6494)
+defines the Registry-owned facet vocabulary required by the Browser Compare
+experience in
+[Inspect Web Compare Experience](inspect-web-compare-experience.md), under the
+end-to-end tracker
+[#5083](https://github.com/richlander/dotnet-inspect/issues/5083).
+
+The extension adds three subject-scoped descriptors:
+
+| ID | Title | Summary and stable purpose | Kind | Order | Role |
+| --- | --- | --- | --- | ---: | --- |
+| `library.compare` | Compare | Diff and clone results organized by Type for the active Library. | Library | 600 | — |
+| `type.compare` | Compare | Diff and clone results organized by Member for the active Type. | Type | 400 | — |
+| `member.compare` | Compare | Detailed diff and clone results for the active Member. | Member | 600 | — |
+
+The descriptors are additive to either the current pre-issuance Root catalog
+or the Workspace/Package replacement catalog below. Their orders append
+Compare after the existing facets without renumbering or changing another
+facet's relative position. None carries a semantic role, so this extension
+does not change Navigation recommendation or fallback policy.
+
+The shared title is presentation, not identity. Exact lookup, persistence, and
+activation use the complete subject-prefixed ID. The Registry does not resolve
+`Compare`, infer the subject from the active UI, or treat `library.compare`,
+`type.compare`, and `member.compare` as aliases. Diff and Clone are
+Compare-owned modes and do not mint `*.diff` or `*.clone` facets.
+
+### Compare applicability and availability
+
+Each descriptor is structurally applicable only to its declared Library, Type,
+or Member kind. Active registration is sequenced after
+[#5518](https://github.com/richlander/dotnet-inspect/issues/5518) replaces the
+coordinate-rooted identity family: every applicable descendant then carries
+one exact retained Package occurrence and Workspace transitively. The Registry
+does not infer that ancestry from display text or accept a coordinate-only
+substitute. A later non-Package structural grammar must make a separate
+Compare applicability decision rather than inheriting these registrations.
+
+Once the active registration and its consumer-paired execution binding ship,
+every structurally applicable exact subject is `Available`. Compare has no
+additional target-aware availability probe. It does not consume a separately
+cached Package capability fact that could be exchanged between equal
+coordinates or Workspace occurrences.
+
+A missing Diff baseline, a package with no predecessor, a Member with no
+eligible Clone seed body, a successful empty result, incomplete Clone
+coverage, or an unavailable immersive destination does not make the Compare
+facet unavailable. Those are mode- or result-level states rendered inside the
+available Compare frame. Switching Diff or Clone therefore does not
+re-resolve, remove, or replace the active facet.
+
+Exact resolution includes these representative outcomes:
+
+| Request and target | Exact result |
+| --- | --- |
+| `library.compare` on an exact Package-bound Library | `Available`, Library Compare descriptor |
+| `type.compare` on an exact Package-bound Type | `Available`, Type Compare descriptor |
+| `member.compare` on an exact Package-bound Member | `Available`, Member Compare descriptor |
+| `library.compare` on a Type | `Inapplicable`, Library Compare descriptor |
+| `compare`, `library.diff`, `library.clone`, `member.diff`, or `member.clone` | `Unknown`, no descriptor |
+
+### Compare delivery and evidence
+
+The first and currently approved production consumer is Inspect Web in the
+Browser/Wasm host. The explicit single-host scope and interactive DOM rendering
+strategy are recorded by Inspect Web Compare Experience. This extension adds
+entries to the existing host-neutral Registry; it does not define a CLI
+Compare renderer or broaden the approved experience beyond that Browser
+consumer.
+
+The future private execution bindings are the host-neutral dispatch identities
+`LibraryCompare`, `TypeCompare`, and `MemberCompare`. They select the
+subject-scoped Compare entry contract only. They do not encode Diff or Clone,
+execute a mode query, or reference Browser implementation types. They remain
+internal to the Registry's owning layer.
+
+[#6519](https://github.com/richlander/dotnet-inspect/issues/6519) owns the
+public host-neutral execution handoff that will consume those private targets
+and return typed Compare entry outcomes. The approved Browser adapter consumes
+that public result and owns interactive DOM lowering; it never reads the
+private binding or maintains a parallel facet-ID-to-renderer table. Other hosts
+likewise cannot inspect the private bindings or reconstruct a mode from the
+descriptor title.
+
+This contract is stage 2 of Compare Experience's nine-stage production
+adoption path. Atomic descendant-subject plus exact-lens activation follows in
+[#6490](https://github.com/richlander/dotnet-inspect/issues/6490). Runtime
+registrations require the exact occurrence-bound subject identity from #5518
+and the Registry's Workspace/Package grammar from
+[#5509](https://github.com/richlander/dotnet-inspect/issues/5509), and they
+must not precede #6519's public executor. They then land with the first Browser
+adapter for that executor or at most one unmerged PR ahead of it. This design
+change does not publish active registrations, tombstones, or unavailable
+placeholders.
+
+Adoption is **unverified** until the Release Registry suite adds:
+
+- `ViewFacetRegistryTests.CompareInventory_MatchesContract`, covering the
+  three exact IDs, common title, summaries, kinds, append-only orders, absent
+  roles, exact private execution targets, and structural applicability; and
+- `ViewFacetRegistryTests.CompareLookup_PreservesFacetAndModeBoundaries`,
+  covering the three exact available results, cross-subject inapplicable
+  results, and unknown label or `*.diff`/`*.clone` outcomes without executing
+  a mode query.
+
+The compatibility manifest adds the three IDs only when their active runtime
+registrations ship. The existing complete-catalog, registration/binding, static
+discovery, target-discovery, exact-resolution, and compatibility gates remain
+applicable; the focused gates above make the shared-title and mode-boundary
+claims independently observable. #5518's exact-ancestry gates establish that
+equal portable coordinates cannot alias the applicable subject; the Compare
+Registry tests do not manufacture or duplicate that identity evidence.
+
 ## Workspace and Package cutover
 
 Issue [#5509](https://github.com/richlander/dotnet-inspect/issues/5509) adopts
@@ -346,11 +461,13 @@ does not choose a subject or a default lens. Availability still consumes
 explicit producer facts: an empty Workspace or empty dependency result is not
 unavailable merely because it has no rows.
 
-Library, Type, and Member facets retain their current IDs, kinds, purposes,
-order, and bindings. The cutover removes `root.package-overview`,
+The pre-existing Library, Type, and Member facets retain their current IDs,
+kinds, purposes, order, and bindings. The cutover removes
+`root.package-overview`,
 `root.package-dependencies`, and `root.overview` from registrations, execution
 bindings, and the pre-issuance manifest, then adds the three descriptors above.
-The resulting first supported catalog still has 16 entries.
+The cutover alone preserves the 16-entry cardinality. When composed with the
+Compare extension, the catalog has 19 entries.
 
 The removed IDs do not become aliases, tombstones, or fallback inputs. They
 were never externally issued. After cutover they fail the canonical ID grammar
@@ -519,9 +636,11 @@ outcomes, and current baseline manifest are implemented by
 
 Workspace/Package grammar, the three replacement descriptors, removal of all
 three Root descriptors and bindings, and establishment of the resulting
-manifest as the first compatibility baseline are not implemented here. The
-current four-kind runtime and 16 pre-issuance manifest entries remain unchanged
-until the consumer-paired adoption above.
+manifest as the first compatibility baseline are not implemented here.
+The three Compare descriptors, bindings, availability facts, and focused gates
+are also not implemented. The current four-kind runtime and 16 pre-issuance
+manifest entries remain unchanged until their respective consumer-paired
+adoptions above.
 
 The initial contract is enforced by
 `ViewFacetRegistryTests.Catalog_IsCompleteUniqueAndDeterministicallyOrdered`,


### PR DESCRIPTION
Build robust, capable inspection experiences that are conventionally sound and distinctively useful. This change gives the approved Compare hierarchy stable product identity without turning its two modes into competing inspectors.

## Demo

The Registry exposes one subject-scoped **Compare** facet at each drill-down level:

```text
Library  library.compare  Compare
Type     type.compare     Compare
Member   member.compare   Compare
```

The shared title is presentation only. Exact IDs remain distinct, and Diff and Clone stay inside the selected Compare surface:

![Type Compare](https://github.com/user-attachments/assets/1e1377a6-ca20-42c4-98e6-1c2fd86eb055)

![Member Compare](https://github.com/user-attachments/assets/349c2947-6c59-4750-b5e7-9e091be99444)

Neighboring lookup behavior remains explicit: `library.compare` on a Type is inapplicable, while `compare`, `library.diff`, and `library.clone` are unknown rather than aliases.

## Design

- Defines `library.compare`, `type.compare`, and `member.compare` with orders 600, 400, and 600, appending them after each subject's existing facets.
- Gives all three the visible title **Compare** and no semantic role, preserving current Navigation recommendations.
- Makes every exact occurrence-bound Library, Type, or Member Registry-available once active registration ships. Missing baselines, empty or incomplete Clone results, and unavailable Explore destinations remain visible mode/result states inside Compare.
- Sequences active registration after occurrence-bound subjects (#5518), the Workspace/Package Registry grammar (#5509), and the public execution handoff (#6519).
- Keeps Registry-private dispatch targets internal. #6519 owns the public host-neutral executor and Browser projection, preventing a Browser-local ID-to-renderer catalog.

This is stage 2 of the nine-stage Compare adoption path under #5083. The approved production consumer remains Inspect Web in Browser/Wasm; this slice does not add a CLI Compare renderer or publish runtime registrations.

## Validation

- `npx markdownlint-cli docs/design/view-facet-registry.md docs/design/inspect-web-compare-experience.md`
- `git diff --check origin/main...HEAD`

Closes #6494
