### PR TITLE
Restore inspect-web Worker runtime startup

### DIFF
--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -387,10 +387,13 @@ All generated facades use the exact same runtime module specifier:
 ./runtime-loader.js
 ```
 
-The published loader resolves the SDK's fingerprinted runtime module without
-requiring a document import map. The coordinator is shared by the implemented
-page host and the separate Worker diagnostic host; sharing its source does not
-share a runtime between realms.
+Publication materializes stable `dotnet.js`, `dotnet.native.js`, and
+`dotnet.runtime.js` modules as exact copies of the SDK's import-map-selected
+fingerprinted modules. The loader imports the stable `dotnet.js`, so the
+Worker and the SDK's internal dynamic imports use one module identity without
+depending on the document import map. The coordinator is shared by the
+implemented page host and the separate Worker diagnostic host; sharing its
+source does not share a runtime between realms.
 
 The consumer owns one coordinator:
 

--- a/prototypes/inspect-web/scripts/publish-runtime-loader.ts
+++ b/prototypes/inspect-web/scripts/publish-runtime-loader.ts
@@ -1,28 +1,105 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-export function publishedRuntimeTarget(siteArgument: string): string {
+interface RuntimeModule {
+  readonly specifier: string;
+  readonly target: string;
+}
+
+const runtimeModulePatterns = new Map<string, RegExp>([
+  ["./_framework/dotnet.js", /^\.\/_framework\/dotnet\.[A-Za-z0-9_-]+\.js$/],
+  [
+    "./_framework/dotnet.native.js",
+    /^\.\/_framework\/dotnet\.native\.[A-Za-z0-9_-]+\.js$/,
+  ],
+  [
+    "./_framework/dotnet.runtime.js",
+    /^\.\/_framework\/dotnet\.runtime\.[A-Za-z0-9_-]+\.js$/,
+  ],
+]);
+
+function isObjectLike(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null;
+}
+
+export function publishedRuntimeModules(siteArgument: string): readonly RuntimeModule[] {
   const site = resolve(siteArgument);
   const index = readFileSync(resolve(site, "index.html"), "utf8");
-  const target = /"\.\/_framework\/dotnet\.js"\s*:\s*"(\.\/_framework\/dotnet\.[^"/]+\.js)"/
+  const importMapSource = /<script\b[^>]*\btype=["']importmap["'][^>]*>([\s\S]*?)<\/script>/i
     .exec(index)?.[1];
-  if (!target) {
-    throw new Error(
-      "Published import map has no valid fingerprinted dotnet.js mapping.");
+  if (importMapSource === undefined) {
+    throw new Error("Published index has no import map.");
   }
-  if (!existsSync(resolve(site, target))) {
-    throw new Error(`Published runtime module '${target}' is missing.`);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(importMapSource);
+  } catch (error: unknown) {
+    throw new Error("Published import map is not valid JSON.", { cause: error });
+  }
+  const imports = isObjectLike(parsed) && isObjectLike(parsed.imports)
+    ? parsed.imports
+    : {};
+
+  const modules = [...runtimeModulePatterns].map(([specifier, pattern]) => {
+    const target = imports[specifier];
+    if (typeof target !== "string" || !pattern.test(target)) {
+      throw new Error(
+        `Published import map has no valid fingerprinted ${specifier.split("/").at(-1)} mapping.`);
+    }
+    if (!existsSync(resolve(site, target))) {
+      throw new Error(`Published runtime module '${target}' is missing.`);
+    }
+    return { specifier, target };
+  });
+  return modules;
+}
+
+export function publishedRuntimeTarget(siteArgument: string): string {
+  const target = publishedRuntimeModules(siteArgument)
+    .find(module => module.specifier === "./_framework/dotnet.js")?.target;
+  if (target === undefined) {
+    throw new Error("Published runtime module inventory has no dotnet.js entry.");
   }
   return target;
 }
 
+export function verifyPublishedRuntimeModules(siteArgument: string): void {
+  const site = resolve(siteArgument);
+  const modules = publishedRuntimeModules(site);
+  for (const module of modules) {
+    const stable = readFileSync(resolve(site, module.specifier));
+    const fingerprinted = readFileSync(resolve(site, module.target));
+    if (!stable.equals(fingerprinted)) {
+      throw new Error(
+        `Published runtime alias '${module.specifier}' does not match '${module.target}'.`);
+    }
+  }
+  const loader = readFileSync(resolve(site, "runtime-loader.js"), "utf8");
+  const expected = 'export { dotnet } from "./_framework/dotnet.js";\n';
+  if (loader !== expected) {
+    throw new Error(
+      "Published runtime loader does not use the stable Worker runtime module.");
+  }
+}
+
 export function publishRuntimeLoader(siteArgument: string): void {
-  const target = publishedRuntimeTarget(siteArgument);
+  const site = resolve(siteArgument);
+  const modules = publishedRuntimeModules(site);
+  for (const module of modules) {
+    copyFileSync(resolve(site, module.target), resolve(site, module.specifier));
+  }
   writeFileSync(
-    resolve(siteArgument, "runtime-loader.js"),
-    `export { dotnet } from ${JSON.stringify(target)};\n`,
+    resolve(site, "runtime-loader.js"),
+    'export { dotnet } from "./_framework/dotnet.js";\n',
   );
+  verifyPublishedRuntimeModules(site);
 }
 
 const invokedPath = process.argv[1];

--- a/prototypes/inspect-web/scripts/verify-published-engine-facades.ts
+++ b/prototypes/inspect-web/scripts/verify-published-engine-facades.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import {
-  existsSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
@@ -199,21 +198,22 @@ assert.deepEqual(
 
 const site = resolve(siteArgument);
 const dotnetModule = publishedRuntimeTarget(site);
+const stableDotnetModule = "./_framework/dotnet.js";
 const runtimeLoader = resolve(site, "runtime-loader.js");
 const originalLoader = readFileSync(runtimeLoader);
 assert.equal(
   originalLoader.toString("utf8"),
-  `export { dotnet } from ${JSON.stringify(dotnetModule)};\n`,
-  "published runtime loader does not address the SDK import-map target");
-assert.equal(
-  existsSync(resolve(site, "_framework/dotnet.js")),
-  false,
-  "published framework unexpectedly contains an unhashed dotnet.js");
+  `export { dotnet } from ${JSON.stringify(stableDotnetModule)};\n`,
+  "published runtime loader does not address the stable Worker runtime module");
+assert.deepEqual(
+  readFileSync(resolve(site, stableDotnetModule)),
+  readFileSync(resolve(site, dotnetModule)),
+  "stable Worker runtime module does not match the SDK import-map target");
 
 try {
   writeFileSync(
     runtimeLoader,
-    `import { dotnet as sdkDotnet } from ${JSON.stringify(dotnetModule)};
+    `import { dotnet as sdkDotnet } from ${JSON.stringify(stableDotnetModule)};
 const runtimes = new Set();
 let createCalls = 0;
 let runMainCount = 0;

--- a/prototypes/inspect-web/scripts/verify-site-artifact.ts
+++ b/prototypes/inspect-web/scripts/verify-site-artifact.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
+import { verifyPublishedRuntimeModules } from "./publish-runtime-loader.ts";
 
 // This script gates `npm run build`, and the manifest it reads is Rollup output rather
 // than a hand-written file, so the shape it relies on can change under it. `JSON.parse`
@@ -124,6 +125,10 @@ export function verifySiteArtifact(siteArgument: string): void {
     if (!index.includes(`href="/${stylesheet}"`)) {
       throw new Error(`index.html does not load Vite stylesheet '${stylesheet}'.`);
     }
+  }
+
+  if (existsSync(resolve(site, "_framework"))) {
+    verifyPublishedRuntimeModules(site);
   }
 }
 

--- a/prototypes/inspect-web/test/runtime-loader.test.ts
+++ b/prototypes/inspect-web/test/runtime-loader.test.ts
@@ -24,25 +24,44 @@ const smokeScript = fileURLToPath(
   new URL("../scripts/verify-published-engine-facades.ts", import.meta.url),
 );
 const sourceRoot = fileURLToPath(new URL("../engine/wwwroot/", import.meta.url));
-const target = "./_framework/dotnet.fingerprint.js";
-const sdkSource = 'export const dotnet = { identity: "SDK runtime" };\n';
+const runtimeModules = [
+  {
+    specifier: "./_framework/dotnet.js",
+    target: "./_framework/dotnet.fingerprint.js",
+    source: 'export const dotnet = { identity: "SDK runtime" };\n',
+  },
+  {
+    specifier: "./_framework/dotnet.native.js",
+    target: "./_framework/dotnet.native.fingerprint.js",
+    source: "export default function createNativeRuntime() {}\n",
+  },
+  {
+    specifier: "./_framework/dotnet.runtime.js",
+    target: "./_framework/dotnet.runtime.fingerprint.js",
+    source: "export function configureRuntimeStartup() {}\n",
+  },
+] as const;
 
 function createSite(context: TestContext): string {
   const site = mkdtempSync(join(tmpdir(), "inspect-web-runtime-loader-"));
   context.after(() => rmSync(site, { recursive: true, force: true }));
   mkdirSync(join(site, "_framework"));
   writeFileSync(join(site, "package.json"), '{"type":"module"}\n');
-  writeFileSync(join(site, target), sdkSource);
+  for (const module of runtimeModules) {
+    writeFileSync(join(site, module.target), module.source);
+  }
   writeFileSync(
     join(site, "index.html"),
     `<script type="importmap">${JSON.stringify({
-      imports: { "./_framework/dotnet.js": target },
+      imports: Object.fromEntries(
+        runtimeModules.map(module => [module.specifier, module.target]),
+      ),
     }, null, 2)}</script>`,
   );
   return site;
 }
 
-test("publication emits the exact SDK runtime target without an import map", async (context) => {
+test("publication emits stable exact SDK runtime modules for a Worker", async (context) => {
   const site = createSite(context);
   const result = spawnSync(process.execPath, [publishScript, site], {
     encoding: "utf8",
@@ -50,26 +69,40 @@ test("publication emits the exact SDK runtime target without an import map", asy
   assert.equal(result.status, 0, result.stderr);
   assert.equal(
     readFileSync(join(site, "runtime-loader.js"), "utf8"),
-    `export { dotnet } from "${target}";\n`,
+    'export { dotnet } from "./_framework/dotnet.js";\n',
   );
   const loader: unknown = await import(
     pathToFileURL(join(site, "runtime-loader.js")).href,
   );
-  const sdk: unknown = await import(pathToFileURL(join(site, target)).href);
+  const sdk: unknown = await import(
+    pathToFileURL(join(site, "_framework/dotnet.js")).href,
+  );
   assert.deepEqual(loader, sdk);
-  assert.equal(readFileSync(join(site, target), "utf8"), sdkSource);
-  assert.equal(existsSync(join(site, "_framework/dotnet.js")), false);
+  for (const module of runtimeModules) {
+    assert.deepEqual(
+      readFileSync(join(site, module.specifier)),
+      readFileSync(join(site, module.target)),
+    );
+  }
 });
 
-test("publication replaces the loader with a newly selected fingerprint", (context) => {
+test("publication refreshes aliases from newly selected fingerprints", (context) => {
   const site = createSite(context);
   publishRuntimeLoader(site);
-  const nextTarget = "./_framework/dotnet.next-fingerprint.js";
-  writeFileSync(join(site, nextTarget), sdkSource);
+  const nextModules = runtimeModules.map(module => ({
+    ...module,
+    target: module.target.replace(".fingerprint.js", ".next-fingerprint.js"),
+    source: `${module.source}// next fingerprint\n`,
+  }));
+  for (const module of nextModules) {
+    writeFileSync(join(site, module.target), module.source);
+  }
   writeFileSync(
     join(site, "index.html"),
     `<script type="importmap">${JSON.stringify({
-      imports: { "./_framework/dotnet.js": nextTarget },
+      imports: Object.fromEntries(
+        nextModules.map(module => [module.specifier, module.target]),
+      ),
     })}</script>`,
   );
 
@@ -77,21 +110,35 @@ test("publication replaces the loader with a newly selected fingerprint", (conte
 
   assert.equal(
     readFileSync(join(site, "runtime-loader.js"), "utf8"),
-    `export { dotnet } from "${nextTarget}";\n`,
+    'export { dotnet } from "./_framework/dotnet.js";\n',
   );
+  for (const module of nextModules) {
+    assert.deepEqual(
+      readFileSync(join(site, module.specifier)),
+      readFileSync(join(site, module.target)),
+    );
+  }
 });
 
-for (const [label, imports] of [
-  ["missing", {}],
-  ["non-string", { "./_framework/dotnet.js": 42 }],
-  ["unfingerprinted", { "./_framework/dotnet.js": "./_framework/dotnet.js" }],
-  ["non-JavaScript", { "./_framework/dotnet.js": "./_framework/dotnet.hash.wasm" }],
+for (const [label, target] of [
+  ["missing", undefined],
+  ["non-string", 42],
+  ["unfingerprinted", "./_framework/dotnet.js"],
+  ["non-JavaScript", "./_framework/dotnet.hash.wasm"],
 ] as const) {
   test(`publication fails visibly for a ${label} mapping`, (context) => {
     const site = createSite(context);
+    const validImports = Object.fromEntries(
+      runtimeModules.map(module => [module.specifier, module.target]),
+    );
     writeFileSync(
       join(site, "index.html"),
-      `<script type="importmap">${JSON.stringify({ imports })}</script>`,
+      `<script type="importmap">${JSON.stringify({
+        imports: {
+          ...validImports,
+          "./_framework/dotnet.js": target,
+        },
+      })}</script>`,
     );
     const result = spawnSync(process.execPath, [publishScript, site], {
       encoding: "utf8",
@@ -104,7 +151,7 @@ for (const [label, imports] of [
 
 test("publication fails visibly when the mapped runtime is missing", (context) => {
   const site = createSite(context);
-  rmSync(join(site, target));
+  rmSync(join(site, runtimeModules[1].target));
 
   const result = spawnSync(process.execPath, [publishScript, site], {
     encoding: "utf8",
@@ -118,7 +165,7 @@ test("publication fails visibly when the mapped runtime is missing", (context) =
 test("the source loader re-exports the SDK build runtime", async (context) => {
   const site = createSite(context);
   copyFileSync(join(sourceRoot, "runtime-loader.js"), join(site, "runtime-loader.js"));
-  writeFileSync(join(site, "_framework/dotnet.js"), sdkSource);
+  writeFileSync(join(site, "_framework/dotnet.js"), runtimeModules[0].source);
 
   const loader: unknown = await import(
     pathToFileURL(join(site, "runtime-loader.js")).href,
@@ -138,7 +185,7 @@ test("published facade smoke restores the exact loader after runtime failure", (
     copyFileSync(join(sourceRoot, facade), join(site, facade));
   }
   writeFileSync(
-    join(site, target),
+    join(site, runtimeModules[0].target),
     'export const dotnet = { create() { throw new Error("runtime fixture failed"); } };\n',
   );
   publishRuntimeLoader(site);
@@ -151,5 +198,8 @@ test("published facade smoke restores the exact loader after runtime failure", (
   assert.equal(result.status, 1);
   assert.match(result.stderr, /runtime fixture failed/);
   assert.deepEqual(readFileSync(join(site, "runtime-loader.js")), original);
-  assert.equal(existsSync(join(site, "_framework/dotnet.js")), false);
+  assert.deepEqual(
+    readFileSync(join(site, "_framework/dotnet.js")),
+    readFileSync(join(site, runtimeModules[0].target)),
+  );
 });


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational
capabilities or compelling user experiences. This hotfix restores the
production inspect-web Worker runtime without weakening the one-Worker,
one-runtime architecture.

## Demo

**Before**

The deployed module Worker loaded the fingerprinted SDK bootstrap module, but
the SDK later resolved `/_framework/dotnet.js`. The document import map does not
apply inside a module Worker, so that stable URL returned 404 and startup ended
with:

```text
startup: error loading dynamically imported module:
https://dotnet-inspect.ca/_framework/dotnet.js
```

**After**

Publication copies the SDK import-map-selected `dotnet.js`,
`dotnet.native.js`, and `dotnet.runtime.js` modules to their stable names. The
shared runtime loader imports stable `dotnet.js`, so the loader and the SDK's
internal dynamic imports use one module identity. The published Firefox Worker
gate reaches readiness, returns `buildIdentity`, and completes package
operations.

**Neighboring case**

Republishing with new SDK fingerprints refreshes every stable alias from the
new import-map targets. Missing, malformed, or absent mappings fail the
publication step visibly.

## Validation

- `npm test`: 1,737 passed
- `npm run analyze`
- `npm run build`
- .NET 11 RC1 Browser/Wasm publish
- published production facade smoke: seven facades, one SDK runtime
- Worker browser gates: 10 runtime/CSP tests and 3 CPU-isolation tests
- package-adoption Browser/Wasm gate: 9 passed
- authored Source comparison gate: 1 passed
- promotion validator self-test
- `markdownlint` for the owning design

## Compatibility

The stable modules are exact copies of the SDK-generated fingerprinted assets;
the import map and fingerprinted deployment files remain unchanged. The repair
does not add a page-thread runtime fallback or alter Worker failure semantics.
