### PR TITLE
Bound custom-attribute enum name work

### DIFF
--- a/docs/design/custom-attribute-value-decoding.md
+++ b/docs/design/custom-attribute-value-decoding.md
@@ -1134,8 +1134,9 @@ metadata-name budget across TypeDef-index rendering and TypeRef candidate
 matching (#5757, #5758). The budget charges encoded metadata string bytes
 before each render or comparison. Encoded byte length is a conservative upper
 bound on decoded character comparisons and is available without first
-materializing the string. Exhaustion uses the same internal malformed-input
-signal as the candidate/frame budget, so `AttributeDecoder` returns `null`.
+materializing the string. Exhaustion uses a decode-local refusal signal, so
+`AttributeDecoder` returns `null` without caching the event as intrinsic
+type-index corruption across later attribute rows.
 
 `CustomAttributeBoundedCostTests` contains two generated shapes:
 

--- a/docs/design/custom-attribute-value-decoding.md
+++ b/docs/design/custom-attribute-value-decoding.md
@@ -181,7 +181,7 @@ memory clause outright. What is near-linear is everything the decoder does
 *besides* emitting its result — which is where every amplification found so far
 has lived, and the only part a gate can meaningfully hold to a linear standard.
 
-The transient clause is a target, and gaps 7 and 8
+The transient clause is a target. Former gaps 7 and 8
 ([#5757](https://github.com/richlander/dotnet-inspect/issues/5757),
 [#5758](https://github.com/richlander/dotnet-inspect/issues/5758)) are two
 instances of the same class: `Θ(rows × name length)` work from
@@ -189,8 +189,9 @@ instances of the same class: `Θ(rows × name length)` work from
 implementation symptom:
 **no per-row operation on the resolution path may cost more than `O(1)` in the
 length of a name that is invariant across the loop.** Rendering violates it;
-so do content comparison and per-row hashing. The linked issues own the measured
-evidence and repair analysis.
+so do content comparison and per-row hashing. The
+[enum-resolution name-work gate](#enum-resolution-name-work-gate) now contains
+both products through one cumulative per-decode budget.
 
 D1 is deliberately stated over aggregate cost rather than per-element
 repetition. "Perform this work once per distinct input" is the right *fix* for
@@ -843,7 +844,7 @@ are gated; full D1, D2, and D3 remain `unverified`.**
 
 | Invariant | Gate | State |
 | --- | --- | --- |
-| **D1** | `CustomAttributeGenericContextTests` measures generic-prefix traversal (#5098). `CustomAttributeBoundedCostTests` jointly varies distinct unresolved enum references and local definitions, counts product-owned candidate visits and structural-match frames, and samples beyond the aggregate cap (#5091). The broad scaling matrix is `Speed=Slow`; small controls and the budget boundary remain in PR CI. | Partial: the #5098 reuse and #5091 aggregate enum-resolution bound are gated. Three known cost gaps remain, so full D1 is unverified. |
+| **D1** | `CustomAttributeGenericContextTests` measures generic-prefix traversal (#5098). `CustomAttributeBoundedCostTests` jointly varies unresolved references, definitions, and invariant name bytes; its product-owned counters enforce candidate/frame and name-work budgets (#5091, #5757, #5758). Broad scaling matrices are `Speed=Slow`; small controls and budget boundaries remain in PR CI. | Partial: #5098 reuse and the per-decode enum-resolution work products are gated. The cross-row #5132 gap remains, so full D1 is unverified. |
 | **D2** | Slice 2 classified and inverted the guard's deferral tests, and added explicit coverage for the defaulted-width signal, caller-boundary provenance (observer and resolver, including `BadImageFormatException` and `ArgumentOutOfRangeException`), and a malformed control. Slice 4 exercises those fixtures through `AttributeDecoder` directly. The [resource-failure propagation gate](#resource-failure-propagation-gate) covers raw `OutOfMemoryException` propagation from SRM string materialization. | Focused refusal, callback, width-signal, and injected resource-failure cases are gated; exhaustive D2 coverage remains unverified. |
 | **D3** | `CustomAttributeFidelityTests.CompilerProducedValues_EqualIndependentSrm` and `RetainedCrossAssemblyEnums_EqualProducerTruth` enforce the fixture subset. `CustomAttributeCorpusTests.PinnedPackages_AllAttributeRowsEqualIndependentOracle` covers the two named package snapshots and records their producer, oracle, and companion-fixture identities. | Bounded fixture and package coverage; broader producer coverage remains unverified. |
 | **Defaulted-width signal** | #5742 asserts that the out-of-band per-argument signal is set for a defaulted width and clear for a resolved width on the same decode path. `DetailedDecode_ReportsDefaultedAndResolvedWidths` and `DetailedDecode_LegacyFuncIsAuthoritative_ButUnresolvedDefaults` gate it. | Gated, landed in #5815. |
@@ -1124,9 +1125,42 @@ on the missing refusal. The repair stops at exactly 65,536 operations and
 refuses that same input.
 
 This gate establishes one aggregate cross-product bound, **not full D1**. It
-does not cover work shared across attribute rows (#5132), type-index
-construction with shared long namespaces (#5757), or repeated comparison of a
-loop-invariant reference name (#5758).
+does not cover work shared across attribute rows (#5132).
+
+### Enum-resolution name-work gate
+
+Within one attribute decode, enum resolution shares one cumulative 4 MiB
+metadata-name budget across TypeDef-index rendering and TypeRef candidate
+matching (#5757, #5758). The budget charges encoded metadata string bytes
+before each render or comparison. Encoded byte length is a conservative upper
+bound on decoded character comparisons and is available without first
+materializing the string. Exhaustion uses the same internal malformed-input
+signal as the candidate/frame budget, so `AttributeDecoder` returns `null`.
+
+`CustomAttributeBoundedCostTests` contains two generated shapes:
+
+- `P` TypeDefs sharing one `L`-byte namespace, followed by one blob-authored
+  enum lookup that builds the local index; and
+- `T` TypeDefs sharing one `L`-byte name, followed by one handle-derived enum
+  lookup whose matching definition is last.
+
+Each gate compares ordinary and measured decode outcomes. Small one-dimensional
+neighbors and the exact 4 MiB refusal boundaries run in PR CI. The broader
+joint `(rows, name length)` matrices are `Speed=Slow` and run with the full
+metadata suite in Deep Inspect.
+
+At instrumentation head
+`d7e2b52ae530a85b8e3eeed606672a266c01c932`, based on pre-repair head
+`6027c6a2690c531dbca3cb472fa565148ce8d32f`, the shared-namespace index case
+completed 4,202,435 name-byte units and returned a value; the invariant
+TypeRef-name case completed 4,203,520 and returned a value. Both boundary tests
+therefore failed on the missing refusal. The repair stops either path at
+exactly 4,194,304 charged bytes.
+
+This gate establishes the per-decode name-work bound, **not full D1**.
+The unused standalone `EnumUnderlyingPrimitive.TryFromSerializedName` scan is
+not a current decoder path and is not claimed by this gate. Work multiplied
+across attribute rows remains #5132.
 
 ## Known gaps
 
@@ -1138,16 +1172,8 @@ component.
 | Legacy gap | Gap | Invariant | Issue |
 | --- | --- | --- | --- |
 | 4 | `A` attribute rows sharing one `B`-byte blob are decoded independently, costing `Θ(A × B)` from `Θ(A + B)` metadata. | D1 | #5132 |
-| 7 | Building the type-definition index costs `Θ(P × L)` for `P` definitions sharing an `L`-character namespace. | D1 | #5757 |
-| 8 | A definition scan performs `O(L)` work per row on a loop-invariant name, costing `Θ(T × L)`. | D1 | #5758 |
 
-Gap 4 is deliberately excluded from that grouping: it is cross-row, so no per-walk
-memo can address it.
-
-Gaps 7 and 8 are a second class: a per-row operation on the resolution path
-costs `O(L)` in a name length that does not vary across the loop. The rule is
-**`O(1)` per row in any loop-invariant name length**. It applies to rendering,
-comparison, hashing, and any future operation with the same cost shape.
+Gap 4 is cross-row, so no per-decode budget can address it.
 
 ### Gaps changed by the inversion
 
@@ -1156,6 +1182,8 @@ place it.
 
 | Former gap | Was | Disposition |
 | --- | --- | --- |
+| Building the type-definition index cost `Θ(P × L)` for `P` definitions sharing an `L`-character namespace. | D1 gap 7 (#5757) | **Contained.** TypeDef-index metadata name bytes share one cumulative 4 MiB per-decode budget, covered by the [enum-resolution name-work gate](#enum-resolution-name-work-gate). |
+| A definition scan performed `O(L)` work per row on one loop-invariant TypeRef name, costing `Θ(T × L)`. | D1 gap 8 (#5758) | **Contained on the active handle path.** TypeRef match name bytes share the same 4 MiB budget and gate. The unused standalone serialized-name scan is not claimed as a product path. |
 | A failed handle-derived enum resolution scanned every type definition, so `P` distinct unresolvable arguments cost `Θ(P × T)`. | D1 gap 1 (#5091) | **Repaired.** Candidate visits and structural-match frames share one aggregate 65,536-operation budget per decode, covered by the [enum-resolution work gate](#enum-resolution-work-gate). Blob-authored names use the existing type-definition index rather than this scan. |
 | SRM re-derived each fixed argument's type from the generic context, costing `Θ(P × G)`; the owned decoder initially retained that prefix-rescan cost. | I2 → D1 (#5098) | **Repaired.** Operation-local lazy prefix reuse is covered by the [generic-context lookup gate](#generic-context-lookup-gate), including alternating and increasing indices. |
 | `SZARRAY` replay re-parsed one element type per value. | D1 gap 2 (#5047) | **Repaired.** The owned decoder resolves one `ArgumentType` before the array value loop and reuses it for every element. |
@@ -1210,11 +1238,11 @@ slice 2. Both are now settled.
 | #5148 | Merged: fixtures-first D3 value equality and retained-image producer truth. Broader package certification remains outstanding in #5065. |
 | #5304 | Stage 2 exhaustive per-position enumeration. |
 | #5397 | Gated: a one-shot SRM string-materialization fault propagates unchanged through all three public decode surfaces. This is fault-injection evidence, not actual memory-pressure testing or exhaustive D2 coverage. |
-| #5733 | Partial: #5098 and #5091 have product-operation gates; #5132, #5757, and #5758 remain. #5065 measures fidelity, not cost. |
+| #5733 | Partial: #5098, #5091, #5757, and the active #5758 path have product-work gates; cross-row #5132 remains. #5065 measures fidelity, not cost. |
 | #5742 | Implemented in #5815: the opt-in defaulted-width signal mitigates D3's row-three carve-out. |
 | #5755 | Retained-name evidence and the representation-bound revisit point if the output-shape hold is lifted. |
-| #5757 | Type-definition index construction costs `Θ(P × L)`. Gap 7. |
-| #5758 | Definition scanning costs `Θ(T × L)` on a loop-invariant name. Gap 8. |
+| #5757 | Contained by the cumulative per-decode enum-resolution name-work budget and gate. |
+| #5758 | Active handle path contained by the same name-work budget and gate; the unused standalone serialized-name scan is not claimed. |
 | #5759 | Repaired in #5815: resolver-exception provenance is preserved. |
 | #4879 | Enum constants whose signature does not match `value__`. Fidelity. |
 | #5062 | Signature decode laundering internal errors into `SignatureRejected`. |

--- a/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
@@ -112,15 +112,19 @@ internal static class CustomAttributeValueDecoder
                 out namedArgumentWidthDefaulted);
         }
         catch (Exception ex) when (
-            ex is BadImageFormatException or ArgumentOutOfRangeException)
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException
+                or EnumResolutionBudgetExceededException)
         {
             // Malformed structure — including truncation, a bad signature, and
             // a definition-index failure — is a decode outcome, not a laundered
             // exception. A caller callback failure is wrapped in
             // CallerCallbackException, which is not one of these types, so it
             // escapes here and is rethrown at the public edge. Resource
-            // exhaustion (OutOfMemoryException) and every other internal failure
-            // also propagate: this filter is exact, never a bare catch.
+            // exhaustion (OutOfMemoryException) and every other internal
+            // failure also propagate. Enum-resolution budget exhaustion is a
+            // separate decode-local refusal so it is never cached as an
+            // intrinsic type-definition-index failure.
             value = default;
             fixedArgumentWidthDefaulted = default;
             namedArgumentWidthDefaulted = default;
@@ -190,9 +194,8 @@ internal static class CustomAttributeValueDecoder
         {
             if (accepted != requested)
             {
-                throw new BadImageFormatException(
-                    "Custom-attribute enum resolution exceeds the "
-                    + "name-work budget.");
+                throw new EnumResolutionBudgetExceededException(
+                    "Custom-attribute enum resolution exceeds the name-work budget.");
             }
         }
 
@@ -200,11 +203,14 @@ internal static class CustomAttributeValueDecoder
         {
             if (Operations >= MaxEnumResolutionWork)
             {
-                throw new BadImageFormatException(
+                throw new EnumResolutionBudgetExceededException(
                     "Custom-attribute enum resolution exceeds the work budget.");
             }
         }
     }
+
+    sealed class EnumResolutionBudgetExceededException(string message)
+        : Exception(message);
 
     /// <summary>
     /// One decode of one attribute value. Fixed arguments are read from the

--- a/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
@@ -161,11 +161,40 @@ internal static class CustomAttributeValueDecoder
             StructuralMatchFrames++;
         }
 
-        internal void VisitTypeDefinitionIndexNameBytes(int bytes) =>
-            TypeDefinitionIndexNameBytes += bytes;
+        internal void VisitTypeDefinitionIndexNameBytes(int bytes)
+        {
+            long accepted = ReserveNameBytes(bytes);
+            TypeDefinitionIndexNameBytes += accepted;
+            RefuseIncompleteNameCharge(accepted, bytes);
+        }
 
-        internal void VisitTypeReferenceMatchNameBytes(int bytes) =>
-            TypeReferenceMatchNameBytes += bytes;
+        internal void VisitTypeReferenceMatchNameBytes(int bytes)
+        {
+            long accepted = ReserveNameBytes(bytes);
+            TypeReferenceMatchNameBytes += accepted;
+            RefuseIncompleteNameCharge(accepted, bytes);
+        }
+
+        long ReserveNameBytes(int bytes)
+        {
+            if (bytes <= 0)
+                return 0;
+            return Math.Min(
+                bytes,
+                MaxEnumResolutionNameWork - NameBytes);
+        }
+
+        static void RefuseIncompleteNameCharge(
+            long accepted,
+            int requested)
+        {
+            if (accepted != requested)
+            {
+                throw new BadImageFormatException(
+                    "Custom-attribute enum resolution exceeds the "
+                    + "name-work budget.");
+            }
+        }
 
         void EnsureBudget()
         {

--- a/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/CustomAttributeValueDecoder.cs
@@ -62,6 +62,13 @@ internal static class CustomAttributeValueDecoder
         MetadataSafetyPolicy.MaxSignatureTypeNodes;
 
     /// <summary>
+    /// Maximum metadata name bytes rendered or compared while resolving enums
+    /// across one attribute decode.
+    /// </summary>
+    public const int MaxEnumResolutionNameWork =
+        MetadataSafetyPolicy.MaxStructuralSignatureWorkChars;
+
+    /// <summary>
     /// Returns <see langword="true"/> and a materialized <paramref name="value"/>
     /// when decoding succeeds, or <see langword="false"/> when the blob is refused.
     /// Caller-callback failures are raised as
@@ -132,8 +139,15 @@ internal static class CustomAttributeValueDecoder
 
         public long StructuralMatchFrames { get; internal set; }
 
+        public long TypeDefinitionIndexNameBytes { get; internal set; }
+
+        public long TypeReferenceMatchNameBytes { get; internal set; }
+
         public long Operations =>
             TypeDefinitionCandidatesVisited + StructuralMatchFrames;
+
+        public long NameBytes =>
+            TypeDefinitionIndexNameBytes + TypeReferenceMatchNameBytes;
 
         internal void VisitTypeDefinitionCandidate()
         {
@@ -146,6 +160,12 @@ internal static class CustomAttributeValueDecoder
             EnsureBudget();
             StructuralMatchFrames++;
         }
+
+        internal void VisitTypeDefinitionIndexNameBytes(int bytes) =>
+            TypeDefinitionIndexNameBytes += bytes;
+
+        internal void VisitTypeReferenceMatchNameBytes(int bytes) =>
+            TypeReferenceMatchNameBytes += bytes;
 
         void EnsureBudget()
         {
@@ -1048,7 +1068,7 @@ internal static class CustomAttributeValueDecoder
                     name = TypeResolver.GetTypeNameFromDefinition(
                         _reader,
                         handle,
-                        ObserveBeforeMaterialize);
+                        ObserveTypeDefinitionIndexName);
                 }
                 catch (Exception ex) when (
                     ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -1061,6 +1081,12 @@ internal static class CustomAttributeValueDecoder
             }
 
             return result;
+        }
+
+        void ObserveTypeDefinitionIndexName(int amount)
+        {
+            _enumResolutionWork.VisitTypeDefinitionIndexNameBytes(amount);
+            ObserveBeforeMaterialize(amount);
         }
 
         void ObserveBeforeMaterialize(int amount)

--- a/src/ILInspector.MetadataPrimitives/EnumUnderlyingPrimitive.cs
+++ b/src/ILInspector.MetadataPrimitives/EnumUnderlyingPrimitive.cs
@@ -394,7 +394,14 @@ static class EnumUnderlyingPrimitive
         var comparer = reader.StringComparer;
         var reference = reader.GetTypeReference(referenceHandle);
         var definition = reader.GetTypeDefinition(definitionHandle);
-        if (!comparer.Equals(definition.Name, reader.GetString(reference.Name)))
+        if (work is not null)
+        {
+            work.VisitTypeReferenceMatchNameBytes(
+                reader.GetBlobReader(reference.Name).Length);
+        }
+        if (!comparer.Equals(
+                definition.Name,
+                reader.GetString(reference.Name)))
             return false;
 
         if (reference.ResolutionScope.Kind == HandleKind.TypeReference)
@@ -409,10 +416,16 @@ static class EnumUnderlyingPrimitive
                     depth + 1);
         }
 
-        return definition.GetDeclaringType().IsNil
-            && comparer.Equals(
-                definition.Namespace,
-                reader.GetString(reference.Namespace));
+        if (!definition.GetDeclaringType().IsNil)
+            return false;
+        if (work is not null)
+        {
+            work.VisitTypeReferenceMatchNameBytes(
+                reader.GetBlobReader(reference.Namespace).Length);
+        }
+        return comparer.Equals(
+            definition.Namespace,
+            reader.GetString(reference.Namespace));
     }
 
     static ReadOnlySpan<char> LeafName(ReadOnlySpan<char> name)

--- a/tests/ILInspector.Metadata.Tests/CustomAttributeBoundedCostTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CustomAttributeBoundedCostTests.cs
@@ -60,6 +60,69 @@ public sealed class CustomAttributeBoundedCostTests
         Assert.Null(ordinary);
     }
 
+    [Fact]
+    public void DecodeLocalNameBudgetExhaustion_DoesNotPoisonSharedIndex()
+    {
+        using var image = Open(BuildSharedNamespaceIndexImage(
+            definitionCount: 16,
+            namespaceLength: 16));
+        CustomAttribute attribute = FirstAttribute(image.Reader);
+        long indexNameBytes =
+            ExpectedTypeDefinitionIndexNameBytes(image.Reader);
+        var context = new AttributeDecoder.MaterializationContext(
+            static _ => { });
+        var exhaustedWork =
+            new CustomAttributeValueDecoder.EnumResolutionWork();
+        exhaustedWork.VisitTypeReferenceMatchNameBytes(
+            checked((int)(
+                CustomAttributeValueDecoder.MaxEnumResolutionNameWork
+                - indexNameBytes
+                + 1)));
+
+        Assert.False(CustomAttributeValueDecoder.TryDecode(
+            image.Reader,
+            attribute,
+            preserveSerializedTypeNames: false,
+            captureDefaultedWidths: false,
+            context.Observe,
+            enumUnderlyingType: null,
+            out _,
+            out _,
+            out _,
+            enumResolutionWork: exhaustedWork));
+        Assert.Equal(
+            CustomAttributeValueDecoder.MaxEnumResolutionNameWork,
+            exhaustedWork.NameBytes);
+
+        var retryWork = new CustomAttributeValueDecoder.EnumResolutionWork();
+        Assert.True(CustomAttributeValueDecoder.TryDecode(
+            image.Reader,
+            attribute,
+            preserveSerializedTypeNames: false,
+            captureDefaultedWidths: false,
+            context.Observe,
+            enumUnderlyingType: null,
+            out _,
+            out _,
+            out _,
+            enumResolutionWork: retryWork));
+        Assert.Equal(indexNameBytes, retryWork.TypeDefinitionIndexNameBytes);
+
+        var cachedWork = new CustomAttributeValueDecoder.EnumResolutionWork();
+        Assert.True(CustomAttributeValueDecoder.TryDecode(
+            image.Reader,
+            attribute,
+            preserveSerializedTypeNames: false,
+            captureDefaultedWidths: false,
+            context.Observe,
+            enumUnderlyingType: null,
+            out _,
+            out _,
+            out _,
+            enumResolutionWork: cachedWork));
+        Assert.Equal(0, cachedWork.TypeDefinitionIndexNameBytes);
+    }
+
     [Theory]
     [InlineData(1, 4096)]
     [InlineData(1024, 1)]

--- a/tests/ILInspector.Metadata.Tests/CustomAttributeBoundedCostTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CustomAttributeBoundedCostTests.cs
@@ -9,6 +9,127 @@ namespace ILInspector.Metadata.Tests;
 public sealed class CustomAttributeBoundedCostTests
 {
     [Theory]
+    [InlineData(1, 4096)]
+    [InlineData(1024, 1)]
+    [InlineData(16, 16)]
+    public void SharedNamespaceIndex_BelowBudgetPreservesValueAndCountsNameBytes(
+        int definitionCount,
+        int namespaceLength)
+    {
+        using var image = Open(BuildSharedNamespaceIndexImage(
+            definitionCount,
+            namespaceLength));
+        CustomAttribute attribute = FirstAttribute(image.Reader);
+        var work = new CustomAttributeValueDecoder.EnumResolutionWork();
+
+        Assert.True(TryDecode(image.Reader, attribute, work, out var measured));
+        CustomAttributeValue<string>? ordinary =
+            AttributeDecoder.TryDecode(image.Reader, attribute);
+
+        Assert.NotNull(ordinary);
+        Assert.Equal(
+            measured.FixedArguments[0],
+            ordinary.Value.FixedArguments[0]);
+        Assert.Equal(
+            ExpectedTypeDefinitionIndexNameBytes(image.Reader),
+            work.TypeDefinitionIndexNameBytes);
+        Assert.Equal(0, work.TypeReferenceMatchNameBytes);
+        Assert.Equal(
+            work.TypeDefinitionIndexNameBytes,
+            work.NameBytes);
+    }
+
+    [Fact]
+    public void SharedNamespaceIndex_CrossProductStopsAtNameBudget()
+    {
+        using var image = Open(BuildSharedNamespaceIndexImage(
+            definitionCount: 1024,
+            namespaceLength: 4096));
+        CustomAttribute attribute = FirstAttribute(image.Reader);
+        var work = new CustomAttributeValueDecoder.EnumResolutionWork();
+
+        bool measured = TryDecode(image.Reader, attribute, work, out _);
+        CustomAttributeValue<string>? ordinary =
+            AttributeDecoder.TryDecode(image.Reader, attribute);
+
+        Assert.Equal(
+            CustomAttributeValueDecoder.MaxEnumResolutionNameWork,
+            work.NameBytes);
+        Assert.Equal(ordinary is not null, measured);
+        Assert.False(measured);
+        Assert.Null(ordinary);
+    }
+
+    [Theory]
+    [InlineData(1, 4096)]
+    [InlineData(1024, 1)]
+    [InlineData(16, 16)]
+    public void InvariantReferenceName_BelowBudgetPreservesValueAndCountsNameBytes(
+        int definitionCount,
+        int nameLength)
+    {
+        using var image = Open(BuildInvariantReferenceNameImage(
+            definitionCount,
+            nameLength));
+        CustomAttribute attribute = FirstAttribute(image.Reader);
+        var work = new CustomAttributeValueDecoder.EnumResolutionWork();
+
+        Assert.True(TryDecode(image.Reader, attribute, work, out var measured));
+        CustomAttributeValue<string>? ordinary =
+            AttributeDecoder.TryDecode(image.Reader, attribute);
+
+        Assert.NotNull(ordinary);
+        Assert.Equal(
+            measured.FixedArguments[0],
+            ordinary.Value.FixedArguments[0]);
+        long expected =
+            ((long)definitionCount + 1) * nameLength
+            + (long)definitionCount * "Match".Length;
+        Assert.Equal(expected, work.TypeReferenceMatchNameBytes);
+        Assert.Equal(0, work.TypeDefinitionIndexNameBytes);
+        Assert.Equal(expected, work.NameBytes);
+    }
+
+    [Fact]
+    public void InvariantReferenceName_CrossProductStopsAtNameBudget()
+    {
+        using var image = Open(BuildInvariantReferenceNameImage(
+            definitionCount: 1024,
+            nameLength: 4096));
+        CustomAttribute attribute = FirstAttribute(image.Reader);
+        var work = new CustomAttributeValueDecoder.EnumResolutionWork();
+
+        bool measured = TryDecode(image.Reader, attribute, work, out _);
+        CustomAttributeValue<string>? ordinary =
+            AttributeDecoder.TryDecode(image.Reader, attribute);
+
+        Assert.Equal(
+            CustomAttributeValueDecoder.MaxEnumResolutionNameWork,
+            work.NameBytes);
+        Assert.Equal(ordinary is not null, measured);
+        Assert.False(measured);
+        Assert.Null(ordinary);
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void ResolutionNameWork_JointDimensionSweepsStayWithinBudget()
+    {
+        int[] rowCounts = [1, 4, 16, 64, 256, 512, 1024];
+        int[] nameLengths = [1, 16, 64, 256, 1024, 4096, 8192];
+        foreach (int rowCount in rowCounts)
+        {
+            foreach (int nameLength in nameLengths)
+            {
+                AssertNameWorkOutcome(
+                    BuildSharedNamespaceIndexImage(rowCount, nameLength));
+                AssertNameWorkOutcome(
+                    BuildInvariantReferenceNameImage(rowCount, nameLength));
+            }
+        }
+    }
+
+    [Theory]
     [InlineData(1, 192)]
     [InlineData(192, 1)]
     [InlineData(8, 8)]
@@ -232,6 +353,247 @@ public sealed class CustomAttributeBoundedCostTests
             constructor,
             metadata.GetOrAddBlob(value));
 
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] BuildSharedNamespaceIndexImage(
+        int definitionCount,
+        int namespaceLength)
+    {
+        MetadataBuilder metadata = CreateMetadata("SharedNamespaceIndex");
+        AssemblyReferenceHandle externalAssembly =
+            AddExternalAssembly(metadata);
+        MemberReferenceHandle constructor =
+            AddObjectConstructor(metadata, externalAssembly);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        StringHandle sharedNamespace = metadata.GetOrAddString(
+            new string('N', namespaceLength));
+        for (int i = 0; i < definitionCount; i++)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                sharedNamespace,
+                metadata.GetOrAddString($"Decoy{i}"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        TypeDefinitionHandle attributedType = AddAttributedType(metadata);
+        var value = new BlobBuilder();
+        value.WriteUInt16(1);
+        value.WriteByte(0x55);
+        value.WriteSerializedString("Missing.Enum");
+        value.WriteInt32(0);
+        value.WriteUInt16(0);
+        metadata.AddCustomAttribute(
+            attributedType,
+            constructor,
+            metadata.GetOrAddBlob(value));
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildInvariantReferenceNameImage(
+        int definitionCount,
+        int nameLength)
+    {
+        MetadataBuilder metadata = CreateMetadata("InvariantReferenceName");
+        AssemblyReferenceHandle externalAssembly =
+            AddExternalAssembly(metadata);
+        StringHandle sharedName = metadata.GetOrAddString(
+            new string('E', nameLength));
+        TypeReferenceHandle enumReference = metadata.AddTypeReference(
+            externalAssembly,
+            metadata.GetOrAddString("Match"),
+            sharedName);
+        MemberReferenceHandle constructor = AddEnumConstructor(
+            metadata,
+            externalAssembly,
+            enumReference);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        for (int i = 0; i < definitionCount; i++)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString(
+                    i == definitionCount - 1 ? "Match" : $"N{i}"),
+                sharedName,
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        TypeDefinitionHandle attributedType = AddAttributedType(metadata);
+        var value = new BlobBuilder();
+        value.WriteUInt16(1);
+        value.WriteInt32(0);
+        value.WriteUInt16(0);
+        metadata.AddCustomAttribute(
+            attributedType,
+            constructor,
+            metadata.GetOrAddBlob(value));
+        return Serialize(metadata);
+    }
+
+    static MetadataBuilder CreateMetadata(string assemblyName)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString($"{assemblyName}.dll"),
+            metadata.GetOrAddGuid(
+                new Guid("e9b384ad-266d-4e18-999e-c4ed08370d51")),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        return metadata;
+    }
+
+    static AssemblyReferenceHandle AddExternalAssembly(
+        MetadataBuilder metadata) =>
+        metadata.AddAssemblyReference(
+            metadata.GetOrAddString("External.Enums"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+
+    static MemberReferenceHandle AddObjectConstructor(
+        MetadataBuilder metadata,
+        AssemblyReferenceHandle externalAssembly)
+    {
+        TypeReferenceHandle attributeType = metadata.AddTypeReference(
+            externalAssembly,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("SampleAttribute"));
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: true).Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Object());
+        return metadata.AddMemberReference(
+            attributeType,
+            metadata.GetOrAddString(".ctor"),
+            metadata.GetOrAddBlob(signature));
+    }
+
+    static MemberReferenceHandle AddEnumConstructor(
+        MetadataBuilder metadata,
+        AssemblyReferenceHandle externalAssembly,
+        TypeReferenceHandle enumReference)
+    {
+        TypeReferenceHandle attributeType = metadata.AddTypeReference(
+            externalAssembly,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("SampleAttribute"));
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: true).Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Type(
+                    enumReference,
+                    isValueType: true));
+        return metadata.AddMemberReference(
+            attributeType,
+            metadata.GetOrAddString(".ctor"),
+            metadata.GetOrAddBlob(signature));
+    }
+
+    static TypeDefinitionHandle AddAttributedType(
+        MetadataBuilder metadata) =>
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("Attributed"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+    static long ExpectedTypeDefinitionIndexNameBytes(
+        MetadataReader reader)
+    {
+        long bytes = 0;
+        foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+        {
+            TypeDefinition definition = reader.GetTypeDefinition(handle);
+            bytes += reader.GetBlobReader(definition.Namespace).Length;
+            bytes += reader.GetBlobReader(definition.Name).Length;
+        }
+        return bytes;
+    }
+
+    static void AssertNameWorkOutcome(byte[] bytes)
+    {
+        using var image = Open(bytes);
+        CustomAttribute attribute = FirstAttribute(image.Reader);
+        var work = new CustomAttributeValueDecoder.EnumResolutionWork();
+
+        bool measured = TryDecode(
+            image.Reader,
+            attribute,
+            work,
+            out _);
+        bool ordinary =
+            AttributeDecoder.TryDecode(image.Reader, attribute) is not null;
+
+        Assert.Equal(ordinary, measured);
+        Assert.InRange(
+            work.NameBytes,
+            0,
+            CustomAttributeValueDecoder.MaxEnumResolutionNameWork);
+    }
+
+    static bool TryDecode(
+        MetadataReader reader,
+        CustomAttribute attribute,
+        CustomAttributeValueDecoder.EnumResolutionWork work,
+        out CustomAttributeValue<string> value) =>
+        CustomAttributeValueDecoder.TryDecode(
+            reader,
+            attribute,
+            preserveSerializedTypeNames: false,
+            captureDefaultedWidths: false,
+            beforeMaterialize: null,
+            enumUnderlyingType: null,
+            out value,
+            out _,
+            out _,
+            enumResolutionWork: work);
+
+    static byte[] Serialize(MetadataBuilder metadata)
+    {
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),
             new MetadataRootBuilder(metadata, suppressValidation: true),


### PR DESCRIPTION
Build robust, capable custom-attribute decoding by containing two remaining
metadata-size amplification paths without adding a parallel index or changing
successful ordinary decoding.

This closes the active production paths in #5757 and #5758 under one D1
resolution-name-work claim. TypeDef-index rendering and TypeRef candidate
matching now charge their encoded metadata string bytes to one cumulative
4 MiB budget per attribute decode. Exhaustion follows the decoder's existing
visible refusal contract.

## Demo

| Generated input | Before | After | Expected |
| --- | --- | --- | --- |
| 1,024 TypeDefs sharing a 4,096-byte namespace | Returned a value after 4,202,435 index name-byte units | Refuses at exactly 4,194,304 units | Bounded refusal |
| 1,024 TypeDefs sharing a 4,096-byte name, matching last | Returned a value after 4,203,520 match name-byte units | Refuses at exactly 4,194,304 units | Bounded refusal |
| Small row count, long name | Returns the same typed value with and without measurement | Unchanged | Preserve valid decoding |
| Large row count, short name | Returns the same typed value with and without measurement | Unchanged | Preserve valid decoding |

The failing boundary evidence is preserved in instrumentation commit
`d7e2b52ae530a85b8e3eeed606672a266c01c932`; the repair is the following
commit.

## Design

- Extends the existing product-owned `EnumResolutionWork` recorder rather than
  adding a second lifecycle.
- Charges TypeDef index names before rendering and TypeRef names before each
  candidate comparison.
- Keeps candidate/frame work and name-byte work as separate fixed aggregate
  limits.
- Keeps budget exhaustion decode-local rather than caching it as intrinsic
  TypeDef-index corruption across later attribute rows.
- Uses `Speed=Slow` for the 98-image joint row-count/name-length sweep while
  retaining focused controls and exact refusal boundaries in PR CI.
- Does not move or duplicate the higher-layer `MetadataTypeDefinitionIndex`,
  which would invert the existing Metadata-to-MetadataPrimitives dependency or
  alter public assembly ownership.

The standalone serialized-name definition scan has no current decoder caller
and is not claimed by this change. Cross-row shared-blob work remains #5132, so
full D1 remains unverified.

## Validation

- Release solution build
- Metadata fast suite: 3,061 passed, 2 environment-dependent skips
- Focused fast boundary suite: 13 passed
- Slow joint-dimension sweep: 98 generated images passed
- D3 package corpus: 189,142 rows exactly matched the independent oracle
- Markdown lint

Closes #5757
Closes #5758
