### PR TITLE
Define the source availability audit contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -193,6 +193,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [C# Declared-Type Self-Name Admission](design/csharp-declared-type-self-name.md) | Proposed typed admission from one exact Metadata leaf to the identifier shared by a type header, constructors, and finalizers. |
 | [C# Memory-Safety Declaration Spelling](design/csharp-memory-safety-spelling.md) | Proposed CSharp-owned spelling of caller contracts independently from pointer syntax and body-context requirements. |
 | [Source Finding Producers](design/source-finding-producers.md) | How source-derived Findings are produced. |
+| [Source Availability Audit](design/source-availability-audit.md) | Operation-scoped source reachability and origin-validated positive reuse. |
 | [Untrusted Data Threat Model](design/untrusted-data-threat-model.md) | Trust boundaries, existing controls, and the security-scope rationale for untrusted internet-origin data. |
 | [Finding Adoption](design/finding-adoption.md) | How Analysis, Findings, and Research compose. |
 | [Call Graph Projection](design/call-graph-projection.md) | Projecting the inspection graph into a call graph. |

--- a/docs/design/source-availability-audit.md
+++ b/docs/design/source-availability-audit.md
@@ -58,8 +58,10 @@ The service classifies each considered observation in this order:
 1. Embedded storage is accessible without cache or network work.
 2. No resolved URL is missing.
 3. A non-HTTP(S) URL is missing.
-4. A canonical path beneath `/artifacts/obj/` is missing. It identifies a
-   build-intermediate observation rather than distributable source.
+4. An authored document path beneath `/artifacts/obj/` is missing. The authored
+   path identifies where the compiler consumed the build-intermediate file;
+   the canonical SourceLink remainder is repository identity and does not
+   rewrite that compiler observation.
 5. An admitted reusable positive observation is accessible.
 6. Otherwise, the service performs the owned HEAD operation.
 7. A successful response is accessible only when
@@ -146,8 +148,9 @@ The contract-defining cases are:
 
 - an empty or non-compiler census is not all-accessible;
 - embedded source uses neither cache nor network;
-- unsupported, unresolved, and build-intermediate observations use neither
-  cache nor network;
+- unsupported, unresolved, and authored build-intermediate observations use
+  neither cache nor network, including when SourceLink gives the latter a
+  non-artifact canonical remainder;
 - an immutable positive observation is reused without expiry;
 - a mutable positive observation is reused for at most one day;
 - a 404 and every other non-success remain operation-local;
@@ -161,6 +164,7 @@ The contract-defining cases are:
 `SourceLinkQueryServiceTests` must gate:
 
 - mixed embedded, reachable, missing, and ignored observations;
+- empty and duplicate-URL censuses retain the explicit denominator semantics;
 - positive cache category, URL key, extension, mutability-based age, and reuse;
 - absence of negative publication for 404 and other non-success responses;
 - absence of publication after final-origin rejection; and

--- a/docs/design/source-availability-audit.md
+++ b/docs/design/source-availability-audit.md
@@ -1,0 +1,182 @@
+# Source availability audit
+
+Status: Implemented existing contract
+
+## Decision
+
+`SourceAvailabilityService` owns whether one source-document census has
+sufficient current or reusable final-origin evidence to classify each compiler
+source observation as embedded, accessible, or missing for the current
+availability audit.
+
+The audit is an operation-scoped reachability fold. It does not prove that a
+file is absent from its repository or that reachable content matches the
+compiler-recorded checksum.
+
+This document specifies an existing host-neutral service. It introduces no new
+capability, shared substrate, host, or rendering path. The CLI library and
+package SourceLink views are its current consumers. A browser/Wasm host may use
+the same service without supplying a persistent cache.
+
+## Owners and boundaries
+
+The service consumes, but does not redefine, these owner-issued facts:
+
+- [Source finding producers](source-finding-producers.md) owns the
+  source-document census and its canonical paths, storage kinds, and resolved
+  URLs.
+- `SourceLinkUrls` owns immutable-content recognition, and
+  `SourceFetchOriginValidator` applies the SourceLink provenance rule for
+  admitting a final response origin.
+- `HttpRetryHelper` owns the bounded, retried HTTP HEAD operation and its
+  transport result.
+- `CoreCache` owns generic persistence, age checks, and storage mechanics.
+- `ISourceLinkQueryCache` is the optional host adapter for those mechanics.
+- `SourceAvailabilityQuery` owns query composition and the typed result.
+- CLI library and package sections own presentation.
+
+`SourceIntegrityService` is adjacent but outside this decision. It separately
+owns content acquisition and checksum verification.
+
+## Census and denominator
+
+The input is one completed source-document census. The audit considers only
+compiler-language observations: C#, Visual Basic, and F# documents selected by
+their canonical file extension.
+
+Each considered observation remains in the denominator even when another
+observation resolves to the same URL. Cache reuse across audits does not
+collapse compiler documents or their report paths.
+
+An empty considered census produces `AllSourcesAccessible = false`. The result
+does not turn lack of evidence into success.
+
+## Classification
+
+The service classifies each considered observation in this order:
+
+1. Embedded storage is accessible without cache or network work.
+2. No resolved URL is missing.
+3. A non-HTTP(S) URL is missing.
+4. A canonical path beneath `/artifacts/obj/` is missing. It identifies a
+   build-intermediate observation rather than distributable source.
+5. An admitted reusable positive observation is accessible.
+6. Otherwise, the service performs the owned HEAD operation.
+7. A successful response is accessible only when
+   `SourceFetchOriginValidator.Validate` admits its final origin.
+8. Every other result is missing for this operation.
+
+Missing paths are reported using the authored document path in ordinal order.
+Embedded, accessible, and missing counts are counts of considered observations.
+`AllSourcesAccessible` is true only when at least one observation was
+considered and none was missing.
+
+Operational diagnostics must not include package-authored URLs or paths. The
+authored paths that consumers may present remain separately typed in
+`MissingSourceFiles`.
+
+## Current observation and final origin
+
+A live success is not sufficient by itself. For a URL with an attributable
+repository origin, the final response URL must preserve the complete origin
+tuple. An unattributed requested URL carries no repository provenance claim
+and remains admissible under `SourceLinkProvenance`'s rule.
+
+A changed or unattributable final origin for an attributed request is missing
+for the current operation and cannot publish reusable evidence.
+
+Non-success HTTP results do not currently carry the final response URL across
+the `HttpRetryHelper` boundary. They therefore cannot establish a durable
+negative observation. A 404 is still missing for the current operation, but it
+is not evidence that a later audit may reuse.
+
+## Cache subject and reuse
+
+The cache subject is:
+
+```text
+(source-audit-v2, resolved URL, positive observation)
+```
+
+The literal resolved URL is the key because reachability is a property of that
+HTTP resource. Compiler document identity remains separate and is used for
+counting and reporting.
+
+The service may read or publish only the `ok` positive extension. The stored
+value is an opaque presence marker; it carries no user-visible fact.
+
+Positive reuse follows provenance mutability:
+
+- When `SourceLinkUrls.IsImmutable` establishes a full commit-pinned content
+  origin, the observation has no age limit.
+- Every other positive observation has a maximum age of one day.
+
+Only a live successful response whose final origin is admitted may publish an
+`ok` observation. Embedded, rejected, unsupported, build-intermediate,
+non-success, transport-failure, and cancellation paths publish nothing.
+
+The category and `ok` extension bind reusable entries to this decision's
+final-origin admission. An entry from another category or extension cannot
+satisfy this audit.
+
+## Failure and cancellation
+
+Malformed or unsupported resolved URLs remain typed missing observations; they
+do not abort the census.
+
+HTTP and transport failures remain visible as missing observations and in the
+aggregate summary. They are not converted into durable misses.
+
+The caller's cancellation token flows into the owned HTTP operation.
+Cancellation is not cacheable evidence and is not translated into a reusable
+availability result.
+
+## Concurrency and ordering
+
+The service performs uncached HEAD operations with a maximum concurrency of 16.
+Completion order does not affect the result: missing authored paths are sorted
+ordinally, and all counts are census totals.
+
+Cache reuse is per resolved URL across audits. Each compiler observation still
+contributes independently to the result counts.
+
+## Pathological cases
+
+The contract-defining cases are:
+
+- an empty or non-compiler census is not all-accessible;
+- embedded source uses neither cache nor network;
+- unsupported, unresolved, and build-intermediate observations use neither
+  cache nor network;
+- an immutable positive observation is reused without expiry;
+- a mutable positive observation is reused for at most one day;
+- a 404 and every other non-success remain operation-local;
+- an attributed request redirected to a different origin is missing and
+  publishes no cache entry; and
+- duplicate URLs retain per-document counts and use the same cross-audit cache
+  subject.
+
+## Required gates
+
+`SourceLinkQueryServiceTests` must gate:
+
+- mixed embedded, reachable, missing, and ignored observations;
+- positive cache category, URL key, extension, mutability-based age, and reuse;
+- absence of negative publication for 404 and other non-success responses;
+- absence of publication after final-origin rejection; and
+- absence of cache and network work for locally classified observations.
+
+`SourceLinkProvenanceTests` owns immutable URL recognition and final-origin
+admission. `HttpRetryHelperTests` owns retry and cancellation behavior. This
+service consumes those gates rather than duplicating their internal matrices.
+
+## Non-claims
+
+This decision does not claim:
+
+- source content integrity, checksum agreement, or repository completeness;
+- permanent absence after any HTTP result;
+- provenance for URLs outside the recognized origin grammars;
+- freshness beyond the stated positive reuse policy;
+- stable snapshots of local files or remote repositories; or
+- parallel or exhaustive source acquisition.

--- a/docs/design/source-availability-audit.md
+++ b/docs/design/source-availability-audit.md
@@ -64,9 +64,11 @@ The service classifies each considered observation in this order:
    rewrite that compiler observation.
 5. An admitted reusable positive observation is accessible.
 6. Otherwise, the service performs the owned HEAD operation.
-7. A successful response is accessible only when
+7. Cancellation observed after HEAD completion propagates before response
+   classification or cache publication.
+8. A successful response is accessible only when
    `SourceFetchOriginValidator.Validate` admits its final origin.
-8. Every other result is missing for this operation.
+9. Every other result is missing for this operation.
 
 Missing paths are reported using the authored document path in ordinal order.
 Embedded, accessible, and missing counts are counts of considered observations.
@@ -115,7 +117,8 @@ Positive reuse follows provenance mutability:
 
 Only a live successful response whose final origin is admitted may publish an
 `ok` observation. Embedded, rejected, unsupported, build-intermediate,
-non-success, transport-failure, and cancellation paths publish nothing.
+non-success, and transport-failure paths publish nothing. Cancellation
+observed before response classification also publishes nothing.
 
 The category and `ok` extension bind reusable entries to this decision's
 final-origin admission. An entry from another category or extension cannot
@@ -130,8 +133,8 @@ HTTP and transport failures remain visible as missing observations and in the
 aggregate summary. They are not converted into durable misses.
 
 The caller's cancellation token flows into the owned HTTP operation.
-Cancellation is not cacheable evidence and is not translated into a reusable
-availability result.
+Cancellation observed before response classification propagates, is not
+cacheable evidence, and is not translated into a reusable availability result.
 
 ## Concurrency and ordering
 
@@ -154,6 +157,7 @@ The contract-defining cases are:
 - an immutable positive observation is reused without expiry;
 - a mutable positive observation is reused for at most one day;
 - a 404 and every other non-success remain operation-local;
+- cancellation observed as a HEAD completes publishes no positive entry;
 - an attributed request redirected to a different origin is missing and
   publishes no cache entry; and
 - duplicate URLs retain per-document counts and use the same cross-audit cache
@@ -167,6 +171,7 @@ The contract-defining cases are:
 - empty and duplicate-URL censuses retain the explicit denominator semantics;
 - positive cache category, URL key, extension, mutability-based age, and reuse;
 - absence of negative publication for 404 and other non-success responses;
+- cancellation between HEAD completion and classification publishes nothing;
 - absence of publication after final-origin rejection; and
 - absence of cache and network work for locally classified observations.
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -564,7 +564,7 @@ empty snapshot is a cache miss rather than authoritative candidate metadata.
 | Package metadata | `$LOCAL_APP_DATA/dotnet-inspect/metadata/` | 1 hour | dotnet-inspect |
 | Symbol miss markers | `$LOCAL_APP_DATA/dotnet-inspect/symbol-misses/` | 1 day | dotnet-inspect |
 | Verified SourceLink bytes | `$LOCAL_APP_DATA/dotnet-inspect/source-bytes-v2/` | Permanent when the caller's checksum validator accepts the bytes | dotnet-inspect |
-| SourceLink availability markers | `$LOCAL_APP_DATA/dotnet-inspect/source-audit-v2/` | Permanent for immutable hits, 1 day for mutable hits and misses | dotnet-inspect |
+| [SourceLink availability markers](source-availability-audit.md#cache-subject-and-reuse) | `$LOCAL_APP_DATA/dotnet-inspect/source-audit-v2/` | Permanent for immutable positives, 1 day for mutable positives; no persisted misses | dotnet-inspect |
 | SourceLink integrity markers | `$LOCAL_APP_DATA/dotnet-inspect/source-integrity-v2/` | Permanent for immutable checksum-verified results | dotnet-inspect |
 
 The app package cache carries a `{source}` segment because cached content is
@@ -576,9 +576,10 @@ feed.
 
 ## Network download/cache behavior
 
-Network calls use the cache behavior below. Negative cache entries are written
-only for definitive 404/not-found responses; transient failures, timeouts,
-offline mode, and unsupported local feed URLs are not cached as misses.
+Network calls use the cache behavior below. Where a cache owner permits
+negative entries, they are written only for definitive 404/not-found responses;
+transient failures, timeouts, offline mode, and unsupported local feed URLs are
+not cached as misses.
 Package-metadata absence is a time-bounded observation rather than a permanent
 coordinate fact; its target semantics are owned by
 [package metadata persistence](package-metadata-persistence.md).
@@ -599,9 +600,8 @@ coordinate fact; its target semantics are owned by
 | Symbol-server PDB 404s | Cached as misses for 1 day, so detailed audit does not retry unavailable PDBs on every run. |
 | Successful `.snupkg` PDB extraction | Extracted PDB is cached permanently under `packages/symbols/{package}/{version}/`. |
 | Missing `.snupkg` URLs and `.snupkg` files without the requested PDB | Cached as misses for 1 day. The `.snupkg` archive itself is not retained. |
-| SourceLink audit source checks | Successful HEAD checks are cached permanently; 404s are cached as misses for 1 day. |
+| SourceLink availability HEAD checks | Origin-validated positives follow the immutable/permanent or mutable/one-day policy; non-success results are not cached. |
 | Selected-member `PDB Source` downloads | Not cached by this command path. |
-| `SourceLink: Availability` URL checks | Not cached by this command path. |
 | Service-index discovery for custom NuGet feeds | Not cached. nuget.org flat-container paths avoid this lookup. |
 | GitHub advisory enrichment | Not separately cached; it is covered when the package metadata cache is hit. |
 

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -330,10 +330,13 @@ network requests.
 - Symbol-package PDB caches are identity-keyed to avoid multi-TFM collisions.
 - Source availability and integrity queries accept an optional host cache;
   filesystem-free hosts may run without one.
-- Positive availability and integrity results are cached permanently only when
-  the provenance grammar establishes an immutable commit-pinned GitHub or Azure
-  DevOps URL. Other availability results retain a TTL; integrity results for
-  unknown hosts and moving or ambiguous selectors are not cached.
+- [Source availability audit](design/source-availability-audit.md) owns
+  availability reuse. Origin-validated positives are permanent only for
+  recognized immutable commit-pinned URLs and otherwise retain a one-day TTL.
+  Non-success results lack final-origin evidence and remain operation-local.
+- Integrity positives are cached permanently only when the provenance grammar
+  establishes an immutable commit-pinned GitHub or Azure DevOps URL. Integrity
+  results for unknown hosts and moving or ambiguous selectors are not cached.
 - The target bare-library effective catalog may persist successful
   package/platform section summaries under its versioned semantic key. The
   slice-5 successor keys on retained assembly content plus complete typed

--- a/src/DotnetInspector.Services/SourceAvailabilityService.cs
+++ b/src/DotnetInspector.Services/SourceAvailabilityService.cs
@@ -23,7 +23,6 @@ public sealed record SourceAvailabilitySummary(
 public static class SourceAvailabilityService
 {
     private const string CacheCategory = "source-audit-v2";
-    private static readonly TimeSpan NegativeCacheTtl = TimeSpan.FromDays(1);
     private static readonly TimeSpan MutablePositiveCacheTtl = TimeSpan.FromDays(1);
 
     public static async Task<SourceAvailabilitySummary> InspectAsync(
@@ -78,14 +77,6 @@ public static class SourceAvailabilityService
             {
                 accessibleCount++;
             }
-            else if (cache?.TryGet(
-                CacheCategory,
-                document.ResolvedUrl!,
-                NegativeCacheTtl,
-                "miss") != null)
-            {
-                missingFiles.Add(document.OriginalPath);
-            }
             else
             {
                 uncachedDocuments.Add(document);
@@ -133,14 +124,6 @@ public static class SourceAvailabilityService
                         {
                             log?.Invoke(
                                 "Could not verify the final SourceLink response origin.");
-                        }
-                        else if (result.IsNotFound)
-                        {
-                            cache?.Set(
-                                CacheCategory,
-                                document.ResolvedUrl!,
-                                "1",
-                                "miss");
                         }
 
                         if (response is null)

--- a/src/DotnetInspector.Services/SourceAvailabilityService.cs
+++ b/src/DotnetInspector.Services/SourceAvailabilityService.cs
@@ -104,6 +104,7 @@ public static class SourceAvailabilityService
                         cancellationToken: ct,
                         trafficKind: NetworkTrafficKind.SourceAudit).ConfigureAwait(false);
                     using var response = result.Response;
+                    ct.ThrowIfCancellationRequested();
                     string? finalUrl = response?.RequestMessage?.RequestUri?.AbsoluteUri;
                     bool originPreserved = response is not null
                         && SourceFetchOriginValidator.Validate(

--- a/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
+++ b/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
@@ -327,6 +327,27 @@ public class SourceLinkQueryServiceTests
     }
 
     [Fact]
+    public async Task Availability_CancellationAfterHeadDoesNotPublishPositiveEvidence()
+    {
+        using CancellationTokenSource cancellation = new();
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            cancellation.Cancel();
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => SourceAvailabilityService.InspectAsync(
+                [Document("/src/A.cs", url: "https://example.test/src/a.cs")],
+                client,
+                cache,
+                cancellationToken: cancellation.Token));
+
+        Assert.Empty(cache.Writes);
+    }
+
+    [Fact]
     public async Task Integrity_DoesNotAcceptMatchingBytesFromCrossOriginRedirect()
     {
         byte[] body = "exact source"u8.ToArray();

--- a/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
+++ b/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
@@ -232,9 +232,14 @@ public class SourceLinkQueryServiceTests
             Document("/src/Embedded.cs", SourceDocumentStorage.Embedded),
             Document("/src/Unresolved.cs"),
             Document("/src/Unsupported.cs", url: "ftp://example.test/unsupported.cs"),
-            Document(
+            new(
+                "src/Generated.g.cs",
                 "/repo/artifacts/obj/Generated.g.cs",
-                url: "https://example.test/generated.cs"),
+                DocumentRowId: 4,
+                SourceDocumentStorage.SourceLink,
+                "https://example.test/generated.cs",
+                ChecksumAlgorithm: null,
+                Checksum: null),
         ];
 
         SourceAvailabilitySummary result = await SourceAvailabilityService.InspectAsync(
@@ -248,6 +253,77 @@ public class SourceLinkQueryServiceTests
         Assert.Equal(0, requests);
         Assert.Empty(cache.Lookups);
         Assert.Empty(cache.Writes);
+    }
+
+    [Fact]
+    public async Task Availability_EmptyCensusIsNotAccessible()
+    {
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+
+        SourceAvailabilitySummary result = await SourceAvailabilityService.InspectAsync(
+            [],
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, result.TotalSourceFiles);
+        Assert.Equal(0, result.AccessibleSourceFiles);
+        Assert.False(result.AllSourcesAccessible);
+        Assert.Equal(0, requests);
+        Assert.Empty(cache.Lookups);
+        Assert.Empty(cache.Writes);
+    }
+
+    [Fact]
+    public async Task Availability_DuplicateUrlRetainsEachDocumentInTheDenominator()
+    {
+        const string Url = "https://example.test/src/a.cs";
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+        cache.Seed("source-audit-v2", Url, "1", "ok");
+        SourceDocumentObservation[] documents =
+        [
+            new(
+                "src/A.cs",
+                "/_/src/A.cs",
+                DocumentRowId: 1,
+                SourceDocumentStorage.SourceLink,
+                Url,
+                ChecksumAlgorithm: null,
+                Checksum: null),
+            new(
+                "src/A.cs",
+                "/_2/src/A.cs",
+                DocumentRowId: 2,
+                SourceDocumentStorage.SourceLink,
+                Url,
+                ChecksumAlgorithm: null,
+                Checksum: null),
+        ];
+
+        SourceAvailabilitySummary result = await SourceAvailabilityService.InspectAsync(
+            documents,
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.TotalSourceFiles);
+        Assert.Equal(2, result.AccessibleSourceFiles);
+        Assert.True(result.AllSourcesAccessible);
+        Assert.Equal(0, requests);
+        Assert.Equal(2, cache.Lookups.Count);
+        Assert.All(cache.Lookups, lookup => Assert.Equal(Url, lookup.Key));
     }
 
     [Fact]

--- a/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
+++ b/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
@@ -94,28 +94,160 @@ public class SourceLinkQueryServiceTests
             "https://dev.azure.com/org/project/_apis/git/repositories/repo/items"
             + "?api-version=7.1&versionType=commit"
             + "&version=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&path=/A.cs";
+        int requests = 0;
         using var client = new HttpClient(new StubHandler(_ =>
-            new HttpResponseMessage((HttpStatusCode)203)
+        {
+            requests++;
+            return new HttpResponseMessage((HttpStatusCode)203)
             {
                 RequestMessage = new HttpRequestMessage(
                     HttpMethod.Head,
                     "https://spsprodeus27.vssps.visualstudio.com/_signin"),
-            }));
+            };
+        }));
         List<string> logs = [];
+        RecordingSourceLinkQueryCache cache = new();
 
         SourceAvailabilitySummary result = await SourceAvailabilityService.InspectAsync(
             [Document("/src/A.cs", url: Url)],
             client,
+            cache,
             log: logs.Add,
+            cancellationToken: TestContext.Current.CancellationToken);
+        SourceAvailabilitySummary repeated = await SourceAvailabilityService.InspectAsync(
+            [Document("/src/A.cs", url: Url)],
+            client,
+            cache,
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, result.AccessibleSourceFiles);
+        Assert.Equal(0, repeated.AccessibleSourceFiles);
         Assert.Equal(["/src/A.cs"], result.MissingSourceFiles);
+        Assert.Equal(2, requests);
+        Assert.Empty(cache.Writes);
         Assert.DoesNotContain(logs, message => message.Contains(Url, StringComparison.Ordinal));
         Assert.DoesNotContain(
             logs,
             message => message.Contains("spsprodeus27", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(logs, message => message.Contains("https://", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(
+        "https://raw.githubusercontent.com/example/repo/0123456789abcdef0123456789abcdef01234567/src/a.cs",
+        true)]
+    [InlineData("https://example.test/src/a.cs", false)]
+    public async Task Availability_ReusesPositiveEvidenceWithProvenanceLifetime(
+        string url,
+        bool immutable)
+    {
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+
+        SourceAvailabilitySummary initial = await SourceAvailabilityService.InspectAsync(
+            [Document("/src/A.cs", url: url)],
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+        SourceAvailabilitySummary repeated = await SourceAvailabilityService.InspectAsync(
+            [Document("/src/A.cs", url: url)],
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(initial.AllSourcesAccessible);
+        Assert.True(repeated.AllSourcesAccessible);
+        Assert.Equal(1, requests);
+        Assert.Equal(2, cache.Lookups.Count);
+        Assert.All(
+            cache.Lookups,
+            lookup =>
+            {
+                Assert.Equal("source-audit-v2", lookup.Category);
+                Assert.Equal(url, lookup.Key);
+                Assert.Equal("ok", lookup.Extension);
+                Assert.Equal(immutable ? null : TimeSpan.FromDays(1), lookup.MaxAge);
+            });
+        Assert.Equal(
+            new CacheWrite("source-audit-v2", url, "1", "ok"),
+            Assert.Single(cache.Writes));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Gone)]
+    public async Task Availability_NonSuccessRemainsOperationLocal(HttpStatusCode statusCode)
+    {
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(statusCode);
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+        cache.Seed(
+            "source-audit-v2",
+            "https://example.test/src/a.cs",
+            "1",
+            "miss");
+        SourceDocumentObservation[] documents =
+            [Document("/src/A.cs", url: "https://example.test/src/a.cs")];
+
+        SourceAvailabilitySummary initial = await SourceAvailabilityService.InspectAsync(
+            documents,
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+        SourceAvailabilitySummary repeated = await SourceAvailabilityService.InspectAsync(
+            documents,
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(initial.AllSourcesAccessible);
+        Assert.False(repeated.AllSourcesAccessible);
+        Assert.Equal(2, requests);
+        Assert.All(cache.Lookups, lookup => Assert.Equal("ok", lookup.Extension));
+        Assert.Empty(cache.Writes);
+    }
+
+    [Fact]
+    public async Task Availability_LocalClassificationsNeedNoCacheOrNetwork()
+    {
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+        SourceDocumentObservation[] documents =
+        [
+            Document("/src/Embedded.cs", SourceDocumentStorage.Embedded),
+            Document("/src/Unresolved.cs"),
+            Document("/src/Unsupported.cs", url: "ftp://example.test/unsupported.cs"),
+            Document(
+                "/repo/artifacts/obj/Generated.g.cs",
+                url: "https://example.test/generated.cs"),
+        ];
+
+        SourceAvailabilitySummary result = await SourceAvailabilityService.InspectAsync(
+            documents,
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.EmbeddedSourceFiles);
+        Assert.Equal(3, result.MissingSourceFiles.Length);
+        Assert.Equal(0, requests);
+        Assert.Empty(cache.Lookups);
+        Assert.Empty(cache.Writes);
     }
 
     [Fact]
@@ -252,6 +384,49 @@ public class SourceLinkQueryServiceTests
             => Task.FromException<HttpResponseMessage>(
                 new InvalidOperationException(message));
     }
+
+    private sealed class RecordingSourceLinkQueryCache : ISourceLinkQueryCache
+    {
+        private readonly Dictionary<(string Category, string Key, string Extension), string>
+            _entries = [];
+
+        public List<CacheLookup> Lookups { get; } = [];
+
+        public List<CacheWrite> Writes { get; } = [];
+
+        public void Seed(string category, string key, string content, string extension)
+            => _entries[(category, key, extension)] = content;
+
+        public string? TryGet(
+            string category,
+            string key,
+            TimeSpan? maxAge,
+            string extension)
+        {
+            Lookups.Add(new CacheLookup(category, key, maxAge, extension));
+            return _entries.TryGetValue((category, key, extension), out string? value)
+                ? value
+                : null;
+        }
+
+        public void Set(string category, string key, string content, string extension)
+        {
+            Writes.Add(new CacheWrite(category, key, content, extension));
+            _entries[(category, key, extension)] = content;
+        }
+    }
+
+    private sealed record CacheLookup(
+        string Category,
+        string Key,
+        TimeSpan? MaxAge,
+        string Extension);
+
+    private sealed record CacheWrite(
+        string Category,
+        string Key,
+        string Content,
+        string Extension);
 
     private sealed class TrackingContent(byte[] content) : HttpContent
     {


### PR DESCRIPTION
Build robust, capable SourceLink auditing by giving
`SourceAvailabilityService` one focused normative contract and correcting a
negative-cache path that lacked the final-origin evidence required by that
contract.

Closes #6525.

## Demo

The focused service gate exercises an immutable positive, a mutable positive,
three non-success statuses, a seeded legacy `miss`, an origin-changing
redirect, local-only classifications, an empty census, duplicate URLs, and
cancellation immediately before a successful HEAD returns:

```console
$ dotnet run --project tests/DotnetInspector.Services.Tests -c Release -- \
    --filter-class DotnetInspector.Services.Tests.SourceLinkQueryServiceTests

Test run summary: Passed!
  total: 15
  failed: 0
  succeeded: 15
  skipped: 0
```

What to notice:

- The test begins with a legacy `source-audit-v2` negative entry that says the
  source was previously missing. Both subsequent audits still make a HEAD
  request. This proves that an old negative observation can no longer cause a
  new audit to report the source missing without checking it again.
- A successful HEAD response is different: after its final URL passes the
  SourceLink origin check, the first audit records positive availability and
  the second audit reuses that result without another request. A commit-pinned
  URL names immutable content, so its positive result does not expire. Other
  URLs may change, so their positive result can be reused for at most one day.

## Summary

- Add `docs/design/source-availability-audit.md` as the single owner for the
  census denominator, classifications, final-origin admission, positive reuse,
  failures, concurrency, pathological cases, and non-claims.
- Preserve `source-audit-v2` positive entries, keyed by exact resolved URL with
  provenance-based lifetime.
- Stop reading and writing negative entries. `HttpRetryResult` disposes
  non-success responses without carrying their final URL, so even a 404 cannot
  mint reusable evidence under the existing final-origin rule.
- Update the broad cache inventory to defer to the focused owner and remove its
  stale one-day-miss guidance.
- Observe cancellation after HEAD completion and before classification or
  publication, preventing a canceled audit from leaving reusable evidence.
- Keep CLI result shapes and operation-local classification unchanged; a
  non-success may now issue a fresh HEAD in a later audit instead of reusing a
  one-day miss.
- Leave `SourceIntegrityService`, `HttpRetryHelper`, PackageHouse, and PR #6511
  untouched.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.Services.Tests -c Release`
  (1,325 passed)
- focused `SourceLinkQueryServiceTests` (15 passed)
- `npx markdownlint-cli docs/design/source-availability-audit.md docs/sourcelink-exposure.md docs/README.md`
- `git diff --check`
