### PR TITLE
Render nested generic enum call arguments

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/ClassicInverse/ClassicInverseExpressionRules.cs
+++ b/src/ILInspector.Decompiler/Pipeline/ClassicInverse/ClassicInverseExpressionRules.cs
@@ -6,7 +6,7 @@ internal static partial class ClassicInverseExpressionRules
     internal static bool IsKnownValueType(TypeRef type, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
         => type.DeclaredValueTypeHint == ValueTypeHint.ValueType
             || TypeFamilies.Of(type) is StackFamily.I4 or StackFamily.I8 or StackFamily.I or StackFamily.F
-            || shapes.GetValueOrDefault(type) is TypeShape.ValueType or TypeShape.Enum
+            || shapes.GetValueOrDefault(CoercionRendering.NamedDefinition(type)) is TypeShape.ValueType or TypeShape.Enum
             || TypeFamilies.IsNullableType(type);
 
     internal static bool IsTypeOf(Call call, TypeOf expression)

--- a/src/ILInspector.Decompiler/Pipeline/ClassicInverse/ClassicInverseSinkRules.cs
+++ b/src/ILInspector.Decompiler/Pipeline/ClassicInverse/ClassicInverseSinkRules.cs
@@ -61,10 +61,11 @@ internal static partial class ClassicInverseExpressionRules
         IrFunction? planningFunction = FunctionOf(planning, budget);
         if (rawFunction is null || planningFunction is null
             || !CoercionRendering.CanSpellIntegerToEnum(raw.ResultType, target, rawFunction.TypeShapes)
-            || planningFunction.TypeShapes.GetValueOrDefault(target) != TypeShape.Enum)
+            || !CoercionRendering.IsEnum(target, planningFunction.TypeShapes))
             return false;
-        rawFunction.EnumUnderlyingTypes.TryGetValue(target, out TypeRef? underlying);
-        planningFunction.EnumUnderlyingTypes.TryGetValue(target, out TypeRef? otherUnderlying);
+        var definition = CoercionRendering.NamedDefinition(target);
+        rawFunction.EnumUnderlyingTypes.TryGetValue(definition, out TypeRef? underlying);
+        planningFunction.EnumUnderlyingTypes.TryGetValue(definition, out TypeRef? otherUnderlying);
         if (underlying is not null && otherUnderlying is not null && !underlying.Equals(otherUnderlying))
             return false;
         underlying ??= otherUnderlying;

--- a/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
@@ -32,7 +32,7 @@ public static class CoercionRendering
         return valueFamily is not null && targetFamily is not null
             && (valueFamily == targetFamily
                 || (valueFamily == StackFamily.I4 && targetFamily == StackFamily.I8
-                    && enumUnderlyingTypes.ContainsKey(valueType)));
+                    && enumUnderlyingTypes.ContainsKey(NamedDefinition(valueType))));
     }
 
     /// <summary>
@@ -57,10 +57,16 @@ public static class CoercionRendering
         TypeRef? valueType,
         TypeRef target,
         IReadOnlyDictionary<TypeRef, TypeShape> shapes)
-        => shapes.GetValueOrDefault(target) == TypeShape.Enum
+        => IsEnum(target, shapes)
             && valueType is not null
             && !target.Equals(valueType)
             && TypeFamilies.IsIntegerLike(valueType);
+
+    internal static bool IsEnum(
+        TypeRef? type,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => type is not null
+            && shapes.GetValueOrDefault(NamedDefinition(type)) == TypeShape.Enum;
 
     public static bool CanSpellEnumToInteger(
         TypeRef? valueType,
@@ -122,8 +128,12 @@ public static class CoercionRendering
     {
         if (type is null || TypeFamilies.Of(type) is not null)
             return null;
-        if (enumUnderlyingTypes.GetValueOrDefault(type) is { } underlying)
+        var definition = NamedDefinition(type);
+        if (enumUnderlyingTypes.GetValueOrDefault(definition) is { } underlying)
             return TypeFamilies.Of(underlying);
-        return shapes.GetValueOrDefault(type) == TypeShape.Enum ? StackFamily.I4 : null;
+        return IsEnum(definition, shapes) ? StackFamily.I4 : null;
     }
+
+    static TypeRef NamedDefinition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType! : type;
 }

--- a/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
@@ -134,6 +134,6 @@ public static class CoercionRendering
         return IsEnum(definition, shapes) ? StackFamily.I4 : null;
     }
 
-    static TypeRef NamedDefinition(TypeRef type)
+    internal static TypeRef NamedDefinition(TypeRef type)
         => type.Kind == TypeRefKind.GenericInstance ? type.ElementType! : type;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -305,8 +305,10 @@ public sealed partial class CSharpPrinter
     /// </summary>
     bool IsEnumLikeInteger(TypeRef? type)
         => type is { Kind: TypeRefKind.Definition }
-            && TypeFamilies.Of(type) is null
-            && _function.TypeShapes.GetValueOrDefault(type) is not (TypeShape.Reference or TypeShape.ValueType);
+                && TypeFamilies.Of(type) is null
+                && _function.TypeShapes.GetValueOrDefault(type) is not (TypeShape.Reference or TypeShape.ValueType)
+            || type is { Kind: TypeRefKind.GenericInstance }
+                && CoercionRendering.IsEnum(type, _function.TypeShapes);
 
     /// <summary>
     /// Wraps a synthesized same-width integer reinterpret cast — <c>(uint)x</c>,
@@ -839,7 +841,7 @@ public sealed partial class CSharpPrinter
         // A cross-assembly enum: the width is genuinely unknown and framework enums
         // are often byte/sbyte-backed [Flags], so conservatively assume the narrowest
         // (sbyte) backing and wrap a negative or a value above sbyte's max.
-        if (_function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Unknown)
+        if (_function.TypeShapes.GetValueOrDefault(NamedDefinition(enumType)) == TypeShape.Unknown)
             return literal < 0 || literal > sbyte.MaxValue;
         // A same-assembly enum shape whose underlying is not in the map (e.g. no
         // `value__` field): assume C#'s default `int` backing, so an int-range value
@@ -1475,7 +1477,7 @@ public sealed partial class CSharpPrinter
 
     bool NeedsIntShiftCast(TypeRef? type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "UInt32" }
-            || (type is not null && _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum);
+            || (type is not null && _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) == TypeShape.Enum);
 
     static int? ShiftWidthMask(TypeRef? leftOperand) => TypeFamilies.Of(leftOperand) switch
     {
@@ -2942,7 +2944,7 @@ public sealed partial class CSharpPrinter
     }
 
     TypeRef? EnumUnderlyingType(TypeRef? type)
-        => type is not null && _function.EnumUnderlyingTypes.TryGetValue(type, out var underlying)
+        => type is not null && _function.EnumUnderlyingTypes.TryGetValue(NamedDefinition(type), out var underlying)
             ? underlying
             : null;
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -6373,7 +6373,8 @@ public sealed partial class CSharpPrinter
     bool IsValueTypeTarget(TypeRef type)
         => TypeFamilies.IsNumericPrimitive(type)
             || type is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
-            || _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) is TypeShape.ValueType or TypeShape.Enum;
+            || !TypeFamilies.IsNullableType(type)
+                && _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) is TypeShape.ValueType or TypeShape.Enum;
 
     /// <summary>The operator form of an op_* call, or null when the name has no spelling (op_True/op_False and friends stay as calls).</summary>
     string? OperatorSpelling(Call call)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1338,7 +1338,7 @@ public sealed partial class CSharpPrinter
         => type.Kind is not (TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.FunctionPointer)
             && (TypeFamilies.Of(type) == StackFamily.O
                 || type.DeclaredValueTypeHint == ValueTypeHint.ReferenceType
-                || _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference);
+                || _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) == TypeShape.Reference);
 
     bool CanAssignType(TypeRef source, TypeRef target)
     {
@@ -1359,11 +1359,11 @@ public sealed partial class CSharpPrinter
             return true;
         if (type.DeclaredValueTypeHint == ValueTypeHint.ReferenceType)
             return true;
-        if (_function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference)
+        if (_function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) == TypeShape.Reference)
             return true;
         return type.Kind is TypeRefKind.Definition or TypeRefKind.GenericInstance
             && type.DeclaredValueTypeHint != ValueTypeHint.ValueType
-            && _function.TypeShapes.GetValueOrDefault(type) is not (TypeShape.ValueType or TypeShape.Enum)
+            && _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) is not (TypeShape.ValueType or TypeShape.Enum)
             && !TypeFamilies.IsNumericPrimitive(type);
     }
 
@@ -1375,7 +1375,7 @@ public sealed partial class CSharpPrinter
             return true;
         if (type.DeclaredValueTypeHint == ValueTypeHint.ReferenceType)
             return true;
-        if (_function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference)
+        if (_function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) == TypeShape.Reference)
             return true;
         return type.Kind is TypeRefKind.SzArray or TypeRefKind.Array;
     }
@@ -4941,10 +4941,10 @@ public sealed partial class CSharpPrinter
                 return null;   // a float is never a branch operand
         }
 
-        // No primitive family. A generic instance is provably a reference; a
-        // bare definition resolves by its same-assembly shape.
+        // A nested enum inside a generic owner is represented as a generic
+        // instance even though its definition-keyed shape is an enum.
         if (type.Kind == TypeRefKind.GenericInstance)
-            return reference;
+            return CoercionRendering.IsEnum(type, _function.TypeShapes) ? integer : reference;
 
         switch (type.DeclaredValueTypeHint)
         {
@@ -4954,7 +4954,7 @@ public sealed partial class CSharpPrinter
                 return integer;
         }
 
-        return _function.TypeShapes.GetValueOrDefault(type) switch
+        return _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) switch
         {
             TypeShape.Reference => reference,
             TypeShape.Enum => integer,
@@ -5045,7 +5045,7 @@ public sealed partial class CSharpPrinter
         return TypeFamilies.Of(source) == StackFamily.O
             || source.Kind is TypeRefKind.SzArray or TypeRefKind.Array
             || source.DeclaredValueTypeHint == ValueTypeHint.ReferenceType
-            || _function.TypeShapes.GetValueOrDefault(source) == TypeShape.Reference;
+            || _function.TypeShapes.GetValueOrDefault(NamedDefinition(source)) == TypeShape.Reference;
     }
 
     /// <summary>
@@ -5272,10 +5272,10 @@ public sealed partial class CSharpPrinter
     {
         TypeRefKind.Definition =>
             !IsNullableDefinition(type)
-            && _function.TypeShapes.GetValueOrDefault(type) != TypeShape.Reference,
+            && _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) != TypeShape.Reference,
         TypeRefKind.GenericInstance =>
             !TypeFamilies.IsNullableType(type)
-            && _function.TypeShapes.GetValueOrDefault(type) != TypeShape.Reference,
+            && _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) != TypeShape.Reference,
         _ => false,
     };
 
@@ -6373,7 +6373,7 @@ public sealed partial class CSharpPrinter
     bool IsValueTypeTarget(TypeRef type)
         => TypeFamilies.IsNumericPrimitive(type)
             || type is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
-            || _function.TypeShapes.GetValueOrDefault(type) is TypeShape.ValueType or TypeShape.Enum;
+            || _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) is TypeShape.ValueType or TypeShape.Enum;
 
     /// <summary>The operator form of an op_* call, or null when the name has no spelling (op_True/op_False and friends stay as calls).</summary>
     string? OperatorSpelling(Call call)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -4476,7 +4476,8 @@ public sealed partial class CSharpPrinter
         // narrow-backed enum's out-of-range/negative value in `unchecked`, e.g.
         // `unchecked((U)(-1))`); naming flag combinations is a later slice. A
         // long-backed enum keeps its `long` payload.
-        Constant { Value: int or long, Type: { } enumType } c when _function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Enum
+        Constant { Value: int or long, Type: { } enumType } c
+            when CoercionRendering.IsEnum(enumType, _function.TypeShapes)
             => WithNodeKind(c, EnumConstantText(c, enumType), "ConversionExpression"),
         Constant { Value: float value } c when !float.IsFinite(value)
             => WithNodeKind(c, SingleText(value), "MemberAccessExpression"),
@@ -6941,7 +6942,7 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string? EnumMemberName(Constant constant)
         => constant.Value is int or long
-            && _function.EnumMembers.TryGetValue(constant.Type, out var members)
+            && _function.EnumMembers.TryGetValue(NamedDefinition(constant.Type), out var members)
             && members.TryGetValue(constant.Value is int i ? i : (long)constant.Value!, out var name)
             ? $"{TypeQualifierText(constant.Type)}.{name}"
             : null;
@@ -6965,7 +6966,7 @@ public sealed partial class CSharpPrinter
         if (_options.EnumCaseLabelOrder != EnumCaseLabelOrder.Alphabetical
             || enumType is null
             || section.Labels.Length < 2
-            || !_function.EnumMembers.TryGetValue(enumType, out var members))
+            || !_function.EnumMembers.TryGetValue(NamedDefinition(enumType), out var members))
         {
             return section.Labels;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -56,7 +56,7 @@ internal static class SwitchTypeFacts
         };
         if (type is null)
             return null;
-        if (function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum)
+        if (CoercionRendering.IsEnum(type, function.TypeShapes))
             return type;
         return type is { Kind: TypeRefKind.Definition, Name: not ("Boolean" or "String") }
             && function.TypeShapes.GetValueOrDefault(type) == TypeShape.Unknown

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -152,19 +152,19 @@ public static class TypeFamilies
     {
         var leftFamily = Of(left);
         var rightFamily = Of(right);
-        // A binary op mixing a resolved primitive with an unresolved Definition
+        // A binary op mixing a resolved primitive with an unresolved named type
         // is the flags-enum idiom: the enum's underlying integer drives the IL
         // `or`/`and`/`add`, but the C# result type is the enum, on whichever side
-        // it sits. `flags | 0x20` and `0x20 | flags` are both `flags`-typed. Only
-        // an enum reaches a Binary opcode as a Definition operand — a struct or
-        // decimal `|`/`+` lowers to an operator-overload call, not this node — so
-        // preferring the Definition keeps a flags-enum OR/AND accumulation
-        // enum-typed instead of collapsing to the underlying integer, which would
-        // then need a cast on every arm and break at the next bare-integer arm
-        // (CS0019, #2990). Symmetric to the both-null fallthrough below.
-        if (left is { Kind: TypeRefKind.Definition } && leftFamily is null && rightFamily is not null)
+        // it sits. Nested enums inside generic owners are GenericInstance values;
+        // ordinary structs and generic classes reach operators as calls, not
+        // Binary nodes. Prefer the named operand so the chain stays enum-typed.
+        if (left is { Kind: TypeRefKind.Definition or TypeRefKind.GenericInstance }
+            && leftFamily is null
+            && rightFamily is not null)
             return left;
-        if (right is { Kind: TypeRefKind.Definition } && rightFamily is null && leftFamily is not null)
+        if (right is { Kind: TypeRefKind.Definition or TypeRefKind.GenericInstance }
+            && rightFamily is null
+            && leftFamily is not null)
             return right;
         if (leftFamily is not { } lf || rightFamily is not { } rf)
             return left;
@@ -209,7 +209,8 @@ public static class TypeFamilies
             return true;
         if (type.DeclaredValueTypeHint == ValueTypeHint.ValueType)
             return true;
-        if (shapes is not null && shapes.TryGetValue(type, out var shape))
+        var factType = type.Kind == TypeRefKind.GenericInstance ? type.ElementType! : type;
+        if (shapes is not null && shapes.TryGetValue(factType, out var shape))
             return shape is TypeShape.ValueType or TypeShape.Enum;
         return type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
             && type.Name is "DateTime" or "DateOnly" or "TimeOnly" or "TimeSpan" or "Guid" or "Decimal"

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -67,17 +67,19 @@ public static class CoercionSinks
     /// The one semantic target for an array-element store, shared by the
     /// printer's cast decision and this sink model: the stelem opcode carries a
     /// storage width (`stelem.i8` says Int64, not the long-backed enum), so the
-    /// array's element type wins exactly when it is an enum-like definition —
-    /// a named type with no primitive stack family that the shape map does not
-    /// class as a reference or non-enum struct. TypedConstantsPass's ungated
-    /// preference is a different question (identity recovery for bool/char,
-    /// where the storage width is never the semantic type).
+    /// array's element type wins exactly when it is a metadata-known enum or an
+    /// unresolved enum-like definition — a named type with no primitive stack
+    /// family that the shape map does not class as a reference or non-enum
+    /// struct. TypedConstantsPass's ungated preference is a different question
+    /// (identity recovery for bool/char, where the storage width is never the
+    /// semantic type).
     /// </summary>
     public static TypeRef? StoreElementTarget(StoreElement store, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
         => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
-            && element is { Kind: TypeRefKind.Definition }
-            && TypeFamilies.Of(element) is null
-            && shapes.GetValueOrDefault(element) is not (TypeShape.Reference or TypeShape.ValueType)
+            && (CoercionRendering.IsEnum(element, shapes)
+                || (element is { Kind: TypeRefKind.Definition }
+                    && TypeFamilies.Of(element) is null
+                    && shapes.GetValueOrDefault(element) is not (TypeShape.Reference or TypeShape.ValueType)))
             ? element
             : store.ElementType;
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -170,9 +170,9 @@ public static class CoercionSinks
                 : LoadSinkTargetType(load, returnType, shapes);
 
     /// <summary>
-    /// The enum family a slot load contributes when it is an operand of a
-    /// flags-enum bitwise op (<c>and</c>/<c>or</c>/<c>xor</c>) whose sibling
-    /// operand is enum-typed. #3009: a spilled accumulator holding a bare
+    /// The enum family a slot load contributes when its contiguous flags-enum
+    /// bitwise chain (<c>and</c>/<c>or</c>/<c>xor</c>) has an enum-typed sibling.
+    /// #3009: a spilled accumulator holding a bare
     /// integer flag constant (<c>long S_0 = (long)512</c>) is only ever
     /// consumed as the enum in the OR chain, so it should testify — and
     /// materialize as — the enum, not the integer storage width the IL stack
@@ -184,15 +184,26 @@ public static class CoercionSinks
     /// </summary>
     static TypeRef? BitwiseEnumSinkType(LoadStackSlot load, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
     {
-        if (load.Parent is not Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary)
-            return null;
-        var sibling = ReferenceEquals(binary.Left, load) ? binary.Right : binary.Left;
-        if (sibling is Constant || sibling.ResultType is not { } siblingType
-                || shapes.GetValueOrDefault(siblingType) != TypeShape.Enum)
-            return null;
-        if (load.Type is { } loadType && shapes.GetValueOrDefault(loadType) == TypeShape.Enum)
-            return null;
-        return siblingType;
+        IrExpression operand = load;
+        while (operand.Parent is Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary)
+        {
+            IrExpression sibling;
+            if (ReferenceEquals(binary.Left, operand))
+                sibling = binary.Right;
+            else if (ReferenceEquals(binary.Right, operand))
+                sibling = binary.Left;
+            else
+                break;
+
+            if (sibling is not Constant
+                && sibling.ResultType is { } siblingType
+                && CoercionRendering.IsEnum(siblingType, shapes))
+            {
+                return CoercionRendering.IsEnum(load.Type, shapes) ? null : siblingType;
+            }
+            operand = binary;
+        }
+        return null;
     }
 
     /// <summary>
@@ -309,7 +320,7 @@ public static class CoercionSinks
                 // counts their mismatches as residuals rather than hiding them
                 // behind the exclusion (#2145).
                 case Conditional { MergedType: { } merged } conditional:
-                    var armScope = function.TypeShapes.GetValueOrDefault(merged) == TypeShape.Enum
+                    var armScope = CoercionRendering.IsEnum(merged, function.TypeShapes)
                         ? SinkScope.Wrappable
                         : SinkScope.PrinterOwned;
                     yield return new(conditional.WhenTrue, merged, armScope);
@@ -347,7 +358,7 @@ public static class CoercionDomain
         // explicit disjunct (it is deliberately not a numeric primitive).
         => TypeFamilies.IsNumericPrimitive(target)
             || TypeFamilies.IsBoolean(target)
-            || shapes.GetValueOrDefault(target) == TypeShape.Enum;
+            || CoercionRendering.IsEnum(target, shapes);
 
     public static bool IsAtTarget(IrExpression value, TypeRef target)
         => value.ResultType is { } resultType && resultType.Equals(target);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DiamondArmTypes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DiamondArmTypes.cs
@@ -50,6 +50,6 @@ static class DiamondArmTypes
     // excluded because the arm printer only casts toward enum targets.
     static bool IsKnownUnderlyingEnum(TypeRef? type, IrFunction function)
         => type is not null
-            && function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum
-            && function.EnumUnderlyingTypes.ContainsKey(type);
+            && CoercionRendering.IsEnum(type, function.TypeShapes)
+            && function.EnumUnderlyingTypes.ContainsKey(CoercionRendering.NamedDefinition(type));
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -759,7 +759,7 @@ public sealed class IncrementDecrementPass : IIrPass
 
     static bool IsEnumOrPotentialEnum(TypeRef type, IrFunction function)
     {
-        if (function.TypeShapes.TryGetValue(type, out var shape))
+        if (function.TypeShapes.TryGetValue(CoercionRendering.NamedDefinition(type), out var shape))
             return shape == TypeShape.Enum
                 || shape == TypeShape.Unknown && type.DeclaredValueTypeHint == ValueTypeHint.ValueType;
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RvaSpanPass.cs
@@ -178,18 +178,20 @@ public sealed class RvaSpanPass : IIrPass
     /// </summary>
     internal static List<IrExpression>? DecodeElements(IrFunction function, TypeRef element, byte[] data, int? elementCount = null)
     {
-        if (element.Kind != TypeRefKind.Definition)
-            return null;
-
         if (PrimitiveElementWidth(element) is { } primitiveWidth)
             return DecodePrimitiveElements(element, data, primitiveWidth, elementCount);
 
-        if (function.TypeShapes.GetValueOrDefault(element) != TypeShape.Enum || elementCount is not { } count)
+        if (!CoercionRendering.IsEnum(element, function.TypeShapes) || elementCount is not { } count)
             return null;
         var enumWidth = InferredEnumWidth(data.Length, count);
         if (enumWidth is null or > 4)
             return null;
-        return DecodeEnumElements(element, data, enumWidth.Value, count, function.EnumMembers.GetValueOrDefault(element));
+        return DecodeEnumElements(
+            element,
+            data,
+            enumWidth.Value,
+            count,
+            function.EnumMembers.GetValueOrDefault(CoercionRendering.NamedDefinition(element)));
     }
 
     static int? PrimitiveElementWidth(TypeRef element)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -2654,7 +2654,8 @@ public sealed class SwitchRaisingPass : IIrPass
                 Right: Constant { Value: int offset },
             } binary
             || SwitchTypeFacts.EnumType(function, left) is not { } enumType
-            || function.EnumUnderlyingTypes.GetValueOrDefault(enumType) is not { } underlying
+            || function.EnumUnderlyingTypes.GetValueOrDefault(
+                CoercionRendering.NamedDefinition(enumType)) is not { } underlying
             || TypeFamilies.Of(underlying) != StackFamily.I4
             || !SwitchTypeFacts.StorageMatchesBacking(function, left, enumType, underlying))
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -133,7 +133,7 @@ public sealed class TypedConstantsPass : IIrPass
                 // BooleanFoldingPass, whose 0/1-arm reconciliation must not be
                 // preempted here.
                 case Conditional { MergedType: { } merged } conditional
-                    when shapes.GetValueOrDefault(merged) == TypeShape.Enum:
+                    when CoercionRendering.IsEnum(merged, shapes):
                     Retype(conditional.WhenTrue, merged, shapes, stepper);
                     Retype(conditional.WhenFalse, merged, shapes, stepper);
                     break;
@@ -164,7 +164,7 @@ public sealed class TypedConstantsPass : IIrPass
         var type = operand is LoadIndirect { Address.ResultType: { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { } pointee } }
             ? pointee
             : operand.ResultType;
-        return type is { } && shapes.GetValueOrDefault(type) == TypeShape.Enum ? type : null;
+        return CoercionRendering.IsEnum(type, shapes) ? type : null;
     }
 
     static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
@@ -206,7 +206,7 @@ public sealed class TypedConstantsPass : IIrPass
                 IsChecked: false,
                 Target: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" or "UInt64" } convertTarget,
                 Operand: Constant { Value: int payload },
-            } convert when shapes.GetValueOrDefault(target) == TypeShape.Enum:
+            } convert when CoercionRendering.IsEnum(target, shapes):
                 long widened = convertTarget.Name == "UInt64" ? (uint)payload : payload;
                 stepper.StepOver($"fold widening conv into enum {target.Name} constant", convert);
                 var widenedConstant = new Constant(widened, target);
@@ -249,7 +249,7 @@ public sealed class TypedConstantsPass : IIrPass
         // (an int, or an ldc.i8 for a long-backed enum); only the type changes.
         // Idempotent: a constant already carrying the target (an earlier run of
         // this pass) is left alone rather than re-replaced on every run.
-        if (shapes.GetValueOrDefault(target) == TypeShape.Enum && constant.Type?.Equals(target) != true)
+        if (CoercionRendering.CanSpellIntegerToEnum(constant.Type, target, shapes))
         {
             stepper.StepOver($"retype constant to enum {target.Name}", constant);
             var enumConstant = new Constant(constant.Value, target);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
@@ -477,7 +477,8 @@ public sealed class UsingStatementPass : IIrPass
             // reference-type resource here and leave it as the flat try/finally.
             ExpressionStatement { Expression: Call bareDispose }
                 when IsDisposeOf(function, bareDispose, storeResource)
-                    && function.TypeShapes.GetValueOrDefault(storeResource.Type) is not TypeShape.Reference
+                    && function.TypeShapes.GetValueOrDefault(
+                        CoercionRendering.NamedDefinition(storeResource.Type)) is not TypeShape.Reference
                 => bareDispose.Callee,
             _ => null,
         };
@@ -522,7 +523,8 @@ public sealed class UsingStatementPass : IIrPass
             return false;
         }
 
-        return function.TypeShapes.GetValueOrDefault(storeResource.Type) is TypeShape.ValueType or TypeShape.Enum;
+        return function.TypeShapes.GetValueOrDefault(
+            CoercionRendering.NamedDefinition(storeResource.Type)) is TypeShape.ValueType or TypeShape.Enum;
     }
 
 }

--- a/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5529,9 +5529,26 @@ public sealed class CfgGenericNestedEnumSink<T>
         Complete,
     }
 
+    [Flags]
+    enum FlagCaps64 : long
+    {
+        None = 0,
+        Protocol = 512,
+        Interactive = 1024,
+        LoadLocal = 128,
+        Secure = 32768,
+        MultiStatements = 65536,
+        MultiResults = 131072,
+    }
+
     public void Set() => Complete(CompletionPart.Attributes);
 
     public void SetUnnamed() => Complete((CompletionPart)3);
+
+    void SetConditional(bool condition) =>
+        Complete(condition ? CompletionPart.Attributes : GetPart());
+
+    static CompletionPart GetPart() => CompletionPart.None;
 
     void StoreNamed(CompletionPart[] values) => values[0] = CompletionPart.Attributes;
 
@@ -5545,6 +5562,17 @@ public sealed class CfgGenericNestedEnumSink<T>
 
     void CompleteInteger(int value)
     {
+    }
+
+    int Accumulate(FlagCaps64 server, bool interactive)
+    {
+        FlagCaps64 caps = FlagCaps64.Protocol
+            | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
+            | (server & FlagCaps64.LoadLocal)
+            | FlagCaps64.Secure
+            | (server & FlagCaps64.MultiStatements)
+            | FlagCaps64.MultiResults;
+        return (int)caps;
     }
 
     int Switch(CompletionPart part)

--- a/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5533,6 +5533,10 @@ public sealed class CfgGenericNestedEnumSink<T>
 
     public void SetUnnamed() => Complete((CompletionPart)3);
 
+    void StoreNamed(CompletionPart[] values) => values[0] = CompletionPart.Attributes;
+
+    void StoreUnnamed(CompletionPart[] values) => values[0] = (CompletionPart)3;
+
     void Complete(CompletionPart part)
     {
     }

--- a/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5524,10 +5524,12 @@ public sealed class CfgGenericNestedEnumSink<T>
     enum CompletionPart
     {
         None,
-        Complete = 4,
+        Attributes = 4,
+        Decoded,
+        Complete,
     }
 
-    public void Set() => Complete(CompletionPart.Complete);
+    public void Set() => Complete(CompletionPart.Attributes);
 
     public void SetUnnamed() => Complete((CompletionPart)3);
 
@@ -5539,6 +5541,17 @@ public sealed class CfgGenericNestedEnumSink<T>
 
     void CompleteInteger(int value)
     {
+    }
+
+    int Switch(CompletionPart part)
+    {
+        return part switch
+        {
+            CompletionPart.Attributes => 1,
+            CompletionPart.Decoded => 2,
+            CompletionPart.Complete => 3,
+            _ => 0,
+        };
     }
 }
 

--- a/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/tests/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5519,6 +5519,29 @@ public enum CfgULong : ulong { None = 0, All = 18446744073709551615UL }
 public enum CfgFlags : uint { None = 0, Top = 0x80000000u }
 public enum CfgTiny : byte { A = 1, B = 2 }
 
+public sealed class CfgGenericNestedEnumSink<T>
+{
+    enum CompletionPart
+    {
+        None,
+        Complete = 4,
+    }
+
+    public void Set() => Complete(CompletionPart.Complete);
+
+    public void SetUnnamed() => Complete((CompletionPart)3);
+
+    void Complete(CompletionPart part)
+    {
+    }
+
+    public void SetInteger() => CompleteInteger(4);
+
+    void CompleteInteger(int value)
+    {
+    }
+}
+
 public sealed class CfgNullableTarget
 {
     public int Value;

--- a/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -102,6 +102,31 @@ public class TypedConstantsPassTests
     }
 
     [Fact]
+    public void GenericNestedEnumArrayStore_RendersNamedMember()
+    {
+        var function = Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            "StoreNamed");
+        var store = Assert.Single(function.Descendants.OfType<StoreElement>());
+        var elementType = store.Array.ResultType!.ElementType!;
+
+        Assert.Equal(TypeRefKind.GenericInstance, elementType.Kind);
+        Assert.Equal(elementType, CoercionSinks.StoreElementTarget(store, function.TypeShapes));
+        Assert.Contains("values[0] = CompletionPart.Attributes;", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void GenericNestedUnnamedEnumArrayStore_RendersCast()
+    {
+        string output = CSharpPrinter.Print(Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            "StoreUnnamed")).Output!;
+
+        Assert.Contains("values[0] = (CompletionPart)3;", output);
+        Assert.DoesNotContain("values[0] = 3;", output);
+    }
+
+    [Fact]
     public void GenericNestedEnumSwitch_RestoresGoverningValueAndNamesLabels()
     {
         string output = CSharpPrinter.Print(Raised(

--- a/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -77,7 +77,7 @@ public class TypedConstantsPassTests
         Assert.Equal(TypeRefKind.GenericInstance, parameterType.Kind);
         Assert.Equal(TypeShape.Enum, function.TypeShapes.GetValueOrDefault(parameterType.ElementType!));
         Assert.Equal(call.Callee.ParameterTypes[0], constant.Type);
-        Assert.Contains("Complete(CompletionPart.Complete);", CSharpPrinter.Print(function).Output);
+        Assert.Contains("Complete(CompletionPart.Attributes);", CSharpPrinter.Print(function).Output);
     }
 
     [Fact]
@@ -99,6 +99,21 @@ public class TypedConstantsPassTests
 
         Assert.Contains("Complete((CompletionPart)3);", output);
         Assert.DoesNotContain("Complete(3);", output);
+    }
+
+    [Fact]
+    public void GenericNestedEnumSwitch_RestoresGoverningValueAndNamesLabels()
+    {
+        string output = CSharpPrinter.Print(Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            "Switch")).Output!;
+
+        Assert.Contains("part switch", output);
+        Assert.Contains("CompletionPart.Attributes => 1", output);
+        Assert.Contains("CompletionPart.Decoded => 2", output);
+        Assert.Contains("CompletionPart.Complete => 3", output);
+        Assert.DoesNotContain("part - 4", output);
+        Assert.DoesNotContain("4 => 1", output);
     }
 
     // --- Slice 2 (value-typed-emission.md): Convert folding, semantic element

--- a/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -17,6 +17,16 @@ public class TypedConstantsPassTests
         return function!;
     }
 
+    static IrFunction Raised(string typeName, string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
     [Fact]
     public void BoolStoredThroughByRef_RetypesConstantToBool()
     {
@@ -52,6 +62,43 @@ public class TypedConstantsPassTests
         Assert.Contains("return S_256[index] ? 1 : 0;", output);
         Assert.DoesNotContain("visited[index] = 1;", output);
         Assert.DoesNotContain("visited[index] == 0", output);
+    }
+
+    [Fact]
+    public void GenericNestedEnumCallArgument_RendersNamedMember()
+    {
+        var function = Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            nameof(CfgGenericNestedEnumSink<int>.Set));
+
+        var call = Assert.Single(function.Descendants.OfType<Call>());
+        var constant = Assert.IsType<Constant>(Assert.Single(call.Arguments.Skip(1)));
+        var parameterType = call.Callee.ParameterTypes[0];
+        Assert.Equal(TypeRefKind.GenericInstance, parameterType.Kind);
+        Assert.Equal(TypeShape.Enum, function.TypeShapes.GetValueOrDefault(parameterType.ElementType!));
+        Assert.Equal(call.Callee.ParameterTypes[0], constant.Type);
+        Assert.Contains("Complete(CompletionPart.Complete);", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void GenericNestedIntegerCallArgument_RemainsInteger()
+    {
+        string output = CSharpPrinter.Print(Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            nameof(CfgGenericNestedEnumSink<int>.SetInteger))).Output!;
+
+        Assert.Contains("CompleteInteger(4);", output);
+    }
+
+    [Fact]
+    public void GenericNestedUnnamedEnumCallArgument_RendersCast()
+    {
+        string output = CSharpPrinter.Print(Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            nameof(CfgGenericNestedEnumSink<int>.SetUnnamed))).Output!;
+
+        Assert.Contains("Complete((CompletionPart)3);", output);
+        Assert.DoesNotContain("Complete(3);", output);
     }
 
     // --- Slice 2 (value-typed-emission.md): Convert folding, semantic element

--- a/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -127,6 +127,33 @@ public class TypedConstantsPassTests
     }
 
     [Fact]
+    public void GenericNestedEnumConditionalArgument_RetainsEnumIdentity()
+    {
+        string output = CSharpPrinter.Print(Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            "SetConditional")).Output!;
+
+        Assert.Contains("CompletionPart.Attributes", output);
+        Assert.DoesNotContain("? 4", output);
+        Assert.DoesNotContain(": 4", output);
+    }
+
+    [Fact]
+    public void GenericNestedFlagsAccumulator_RetainsEnumTyping()
+    {
+        string output = CSharpPrinter.Print(Raised(
+            typeof(CfgGenericNestedEnumSink<>).FullName!,
+            "Accumulate")).Output!;
+
+        Assert.Contains("FlagCaps64.Protocol", output);
+        Assert.Contains("FlagCaps64.Secure", output);
+        Assert.Contains("FlagCaps64.MultiStatements", output);
+        Assert.Contains("FlagCaps64.MultiResults", output);
+        Assert.DoesNotContain("long S_", output);
+        Assert.DoesNotContain("| (long)", output);
+    }
+
+    [Fact]
     public void GenericNestedEnumSwitch_RestoresGoverningValueAndNamesLabels()
     {
         string output = CSharpPrinter.Print(Raised(


### PR DESCRIPTION
dotnet-inspect builds robust, capable inspection features that are conventionally sound and capable of producing compelling user experiences. This fix restores valid, idiomatic C# when an integer constant flows to an enum nested in a generic type.

- Fixes #3110
- Advances #5876
- Changes nested-generic-enum constants from bare integers to named members or explicit casts
- Card revision: `657f175ccf88344d14f782be57641776955f3ff8`

## Demo

Microsoft.CodeAnalysis.Common 5.0.0, `CustomAttributesBag<T>.SetAttributes`:

```diff
-    NotePartComplete(4);
+    NotePartComplete(CustomAttributeBagCompletionPart.Attributes);
```

The neighboring integer sink remains `CompleteInteger(4)`. An unnamed enum
value renders `Complete((CompletionPart)3)`, not a bare integer. A
compiler-produced offset switch restores `part` as its governing expression
and names all three nested-enum labels. Array stores render
`values[0] = CompletionPart.Attributes` or
`values[0] = (CompletionPart)3`, never an integer coercion. Conditional joins
retain the nested enum member, and a long-backed flags accumulator renders one
enum-typed OR chain rather than invalid enum/`long` combinations.

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the product now resolves definition-keyed enum facts
for constructed nested enum types while retaining the constructed type identity
for C# spelling. The 17,331-method package comparison found no
`valid->invalid` transition.

### Correctness-fix contract

| Obligation | Contract |
| --- | --- |
| False claim | The decompiler emitted `NotePartComplete(4)` for an enum parameter and presented invalid C# (`CS1503`). |
| Root cause | Import correctly materialized enum facts under the named definition, but use-site types carried the nested enum as a generic instance of `CustomAttributesBag<T>`. Direct fact lookups therefore missed in call, printer, switch, array-store, conditional-join, and flags-slot paths. |
| Fix shape | Normalize constructed types to their named definition only when reading shape/member/underlying-type facts. Preserve the constructed target on the retyped constant so identity and C# qualification remain exact. |
| Scope boundary | This does not infer enum identity without metadata, alter ordinary integer sinks, or repair the four unrelated methods that remain invalid in the package semantic lane. |
| Falsifier | A nested-generic enum sink remains a bare integer, an ordinary integer sink is retyped, or the same-population comparison introduces a `valid->invalid` transition. |

### Two-lens review

#### Before -> After: structural raise delta

Structural review status: **Generated — partial; the claimed change appears in
a supported generated row.** Ten unrelated unsupported or ambiguous nodes were
excluded.

# Structural review

Target: `` Microsoft.CodeAnalysis.CustomAttributesBag`1.SetAttributes (0x060017E7) ``

Structural review status: **Partial** - 10 unsupported or ambiguous nodes were excluded. Supported rows do not establish changes represented only by the gaps below.

## Before

```csharp
ImmutableArray<T> immutableArray = default;
ImmutableArray<T> S_256 = ImmutableInterlocked.InterlockedCompareExchange<T>(ref _customAttributes, newCustomAttributes, immutableArray);
immutableArray = default;
bool S_257 = S_256 == immutableArray;
NotePartComplete(4);
//               ^
//               raise: LiteralExpression; changed to CustomAttributeBagCompletionPart.Attributes
return S_257;

```

## After

```csharp
ImmutableArray<T> immutableArray = default;
ImmutableArray<T> S_256 = ImmutableInterlocked.InterlockedCompareExchange<T>(ref _customAttributes, newCustomAttributes, immutableArray);
immutableArray = default;
bool S_257 = S_256 == immutableArray;
NotePartComplete(CustomAttributeBagCompletionPart.Attributes);
//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//               raise: MemberAccessExpression; changed from 4
return S_257;

```

## Structural diff

| Change | Structure | Region | Detail |
| --- | --- | --- | --- |
| Changed | LiteralExpression -> MemberAccessExpression |  | 4 -> CustomAttributeBagCompletionPart.Attributes |

## Correspondence gaps

| Side | Reason | Count | Example nodes |
| --- | --- | ---: | --- |
| Before | Unsupported | 1 | 14 |
| Before | Ambiguous | 4 | 6, 7, 10, 11 |
| After | Unsupported | 1 | 14 |
| After | Ambiguous | 4 | 6, 7, 10, 11 |

#### PDB Source -> After: source convergence

Source convergence status: **Different overall; the repaired statement matches
the PDB source.**

```diff
PDB source  https://raw.githubusercontent.com/dotnet/roslyn/6c4a46a31302167b425d5e0a31ea83c9a9aa1d09/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
Integrity   PDB source document matches portable-PDB SHA256 checksum 9FFE26A4852E01FC1F1A5350E5C080AA8C8E507DF807C707831F9D249582F5CC after CR/LF normalization.

--- PDB comparison
+++ Decompiled comparison
@@ -1,7 +1,9 @@
 public bool SetAttributes(ImmutableArray<T> newCustomAttributes)
 {
-    Debug.Assert(!newCustomAttributes.IsDefault);
-    var setOnOurThread = ImmutableInterlocked.InterlockedCompareExchange(ref _customAttributes, newCustomAttributes, default(ImmutableArray<T>)) == default(ImmutableArray<T>);
+    ImmutableArray<T> immutableArray = default;
+    ImmutableArray<T> S_256 = ImmutableInterlocked.InterlockedCompareExchange<T>(ref _customAttributes, newCustomAttributes, immutableArray);
+    immutableArray = default;
+    bool S_257 = S_256 == immutableArray;
     NotePartComplete(CustomAttributeBagCompletionPart.Attributes);
-    return setOnOurThread;
+    return S_257;
 }
\ No newline at end of file
```

- PDB source: `CustomAttributesBag.cs` at Roslyn commit `6c4a46a31302167b425d5e0a31ea83c9a9aa1d09`
- Integrity: Portable-PDB SHA256 matches after CR/LF normalization
- Source correspondence: Different overall; repaired statement identical
- Compile-back status: Package witness not currently checkable; the
  compiler-produced nested-enum fixture family is 11/11 Full exact

### Benchmark target

Benchmark target: `Microsoft.CodeAnalysis.Common@5.0.0`,
`lib/net9.0/Microsoft.CodeAnalysis.dll`

```bash
dotnet-inspect member 'Microsoft.CodeAnalysis.CustomAttributesBag<T>' \
  'SetAttributes:1' --package Microsoft.CodeAnalysis.Common@5.0.0 --all \
  -S "Decompiled Source"
```

### Before

- Valid: False (`CS1503`, `int` cannot convert to `CustomAttributeBagCompletionPart`)
- Correct: False; the emitted C# does not bind
- Printer exact: Not enrolled
- IL fidelity: Not currently checkable for this package witness
- Taste applied: None
- Commit: `941ddf9997968063f034cc421a67432be729ae8f`

### After

- Valid: True
- Correct: True; the named enum member has the original `ldc.i4.4` value
- Printer exact: Not enrolled
- IL fidelity: Package witness not currently checkable; fixture family 11/11 Full exact
- Taste applied: None
- Commit: `657f175ccf88344d14f782be57641776955f3ff8`

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Main CI pass | Release solution build pass |
| Focused tests | Historical real witness emits bare `4` | 44/44 enum typing, conditional-join, and flags tests pass |
| Compiler-produced positive | Nested-generic enum arguments, switch labels, array stores, conditional joins, and flags slots lose enum facts | Named and unnamed values render as member/cast; offset switch restores its enum governing value and labels; arrays, conditionals, and flags chains retain their constructed enum target |
| Adversarial decline | Integer sink renders `4` | Integer sink still renders `4` |
| Nullable type-test boundary | `Nullable<T>` uses reference-compatible `as` spelling | Still uses `as`; never invalid `is`-to-nullable cast |
| Reduced fixture fidelity | Not applicable | Nested-generic enum fixture family 11/11 Full exact |
| Decompiler fast suite | Main CI pass | Replacement head: 6,569/6,569 |
| Structural review | Exact base document acquired | Partial; claimed `LiteralExpression -> MemberAccessExpression` row supported |
| Real witness | `CustomAttributesBag<T>.SetAttributes` invalid | `CustomAttributeBagCompletionPart.Attributes` |

## Corpus validity

> Did this change introduce any new invalid-`Full` defects?

**Conclusion:** **PASS** — the same 17,331-method Microsoft.CodeAnalysis.Common
5.0.0 population has zero `valid->invalid` transitions.

Run: exact-base Render A/B baseline at `941ddf9997968063f034cc421a67432be729ae8f`,
replayed at `657f175ccf88344d14f782be57641776955f3ff8`.

| Metric | Baseline | Head |
| --- | ---: | ---: |
| Methods evaluated | 17,331 | 17,331 |
| Changed structural renders | - | 31 |
| Valid to invalid (-) | - | 0 |
| Invalid to valid (+) | - | 0 |
| Valid to valid | - | 27 |
| Invalid to invalid, changed | - | 4 |
| Structural correspondence | Base documents acquired | 21 complete, 10 partial, 0 unavailable |

All 31 changes are the intended nested-generic-enum fact recovery:

| Type / method | Semantic | Structural result |
| --- | --- | --- |
| `ImmutableSegmentedDictionary<TKey,TValue>.Enumerator::IEnumerator.get_Current` | valid->valid | `1 -> ReturnType.DictionaryEntry` |
| `ImmutableSegmentedDictionary<TKey,TValue>.ValueBuilder::GetEnumerator` | valid->valid | `0 -> ReturnType.KeyValuePair` |
| `ImmutableSegmentedDictionary<TKey,TValue>.ValueBuilder::IEnumerable<KeyValuePair<TKey,TValue>>.GetEnumerator` | invalid->invalid | `0 -> ReturnType.KeyValuePair` |
| `ImmutableSegmentedDictionary<TKey,TValue>.ValueBuilder::IDictionary.GetEnumerator` | valid->valid | `1 -> ReturnType.DictionaryEntry` |
| `ImmutableSegmentedDictionary<TKey,TValue>.ValueBuilder::IEnumerable.GetEnumerator` | valid->valid | `0 -> ReturnType.KeyValuePair` |
| `ImmutableSegmentedDictionary<TKey,TValue>::GetEnumerator` | valid->valid | `0 -> ReturnType.KeyValuePair` |
| `ImmutableSegmentedDictionary<TKey,TValue>::IEnumerable<KeyValuePair<TKey,TValue>>.GetEnumerator` | invalid->invalid | `0 -> ReturnType.KeyValuePair` |
| `ImmutableSegmentedDictionary<TKey,TValue>::IDictionary.GetEnumerator` | valid->valid | `1 -> ReturnType.DictionaryEntry` |
| `ImmutableSegmentedDictionary<TKey,TValue>::IEnumerable.GetEnumerator` | valid->valid | `0 -> ReturnType.KeyValuePair` |
| `CompoundUseSiteInfo<T>::.ctor` | invalid->invalid | Three literals -> `DiscardLevel` members |
| `CompoundUseSiteInfo<T>::get_AccumulatesDependencies` | valid->valid | `0 -> DiscardLevel.None` |
| `CompoundUseSiteInfo<T>::get_AccumulatesDiagnostics` | valid->valid | `2 -> DiscardLevel.DiagnosticsAndDependencies` |
| `CompoundUseSiteInfo<T>::get_Discarded` | valid->valid | `2 -> DiscardLevel.DiagnosticsAndDependencies` |
| `CompoundUseSiteInfo<T>::get_DiscardedDependencies` | valid->valid | `1 -> DiscardLevel.Dependencies` |
| `CustomAttributesBag<T>::.cctor` | valid->valid | `7 -> CustomAttributeBagCompletionPart.All` |
| `CustomAttributesBag<T>::NotePartComplete` | valid->valid | Required enum-to-int cast |
| `CustomAttributesBag<T>::SetAttributes` | valid->valid | `4 -> CustomAttributeBagCompletionPart.Attributes` |
| `CustomAttributesBag<T>::SetDecodedWellKnownAttributeData` | valid->valid | `2 -> CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData` |
| `CustomAttributesBag<T>::SetEarlyDecodedWellKnownAttributeData` | valid->valid | `1 -> CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData` |
| `CustomAttributesBag<T>::WithEmptyData` | valid->valid | `3 -> (CustomAttributeBagCompletionPart)3` |
| `CustomAttributesBag<T>::get_IsDecodedWellKnownAttributeDataComputed` | valid->valid | `2 -> CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData` |
| `CustomAttributesBag<T>::get_IsEarlyDecodedWellKnownAttributeDataComputed` | valid->valid | `1 -> CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData` |
| `CustomAttributesBag<T>::get_IsSealed` | valid->valid | `7 -> CustomAttributeBagCompletionPart.All` |
| `CustomAttributesBag<T>::get_State` | valid->valid | Required integer-to-enum cast |
| `CustomAttributesBag<T>::set_State` | valid->valid | Required enum-to-int cast |
| `LineDirectiveMap<T>.<>c::<HasAnyHiddenRegions>b__11_0` | invalid->invalid | `6 -> PositionState.Hidden` |
| `LineDirectiveMap<T>.LineMappingEntry::.ctor(int)` | valid->valid | `1 -> PositionState.Unmapped` |
| `LineDirectiveMap<T>.LineMappingEntry::.ctor(int,...)` | valid->valid | `3 -> PositionState.RemappedSpan` |
| `LineDirectiveMap<T>.LineMappingEntry::get_IsHidden` | valid->valid | `6 -> PositionState.Hidden` |
| `LineDirectiveMap<T>::CreateLineMapping` | valid->valid | State literals -> `PositionState` members |
| `LineDirectiveMap<T>::TranslateSpan` | valid->valid | `3 -> PositionState.RemappedSpan` |

The four `invalid->invalid` rows retain unrelated pre-existing diagnostics; the
enum changes neither introduce nor conceal those failures.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project tests/ILInspector.Decompiler.Tests -c Release -- \
  -class ILInspector.Decompiler.Tests.TypedConstantsPassTests \
  -class ILInspector.Decompiler.Tests.CrossAssemblyEnumIntegerTests
CB_TYPE='CfgGenericNestedEnumSink`1' CB_DUMP=1 \
  dotnet run --project tools/DecompilerHarness -c Release --no-build -- \
  --fidelity-check \
  artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll
dotnet run --project tests/ILInspector.Decompiler.Tests -c Release -- \
  --gate no-corpus
```
