### PR TITLE
Route type-mode depends through Workspace Roots

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -108,7 +108,8 @@ reusable owners produce the facts.
 The first production adoption in
 [#6170](https://github.com/richlander/dotnet-inspect/issues/6170) routes the
 existing `find`, member-find, `implements`, `extensions`, and reachable
-extension implementations through one invocation-owned asynchronous
+extension implementations, plus type-mode `depends`, through one
+invocation-owned asynchronous
 `InspectionWorkspace` for a deliberately bounded source shape:
 
 - normalized source intent contains exactly one explicitly versioned package
@@ -121,19 +122,22 @@ extension implementations through one invocation-owned asynchronous
 The host acquires one package Root, commits it with `ReplaceScopeAsync`, retains
 the committed correspondence and generation, and executes the existing typed
 group queries through `ExecutePackageRootQueryAsync`. Type search reuses that
-same committed Root for its direct and fallback census passes. Package results
-project library and source provenance from `PackageRootIdentity` and
-`PackageCompileAsset`; the CLI does not manufacture host filesystem paths for
-package-relative assets.
+same committed Root for its direct and fallback census passes. Type-mode
+`depends` runs one group-scoped dependency query over the committed surface
+population; `--rows` windows only the emitted edges and does not limit
+acquisition. Package results project library and source provenance from
+`PackageRootIdentity` and `PackageCompileAsset`; the CLI does not manufacture
+host filesystem paths for package-relative assets.
 
 Floating, `@latest`, and wildcard package versions; package archives, package
 groups and prefixes; multiple or mixed sources; implicit and `all` target
 frameworks; and limited searches retain the `AssemblySetResolver` and
 `AssemblySetInspectionWorkspace` path. That boundary preserves the CLI's
 existing version-selection and streaming-limit behavior rather than making
-Workspace acquisition redefine either contract. Type-mode `depends` remains
-outside this slice: its group-scoped dependency query and production caller
-land together rather than adding another caller-free query surface.
+Workspace acquisition redefine either contract. Type-mode `depends` preserves
+the same legacy route for those ineligible source shapes, while exact-pinned
+package scans carry participant rejection beside any partial graph or miss so
+the command never presents an incomplete result as certified.
 
 This cutover consumes the package Root's reference-preferred compile surface.
 An explicit empty compile group therefore remains an empty configured Root and

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -1581,6 +1581,11 @@ canaries:
   from an empty dependency set.
   Browser-Wasm composes those two typed results without parsing XML or opening
   an assembly session.
+- `AssemblyContextTypeDependencyQuery` retains the admitted descriptors for one
+  binding-consistent group and invokes the Metadata-owned population scan once
+  over the committed participant order. It returns resource-free subjects,
+  graph facts, and typed per-participant failures; the CLI `depends` host
+  projects package diagnostics without inventing filesystem paths.
 - `ExtensionMethodsQuery` returns one immutable result shared by `Library Info`
   and `Extension Methods`. The CLI adds path-based Finding provenance and
   compatibility projections after query execution.

--- a/docs/metadata-primitives.md
+++ b/docs/metadata-primitives.md
@@ -290,6 +290,16 @@ How a command presents a scan that carries rejections is a separate, CLI-owned
 concern, owned by [Uncertified scan results](design/uncertified-scan-results.md);
 today `depends` is its only adopter.
 
+The retained-descriptor population entry point applies the same staged
+candidate indexing and graph construction to acquisition-issued
+`ResolvedAssemblyReference` values. Candidate outcomes remain ordered and are
+joined by `AssemblyAcquisitionRegistration`; successful outcomes carry no
+reader or stream capability, while rejected outcomes carry
+`CandidateOpenFailure`. A miss is certified only when every selected
+participant completed. If no participant survives, the population result is
+unavailable rather than a type-absence claim. The path entry point preserves
+its compatibility exception behavior while sharing the same scanning core.
+
 **Known limit: decoding is not complete metadata validation.** A generic
 parameter outside its enclosing type's context can decode to a synthesized
 `T0` instead of a rejection. That candidate can still participate and shadow a

--- a/src/DotnetInspect.Cli/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/DotnetInspect.Cli/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -668,7 +668,9 @@ public static class SearchCommandDefinitions
                 SourceOptions = sourceOptions
             };
 
-            var outcome = await DependsCommand.ExecuteTypeDependsAsync(options);
+            var outcome = await DependsCommand.ExecuteTypeDependsAsync(
+                options,
+                ct);
 
             // Type not found — fall back to library mode if the name could be a
             // library. A source option makes the positional argument

--- a/src/DotnetInspect.Cli/Commands/DependsCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/DependsCommand.cs
@@ -42,7 +42,8 @@ public class DependsCommand
         bool Uncertified);
 
     internal static async Task<TypeDependsOutcome> ExecuteTypeDependsAsync(
-        DependsOptions options)
+        DependsOptions options,
+        CancellationToken cancellationToken = default)
     {
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
@@ -60,17 +61,29 @@ public class DependsCommand
             }
 
             var result = await DependencyGraphService.BuildTypeDependencyTreeAsync(
-                context.HttpClient, options, logger);
+                context.HttpClient,
+                options,
+                logger,
+                cancellationToken);
 
             // A rejected participant scopes to itself and leaves the rest of
             // the scan intact, but the resulting graph is uncertified: it may
             // omit edges the rejected assembly would have contributed. Name
             // each rejection before any result or absence claim, so neither a
             // partial graph nor a "not found" is reported as certified.
-            WriteRejectionWarnings(result.Rejections);
-            bool uncertified = result.Rejections.Count > 0;
+            WriteRejectionWarnings(result.Diagnostics);
+            bool uncertified = result.Diagnostics.Count > 0;
+            if (!result.IsAvailable)
+            {
+                if (uncertified)
+                {
+                    CommandError.Write(
+                        "Dependency scan unavailable because every selected assembly was rejected.");
+                }
+                return new TypeDependsOutcome(1, false);
+            }
 
-            if (!result.Found)
+            if (!result.Dependency.Found)
             {
                 // Report the absence as an absence so the caller can still fall
                 // back or diagnose it, and carry the uncertainty alongside.
@@ -78,7 +91,7 @@ public class DependsCommand
             }
 
             DependencyGraphDocument document =
-                DependencyGraphProjection.Type(result);
+                DependencyGraphProjection.Type(result.Dependency);
             IReadOnlyList<DependencyGraphEdgeRow> rows =
                 RowWindow.Apply(
                     options.Rows,
@@ -90,7 +103,7 @@ public class DependsCommand
             else if (options.JsonOutput && !options.Tree)
             {
                 var visibleNodes = TreeRowWindow.Apply(
-                    result.Tree,
+                    result.Dependency.Tree,
                     options.Rows,
                     node => node.Children,
                     (node, children) => node with { Children = children });
@@ -233,20 +246,24 @@ public class DependsCommand
     /// construction, so every renderer of the node inherits it.
     /// </summary>
     private static void WriteRejectionWarnings(
-        IReadOnlyList<TypeDependencyRejection> rejections)
+        IReadOnlyList<TypeDependencyScanDiagnostic> diagnostics)
     {
-        foreach (TypeDependencyRejection rejection in rejections)
+        foreach (TypeDependencyScanDiagnostic diagnostic in diagnostics)
         {
-            string mechanism = rejection.Kind switch
+            string mechanism = diagnostic.Failure.Kind switch
             {
-                TypeDependencyRejectionKind.UnsupportedMetadataFormat =>
+                CandidateOpenFailureKind.UnsupportedMetadataFormat =>
                     "unsupported metadata format (Windows Metadata)",
-                TypeDependencyRejectionKind.MalformedMetadataRoot =>
-                    $"malformed metadata root ({rejection.MetadataRootReason})",
+                CandidateOpenFailureKind.ResourceBudget =>
+                    $"resource budget ({diagnostic.Failure.Detail})",
+                CandidateOpenFailureKind.Unreadable =>
+                    $"unreadable image ({diagnostic.Failure.Detail})",
+                _ when diagnostic.Failure.MetadataRootReason is { } reason =>
+                    $"malformed metadata root ({reason})",
                 _ => "invalid image",
             };
             CommandError.WriteWarning(
-                $"Excluded '{ContainLabel(Path.GetFileName(rejection.AssemblyPath))}' from the dependency scan: {mechanism}.",
+                $"Excluded '{ContainLabel(diagnostic.Subject)}' from the dependency scan: {mechanism}.",
                 "Results may be incomplete.");
         }
     }

--- a/src/DotnetInspect.Cli/Inspectors/DependencyGraphService.cs
+++ b/src/DotnetInspect.Cli/Inspectors/DependencyGraphService.cs
@@ -3,6 +3,7 @@ using DotnetInspector.Core;
 using DotnetInspect.Cli.Options;
 using DotnetInspect.Cli.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Queries;
 using DotnetInspector.Services;
 using DotnetInspect.Cli.Services;
 using ILInspector.Metadata;
@@ -11,6 +12,54 @@ using NuGetFetch;
 using PackageExtractor = DotnetInspector.Packages.PackageExtractor;
 
 namespace DotnetInspect.Cli.Inspectors;
+
+internal sealed record TypeDependencyScanDiagnostic(
+    string Subject,
+    CandidateOpenFailure Failure);
+
+internal sealed record TypeDependencyExecutionResult(
+    TypeDependencyResult Dependency,
+    IReadOnlyList<TypeDependencyScanDiagnostic> Diagnostics,
+    bool IsAvailable)
+{
+    internal static TypeDependencyExecutionResult Unavailable() =>
+        new(
+            new TypeDependencyResult(null, []),
+            [],
+            IsAvailable: false);
+
+    internal static TypeDependencyExecutionResult FromLegacy(
+        TypeDependencyResult dependency) =>
+        new(
+            dependency,
+            dependency.Rejections.Select(
+                static rejection =>
+                    new TypeDependencyScanDiagnostic(
+                        Path.GetFileName(rejection.AssemblyPath),
+                        new CandidateOpenFailure(
+                            rejection.Kind
+                                is TypeDependencyRejectionKind
+                                    .UnsupportedMetadataFormat
+                                ? CandidateOpenFailureKind
+                                    .UnsupportedMetadataFormat
+                                : CandidateOpenFailureKind.InvalidImage,
+                            rejection.Kind switch
+                            {
+                                TypeDependencyRejectionKind
+                                    .UnsupportedMetadataFormat =>
+                                    "unsupported metadata format (Windows Metadata)",
+                                TypeDependencyRejectionKind
+                                    .MalformedMetadataRoot =>
+                                    "malformed metadata root",
+                                _ => "invalid image",
+                            })
+                        {
+                            MetadataRootReason =
+                                rejection.MetadataRootReason,
+                        }))
+                .ToArray(),
+            IsAvailable: true);
+}
 
 /// <summary>
 /// Builds dependency graph data for the depends command.
@@ -21,21 +70,88 @@ internal static class DependencyGraphService
     private static readonly TimeSpan CachedVersionResolutionTimeout =
         TimeSpan.FromSeconds(1);
 
-    public static Task<TypeDependencyResult> BuildTypeDependencyTreeAsync(
+    public static async Task<TypeDependencyExecutionResult>
+        BuildTypeDependencyTreeAsync(
         HttpClient httpClient,
         DependsOptions options,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        CancellationToken cancellationToken = default)
     {
-        return WithAssemblySetAsync(
+        cancellationToken.ThrowIfCancellationRequested();
+        AssemblySetRequest request =
+            options.ToAssemblySetRequest(TempDirPrefix);
+        if (ConfiguredPackageSearchWorkspace.IsEligible(
+                options.SourceSelection,
+                request,
+                options.Tfm))
+        {
+            await using ConfiguredPackageSearchWorkspace? workspace =
+                await ConfiguredPackageSearchWorkspace.OpenAsync(
+                    httpClient,
+                    request,
+                    options.Tfm!,
+                    logger.Log,
+                    cancellationToken).ConfigureAwait(false);
+            if (workspace is null)
+                return TypeDependencyExecutionResult.Unavailable();
+
+            ConfiguredPackageSearchQueryResult<
+                AssemblyContextTypeDependencyResult>? execution =
+                    await workspace.QuerySurfaceAsync(
+                        context =>
+                            AssemblyContextTypeDependencyQuery.Execute(
+                                context.Group,
+                                options.TargetType),
+                        cancellationToken).ConfigureAwait(false);
+            if (execution is null)
+                return TypeDependencyExecutionResult.Unavailable();
+            if (execution.Result is null)
+            {
+                return new TypeDependencyExecutionResult(
+                    new TypeDependencyResult(null, []),
+                    [],
+                    IsAvailable: true);
+            }
+
+            PackageSearchQuerySources sources =
+                execution.Sources
+                ?? throw new InvalidOperationException(
+                    "A package Root dependency result requires source correspondence.");
+            IReadOnlyList<TypeDependencyScanDiagnostic> diagnostics =
+                execution.Result.Participants
+                    .OfType<
+                        AssemblyContextTypeDependencyEntry.Rejected>()
+                    .Select(
+                        rejected =>
+                            new TypeDependencyScanDiagnostic(
+                                sources.SourceFor(
+                                    rejected.Subject)
+                                    .DiagnosticSubject,
+                                rejected.Failure))
+                    .ToArray();
+            return new TypeDependencyExecutionResult(
+                execution.Result.Dependency,
+                diagnostics,
+                execution.Result.HasSurvivingParticipant);
+        }
+
+        return await WithAssemblySetAsync(
             httpClient,
-            options.ToAssemblySetRequest(TempDirPrefix),
+            request,
             logger,
             assemblySet =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 logger.Log($"Scanning {assemblySet.Assemblies.Count} libraries for type {options.TargetType}");
                 var assemblyPaths = assemblySet.Assemblies.Select(a => a.Path).ToList();
-                return TypeDependencyScanner.BuildDependencyTree(options.TargetType, assemblyPaths);
-            });
+                TypeDependencyResult dependency =
+                    TypeDependencyScanner.BuildDependencyTree(
+                        options.TargetType,
+                        assemblyPaths);
+                cancellationToken.ThrowIfCancellationRequested();
+                return TypeDependencyExecutionResult.FromLegacy(
+                    dependency);
+            }).ConfigureAwait(false);
     }
 
     public static async Task<LibraryDependencyGraphResult> BuildLibraryDependencyTreeAsync(

--- a/src/DotnetInspector.Queries/AssemblyContextTypeDependencyQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextTypeDependencyQuery.cs
@@ -1,0 +1,178 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// One resource-free participant outcome from a population type-dependency
+/// query.
+/// </summary>
+public abstract record AssemblyContextTypeDependencyEntry(
+    AssemblyContextSubject Subject)
+{
+    public sealed record Completed(
+        AssemblyContextSubject Subject)
+        : AssemblyContextTypeDependencyEntry(Subject);
+
+    public sealed record Rejected(
+        AssemblyContextSubject Subject,
+        CandidateOpenFailure Failure)
+        : AssemblyContextTypeDependencyEntry(Subject);
+}
+
+/// <summary>
+/// Population-scoped type-dependency graph facts and ordered participant
+/// outcomes.
+/// </summary>
+public sealed record AssemblyContextTypeDependencyResult(
+    TypeDependencyResult Dependency,
+    ImmutableArray<AssemblyContextTypeDependencyEntry> Participants)
+{
+    public bool HasSurvivingParticipant =>
+        Participants.Any(
+            static participant =>
+                participant
+                    is AssemblyContextTypeDependencyEntry.Completed);
+
+    public bool IsComplete =>
+        HasSurvivingParticipant
+        && Participants.All(
+            static participant =>
+                participant
+                    is AssemblyContextTypeDependencyEntry.Completed);
+}
+
+/// <summary>
+/// Scans type dependencies once over the successfully retained participants of
+/// one binding-consistent assembly context group.
+/// </summary>
+public static class AssemblyContextTypeDependencyQuery
+{
+    public static InspectionQuery<AssemblyContextTypeDependencyResult>
+        Definition { get; } =
+        new(
+            "Assembly context type dependencies",
+            InspectionCost.Unbounded);
+
+    public static AssemblyContextTypeDependencyResult Execute(
+        AssemblyContextGroup group,
+        string targetType)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        var retained =
+            ImmutableArray.CreateBuilder<ResolvedAssemblyReference>(
+                group.Participants.Length);
+        var subjects =
+            ImmutableArray.CreateBuilder<AssemblyContextSubject>(
+                group.Participants.Length);
+        var acquisitionFailures =
+            new Dictionary<
+                AssemblyAcquisitionRegistration,
+                CandidateOpenFailure>(
+                    ReferenceEqualityComparer.Instance);
+
+        foreach (AssemblyContextParticipant participant
+            in group.Participants)
+        {
+            var subject =
+                new AssemblyContextSubject(participant.Assembly);
+            subjects.Add(subject);
+
+            AssemblyImageAccessResult<ResolvedAssemblyReference> access =
+                group.RetainAssemblyReference(
+                    participant.Assembly);
+            switch (access)
+            {
+                case AssemblyImageAccessResult<
+                    ResolvedAssemblyReference>.Available available:
+                    retained.Add(available.Value);
+                    break;
+                case AssemblyImageAccessResult<
+                    ResolvedAssemblyReference>.Rejected rejected:
+                    acquisitionFailures.Add(
+                        subject.Registration,
+                        rejected.Failure);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        "Unknown participant image-access result.");
+            }
+        }
+
+        TypeDependencyPopulationResult population =
+            TypeDependencyScanner.BuildDependencyPopulation(
+                targetType,
+                retained.ToImmutable());
+        var metadataOutcomes =
+            new Dictionary<
+                AssemblyAcquisitionRegistration,
+                TypeDependencyCandidateOutcome>(
+                    ReferenceEqualityComparer.Instance);
+        foreach (TypeDependencyCandidateOutcome outcome
+            in population.Candidates)
+        {
+            if (!metadataOutcomes.TryAdd(
+                    outcome.Registration,
+                    outcome))
+            {
+                throw new InspectionQueryException(
+                    "Metadata returned duplicate type-dependency candidate outcomes.");
+            }
+        }
+
+        var candidates =
+            ImmutableArray.CreateBuilder<
+                AssemblyContextTypeDependencyEntry>(
+                    subjects.Count);
+        foreach (AssemblyContextSubject subject in subjects)
+        {
+            if (acquisitionFailures.TryGetValue(
+                    subject.Registration,
+                    out CandidateOpenFailure? acquisitionFailure))
+            {
+                candidates.Add(
+                    new AssemblyContextTypeDependencyEntry.Rejected(
+                        subject,
+                        acquisitionFailure));
+                continue;
+            }
+
+            if (!metadataOutcomes.Remove(
+                    subject.Registration,
+                    out TypeDependencyCandidateOutcome? metadataOutcome))
+            {
+                throw new InspectionQueryException(
+                    "Metadata did not return a type-dependency outcome for a retained participant.");
+            }
+
+            candidates.Add(
+                metadataOutcome switch
+                {
+                    TypeDependencyCandidateOutcome.Completed =>
+                        new AssemblyContextTypeDependencyEntry.Completed(
+                            subject),
+                    TypeDependencyCandidateOutcome.Rejected rejected =>
+                        new AssemblyContextTypeDependencyEntry.Rejected(
+                            subject,
+                            rejected.Failure),
+                    _ => throw new InvalidOperationException(
+                        "Unknown Metadata type-dependency candidate outcome."),
+                });
+        }
+
+        if (metadataOutcomes.Count != 0)
+        {
+            throw new InspectionQueryException(
+                "Metadata returned a type-dependency outcome outside the assembly context group.");
+        }
+
+        ImmutableArray<AssemblyContextTypeDependencyEntry> outcomes =
+            candidates.MoveToImmutable();
+        return new AssemblyContextTypeDependencyResult(
+            population.Dependency,
+            outcomes);
+    }
+}

--- a/src/ILInspector.Metadata/TypeDependencyScanner.cs
+++ b/src/ILInspector.Metadata/TypeDependencyScanner.cs
@@ -105,6 +105,83 @@ public record TypeDependencyResult(string? MatchedType, List<TypeDependencyNode>
 }
 
 /// <summary>
+/// One acquisition-issued candidate's resource-free dependency-scan outcome.
+/// </summary>
+public abstract class TypeDependencyCandidateOutcome
+{
+    private protected TypeDependencyCandidateOutcome(
+        AssemblyAcquisitionRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        Registration = registration;
+    }
+
+    public AssemblyAcquisitionRegistration Registration { get; }
+
+    /// <summary>The candidate contributed its complete staged metadata rows.</summary>
+    public sealed class Completed : TypeDependencyCandidateOutcome
+    {
+        internal Completed(
+            AssemblyAcquisitionRegistration registration)
+            : base(registration)
+        {
+        }
+    }
+
+    /// <summary>The candidate was excluded before any staged rows were published.</summary>
+    public sealed class Rejected : TypeDependencyCandidateOutcome
+    {
+        internal Rejected(
+            AssemblyAcquisitionRegistration registration,
+            CandidateOpenFailure failure)
+            : base(registration)
+        {
+            ArgumentNullException.ThrowIfNull(failure);
+            Failure = failure;
+        }
+
+        public CandidateOpenFailure Failure { get; }
+    }
+}
+
+/// <summary>
+/// Dependency graph facts and ordered candidate outcomes for one retained
+/// descriptor population.
+/// </summary>
+public sealed class TypeDependencyPopulationResult
+{
+    internal TypeDependencyPopulationResult(
+        TypeDependencyResult dependency,
+        ImmutableArray<TypeDependencyCandidateOutcome> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(dependency);
+        Dependency = dependency;
+        Candidates = candidates;
+    }
+
+    public TypeDependencyResult Dependency { get; }
+    public ImmutableArray<TypeDependencyCandidateOutcome> Candidates { get; }
+
+    /// <summary>
+    /// Whether at least one candidate contributed its complete staged rows.
+    /// </summary>
+    public bool HasSurvivingParticipant =>
+        Candidates.Any(
+            static candidate =>
+                candidate is TypeDependencyCandidateOutcome.Completed);
+
+    /// <summary>
+    /// Whether at least one candidate survived and every selected candidate
+    /// completed.
+    /// </summary>
+    public bool IsComplete =>
+        HasSurvivingParticipant
+        && Candidates.All(
+            static candidate =>
+                candidate is TypeDependencyCandidateOutcome.Completed);
+}
+
+/// <summary>
 /// Walks the inheritance and interface implementation graph upward from a type.
 /// This is the inverse of <see cref="TypeHierarchyScanner.FindImplementers"/> —
 /// it shows what a type depends on, not what depends on it.
@@ -120,9 +197,8 @@ public static class TypeDependencyScanner
         string targetType,
         IReadOnlyList<string> assemblyPaths)
     {
-        var typeIndex = new Dictionary<string, (PEReader PeReader, MetadataReader MdReader, TypeDefinition TypeDef)>(
-            StringComparer.Ordinal);
-        var peReaders = new List<PEReader>();
+        var typeIndex = CreateTypeIndex();
+        var images = new List<CandidateImage>();
         var rejections = new List<TypeDependencyRejection>();
         var admittedAny = false;
         ExceptionDispatchInfo? firstInvalidImage = null;
@@ -139,66 +215,20 @@ public static class TypeDependencyScanner
             {
                 try
                 {
-                    var stream = File.OpenRead(path);
-                    PEReader peReader;
-                    try
-                    {
-                        peReader = new PEReader(stream);
-                    }
-                    catch
-                    {
-                        stream.Dispose();
-                        throw;
-                    }
-                    peReaders.Add(peReader);
+                    CandidateImage image =
+                        CandidateImage.Open(() => File.OpenRead(path));
+                    images.Add(image);
 
                     try
                     {
-                        if (!MetadataFormatAdmission.AdmitImage(peReader))
+                        CandidateStage stage =
+                            StageCandidate(
+                                image.PeReader,
+                                descriptor: null);
+                        if (!stage.HasManagedMetadata)
                             continue;
 
-                        MetadataReader mdReader =
-                            MetadataFormatAdmission.GetMetadataReader(peReader);
-
-                        // Stage this participant's rows separately. A rejection
-                        // must exclude the whole participant, so rows decoded
-                        // before a later failure cannot be allowed to reach the
-                        // shared index — they would shadow a healthy same-name
-                        // definition under TryAdd and make the emitted tree
-                        // wrong rather than merely incomplete.
-                        var staged =
-                            new Dictionary<string, (PEReader, MetadataReader, TypeDefinition)>(
-                                StringComparer.Ordinal);
-                        foreach (var typeDefHandle in mdReader.TypeDefinitions)
-                        {
-                            var typeDef = mdReader.GetTypeDefinition(typeDefHandle);
-                            if (!typeDef.IsPublic)
-                                continue;
-
-                            var name = mdReader.GetString(typeDef.Name);
-                            if (TypeFilters.IsCompilerGenerated(name))
-                                continue;
-
-                            var ns = mdReader.GetString(typeDef.Namespace);
-                            var fullName = TypeResolver.GetFullName(ns, name);
-
-                            // Decode the relationship facts the tree will need
-                            // while still inside this participant's rejection
-                            // scope. Names alone are not enough: a malformed
-                            // base-type or interface token throws only when the
-                            // tree is built, which happens after every
-                            // participant has published and is therefore
-                            // unscoped. Reaching them here keeps a relationship
-                            // failure attributable to the participant that
-                            // caused it.
-                            ValidateRelationships(mdReader, typeDef);
-
-                            // Index by ECMA name for lookup
-                            staged.TryAdd(fullName, (peReader, mdReader, typeDef));
-                        }
-
-                        foreach (var entry in staged)
-                            typeIndex.TryAdd(entry.Key, entry.Value);
+                        PublishStage(typeIndex, stage);
 
                         // Only a participant that decoded all the way through
                         // counts as surviving. A partially indexed one cannot
@@ -310,51 +340,331 @@ public static class TypeDependencyScanner
                     invalidImageCauses);
             }
 
-            // Find the target type
-            var normalizedTarget = FqnParser.NormalizeTypeName(targetType);
-            // User lookup stays fuzzy, but exact casing selects the exact CLR
-            // identity when metadata contains case-distinct type names.
-            string? matchKey = typeIndex.ContainsKey(normalizedTarget)
-                ? normalizedTarget
-                : typeIndex.Keys.FirstOrDefault(k =>
-                    TypeMatcher.Matches(k, normalizedTarget));
-            if (matchKey == null)
-                return new TypeDependencyResult(null, []) { Rejections = rejections };
-
-            var match = typeIndex[matchKey];
-            var treeSeen = new HashSet<string>(StringComparer.Ordinal);
-            var relationshipSeen =
-                new HashSet<string>(StringComparer.Ordinal);
-            var activeDefinitions =
-                new HashSet<string>(StringComparer.Ordinal)
-                {
-                    matchKey,
-                };
-            var relationships = new List<TypeDependencyRelationship>();
-            string matchedType = TypeResolver.FormatDisplayName(matchKey);
-            var tree = BuildNode(
-                matchedType,
-                match.MdReader,
-                match.TypeDef,
-                GenericContext.ForType(match.MdReader, match.TypeDef),
-                typeIndex,
-                treeSeen,
-                relationshipSeen,
-                activeDefinitions,
-                relationships,
-                includeTree: true,
-                collectRelationships: true);
-            return new TypeDependencyResult(TypeResolver.FormatDisplayName(matchKey), tree)
+            TypeDependencyResult dependency =
+                BuildGraph(targetType, typeIndex);
+            return dependency with
             {
-                Relationships = relationships,
                 Rejections = rejections,
             };
         }
         finally
         {
-            foreach (var pr in peReaders)
-                pr.Dispose();
+            foreach (CandidateImage image in images)
+                image.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Builds dependency graph facts over acquisition-issued descriptors while
+    /// retaining one ordered, registration-keyed outcome per candidate.
+    /// </summary>
+    public static TypeDependencyPopulationResult BuildDependencyPopulation(
+        string targetType,
+        IReadOnlyList<ResolvedAssemblyReference> assemblies)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        var typeIndex = CreateTypeIndex();
+        var images = new List<CandidateImage>();
+        var outcomes =
+            ImmutableArray.CreateBuilder<TypeDependencyCandidateOutcome>(
+                assemblies.Count);
+        var registrations =
+            new HashSet<AssemblyAcquisitionRegistration>(
+                ReferenceEqualityComparer.Instance);
+
+        try
+        {
+            foreach (ResolvedAssemblyReference assembly in assemblies)
+            {
+                if (assembly is null)
+                {
+                    throw new ArgumentException(
+                        "A dependency-scan candidate cannot be null.",
+                        nameof(assemblies));
+                }
+                if (!registrations.Add(assembly.Registration))
+                {
+                    throw new ArgumentException(
+                        "An acquisition registration may appear only once in a dependency-scan population.",
+                        nameof(assemblies));
+                }
+
+                CandidateImage? image = null;
+                bool outcomeEstablished = false;
+                try
+                {
+                    image = CandidateImage.Open(assembly.OpenRead);
+                    CandidateStage stage =
+                        StageCandidate(image.PeReader, assembly);
+                    if (!stage.HasManagedMetadata)
+                    {
+                        outcomes.Add(
+                            Rejected(
+                                assembly,
+                                CandidateOpenFailureKind.InvalidImage,
+                                "The selected image has no managed metadata."));
+                        outcomeEstablished = true;
+                        continue;
+                    }
+
+                    images.Add(image);
+                    image = null;
+                    PublishStage(typeIndex, stage);
+                    outcomes.Add(
+                        new TypeDependencyCandidateOutcome.Completed(
+                            assembly.Registration));
+                }
+                catch (UnsupportedMetadataFormatException)
+                {
+                    outcomes.Add(
+                        Rejected(
+                            assembly,
+                            CandidateOpenFailureKind
+                                .UnsupportedMetadataFormat,
+                            "The selected image uses an unsupported metadata format."));
+                    outcomeEstablished = true;
+                }
+                catch (MalformedMetadataRootException ex)
+                {
+                    outcomes.Add(
+                        Rejected(
+                            assembly,
+                            CandidateOpenFailureKind.InvalidImage,
+                            $"The selected image has a malformed metadata root ({ex.Reason}).",
+                            ex.Reason));
+                    outcomeEstablished = true;
+                }
+                catch (Exception ex) when (
+                    ex is IOException
+                        or UnauthorizedAccessException
+                        or NotSupportedException
+                        or ObjectDisposedException)
+                {
+                    outcomes.Add(
+                        Rejected(
+                            assembly,
+                            CandidateOpenFailureKind.Unreadable,
+                            "The selected image could not be read."));
+                    outcomeEstablished = true;
+                }
+                catch (Exception ex) when (
+                    ex is BadImageFormatException
+                        or ArgumentOutOfRangeException
+                        or OverflowException)
+                {
+                    outcomes.Add(
+                        Rejected(
+                            assembly,
+                            CandidateOpenFailureKind.InvalidImage,
+                            "The selected image contains invalid metadata."));
+                    outcomeEstablished = true;
+                }
+                catch (Exception ex)
+                {
+                    OwnedResourceCleanup.DisposeAfterFailure(
+                        image,
+                        ex);
+                    image = null;
+                    throw;
+                }
+                finally
+                {
+                    if (outcomeEstablished)
+                    {
+                        OwnedResourceCleanup
+                            .DisposeWithoutReplacingOutcome(
+                                image);
+                    }
+                    else
+                    {
+                        image?.Dispose();
+                    }
+                }
+            }
+
+            ImmutableArray<TypeDependencyCandidateOutcome> candidates =
+                outcomes.MoveToImmutable();
+            TypeDependencyPopulationResult result = new(
+                BuildGraph(targetType, typeIndex),
+                candidates);
+            DisposeAll(images);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            foreach (CandidateImage image in images)
+            {
+                OwnedResourceCleanup.DisposeAfterFailure(
+                    image,
+                    ex);
+            }
+            images.Clear();
+            throw;
+        }
+        finally
+        {
+            foreach (CandidateImage image in images)
+            {
+                OwnedResourceCleanup
+                    .DisposeWithoutReplacingOutcome(image);
+            }
+        }
+    }
+
+    private static Dictionary<string, IndexedType> CreateTypeIndex() =>
+        new(StringComparer.Ordinal);
+
+    private static CandidateStage StageCandidate(
+        PEReader peReader,
+        ResolvedAssemblyReference? descriptor)
+    {
+        if (!MetadataFormatAdmission.AdmitImage(peReader))
+            return CandidateStage.Descriptorless;
+
+        MetadataReader reader =
+            MetadataFormatAdmission.GetMetadataReader(peReader);
+        if (descriptor is not null)
+        {
+            descriptor.ValidateArtifactContent(peReader);
+            if (!reader.IsAssembly)
+            {
+                throw new BadImageFormatException(
+                    "The opened image is a module, not an assembly.");
+            }
+
+            AssemblyReferenceIdentity actual =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    reader);
+            if (!AssemblyImageSnapshot.IdentityMatches(
+                    descriptor.Identity,
+                    actual))
+            {
+                throw new BadImageFormatException(
+                    "The opened image identity does not match the acquisition descriptor.");
+            }
+        }
+
+        // Stage this participant's rows separately. A rejection must exclude
+        // the whole participant, including rows decoded before a later
+        // relationship failure.
+        var staged =
+            new Dictionary<string, IndexedType>(
+                StringComparer.Ordinal);
+        foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+        {
+            TypeDefinition definition =
+                reader.GetTypeDefinition(handle);
+            if (!definition.IsPublic)
+                continue;
+
+            string name = reader.GetString(definition.Name);
+            if (TypeFilters.IsCompilerGenerated(name))
+                continue;
+
+            string ns = reader.GetString(definition.Namespace);
+            string fullName = TypeResolver.GetFullName(ns, name);
+            ValidateRelationships(reader, definition);
+            staged.TryAdd(
+                fullName,
+                new IndexedType(reader, definition));
+        }
+
+        return new CandidateStage(staged);
+    }
+
+    private static void PublishStage(
+        Dictionary<string, IndexedType> typeIndex,
+        CandidateStage stage)
+    {
+        foreach ((string name, IndexedType type) in stage.Types)
+            typeIndex.TryAdd(name, type);
+    }
+
+    private static TypeDependencyResult BuildGraph(
+        string targetType,
+        Dictionary<string, IndexedType> typeIndex)
+    {
+        string normalizedTarget =
+            FqnParser.NormalizeTypeName(targetType);
+        // User lookup stays fuzzy, but exact casing selects the exact CLR
+        // identity when metadata contains case-distinct type names.
+        string? matchKey = typeIndex.ContainsKey(normalizedTarget)
+            ? normalizedTarget
+            : typeIndex.Keys.FirstOrDefault(key =>
+                TypeMatcher.Matches(key, normalizedTarget));
+        if (matchKey is null)
+            return new TypeDependencyResult(null, []);
+
+        IndexedType match = typeIndex[matchKey];
+        var treeSeen = new HashSet<string>(StringComparer.Ordinal);
+        var relationshipSeen =
+            new HashSet<string>(StringComparer.Ordinal);
+        var activeDefinitions =
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                matchKey,
+            };
+        var relationships = new List<TypeDependencyRelationship>();
+        string matchedType = TypeResolver.FormatDisplayName(matchKey);
+        List<TypeDependencyNode> tree = BuildNode(
+            matchedType,
+            match.Reader,
+            match.Definition,
+            GenericContext.ForType(match.Reader, match.Definition),
+            typeIndex,
+            treeSeen,
+            relationshipSeen,
+            activeDefinitions,
+            relationships,
+            includeTree: true,
+            collectRelationships: true);
+        return new TypeDependencyResult(matchedType, tree)
+        {
+            Relationships = relationships,
+        };
+    }
+
+    private static TypeDependencyCandidateOutcome.Rejected Rejected(
+        ResolvedAssemblyReference assembly,
+        CandidateOpenFailureKind kind,
+        string detail,
+        MetadataRootMalformedReason? metadataRootReason = null) =>
+        new(
+            assembly.Registration,
+            new CandidateOpenFailure(kind, detail)
+            {
+                MetadataRootReason = metadataRootReason,
+            });
+
+    private static void DisposeAll(
+        List<CandidateImage> images)
+    {
+        List<Exception>? failures = null;
+        foreach (CandidateImage image in images)
+        {
+            try
+            {
+                image.Dispose();
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+        }
+        images.Clear();
+
+        if (failures is null)
+            return;
+        if (failures.Count == 1)
+        {
+            ExceptionDispatchInfo.Capture(failures[0]).Throw();
+        }
+
+        throw new AggregateException(
+            "One or more dependency-scan images could not be released.",
+            failures);
     }
 
     /// <summary>
@@ -412,7 +722,7 @@ public static class TypeDependencyScanner
         MetadataReader reader,
         TypeDefinition typeDef,
         GenericContext context,
-        Dictionary<string, (PEReader PeReader, MetadataReader MdReader, TypeDefinition TypeDef)> typeIndex,
+        Dictionary<string, IndexedType> typeIndex,
         HashSet<string> treeSeen,
         HashSet<string> relationshipSeen,
         HashSet<string> activeDefinitions,
@@ -520,7 +830,7 @@ public static class TypeDependencyScanner
     /// </summary>
     private static void CollectTransitive(
         string typeName,
-        Dictionary<string, (PEReader PeReader, MetadataReader MdReader, TypeDefinition TypeDef)> typeIndex,
+        Dictionary<string, IndexedType> typeIndex,
         HashSet<string> result,
         HashSet<string> visited)
     {
@@ -532,7 +842,8 @@ public static class TypeDependencyScanner
         if (!typeIndex.TryGetValue(normalized, out var match))
             return;
 
-        var (_, mdReader, typeDef) = match;
+        MetadataReader mdReader = match.Reader;
+        TypeDefinition typeDef = match.Definition;
         GenericContext context =
             ContextForConstructedType(mdReader, typeDef, typeName);
 
@@ -630,7 +941,7 @@ public static class TypeDependencyScanner
 
     private static List<TypeDependencyNode> ResolveChildren(
         string typeName,
-        Dictionary<string, (PEReader PeReader, MetadataReader MdReader, TypeDefinition TypeDef)> typeIndex,
+        Dictionary<string, IndexedType> typeIndex,
         HashSet<string> treeSeen,
         HashSet<string> relationshipSeen,
         HashSet<string> activeDefinitions,
@@ -649,11 +960,11 @@ public static class TypeDependencyScanner
         {
             return BuildNode(
                 typeName,
-                match.MdReader,
-                match.TypeDef,
+                match.Reader,
+                match.Definition,
                 ContextForConstructedType(
-                    match.MdReader,
-                    match.TypeDef,
+                    match.Reader,
+                    match.Definition,
                     typeName),
                 typeIndex,
                 treeSeen,
@@ -694,5 +1005,82 @@ public static class TypeDependencyScanner
     {
         return typeName is "System.Object" or "System.ValueType" or "System.Enum"
             or "System.Delegate" or "System.MulticastDelegate";
+    }
+
+    private sealed record IndexedType(
+        MetadataReader Reader,
+        TypeDefinition Definition);
+
+    private sealed class CandidateStage
+    {
+        private CandidateStage(
+            bool hasManagedMetadata,
+            IReadOnlyDictionary<string, IndexedType> types)
+        {
+            HasManagedMetadata = hasManagedMetadata;
+            Types = types;
+        }
+
+        internal static CandidateStage Descriptorless { get; } =
+            new(
+                hasManagedMetadata: false,
+                new Dictionary<string, IndexedType>());
+
+        internal CandidateStage(
+            IReadOnlyDictionary<string, IndexedType> types)
+            : this(hasManagedMetadata: true, types)
+        {
+        }
+
+        internal bool HasManagedMetadata { get; }
+        internal IReadOnlyDictionary<string, IndexedType> Types { get; }
+    }
+
+    private sealed class CandidateImage : IDisposable
+    {
+        private readonly Stream stream;
+
+        private CandidateImage(
+            Stream stream,
+            PEReader peReader)
+        {
+            this.stream = stream;
+            PeReader = peReader;
+        }
+
+        internal PEReader PeReader { get; }
+
+        internal static CandidateImage Open(
+            Func<Stream> openRead)
+        {
+            Stream? stream = null;
+            try
+            {
+                stream = openRead();
+                if (stream is null || !stream.CanRead)
+                {
+                    throw new IOException(
+                        "The assembly opener did not return a readable stream.");
+                }
+
+                var peReader = new PEReader(
+                    stream,
+                    PEStreamOptions.LeaveOpen);
+                return new CandidateImage(stream, peReader);
+            }
+            catch (Exception ex)
+            {
+                OwnedResourceCleanup.DisposeAfterFailure(
+                    stream,
+                    ex);
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            PeReader.Dispose();
+            stream.Dispose();
+        }
     }
 }

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.SearchWorkspace.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.SearchWorkspace.cs
@@ -127,6 +127,138 @@ public sealed partial class ConfiguredPayloadAcquisitionTests
         }
     }
 
+    [Fact]
+    public async Task Depends_QueryCommittedPackageRoot()
+    {
+        string id = $"Workspace.Depends.{Guid.NewGuid():N}";
+        byte[] assembly = await File.ReadAllBytesAsync(
+            typeof(ConfiguredPayloadAcquisitionTests).Assembly.Location,
+            TestContext.Current.CancellationToken);
+        byte[] package = CreatePackage(
+            id,
+            "selected dependency package",
+            library: assembly,
+            libraryName: "Workspace.Depends.dll");
+        var requests = new ConcurrentQueue<string>();
+        ConfigureCommandFeed(id, package, requests);
+
+        var result = await RunCommandAsync(
+            [
+                "depends",
+                typeof(WorkspaceImplementation).FullName!,
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--json",
+                "--rows", "1",
+                "--verbose",
+                "--tips", "q",
+            ]);
+
+        Assert.Equal(0, result.Exit);
+        Assert.Contains(
+            "Using committed package Root for search:",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            typeof(IWorkspaceImplementationMarker).FullName!,
+            result.Output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            requests,
+            request => request.EndsWith(
+                ".nupkg",
+                StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("README.md", "NoCompileAssets")]
+    [InlineData("ref/net11.0/_._", "EmptyCompileGroup")]
+    public async Task Depends_PackageWithoutSurfaceIsCertifiedMiss(
+        string packageEntry,
+        string expectedStatus)
+    {
+        string id =
+            $"Workspace.Depends.Empty.{Guid.NewGuid():N}";
+        byte[] package;
+        if (expectedStatus == "EmptyCompileGroup")
+        {
+            byte[] fallbackAssembly = await File.ReadAllBytesAsync(
+                typeof(ConfiguredPayloadAcquisitionTests).Assembly.Location,
+                TestContext.Current.CancellationToken);
+            package = SnupkgPdbReaderTests.MakeSnupkg(
+                ($"{id}.nuspec", "<package />"u8.ToArray()),
+                (packageEntry, []),
+                ("lib/net8.0/Fallback.dll", fallbackAssembly));
+        }
+        else
+        {
+            package = SnupkgPdbReaderTests.MakeSnupkg(
+                ($"{id}.nuspec", "<package />"u8.ToArray()),
+                (packageEntry, []));
+        }
+        ConfigureCommandFeed(id, package);
+
+        var result = await RunCommandAsync(
+            [
+                "depends", "No.Such.Type",
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ]);
+
+        Assert.Equal(1, result.Exit);
+        Assert.Contains(
+            "Using committed package Root for search:",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            expectedStatus,
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Type 'No.Such.Type' not found in the specified scope.",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Equal("", result.Output.Trim());
+    }
+
+    [Fact]
+    public async Task Depends_PackageRootPreparationFailureIsVisible()
+    {
+        string id =
+            $"Workspace.Depends.Invalid.{Guid.NewGuid():N}";
+        byte[] package = SnupkgPdbReaderTests.MakeSnupkg(
+            ($"{id}.nuspec", "<package />"u8.ToArray()),
+            ("lib/net11.0/Invalid.dll", [1, 2, 3]));
+        ConfigureCommandFeed(id, package);
+
+        var result = await RunCommandAsync(
+            [
+                "depends", "No.Such.Type",
+                "--package", $"{id}@{Version}",
+                "--tfm", "net11.0",
+                "--source", FirstFeed,
+                "--json",
+                "--verbose",
+                "--tips", "q",
+            ]);
+
+        Assert.Equal(1, result.Exit);
+        Assert.Contains(
+            $"Could not commit package Root '{id}@{Version}'",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Type 'No.Such.Type' not found",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Equal("", result.Output.Trim());
+    }
+
     [Theory]
     [InlineData("README.md", "NoCompileAssets")]
     [InlineData("ref/net11.0/_._", "EmptyCompileGroup")]

--- a/tests/DotnetInspector.Queries.Tests/AssemblyContextTypeDependencyQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/AssemblyContextTypeDependencyQueryTests.cs
@@ -1,0 +1,421 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public interface AssemblyContextTypeDependencyLeaf
+{
+}
+
+public interface AssemblyContextTypeDependencyRoot :
+    AssemblyContextTypeDependencyLeaf
+{
+}
+
+public sealed class AssemblyContextTypeDependencyQueryTests
+{
+    [Fact]
+    public void Execute_FoundAndAllHealthyIsComplete()
+    {
+        var policy = new TestBindingPolicy();
+        TestAssembly source =
+            TestAssembly.Create("healthy", policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [source.Participant]);
+
+        AssemblyContextTypeDependencyResult result =
+            AssemblyContextTypeDependencyQuery.Execute(
+                group,
+                typeof(AssemblyContextTypeDependencyRoot)
+                    .FullName!);
+
+        Assert.True(result.HasSurvivingParticipant);
+        Assert.True(result.IsComplete);
+        Assert.True(result.Dependency.Found);
+        Assert.Contains(
+            result.Dependency.Relationships,
+            static relationship =>
+                relationship.TargetTypeName.EndsWith(
+                    nameof(AssemblyContextTypeDependencyLeaf),
+                    StringComparison.Ordinal));
+        var completed =
+            Assert.IsType<
+                AssemblyContextTypeDependencyEntry.Completed>(
+                    Assert.Single(result.Participants));
+        Assert.Same(
+            source.Participant.Assembly.Registration,
+            completed.Subject.Registration);
+    }
+
+    [Fact]
+    public void Execute_HealthyMissIsCertified()
+    {
+        var policy = new TestBindingPolicy();
+        TestAssembly source =
+            TestAssembly.Create("healthy miss", policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [source.Participant]);
+
+        AssemblyContextTypeDependencyResult result =
+            AssemblyContextTypeDependencyQuery.Execute(
+                group,
+                "No.Such.Type");
+
+        Assert.True(result.HasSurvivingParticipant);
+        Assert.True(result.IsComplete);
+        Assert.False(result.Dependency.Found);
+        Assert.IsType<
+            AssemblyContextTypeDependencyEntry.Completed>(
+                Assert.Single(result.Participants));
+    }
+
+    [Fact]
+    public void Execute_PreservesAcquisitionRejectionBesideSurvivingGraph()
+    {
+        var policy = new TestBindingPolicy();
+        TestAssembly rejected =
+            TestAssembly.Create(
+                "rejected",
+                policy,
+                selectedName: "WrongIdentity");
+        TestAssembly healthy =
+            TestAssembly.Create("healthy", policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    rejected.Participant,
+                    healthy.Participant,
+                ]);
+
+        AssemblyContextTypeDependencyResult result =
+            AssemblyContextTypeDependencyQuery.Execute(
+                group,
+                typeof(AssemblyContextTypeDependencyRoot)
+                    .FullName!);
+
+        Assert.True(result.HasSurvivingParticipant);
+        Assert.True(result.Dependency.Found);
+        Assert.False(result.IsComplete);
+        var rejectedOutcome =
+            Assert.IsType<
+                AssemblyContextTypeDependencyEntry.Rejected>(
+                    result.Participants[0]);
+        Assert.Same(
+            rejected.Participant.Assembly.Registration,
+            rejectedOutcome.Subject.Registration);
+        Assert.Equal(
+            CandidateOpenFailureKind.InvalidImage,
+            rejectedOutcome.Failure.Kind);
+        var completed =
+            Assert.IsType<
+                AssemblyContextTypeDependencyEntry.Completed>(
+                    result.Participants[1]);
+        Assert.Same(
+            healthy.Participant.Assembly.Registration,
+            completed.Subject.Registration);
+    }
+
+    [Fact]
+    public void Execute_MapsMetadataRejectionByRegistration()
+    {
+        var policy = new TestBindingPolicy();
+        Type target =
+            typeof(AssemblyContextTypeDependencyRoot);
+        TestAssembly rejected =
+            TestAssembly.CreateMalformedRelationship(
+                "metadata rejected",
+                policy,
+                target.Namespace!,
+                target.Name);
+        TestAssembly healthy =
+            TestAssembly.Create("healthy", policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    rejected.Participant,
+                    healthy.Participant,
+                ]);
+
+        AssemblyContextTypeDependencyResult result =
+            AssemblyContextTypeDependencyQuery.Execute(
+                group,
+                target.FullName!);
+
+        Assert.True(result.HasSurvivingParticipant);
+        Assert.True(result.Dependency.Found);
+        Assert.False(result.IsComplete);
+        var rejectedOutcome =
+            Assert.IsType<
+                AssemblyContextTypeDependencyEntry.Rejected>(
+                    result.Participants[0]);
+        Assert.Same(
+            rejected.Participant.Assembly.Registration,
+            rejectedOutcome.Subject.Registration);
+        Assert.Equal(
+            CandidateOpenFailureKind.InvalidImage,
+            rejectedOutcome.Failure.Kind);
+        Assert.IsType<
+            AssemblyContextTypeDependencyEntry.Completed>(
+                result.Participants[1]);
+        Assert.Equal(1, rejected.OpenCount);
+        Assert.Equal(1, healthy.OpenCount);
+    }
+
+    [Fact]
+    public void Execute_AllRejectedIsUnavailable()
+    {
+        var policy = new TestBindingPolicy();
+        TestAssembly first =
+            TestAssembly.Create(
+                "first",
+                policy,
+                selectedName: "WrongFirst");
+        TestAssembly second =
+            TestAssembly.Create(
+                "second",
+                policy,
+                selectedName: "WrongSecond");
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    first.Participant,
+                    second.Participant,
+                ]);
+
+        AssemblyContextTypeDependencyResult result =
+            AssemblyContextTypeDependencyQuery.Execute(
+                group,
+                "No.Such.Type");
+
+        Assert.False(result.HasSurvivingParticipant);
+        Assert.False(result.IsComplete);
+        Assert.False(result.Dependency.Found);
+        Assert.Equal(
+            [
+                first.Participant.Assembly.Registration,
+                second.Participant.Assembly.Registration,
+            ],
+            result.Participants.Select(
+                static participant =>
+                    participant.Subject.Registration));
+        Assert.All(
+            result.Participants,
+            static participant =>
+                Assert.IsType<
+                    AssemblyContextTypeDependencyEntry.Rejected>(
+                        participant));
+    }
+
+    [Fact]
+    public void Execute_PreservesParticipantOrderAndReusesSnapshots()
+    {
+        var policy = new TestBindingPolicy();
+        TestAssembly first =
+            TestAssembly.Create("first", policy);
+        TestAssembly second =
+            TestAssembly.Create("second", policy);
+        TestAssembly third =
+            TestAssembly.Create("third", policy);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    first.Participant,
+                    second.Participant,
+                    third.Participant,
+                ]);
+
+        AssemblyContextTypeDependencyResult firstResult =
+            AssemblyContextTypeDependencyQuery.Execute(
+                group,
+                typeof(AssemblyContextTypeDependencyRoot)
+                    .FullName!);
+        AssemblyContextTypeDependencyResult secondResult =
+            AssemblyContextTypeDependencyQuery.Execute(
+                group,
+                typeof(AssemblyContextTypeDependencyRoot)
+                    .FullName!);
+
+        Assert.True(firstResult.IsComplete);
+        Assert.True(secondResult.IsComplete);
+        Assert.Equal(
+            group.Participants.Select(
+                static participant =>
+                    participant.Assembly.Registration),
+            firstResult.Participants.Select(
+                static participant =>
+                    participant.Subject.Registration));
+        Assert.Equal(1, first.OpenCount);
+        Assert.Equal(1, second.OpenCount);
+        Assert.Equal(1, third.OpenCount);
+    }
+
+    sealed class TestAssembly
+    {
+        private int openCount;
+
+        private TestAssembly(
+            byte[] bytes,
+            AssemblyContextParticipant participant)
+        {
+            Bytes = bytes;
+            Participant = participant;
+        }
+
+        internal byte[] Bytes { get; }
+        internal AssemblyContextParticipant Participant { get; }
+        internal int OpenCount => Volatile.Read(ref openCount);
+
+        internal static TestAssembly Create(
+            string label,
+            IAssemblyBindingPolicy policy,
+            string? selectedName = null)
+        {
+            string path =
+                typeof(AssemblyContextTypeDependencyQueryTests)
+                    .Assembly.Location;
+            byte[] bytes = File.ReadAllBytes(path);
+            ResolvedAssemblyReference source =
+                ResolvedAssemblyReference.CreateFromPath(
+                    path,
+                    AssemblyResolutionProvenance.Local(label));
+            return Create(
+                bytes,
+                source.Identity,
+                label,
+                policy,
+                selectedName);
+        }
+
+        internal static TestAssembly CreateMalformedRelationship(
+            string label,
+            IAssemblyBindingPolicy policy,
+            string typeNamespace,
+            string typeName)
+        {
+            byte[] bytes =
+                BuildMalformedRelationshipImage(
+                    typeNamespace,
+                    typeName);
+            using var peReader =
+                new PEReader(
+                    new MemoryStream(bytes, writable: false));
+            AssemblyReferenceIdentity identity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            return Create(
+                bytes,
+                identity,
+                label,
+                policy,
+                selectedName: null);
+        }
+
+        static TestAssembly Create(
+            byte[] bytes,
+            AssemblyReferenceIdentity identity,
+            string label,
+            IAssemblyBindingPolicy policy,
+            string? selectedName)
+        {
+            TestAssembly? testAssembly = null;
+            ResolvedAssemblyReference descriptor =
+                ResolvedAssemblyReference.Create(
+                    identity with
+                    {
+                        Name = selectedName
+                            ?? identity.Name,
+                    },
+                    path: null,
+                    () =>
+                    {
+                        Interlocked.Increment(
+                            ref testAssembly!.openCount);
+                        return new MemoryStream(
+                            testAssembly.Bytes,
+                            writable: false);
+                    },
+                    AssemblyResolutionProvenance.Local(label));
+            var participant =
+                new AssemblyContextParticipant(
+                    descriptor,
+                    policy);
+            testAssembly =
+                new TestAssembly(bytes, participant);
+            return testAssembly;
+        }
+
+        static byte[] BuildMalformedRelationshipImage(
+            string typeNamespace,
+            string typeName)
+        {
+            var metadata = new MetadataBuilder();
+            metadata.AddAssembly(
+                metadata.GetOrAddString(
+                    "MalformedRelationship"),
+                new Version(1, 0, 0, 0),
+                default,
+                default,
+                0,
+                default);
+            metadata.AddModule(
+                0,
+                metadata.GetOrAddString(
+                    "MalformedRelationship.dll"),
+                metadata.GetOrAddGuid(Guid.NewGuid()),
+                default,
+                default);
+            metadata.AddTypeDefinition(
+                TypeAttributes.NotPublic,
+                default,
+                metadata.GetOrAddString("<Module>"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public | TypeAttributes.Class,
+                metadata.GetOrAddString(typeNamespace),
+                metadata.GetOrAddString(typeName),
+                MetadataTokens.TypeReferenceHandle(999),
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+
+            var pe = new ManagedPEBuilder(
+                PEHeaderBuilder.CreateLibraryHeader(),
+                new MetadataRootBuilder(
+                    metadata,
+                    suppressValidation: true),
+                new BlobBuilder(),
+                flags: CorFlags.ILOnly);
+            var image = new BlobBuilder();
+            pe.Serialize(image);
+            return image.ToArray();
+        }
+    }
+
+    sealed class TestBindingPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } =
+            new();
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request) =>
+            new(
+                Version,
+                AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind
+                            .CandidateUnavailable)));
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/TypeDependencyScannerTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeDependencyScannerTests.cs
@@ -361,6 +361,251 @@ public class TypeDependencyScannerTests
         Assert.DoesNotContain(allNames, n => n == "System.Enum");
     }
 
+    [Fact]
+    public void DescriptorPopulation_FoundAndAllHealthyIsComplete()
+    {
+        const string root =
+            "ILInspector.Metadata.TypeDependencyCrossAssemblyFixtures.Root";
+        ResolvedAssemblyReference consumer =
+            Descriptor(
+                FixtureCatalog.MetadataTypeDependencyConsumer
+                    .AssemblyPath());
+        ResolvedAssemblyReference reference =
+            Descriptor(
+                FixtureCatalog.MetadataTypeDependencyReference
+                    .AssemblyPath());
+
+        TypeDependencyPopulationResult result =
+            TypeDependencyScanner.BuildDependencyPopulation(
+                root,
+                [consumer, reference]);
+        TypeDependencyResult pathResult =
+            TypeDependencyScanner.BuildDependencyTree(
+                root,
+                [
+                    FixtureCatalog.MetadataTypeDependencyConsumer
+                        .AssemblyPath(),
+                    FixtureCatalog.MetadataTypeDependencyReference
+                        .AssemblyPath(),
+                ]);
+
+        Assert.True(result.HasSurvivingParticipant);
+        Assert.True(result.IsComplete);
+        Assert.True(result.Dependency.Found);
+        Assert.Equal(pathResult.MatchedType, result.Dependency.MatchedType);
+        Assert.Equal(
+            TreeShape(pathResult.Tree),
+            TreeShape(result.Dependency.Tree));
+        Assert.Equal(
+            pathResult.Relationships,
+            result.Dependency.Relationships);
+        Assert.Equal(
+            [consumer.Registration, reference.Registration],
+            result.Candidates.Select(
+                static candidate => candidate.Registration));
+        Assert.All(
+            result.Candidates,
+            static candidate =>
+                Assert.IsType<
+                    TypeDependencyCandidateOutcome.Completed>(
+                        candidate));
+    }
+
+    [Fact]
+    public void DescriptorPopulation_NotFoundAndAllHealthyIsCertified()
+    {
+        ResolvedAssemblyReference assembly =
+            Descriptor(
+                typeof(TypeDependencyScannerTests)
+                    .Assembly.Location);
+
+        TypeDependencyPopulationResult result =
+            TypeDependencyScanner.BuildDependencyPopulation(
+                "No.Such.Type",
+                [assembly]);
+
+        Assert.True(result.HasSurvivingParticipant);
+        Assert.True(result.IsComplete);
+        Assert.False(result.Dependency.Found);
+        Assert.Empty(result.Dependency.Tree);
+        Assert.Empty(result.Dependency.Relationships);
+    }
+
+    [Fact]
+    public void DescriptorPopulation_RejectionMakesSurvivingGraphIncomplete()
+    {
+        const string root =
+            "ILInspector.Metadata.TypeDependencyCrossAssemblyFixtures.Root";
+        ResolvedAssemblyReference rejected =
+            Descriptor(
+                FixtureCatalog.MetadataTypeDependencyConsumer
+                    .AssemblyPath(),
+                selectedName: "WrongIdentity");
+        ResolvedAssemblyReference healthy =
+            Descriptor(
+                FixtureCatalog.MetadataTypeDependencyConsumer
+                    .AssemblyPath());
+
+        TypeDependencyPopulationResult result =
+            TypeDependencyScanner.BuildDependencyPopulation(
+                root,
+                [rejected, healthy]);
+
+        Assert.True(result.HasSurvivingParticipant);
+        Assert.True(result.Dependency.Found);
+        Assert.False(result.IsComplete);
+        var failure =
+            Assert.IsType<TypeDependencyCandidateOutcome.Rejected>(
+                result.Candidates[0]);
+        Assert.Equal(
+            CandidateOpenFailureKind.InvalidImage,
+            failure.Failure.Kind);
+        Assert.Same(rejected.Registration, failure.Registration);
+        Assert.IsType<TypeDependencyCandidateOutcome.Completed>(
+            result.Candidates[1]);
+        Assert.Same(
+            healthy.Registration,
+            result.Candidates[1].Registration);
+    }
+
+    [Fact]
+    public void DescriptorPopulation_RejectionCleanupCannotAbortHealthyNeighbor()
+    {
+        const string root =
+            "ILInspector.Metadata.TypeDependencyCrossAssemblyFixtures.Root";
+        string path =
+            FixtureCatalog.MetadataTypeDependencyConsumer
+                .AssemblyPath();
+        ResolvedAssemblyReference rejected =
+            Descriptor(
+                path,
+                selectedName: "WrongIdentity",
+                openRead: () =>
+                    new ThrowingDisposeStream(
+                        File.ReadAllBytes(path)));
+        ResolvedAssemblyReference healthy =
+            Descriptor(path);
+
+        TypeDependencyPopulationResult result =
+            TypeDependencyScanner.BuildDependencyPopulation(
+                root,
+                [rejected, healthy]);
+
+        Assert.True(result.Dependency.Found);
+        Assert.False(result.IsComplete);
+        Assert.IsType<TypeDependencyCandidateOutcome.Rejected>(
+            result.Candidates[0]);
+        Assert.IsType<TypeDependencyCandidateOutcome.Completed>(
+            result.Candidates[1]);
+    }
+
+    [Fact]
+    public void DescriptorPopulation_ReleaseAttemptsEveryCompletedImage()
+    {
+        string path =
+            FixtureCatalog.MetadataTypeDependencyConsumer
+                .AssemblyPath();
+        byte[] bytes = File.ReadAllBytes(path);
+        int disposeCount = 0;
+        ResolvedAssemblyReference first =
+            Descriptor(
+                path,
+                openRead: () =>
+                    new ThrowingDisposeStream(
+                        bytes,
+                        () => disposeCount++));
+        ResolvedAssemblyReference second =
+            Descriptor(
+                path,
+                openRead: () =>
+                    new ThrowingDisposeStream(
+                        bytes,
+                        () => disposeCount++));
+
+        AggregateException failure =
+            Assert.Throws<AggregateException>(() =>
+                TypeDependencyScanner.BuildDependencyPopulation(
+                    "No.Such.Type",
+                    [first, second]));
+
+        Assert.Equal(2, failure.InnerExceptions.Count);
+        Assert.Equal(2, disposeCount);
+    }
+
+    [Fact]
+    public void DescriptorPopulation_AllRejectedIsUnavailableInInputOrder()
+    {
+        string path =
+            typeof(TypeDependencyScannerTests).Assembly.Location;
+        ResolvedAssemblyReference first =
+            Descriptor(path, selectedName: "WrongFirst");
+        ResolvedAssemblyReference second =
+            Descriptor(path, selectedName: "WrongSecond");
+
+        TypeDependencyPopulationResult result =
+            TypeDependencyScanner.BuildDependencyPopulation(
+                "No.Such.Type",
+                [first, second]);
+
+        Assert.False(result.HasSurvivingParticipant);
+        Assert.False(result.IsComplete);
+        Assert.False(result.Dependency.Found);
+        Assert.Equal(
+            [first.Registration, second.Registration],
+            result.Candidates.Select(
+                static candidate => candidate.Registration));
+        Assert.All(
+            result.Candidates,
+            static candidate =>
+            {
+                var rejected =
+                    Assert.IsType<
+                        TypeDependencyCandidateOutcome.Rejected>(
+                            candidate);
+                Assert.Equal(
+                    CandidateOpenFailureKind.InvalidImage,
+                    rejected.Failure.Kind);
+            });
+    }
+
+    private static ResolvedAssemblyReference Descriptor(
+        string path,
+        string? selectedName = null,
+        Func<Stream>? openRead = null)
+    {
+        ResolvedAssemblyReference source =
+            ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local(
+                    "type dependency scanner tests"));
+        return ResolvedAssemblyReference.Create(
+            source.Identity with
+            {
+                Name = selectedName ?? source.Identity.Name,
+            },
+            path: null,
+            openRead ?? (() => File.OpenRead(path)),
+            source.Provenance,
+            source.LastWriteTimeUtc);
+    }
+
+    private sealed class ThrowingDisposeStream(
+        byte[] bytes,
+        Action? onDispose = null)
+        : MemoryStream(bytes, writable: false)
+    {
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                onDispose?.Invoke();
+                throw new IOException(
+                    "Synthetic dependency-scan cleanup failure.");
+            }
+        }
+    }
+
     private static void CollectNames(List<TypeDependencyNode> nodes, List<string> result)
     {
         foreach (var node in nodes)
@@ -385,4 +630,20 @@ public class TypeDependencyScannerTests
     private static int CountNodes(IReadOnlyList<TypeDependencyNode> nodes) =>
         nodes.Count
         + nodes.Sum(static node => CountNodes(node.Children));
+
+    private static IEnumerable<string> TreeShape(
+        IReadOnlyList<TypeDependencyNode> nodes,
+        string prefix = "")
+    {
+        foreach (TypeDependencyNode node in nodes)
+        {
+            yield return prefix + node.TypeName;
+            foreach (string child in TreeShape(
+                node.Children,
+                prefix + "  "))
+            {
+                yield return child;
+            }
+        }
+    }
 }


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational capabilities or compelling user experiences while remaining conventionally sound and, where useful, delightfully new.

## Summary

- add a Metadata-owned type-dependency population scan over retained `ResolvedAssemblyReference` descriptors, preserving ordered registration-keyed outcomes and the existing path scanner behavior
- add `AssemblyContextTypeDependencyQuery` over one admitted group, returning resource-free participant outcomes and graph facts
- route exact-pinned single-package type-mode `depends` with an explicit TFM through the committed package Root; retain the existing AssemblySet route for floating, `@latest`, wildcard, archive, mixed, implicit-TFM, and platform requests
- preserve certified miss versus incomplete scan versus unavailable-all-rejected behavior without manufacturing package filesystem paths

## Demo

An exact-pinned package request now reports the committed Root and runs the real dependency command over its reference-preferred compile surface:

```console
$ dotnet-inspect depends Npgsql.NpgsqlConnection --package Npgsql@8.0.5 --tfm net8.0 --rows 1 --verbose
Downloading: npgsql 8.0.5 from nuget.org
Using committed package Root for search: Npgsql@8.0.5 (Selected).
└─ Npgsql.NpgsqlConnection
   └─ System.Data.Common.DbConnection (base-type)
```

The neighboring platform route remains unchanged:

```console
$ dotnet-inspect depends System.Int128 --platform System.Private.CoreLib --rows 1
└─ System.Int128
   └─ System.Numerics.IBinaryInteger<System.Int128>
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- 21 focused `TypeDependencyScannerTests`
- 6 `AssemblyContextTypeDependencyQueryTests`
- 18 committed-Root and existing CLI `depends` tests
- `markdownlint` on all changed Markdown
- `git diff --check origin/main...HEAD`

Closes #6169
Advances #6170 and #6167
