### PR TITLE
Implement the package version-selection resolver

### DIFF
--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -107,6 +107,20 @@ Caller cancellation remains cancellation rather than becoming a receipt.
 Typed non-success keeps the discovery evidence and does not manufacture an
 exact coordinate.
 
+`PackageVersionSelectionResolver` is the owner's total request-to-receipt
+operation. Discovery that omits package identity or names a package other than
+the request is `Rejected` before terminal-state precedence. Compatible
+authoritative evidence produces `Resolved`, `NotFound`, or `NoMatch`.
+Incompatible authoritative evidence is `Rejected`. Partial evidence and
+incomplete listing metadata are `Incomplete`. Failed discovery is `Failed`
+when timeout or transport evidence is present, `Rejected` when input or
+returned evidence is unusable, and otherwise `Unavailable` when the configured
+source or capability cannot answer. Operational failure takes precedence in a
+mixed failed-discovery set after request correspondence is established. The
+current closed request forms are deterministic, so `Ambiguous` remains a
+reserved owner-issued arm rather than an outcome manufactured by this
+resolver.
+
 An authoritative empty selectable list is not automatically `NotFound`.
 `PackageVersionDiscoveryResult.HasAnyCandidate` distinguishes authoritative
 package absence from a package whose observed versions were excluded by
@@ -137,6 +151,8 @@ PackageHouse adoption work under #6426.
 
 - distinct request forms and discovery requirements;
 - semantic latest, prerelease, wildcard, and directed-range selection;
+- total request-to-receipt resolution and deterministic terminal precedence;
+- rejection of missing or mismatched discovery package identity;
 - refresh evidence for `AlwaysLatest`;
 - authoritative absence versus no matching version;
 - rejection of selection from partial discovery;

--- a/src/DotnetInspector.Packages/PackageVersionSelection.cs
+++ b/src/DotnetInspector.Packages/PackageVersionSelection.cs
@@ -407,6 +407,139 @@ public abstract class PackageVersionResolutionReceipt
     }
 }
 
+/// <summary>
+/// Resolves one typed package version-selection request from retained
+/// configured-authority discovery evidence.
+/// </summary>
+public static class PackageVersionSelectionResolver
+{
+    /// <summary>
+    /// Resolves one request from the supplied discovery evidence without
+    /// performing source I/O.
+    /// </summary>
+    public static PackageVersionResolutionReceipt Resolve(
+        PackageVersionSelectionRequest request,
+        PackageVersionDiscoveryResult discovery,
+        PackageVersionDiscoveryFreshness freshness)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(discovery);
+        if (!Enum.IsDefined(freshness))
+            throw new ArgumentOutOfRangeException(nameof(freshness));
+
+        if (PackageVersionSelectionContract
+                .GetPackageIdentityIncompatibility(
+                    request,
+                    discovery) is { } identityIncompatibility)
+        {
+            return new PackageVersionResolutionReceipt.Rejected(
+                request,
+                discovery,
+                freshness,
+                identityIncompatibility);
+        }
+
+        if (discovery.State
+            == PackageVersionDiscoveryState.Authoritative)
+        {
+            if (PackageVersionSelectionContract
+                    .GetDiscoveryIncompatibility(
+                        request,
+                        discovery,
+                        freshness) is { } incompatibility)
+            {
+                return new PackageVersionResolutionReceipt.Rejected(
+                    request,
+                    discovery,
+                    freshness,
+                    incompatibility);
+            }
+
+            if (!discovery.HasAnyCandidate)
+            {
+                return new PackageVersionResolutionReceipt.NotFound(
+                    request,
+                    discovery,
+                    freshness,
+                    Reason(
+                        "No configured authority reported the package."));
+            }
+
+            return PackageVersionSelectionContract.SelectVersion(
+                    request,
+                    discovery) is null
+                ? new PackageVersionResolutionReceipt.NoMatch(
+                    request,
+                    discovery,
+                    freshness,
+                    Reason(
+                        "No listed version satisfies the version-selection request."))
+                : new PackageVersionResolutionReceipt.Resolved(
+                    request,
+                    discovery,
+                    freshness);
+        }
+
+        if (discovery.State == PackageVersionDiscoveryState.Partial)
+        {
+            return new PackageVersionResolutionReceipt.Incomplete(
+                request,
+                discovery,
+                freshness,
+                Reason(
+                    "Required configured-authority discovery is incomplete."));
+        }
+
+        if (discovery.Failures.Any(failure =>
+                failure.Kind is PackageAuthorityFailureKind.Timeout
+                    or PackageAuthorityFailureKind.Transport))
+        {
+            return new PackageVersionResolutionReceipt.Failed(
+                request,
+                discovery,
+                freshness,
+                Reason(
+                    "Version discovery failed before the request could be resolved."));
+        }
+
+        if (discovery.Failures.Any(failure =>
+                failure.Kind
+                    == PackageAuthorityFailureKind.IncompleteMetadata))
+        {
+            return new PackageVersionResolutionReceipt.Incomplete(
+                request,
+                discovery,
+                freshness,
+                Reason(
+                    "Required configured-authority discovery is incomplete."));
+        }
+
+        if (discovery.Failures.Count == 0
+            || discovery.Failures.Any(failure =>
+                failure.Kind is PackageAuthorityFailureKind.Input
+                    or PackageAuthorityFailureKind.InvalidResponse
+                    or PackageAuthorityFailureKind.ResponseRejected))
+        {
+            return new PackageVersionResolutionReceipt.Rejected(
+                request,
+                discovery,
+                freshness,
+                Reason(
+                    "Configured-authority evidence is unusable for version selection."));
+        }
+
+        return new PackageVersionResolutionReceipt.Unavailable(
+            request,
+            discovery,
+            freshness,
+            Reason(
+                "Required version-selection source capability is unavailable."));
+    }
+
+    private static InertString Reason(string text) =>
+        new(TextPolicy.Field, text);
+}
+
 internal static class PackageVersionSelectionContract
 {
     private static readonly IVersionComparer VersionComparer =
@@ -455,35 +588,89 @@ internal static class PackageVersionSelectionContract
         PackageVersionDiscoveryResult discovery,
         PackageVersionDiscoveryFreshness freshness)
     {
+        if (GetDiscoveryIncompatibility(
+                request,
+                discovery,
+                freshness) is { } incompatibility)
+            throw new ArgumentException(
+                incompatibility.ToString(),
+                nameof(discovery));
+    }
+
+    internal static InertString? GetDiscoveryIncompatibility(
+        PackageVersionSelectionRequest request,
+        PackageVersionDiscoveryResult discovery,
+        PackageVersionDiscoveryFreshness freshness)
+    {
+        if (GetPackageIdentityIncompatibility(
+                request,
+                discovery) is { } identityIncompatibility)
+        {
+            return identityIncompatibility;
+        }
         if (discovery.State
             != PackageVersionDiscoveryState.Authoritative)
         {
-            throw new ArgumentException(
-                "Version selection requires authoritative discovery from every configured authority.",
-                nameof(discovery));
+            return new(
+                TextPolicy.Field,
+                "Version selection requires authoritative discovery from every configured authority.");
         }
         if (freshness
-                == PackageVersionDiscoveryFreshness.NotEstablished
-            || request.Discovery.Freshness
-                == PackageVersionDiscoveryFreshness.RefreshedForRequest
-                && freshness
-                    != PackageVersionDiscoveryFreshness.RefreshedForRequest)
+            == PackageVersionDiscoveryFreshness.NotEstablished)
         {
-            throw new ArgumentException(
-                "The discovery freshness does not satisfy the version-selection request.",
-                nameof(freshness));
+            return new(
+                TextPolicy.Field,
+                "Version-selection discovery freshness was not established.");
+        }
+        if (request.Discovery.Freshness
+                == PackageVersionDiscoveryFreshness.RefreshedForRequest
+            && freshness
+                != PackageVersionDiscoveryFreshness.RefreshedForRequest)
+        {
+            return new(
+                TextPolicy.Field,
+                "The request requires discovery refreshed for this exact version selection.");
         }
 
         PackageVersionDiscoveryContract contract = discovery.Contract;
-        if (contract.IncludeUnlisted
-            || contract.Limit is not null
-            || request.Discovery.IncludePrerelease
-                && !contract.IncludePrerelease)
+        if (contract.IncludeUnlisted)
         {
-            throw new ArgumentException(
-                "The discovery contract does not satisfy the version-selection request.",
-                nameof(discovery));
+            return new(
+                TextPolicy.Field,
+                "Automatic version selection requires listed-only discovery.");
         }
+        if (contract.Limit is not null)
+        {
+            return new(
+                TextPolicy.Field,
+                "Automatic version selection requires the complete candidate set.");
+        }
+        if (request.Discovery.IncludePrerelease
+            && !contract.IncludePrerelease)
+        {
+            return new(
+                TextPolicy.Field,
+                "The discovery evidence omitted prerelease candidates required by the request.");
+        }
+
+        return null;
+    }
+
+    internal static InertString? GetPackageIdentityIncompatibility(
+        PackageVersionSelectionRequest request,
+        PackageVersionDiscoveryResult discovery)
+    {
+        if (discovery.PackageId is null
+            || !discovery.PackageId.Equals(
+                request.PackageId,
+                StringComparison.Ordinal))
+        {
+            return new(
+                TextPolicy.Field,
+                "Version-discovery evidence does not identify the requested package.");
+        }
+
+        return null;
     }
 
     internal static void RequireFailedDiscovery(

--- a/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
@@ -99,38 +99,49 @@ public sealed class PackageHouseContractTests
             "2.0.0",
             "1.5.0",
             "1.0.0");
-        var stable = new PackageVersionResolutionReceipt.Resolved(
-            new PackageVersionSelectionRequest.LatestStable("contoso.json"),
-            allVersions,
-            PackageVersionDiscoveryFreshness.Current);
-        var prerelease = new PackageVersionResolutionReceipt.Resolved(
-            new PackageVersionSelectionRequest.LatestPrerelease(
-                "contoso.json"),
-            allVersions,
-            PackageVersionDiscoveryFreshness.Current);
-        var always = new PackageVersionResolutionReceipt.Resolved(
-            new PackageVersionSelectionRequest.AlwaysLatest(
-                "contoso.json",
-                includePrerelease: true),
-            allVersions,
-            PackageVersionDiscoveryFreshness.RefreshedForRequest);
-        var wildcard = new PackageVersionResolutionReceipt.Resolved(
-            new PackageVersionSelectionRequest.Wildcard(
-                "contoso.json",
-                "1."),
-            allVersions,
-            PackageVersionDiscoveryFreshness.Current);
+        PackageVersionResolutionReceipt.Resolved stable = Assert.IsType<
+            PackageVersionResolutionReceipt.Resolved>(
+            PackageVersionSelectionResolver.Resolve(
+                new PackageVersionSelectionRequest.LatestStable(
+                    "contoso.json"),
+                allVersions,
+                PackageVersionDiscoveryFreshness.Current));
+        PackageVersionResolutionReceipt.Resolved prerelease = Assert.IsType<
+            PackageVersionResolutionReceipt.Resolved>(
+            PackageVersionSelectionResolver.Resolve(
+                new PackageVersionSelectionRequest.LatestPrerelease(
+                    "contoso.json"),
+                allVersions,
+                PackageVersionDiscoveryFreshness.Current));
+        PackageVersionResolutionReceipt.Resolved always = Assert.IsType<
+            PackageVersionResolutionReceipt.Resolved>(
+            PackageVersionSelectionResolver.Resolve(
+                new PackageVersionSelectionRequest.AlwaysLatest(
+                    "contoso.json",
+                    includePrerelease: true),
+                allVersions,
+                PackageVersionDiscoveryFreshness.RefreshedForRequest));
+        PackageVersionResolutionReceipt.Resolved wildcard = Assert.IsType<
+            PackageVersionResolutionReceipt.Resolved>(
+            PackageVersionSelectionResolver.Resolve(
+                new PackageVersionSelectionRequest.Wildcard(
+                    "contoso.json",
+                    "1."),
+                allVersions,
+                PackageVersionDiscoveryFreshness.Current));
         Assert.True(PackageVersionRange.TryParse(
             "contoso.json@1.0.0..2.0.0",
             out PackageVersionRange? versionRange,
             out string? error),
             error);
-        var range = new PackageVersionResolutionReceipt.Resolved(
-            new PackageVersionSelectionRequest.Range(
-                versionRange!,
-                new PackageVersionRangeSelection.Ordinal(2)),
-            allVersions,
-            PackageVersionDiscoveryFreshness.Current);
+        PackageVersionResolutionReceipt.Resolved range = Assert.IsType<
+            PackageVersionResolutionReceipt.Resolved>(
+            PackageVersionSelectionResolver.Resolve(
+                new PackageVersionSelectionRequest.Range(
+                    versionRange!,
+                    new PackageVersionRangeSelection.Ordinal(2)),
+                allVersions,
+                PackageVersionDiscoveryFreshness.Current));
 
         Assert.Equal("2.0.0", stable.Coordinate.Version);
         Assert.Equal("3.0.0-preview.1", prerelease.Coordinate.Version);
@@ -463,6 +474,176 @@ public sealed class PackageHouseContractTests
                 receipt.Discovery,
                 new[] { authoritative, failed });
         });
+    }
+
+    [Fact]
+    public void VersionSelectionResolverMapsTerminalEvidence()
+    {
+        var request = new PackageVersionSelectionRequest.LatestStable(
+            "contoso.json");
+        PackageVersionDiscoveryResult absent = VersionDiscovery(
+            PackageVersionDiscoveryState.Authoritative,
+            includePrerelease: false,
+            hasAnyCandidate: false);
+        PackageVersionDiscoveryResult noMatch = VersionDiscovery(
+            PackageVersionDiscoveryState.Authoritative,
+            includePrerelease: false,
+            hasAnyCandidate: true);
+        PackageVersionDiscoveryResult partial = VersionDiscovery(
+            PackageVersionDiscoveryState.Partial,
+            includePrerelease: false,
+            hasAnyCandidate: true,
+            "4.0.0");
+        PackageVersionDiscoveryResult unavailable =
+            VersionDiscoveryWithFailure(
+                PackageAuthorityFailureKind.Unsupported);
+        PackageVersionDiscoveryResult rejected =
+            VersionDiscoveryWithFailure(
+                PackageAuthorityFailureKind.InvalidResponse);
+        PackageVersionDiscoveryResult failed =
+            VersionDiscoveryWithFailure(
+                PackageAuthorityFailureKind.Transport);
+        PackageVersionDiscoveryResult mixedFailure =
+            VersionDiscoveryWithFailure(
+                PackageAuthorityFailureKind.IncompleteMetadata,
+                PackageAuthorityFailureKind.Timeout);
+
+        PackageVersionResolutionReceipt.NotFound notFoundResult =
+            Assert.IsType<PackageVersionResolutionReceipt.NotFound>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                absent,
+                PackageVersionDiscoveryFreshness.Current));
+        Assert.IsType<PackageVersionResolutionReceipt.NoMatch>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                noMatch,
+                PackageVersionDiscoveryFreshness.Current));
+        Assert.IsType<PackageVersionResolutionReceipt.Incomplete>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                partial,
+                PackageVersionDiscoveryFreshness.Current));
+        Assert.IsType<PackageVersionResolutionReceipt.Unavailable>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                unavailable,
+                PackageVersionDiscoveryFreshness.NotEstablished));
+        Assert.IsType<PackageVersionResolutionReceipt.Rejected>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                rejected,
+                PackageVersionDiscoveryFreshness.NotEstablished));
+        Assert.IsType<PackageVersionResolutionReceipt.Failed>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                failed,
+                PackageVersionDiscoveryFreshness.NotEstablished));
+        Assert.IsType<PackageVersionResolutionReceipt.Failed>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                mixedFailure,
+                PackageVersionDiscoveryFreshness.NotEstablished));
+        Assert.Same(request, notFoundResult.Request);
+        Assert.Same(absent, notFoundResult.Discovery);
+    }
+
+    [Fact]
+    public void VersionSelectionResolverRejectsIncompatibleDiscovery()
+    {
+        var request = new PackageVersionSelectionRequest.AlwaysLatest(
+            "contoso.json",
+            includePrerelease: true);
+        PackageVersionDiscoveryResult stale = VersionDiscovery(
+            PackageVersionDiscoveryState.Authoritative,
+            includePrerelease: true,
+            hasAnyCandidate: true,
+            "4.0.0-preview.1");
+        PackageVersionDiscoveryResult limited = VersionDiscovery(
+            PackageVersionDiscoveryState.Authoritative,
+            includePrerelease: true,
+            includeUnlisted: false,
+            limit: 1,
+            hasAnyCandidate: true,
+            "4.0.0-preview.1");
+
+        PackageVersionResolutionReceipt.Rejected staleResult = Assert.IsType<
+            PackageVersionResolutionReceipt.Rejected>(
+            PackageVersionSelectionResolver.Resolve(
+                request,
+                stale,
+                PackageVersionDiscoveryFreshness.Current));
+        PackageVersionResolutionReceipt.Rejected limitedResult =
+            Assert.IsType<PackageVersionResolutionReceipt.Rejected>(
+                PackageVersionSelectionResolver.Resolve(
+                    request,
+                    limited,
+                    PackageVersionDiscoveryFreshness.RefreshedForRequest));
+
+        Assert.Same(request, staleResult.Request);
+        Assert.Same(stale, staleResult.Discovery);
+        Assert.Same(limited, limitedResult.Discovery);
+    }
+
+    [Fact]
+    public void VersionSelectionResolverRejectsMissingOrMismatchedDiscoveryIdentity()
+    {
+        var request = new PackageVersionSelectionRequest.LatestStable(
+            "contoso.json");
+        var mismatchedAuthoritative = new PackageVersionDiscoveryResult(
+            "other.package",
+            PackageVersionDiscoveryState.Authoritative,
+            sourceListings: [],
+            failures: [],
+            hasAnyCandidate: false,
+            contract: PackageVersionDiscoveryContract.Create(
+                includePrerelease: false,
+                includeUnlisted: false,
+                limit: null));
+        PackageVersionDiscoveryResult mismatchedFailure =
+            VersionDiscoveryWithFailureForPackage(
+                "other.package",
+                PackageAuthorityFailureKind.Transport);
+        var missingIdentity = new PackageVersionDiscoveryResult(
+            packageId: null,
+            PackageVersionDiscoveryState.Failed,
+            sourceListings: [],
+            failures:
+            [
+                new PackageAuthorityFailure(
+                    InertString.Empty,
+                    PackageAuthorityFailureKind.Input,
+                    "The package ID is invalid."),
+            ],
+            hasAnyCandidate: false);
+
+        PackageVersionDiscoveryResult[] incompatible =
+        [
+            mismatchedAuthoritative,
+            mismatchedFailure,
+            missingIdentity,
+        ];
+        Assert.All(incompatible, discovery =>
+        {
+            PackageVersionResolutionReceipt.Rejected rejected =
+                Assert.IsType<PackageVersionResolutionReceipt.Rejected>(
+                    PackageVersionSelectionResolver.Resolve(
+                        request,
+                        discovery,
+                        PackageVersionDiscoveryFreshness.NotEstablished));
+            Assert.Same(request, rejected.Request);
+            Assert.Same(discovery, rejected.Discovery);
+            Assert.Contains(
+                "requested package",
+                rejected.Reason.ToString(),
+                StringComparison.Ordinal);
+        });
+        Assert.Throws<ArgumentException>(
+            () => new PackageVersionResolutionReceipt.NotFound(
+                request,
+                mismatchedAuthoritative,
+                PackageVersionDiscoveryFreshness.Current,
+                Reason("Wrong package.")));
     }
 
     [Fact]
@@ -1771,6 +1952,36 @@ public sealed class PackageHouseContractTests
                 limit),
             candidateIssuer: new object());
     }
+
+    private static PackageVersionDiscoveryResult
+        VersionDiscoveryWithFailure(
+            params PackageAuthorityFailureKind[] kinds) =>
+        VersionDiscoveryWithFailureForPackage(
+            "contoso.json",
+            kinds);
+
+    private static PackageVersionDiscoveryResult
+        VersionDiscoveryWithFailureForPackage(
+            string packageId,
+            params PackageAuthorityFailureKind[] kinds) =>
+        new(
+            packageId,
+            PackageVersionDiscoveryState.Failed,
+            sourceListings: [],
+            failures:
+            [
+                .. kinds.Select(kind => new PackageAuthorityFailure(
+                    Reason("version-authority"),
+                    kind,
+                    "Version discovery did not settle.")),
+            ],
+            hasAnyCandidate: false,
+            candidates: [],
+            contract: PackageVersionDiscoveryContract.Create(
+                includePrerelease: false,
+                includeUnlisted: false,
+                limit: null),
+            candidateIssuer: new object());
 
     private static PackageSourceResultFactory ResultFactory(
         PackageSourceAssociation association)


### PR DESCRIPTION
PackageHouse is the package-processing clearing house where source leases are
issued and owner receipts are settled. This slice gives its version-policy
owner one total, resource-free operation for settling unresolved package
versions before House execution begins.

## Summary

- add `PackageVersionSelectionResolver.Resolve` for every existing typed
  selection request
- preserve exact request and discovery evidence while mapping authoritative,
  partial, failed, incompatible, and unavailable evidence to one typed receipt
- reject discovery with missing or mismatched package identity before terminal
  precedence
- distinguish authoritative package absence from a package with no selectable
  listed version
- keep `Ambiguous` reserved because the current closed request forms are
  deterministic

Closes #6509.
Implements the version-policy prerequisite for #6508 and #6426 step 4.

## Demo

Compatible authoritative discovery resolves to the exact candidate issued by
the Package Source Model:

```csharp
PackageVersionResolutionReceipt.Resolved resolved =
    Assert.IsType<PackageVersionResolutionReceipt.Resolved>(
        PackageVersionSelectionResolver.Resolve(
            new PackageVersionSelectionRequest.LatestStable("contoso.json"),
            discovery,
            PackageVersionDiscoveryFreshness.Current));

Assert.Equal("4.0.0", resolved.Coordinate.Version);
```

An authoritative empty result becomes `NotFound`; an observed package whose
versions do not satisfy the request becomes `NoMatch`. A partial result cannot
produce a coordinate, and evidence for another package is always `Rejected`
even when it also reports a transport failure.

## Compatibility and boundaries

The resolver performs no source I/O, selector parsing, authorization, retries,
payload acquisition, or PackageHouse execution. It adds no request forms or
version policies. Existing exact-coordinate acquisition remains outside this
unresolved selection family.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.Services.Tests -c Release --no-build -- --filter-class '*PackageHouseContractTests'`
- `npx markdownlint-cli docs/design/version-resolution.md`
