### PR TITLE
Require real assets and production adoption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,12 @@ development model and rationale. The binding summary:
   user-observable experience.
 - **Design first and state the basis.** Name one normative owner and exact
   claim, then supporting designs, models, constraints, and evidence by role.
-- **Start architectures from production-host adoption.** Every new architecture,
-  capability, or substrate names its consumer and links an end-to-end tracker
-  that enumerates the production-host adoption path and total step count, even
-  when the component is host-neutral. Test infrastructure may treat its harness
-  as the production host. An alternative to an existing architecture must also
-  track that architecture's retirement. Shared product substrate must plan
-  enablement through both CLI and browser/Wasm hosts; single-consumer or
-  single-host scope requires explicit user approval.
+- **Plan every feature through production adoption.** Each feature, architecture,
+  capability, or substrate links an overall plan with a direct path to CLI or
+  website use. A sliced or stacked plan includes a production-consumer adoption
+  slice. Test infrastructure may treat its harness as the production host.
+  Alternatives track retirement; shared substrate plans both CLI and
+  browser/Wasm adoption, while narrower scope requires explicit user approval.
 - **Keep hosts thin.** Put reusable concepts and algorithms in host-neutral
   code. Duplicated host logic triggers a review for a shared abstraction that
   would also benefit another future host.
@@ -60,9 +58,9 @@ development model and rationale. The binding summary:
 - **Treat critical review feedback as a design question first.** Ask whether
   the owning design addresses it before repairing code; keep paired design
   work moving quickly when the contract needs clarification.
-- **Use extraordinary pre-work for complicated features.** Corpus evidence,
-  an established oracle, a TLA+ model, or a closely developed specification
-  should bound the contract before implementation.
+- **Ground behavior in real assets.** Features and significant fixes cite a
+  motivating nuget.org package or real repository in their design and normally
+  preserve it in tests; synthetic-only work requires user/operator approval.
 - **Use only approved OpenAI GPT configurations.** In agent harnesses that
   advertise GPT models, never start non-GPT, `Fast`, or extra-high (`xhigh`)
   configurations. This launch prohibition does not invalidate work: observe and

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -69,12 +69,55 @@ developed closely with the user can reveal the actual boundary before code
 makes an accidental behavior expensive to undo. Much of the architecture is
 the act of bounding a contract and making its important properties invariant.
 
-## Start architectures from production hosts
+## Ground product behavior in real assets
 
-Every new architecture, capability, or substrate must name a concrete consumer
-from the start. The consumer may land in a later slice, but the focused
-specification and implementation issue must identify it, and a single overall
-end-to-end tracking issue must link the architecture and consumer work.
+Every feature and significant fix must be motivated by at least one real asset:
+
+- an exact package ID and version published on nuget.org; or
+- a relevant source construct from a real repository, pinned to a commit and
+  path.
+
+Synthetic packages and authored source examples remain useful for boundary
+coverage and seam isolation, but they cannot be the sole motivation for product
+behavior. Before implementation, record the asset in the owning design
+document, including its stable identity or link, the observed shape or
+behavior, the exact product claim it motivates, and the plan for durable test
+evidence. A reviewer concern, hypothetical edge case, or synthetic
+reconstruction does not replace that record.
+
+Promote the motivating asset into repository evidence in most cases:
+
+- Add a nuget.org package and version to the appropriate pinned test population
+  or corpus, exercising it through the normal product acquisition path.
+- Use repository source to form a focused fixture that preserves the relevant
+  source or compiler-produced shape, and retain the source commit and path as
+  provenance. Copy source only when its license permits; otherwise author the
+  smallest fixture that reproduces the observed shape.
+
+The real asset establishes that the need exists; deterministic fixtures,
+neighboring controls, and synthetic boundary cases establish the supported
+contract. When license, size, nondeterminism, or test-environment constraints
+make direct retention impractical, document the reason and preserve a
+reproducible acquisition or observation procedure.
+
+Starting a feature or significant fix without a qualifying real asset and its
+design record requires explicit user/operator approval. Record the approval,
+its scope, and the residual evidence gap in the owning design before
+implementation.
+
+## Plan every feature through production adoption
+
+Every new feature, architecture, capability, or substrate must have a direct
+path to observable use by a production consumer: the CLI or website. The
+consumer may land later, but the focused specification and implementation issue
+must identify it, and a single overall end-to-end tracking issue must link the
+product work to its adoption.
+
+When work is divided into slices or a stacked PR sequence, the overall plan
+must include at least one slice that adopts the feature in a production
+consumer. A plan that ends at a reusable library, protocol, serializer, or
+other host-neutral substrate is incomplete. The adoption slice may be separate,
+but it is part of the feature's plan rather than optional follow-up work.
 
 The tracker must identify each production host, enumerate the concrete adoption
 slices in order, and state the current total step count from the architecture


### PR DESCRIPTION
These practices serve robust, capable features that provide foundational capabilities or compelling user experiences, with evidence that the behavior exists in the real world and a direct path to production use.

## Summary

- Require every feature and significant fix to cite a motivating nuget.org package or real repository construct in its owning design.
- Normally promote that asset into a pinned package population or focused source fixture; synthetic-only motivation requires explicit user/operator approval.
- Require every feature plan, including sliced and stacked work, to contain a direct CLI or website adoption path and a production-consumer adoption slice.
- Keep `AGENTS.md` below its 600-line cap by replacing superseded summary wording while retaining detailed mechanics in `docs/development-practices.md`.

## Demo

Before this change, synthetic fixtures could become the sole motivation for new product behavior, and a multi-slice feature plan could end at host-neutral substrate without a committed production adoption slice.

After this change, the required planning chain is explicit:

```text
real nuget.org package or repository source
  -> owning design record
  -> pinned package population or focused fixture
  -> product implementation
  -> CLI or website adoption slice
```

Exceptions require explicit user/operator approval recorded with their scope and residual evidence gap.

## Validation

- `wc -l AGENTS.md` -> 598 lines
- `npx markdownlint-cli AGENTS.md docs/development-practices.md`
- `git diff --check`