### PR TITLE
Migrate IL diff tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -249,6 +249,14 @@ pinned outcome-level host gate without changing the suite's instruction
 decoding, block graph, typed-stack, metadata resolution, fidelity, comparison,
 analysis-diff, Finding value-equality, or review-fix evidence.
 
+`ILInspector.ILDiff.Tests` is the seventeenth migrated adopter. Its required PR
+and developer commands remain unfiltered, while process-isolated signature and
+metadata-graph safety workers select their child methods through MTP filters.
+These paths reuse the pinned outcome-level host gate without changing the
+suite's IL body and assembly comparison, normalization, member alignment,
+Finding census and matching, compiler-generated ordinal, metadata-graph
+safety, or diff presentation evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/ILInspector.ILDiff.Tests/ILInspector.ILDiff.Tests.csproj
+++ b/tests/ILInspector.ILDiff.Tests/ILInspector.ILDiff.Tests.csproj
@@ -10,6 +10,7 @@
     <IsAotCompatible>false</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ILInspector.ILDiff.Tests/IlAssemblyDiffMetadataGraphSafetyTests.cs
+++ b/tests/ILInspector.ILDiff.Tests/IlAssemblyDiffMetadataGraphSafetyTests.cs
@@ -116,7 +116,7 @@ public class IlAssemblyDiffMetadataGraphSafetyTests
             UseShellExecute = false,
         };
         startInfo.ArgumentList.Add(typeof(IlAssemblyDiffMetadataGraphSafetyTests).Assembly.Location);
-        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add("--filter-method");
         startInfo.ArgumentList.Add($"*{workerMethod}*");
         startInfo.Environment[WorkerVariable] = workerMethod;
 

--- a/tests/ILInspector.ILDiff.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.ILDiff.Tests/SignatureDecoderSafetyTests.cs
@@ -130,7 +130,7 @@ public class SignatureDecoderSafetyTests
             UseShellExecute = false,
         };
         startInfo.ArgumentList.Add(typeof(SignatureDecoderSafetyTests).Assembly.Location);
-        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add("--filter-method");
         startInfo.ArgumentList.Add($"*{workerMethod}*");
         startInfo.Environment[WorkerVariable] = workerMethod;
 


### PR DESCRIPTION
This advances robust, conventional test evidence by making stale
`ILInspector.ILDiff.Tests` selectors fail through the test platform that owns
discovery and filtering.

## Demo

Before this change, the native xUnit host accepts an unmatched class selector
as successful evidence:

```text
ILInspector.ILDiff.Tests  Total: 0
exit=0
```

With Microsoft Testing Platform selected, the equivalent stale filter fails:

```text
Test run summary: Zero tests ran
  total: 0
exit=8
```

Neighboring evidence continues to execute normally:

```text
IlAssemblyDiffTests                    total: 8    exit=0
FindingCensusTests                     total: 11   exit=0
CompilerGeneratedOrdinalTests          total: 109  exit=0
SignatureDecoderSafetyTests            total: 4    exit=0
IlAssemblyDiffMetadataGraphSafetyTests total: 5    exit=0
full suite                             total: 253  exit=0
```

## Summary

- Select Microsoft Testing Platform for `ILInspector.ILDiff.Tests` through the
  `xunit.v3` integration already pinned by the repository.
- Migrate the suite's process-isolated signature and metadata-graph workers
  from native xUnit method selection to MTP method filters.
- Record the suite as the seventeenth migrated adopter in the xUnit host owner.
- Preserve the unfiltered required-CI and developer commands unchanged.
- Preserve IL comparison, normalization, alignment, Finding, ordinal,
  metadata-safety, and presentation evidence.

## Design basis

`docs/design/xunit-test-host.md` owns repository xUnit host selection and
aggregate zero-test behavior. MTP owns parsing, discovery, filtering,
execution, and exit code `8`; the safety tests retain ownership of their
process-isolation worker selection and now express it in MTP grammar.

`ILInspector.ILDiff` remains the owner of body and assembly comparison over
decoded instruction streams. This migration changes only the executable host
and its owned child invocations; it does not broaden product behavior.

## Validation

- Unmatched MTP class filter: 0 tests, exit `8`.
- `IlAssemblyDiffTests`: 8 passed.
- `FindingCensusTests`: 11 passed.
- `CompilerGeneratedOrdinalTests`: 109 passed.
- `SignatureDecoderSafetyTests`: 4 passed.
- `IlAssemblyDiffMetadataGraphSafetyTests`: 5 passed.
- Full `ILInspector.ILDiff.Tests` suite: 253 passed.
- Full Release solution build.
- `markdownlint` and `git diff --check`.

Closes the seventeenth migration slice of #5379.
