### PR TITLE
Adapt runtime dependency evidence

### DIFF
--- a/docs/design/package-dependency-evidence.md
+++ b/docs/design/package-dependency-evidence.md
@@ -12,12 +12,13 @@ package-prefix admission, and failure core is implemented under #5533 as
 `PackageDependencyEvidenceQuery`. The current query also implements the larger
 input-kind, declaration-basis, authorship, produced-relationship, positive
 processing, and independent phase-count vocabulary for package-manifest and
-restored-project inputs. The authored-project facts provider is implemented by
-`AuthoredProjectDependencyFactsQuery`; #6348 adds its normalized adapter.
-Runtime-dependency providers, policy composition, and host adoption remain
-staged work. Restored-project inputs consume typed pruning-processing evidence
-from their artifact owner. Optional owner observations remain dependent on
-issue #5315.
+restored-project inputs. The authored-project facts provider and normalized
+adapter are implemented by `AuthoredProjectDependencyFactsQuery` and this
+query. The runtime provider and normalized adapter are implemented by
+`RuntimeDependencyFactsQuery` and this query. Policy composition and host
+adoption remain staged work. Restored-project inputs consume typed
+pruning-processing evidence from their artifact owner. Optional owner
+observations remain dependent on issue #5315.
 
 ## Owner
 
@@ -79,7 +80,8 @@ steps are:
 3. Add typed pruning-processing evidence to restored-project facts
    (implemented by the current query).
 4. Add typed authored-project facts and their normalized adapter.
-5. Add a typed runtime-dependency provider for `.deps.json`.
+5. Add a typed runtime-dependency provider for `.deps.json` and adapt its
+   facts into this owner.
 6. Adopt the shape in package-pruning policy.
 7. Adopt the composed policy result in the CLI dependency experience.
 8. Adopt the same result in inspect-web Browser/Wasm.
@@ -352,10 +354,41 @@ syntax projection to evaluated evidence.
 
 ### Runtime dependency manifest
 
-The future runtime-dependency adapter supplies provider-issued runtime target,
-package nodes, package relationships, provenance, completion, and failures from
-one already-acquired `.deps.json` document. It does not invent project-authored
-constraints that the artifact does not retain.
+The runtime-dependency adapter consumes one complete
+`RuntimeDependencyFactsResult`, not bytes or a path. Its sole acquisition form
+is `RuntimeDependencyManifest`, meaning already-acquired `.deps.json` bytes
+were projected by the runtime-dependency owner.
+
+An available provider result becomes one admitted root:
+
+- root identity is the provider-issued `RuntimeDependencyRootIdentity`;
+- content provenance is the provider-issued
+  `RuntimeDependencyContentProvenance`;
+- the exact provider-issued `RuntimeDependencyTarget` remains associated with
+  the root, is mutually exclusive with restored-target evidence, and must agree
+  with the target identity carried by the runtime-manifest identity;
+- input kind is `RuntimeDependencyManifest`;
+- declaration basis is `NotApplicable`;
+- declaration-group selection is unavailable;
+- package nodes and package-resolving relationships retain provider-issued
+  identities and exact resolved coordinates;
+- requested constraints, direct/transitive roles, and declaration
+  associations remain absent;
+- a package parent is `LibraryDeclared`, while an opaque non-package parent is
+  `Unattributed`;
+- graph failures remain typed relationship failures and independently make the
+  relationship phase incomplete; and
+- processing is complete positive evidence of
+  `RuntimeDependencyProjection`, independently of relationship completion.
+
+A failed provider result has no established runtime-manifest identity, target,
+or provenance. It therefore becomes one typed failed root and never a
+successful empty, unavailable, or anonymous admitted root.
+
+The adapter does not reparse package IDs, versions, runtime targets, parent
+identities, or failure evidence. A valid empty provider graph remains a
+complete-empty relationship phase, distinct from provider failure or
+incomplete usable graph evidence.
 
 Framework assemblies absent from a framework-dependent application's runtime
 manifest are outside that manifest's package-library set. Their absence is not
@@ -773,6 +806,11 @@ Restored-project roots currently do not, so package/restored selected-group
 comparison is not comparable even when their full core or scoped declarations
 are equal.
 
+A runtime-dependency root has declaration basis `NotApplicable`. Comparing it
+through the declaration-equivalence operation is therefore not comparable with
+reason `DeclarationNotApplicable`, distinct from an applicable but incomplete
+declaration projection.
+
 Input-specific evidence is asserted separately. A restored graph may therefore
 be equal under the declared projection while also reporting resolved versions
 and transitive relationships unavailable from the nuspec.
@@ -1143,13 +1181,21 @@ and current larger-shape properties are gated in Release by
 - `Compare_AuthoredExactScopeMatchesEquivalentPackageManifest`; and
 - `CreateAuthoredProjectInput_RequiresProjectXmlAcquisition`;
 - `Create_RetainsAuthoredIdentityProvenanceOccurrencesAndFailures`; and
-- `Create_OpaqueAuthoredScopesExposeOnlyInertDisplayEvidence`.
+- `Create_OpaqueAuthoredScopesExposeOnlyInertDisplayEvidence`;
+- `Execute_CurrentRuntimeManifestRetainsProviderIdentityTargetAndProvenance`;
+- `PackageInput_RuntimeRelationshipsDoNotInventConstraintsRolesOrPruning`;
+- `Execute_RuntimeIncompleteFactsRetainUsableGraphAndFailures`;
+- `Execute_RuntimeCompleteEmptyGraphIsNotUnavailable`;
+- `Compare_RuntimeDeclarationNotApplicableIsDistinctFromIncomplete`;
+- `Execute_RuntimeProviderFailureBecomesFailedRoot`; and
+- `CreateRuntimeDependencyManifestInput_RequiresRuntimeManifestAcquisition`;
+  and
+- `RuntimeRoot_RequiresExclusiveMatchingTargetEvidence`.
 
 Owner-enrichment behavior remains `unverified` until #5315 supplies its typed
-input and focused gates. The remaining runtime-dependency and cross-host
-properties remain `unverified` until these Release gates land:
+input and focused gates. Cross-host retention remains `unverified` until this
+Release gate lands:
 
-- `PackageInput_DepsAbsenceNeverBecomesPruningEvidence`;
 - `PackageInput_CliAndBrowserConsumeTheSameTypedSnapshot`.
 
 ## Existing dependency-evidence adoption sequence

--- a/docs/design/runtime-dependency-facts.md
+++ b/docs/design/runtime-dependency-facts.md
@@ -29,9 +29,9 @@ assemblies, or choose a renderer.
 ## Consumer and delivery
 
 The immediate consumer is the **Package Dependency Evidence Query** specified
-by `docs/design/package-dependency-evidence.md`. Its adapter is a separate
-focused slice because normalized cross-input identity, authorship, processing,
-and relationship vocabulary belong to that owner.
+by `docs/design/package-dependency-evidence.md`. Its adapter is implemented as
+a separate focused slice because normalized cross-input identity, authorship,
+processing, and relationship vocabulary belong to that owner.
 
 The end-to-end tracker is #6266. Its eight-step path connects this provider and
 adapter to package-pruning policy in step 6, the CLI dependency experience in
@@ -277,5 +277,6 @@ Release tests in `RuntimeDependencyFactsQueryTests` gate:
 - framework-library absence remaining ordinary absence rather than pruning
   evidence.
 
-The normalized adapter and CLI/Browser sink retention remain unverified until
-their separately owned #6266 slices land.
+The normalized adapter is gated by
+`PackageDependencyEvidenceQueryTests`. CLI/Browser sink retention remains
+unverified until its separately owned #6266 slices land.

--- a/src/DotnetInspector.Queries/PackageDependencyEvidenceQuery.cs
+++ b/src/DotnetInspector.Queries/PackageDependencyEvidenceQuery.cs
@@ -25,6 +25,7 @@ public enum PackageDependencyEvidenceAcquisitionForm
     ProjectAssets,
     ProjectLocator,
     ProjectXml,
+    RuntimeDependencyManifest,
 }
 
 /// <summary>The fidelity basis claimed by one root's declaration phase.</summary>
@@ -86,6 +87,12 @@ public abstract record PackageDependencyEvidenceInput
         AuthoredProjectDependencyFactsResult Result,
         PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         InertString? SourceLabel = null) : PackageDependencyEvidenceInput;
+
+    /// <summary>Runtime dependency facts, including failed provider outcomes.</summary>
+    public sealed record RuntimeDependencyManifest(
+        RuntimeDependencyFactsResult Result,
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
+        InertString? SourceLabel = null) : PackageDependencyEvidenceInput;
 }
 
 /// <summary>One typed upstream failure for a root that could not be admitted.</summary>
@@ -109,6 +116,11 @@ public abstract record PackageDependencyEvidenceRootFailure
     public sealed record AuthoredProject(
         PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         AuthoredProjectDependencyFactsFailure Failure,
+        InertString? SourceLabel = null) : PackageDependencyEvidenceRootFailure;
+
+    public sealed record RuntimeDependencyManifest(
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
+        RuntimeDependencyFailure Failure,
         InertString? SourceLabel = null) : PackageDependencyEvidenceRootFailure;
 
     public sealed record PackageProfile(
@@ -221,7 +233,7 @@ public sealed record PackageDependencyEvidenceRequest
         PackagePrefixCompletion { get; }
 }
 
-/// <summary>Stable identity for one admitted package or restored-project root.</summary>
+/// <summary>Stable owner-issued identity for one admitted package input root.</summary>
 public abstract record PackageDependencyEvidenceRootIdentity
 {
     private PackageDependencyEvidenceRootIdentity()
@@ -235,6 +247,10 @@ public abstract record PackageDependencyEvidenceRootIdentity
         PackageDependencyEvidenceRootIdentity;
 
     public sealed record AuthoredProject(AuthoredProjectIdentity Identity) :
+        PackageDependencyEvidenceRootIdentity;
+
+    public sealed record RuntimeDependencyManifest(
+        RuntimeDependencyRootIdentity Identity) :
         PackageDependencyEvidenceRootIdentity;
 }
 
@@ -265,6 +281,11 @@ public abstract record PackageDependencyEvidenceRootProvenance
     public sealed record AuthoredProject(
         PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
         AuthoredProjectContentProvenance ContentProvenance,
+        InertString? SourceLabel) : PackageDependencyEvidenceRootProvenance;
+
+    public sealed record RuntimeDependencyManifest(
+        PackageDependencyEvidenceAcquisitionForm AcquisitionForm,
+        RuntimeDependencyContentProvenance ContentProvenance,
         InertString? SourceLabel) : PackageDependencyEvidenceRootProvenance;
 }
 
@@ -536,6 +557,10 @@ public abstract record PackageDependencyEvidencePackageIdentity
     public sealed record RestoredProject(
         RestoredProjectPackageNodeIdentity Identity) :
         PackageDependencyEvidencePackageIdentity;
+
+    public sealed record RuntimeDependencyManifest(
+        RuntimeDependencyPackageNodeIdentity Identity) :
+        PackageDependencyEvidencePackageIdentity;
 }
 
 /// <summary>The closed parent identity of one produced package relationship.</summary>
@@ -553,6 +578,10 @@ public abstract record PackageDependencyEvidenceRelationshipParentIdentity
 
     public sealed record Project(RestoredProjectProjectNodeIdentity Identity) :
         PackageDependencyEvidenceRelationshipParentIdentity;
+
+    public sealed record RuntimeDependencyLibrary(
+        RuntimeDependencyLibraryNodeIdentity Identity) :
+        PackageDependencyEvidenceRelationshipParentIdentity;
 }
 
 /// <summary>Stable provider-issued identity for one produced relationship.</summary>
@@ -563,6 +592,10 @@ public abstract record PackageDependencyEvidenceRelationshipIdentity
     }
 
     public sealed record RestoredProject(RestoredProjectEdgeIdentity Identity) :
+        PackageDependencyEvidenceRelationshipIdentity;
+
+    public sealed record RuntimeDependencyManifest(
+        RuntimeDependencyEdgeIdentity Identity) :
         PackageDependencyEvidenceRelationshipIdentity;
 }
 
@@ -599,6 +632,10 @@ public abstract record PackageDependencyEvidenceRelationshipFailure
     }
 
     public sealed record RestoredProject(RestoredProjectGraphFailure Failure) :
+        PackageDependencyEvidenceRelationshipFailure;
+
+    public sealed record RuntimeDependencyManifest(
+        RuntimeDependencyGraphFailure Failure) :
         PackageDependencyEvidenceRelationshipFailure;
 }
 
@@ -737,7 +774,8 @@ public sealed record PackageDependencyEvidenceRoot(
     PackageDependencyEvidenceSelection Selection,
     RestoredProjectSelectedTarget? RestoredTarget,
     PackageDependencyEvidenceRelationshipResult Relationships,
-    PackageDependencyEvidenceProcessingResult Processing)
+    PackageDependencyEvidenceProcessingResult Processing,
+    RuntimeDependencyTarget? RuntimeTarget = null)
 {
     public PackageDependencyEvidenceRootIdentity Identity { get; } =
         Identity ?? throw new ArgumentNullException(nameof(Identity));
@@ -753,6 +791,10 @@ public sealed record PackageDependencyEvidenceRoot(
                     Provenance,
             (PackageDependencyEvidenceRootIdentity.AuthoredProject _,
                 PackageDependencyEvidenceRootProvenance.AuthoredProject _) =>
+                    Provenance,
+            (PackageDependencyEvidenceRootIdentity.RuntimeDependencyManifest _,
+                PackageDependencyEvidenceRootProvenance
+                    .RuntimeDependencyManifest _) =>
                     Provenance,
             _ => throw new ArgumentException(
                 "Root identity and provenance must describe the same semantic input.",
@@ -771,6 +813,11 @@ public sealed record PackageDependencyEvidenceRoot(
             (PackageDependencyEvidenceRootIdentity.AuthoredProject _,
                 PackageDependencyEvidenceRootProvenance.AuthoredProject _) =>
                     PackageDependencyEvidenceInputKind.AuthoredProject,
+            (PackageDependencyEvidenceRootIdentity.RuntimeDependencyManifest _,
+                PackageDependencyEvidenceRootProvenance
+                    .RuntimeDependencyManifest _) =>
+                    PackageDependencyEvidenceInputKind
+                        .RuntimeDependencyManifest,
             _ => throw new ArgumentException(
                 "Root identity and provenance must describe the same semantic input kind.",
                 nameof(Provenance)),
@@ -789,10 +836,54 @@ public sealed record PackageDependencyEvidenceRoot(
                 PackageDependencyEvidenceRootProvenance.AuthoredProject _) =>
                     PackageDependencyEvidenceDeclarationBasis
                         .AuthoredProjectSyntax,
+            (PackageDependencyEvidenceRootIdentity.RuntimeDependencyManifest _,
+                PackageDependencyEvidenceRootProvenance
+                    .RuntimeDependencyManifest _) =>
+                    PackageDependencyEvidenceDeclarationBasis.NotApplicable,
             _ => throw new ArgumentException(
                 "Root identity and provenance must describe the same declaration basis.",
                 nameof(Provenance)),
         };
+
+    public RestoredProjectSelectedTarget? RestoredTarget { get; } =
+        (Identity, RestoredTarget) switch
+        {
+            (PackageDependencyEvidenceRootIdentity.RestoredProject restored,
+                { } target)
+                when RestoredTargetIdentity(target)
+                    == restored.Identity.Selection.TargetIdentity =>
+                    target,
+            (PackageDependencyEvidenceRootIdentity.RestoredProject _, null) =>
+                null,
+            (_, null) => null,
+            _ => throw new ArgumentException(
+                "Only the matching restored-project root can carry a restored target.",
+                nameof(RestoredTarget)),
+        };
+
+    public RuntimeDependencyTarget? RuntimeTarget { get; } =
+        (Identity, RuntimeTarget) switch
+        {
+            (PackageDependencyEvidenceRootIdentity.RuntimeDependencyManifest
+                runtime, { } target)
+                when target.Identity
+                    == runtime.Identity.Manifest.TargetIdentity =>
+                    target,
+            (PackageDependencyEvidenceRootIdentity.RuntimeDependencyManifest _,
+                null) => throw new ArgumentNullException(
+                    nameof(RuntimeTarget),
+                    "A runtime dependency root requires its selected target."),
+            (_, null) => null,
+            _ => throw new ArgumentException(
+                "Only a runtime dependency root can carry a runtime target.",
+                nameof(RuntimeTarget)),
+        };
+
+    private static string RestoredTargetIdentity(
+        RestoredProjectSelectedTarget target) =>
+        target.RuntimeIdentifierIdentity is null
+            ? target.FrameworkIdentity
+            : $"{target.FrameworkIdentity}/{target.RuntimeIdentifierIdentity}";
 }
 
 /// <summary>Root-set admission accounting kept independent from per-root phase completion.</summary>
@@ -829,6 +920,7 @@ public sealed record PackageDependencyEvidenceOutcome(
 /// <summary>Why two declaration projections cannot truthfully be compared.</summary>
 public enum PackageDependencyEvidenceNotComparableReason
 {
+    DeclarationNotApplicable,
     DeclarationProjectionIncomplete,
     FrameworkScope,
     SelectionStatusUnavailable,
@@ -858,8 +950,7 @@ public sealed record PackageDependencyEvidenceComparison(
     PackageDependencyEvidenceComparisonResult SelectedScoped);
 
 /// <summary>
-/// Composes existing package-manifest/group and restored-project facts into one host-neutral
-/// dependency-evidence result.
+/// Composes owner-issued package-input facts into one host-neutral dependency-evidence result.
 /// </summary>
 public static class PackageDependencyEvidenceQuery
 {
@@ -942,6 +1033,23 @@ public static class PackageDependencyEvidenceQuery
         ArgumentNullException.ThrowIfNull(result);
         RequireAuthoredProjectAcquisitionForm(acquisitionForm);
         return new PackageDependencyEvidenceInput.AuthoredProject(
+            result,
+            acquisitionForm,
+            sourceLabel);
+    }
+
+    /// <summary>Builds a runtime dependency input from one complete provider outcome.</summary>
+    public static PackageDependencyEvidenceInput.RuntimeDependencyManifest
+        CreateRuntimeDependencyManifestInput(
+            RuntimeDependencyFactsResult result,
+            PackageDependencyEvidenceAcquisitionForm acquisitionForm =
+                PackageDependencyEvidenceAcquisitionForm
+                    .RuntimeDependencyManifest,
+            InertString? sourceLabel = null)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        RequireRuntimeDependencyAcquisitionForm(acquisitionForm);
+        return new PackageDependencyEvidenceInput.RuntimeDependencyManifest(
             result,
             acquisitionForm,
             sourceLabel);
@@ -1032,6 +1140,12 @@ public static class PackageDependencyEvidenceQuery
                         authored.AcquisitionForm);
                     ArgumentNullException.ThrowIfNull(authored.Failure);
                     break;
+                case PackageDependencyEvidenceRootFailure
+                    .RuntimeDependencyManifest runtime:
+                    RequireRuntimeDependencyAcquisitionForm(
+                        runtime.AcquisitionForm);
+                    ArgumentNullException.ThrowIfNull(runtime.Failure);
+                    break;
                 case PackageDependencyEvidenceRootFailure.PackageProfile profile:
                     if (profile.Kind is PackageProfileFailureKind.Search
                             or PackageProfileFailureKind.SearchContract
@@ -1077,6 +1191,23 @@ public static class PackageDependencyEvidenceQuery
                 continue;
             }
 
+            if (input is PackageDependencyEvidenceInput.RuntimeDependencyManifest
+                {
+                    Result: RuntimeDependencyFactsResult.Failed runtimeFailed,
+                } runtime)
+            {
+                RequireRuntimeDependencyAcquisitionForm(
+                    runtime.AcquisitionForm);
+                ArgumentNullException.ThrowIfNull(runtimeFailed.Failure);
+                failedRoots.Add(
+                    new PackageDependencyEvidenceRootFailure
+                        .RuntimeDependencyManifest(
+                            runtime.AcquisitionForm,
+                            runtimeFailed.Failure,
+                            runtime.SourceLabel));
+                continue;
+            }
+
             roots.Add(ProjectRoot(input));
         }
 
@@ -1110,6 +1241,22 @@ public static class PackageDependencyEvidenceQuery
     {
         ArgumentNullException.ThrowIfNull(left);
         ArgumentNullException.ThrowIfNull(right);
+
+        if (left.Declaration
+                is PackageDependencyEvidenceDeclarationResult.NotApplicable
+            || right.Declaration
+                is PackageDependencyEvidenceDeclarationResult.NotApplicable)
+        {
+            PackageDependencyEvidenceComparisonResult notComparable =
+                new PackageDependencyEvidenceComparisonResult.NotComparable(
+                    PackageDependencyEvidenceNotComparableReason
+                        .DeclarationNotApplicable);
+            return new PackageDependencyEvidenceComparison(
+                notComparable,
+                notComparable,
+                notComparable,
+                notComparable);
+        }
 
         if (left.Declaration is not PackageDependencyEvidenceDeclarationResult.Available
                 { IsComplete: true } leftDeclaration
@@ -1155,6 +1302,8 @@ public static class PackageDependencyEvidenceQuery
                 ProjectRestoredProject(restored),
             PackageDependencyEvidenceInput.AuthoredProject authored =>
                 ProjectAuthoredProject(authored),
+            PackageDependencyEvidenceInput.RuntimeDependencyManifest runtime =>
+                ProjectRuntimeDependencyManifest(runtime),
             _ => throw new InvalidOperationException(
                 "Unknown package dependency evidence input."),
         };
@@ -1189,6 +1338,57 @@ public static class PackageDependencyEvidenceQuery
             null,
             new PackageDependencyEvidenceRelationshipResult.NotApplicable(),
             new PackageDependencyEvidenceProcessingResult.NotApplicable());
+    }
+
+    private static PackageDependencyEvidenceRoot
+        ProjectRuntimeDependencyManifest(
+            PackageDependencyEvidenceInput.RuntimeDependencyManifest input)
+    {
+        ArgumentNullException.ThrowIfNull(input.Result);
+        RequireRuntimeDependencyAcquisitionForm(input.AcquisitionForm);
+        RuntimeDependencyFacts facts = input.Result switch
+        {
+            RuntimeDependencyFactsResult.Available available =>
+                available.Value,
+            RuntimeDependencyFactsResult.Failed =>
+                throw new InvalidOperationException(
+                    "Failed runtime dependency facts must be projected as a failed root."),
+            _ => throw new InvalidOperationException(
+                "Unknown runtime dependency facts result."),
+        };
+        ArgumentNullException.ThrowIfNull(facts);
+
+        var rootIdentity =
+            new PackageDependencyEvidenceRootIdentity
+                .RuntimeDependencyManifest(facts.Root);
+        return new PackageDependencyEvidenceRoot(
+            rootIdentity,
+            new PackageDependencyEvidenceRootProvenance
+                .RuntimeDependencyManifest(
+                    input.AcquisitionForm,
+                    facts.ContentProvenance,
+                    input.SourceLabel),
+            input.SourceLabel
+                ?? new InertString(
+                    TextPolicy.Prose,
+                    "Runtime dependency manifest"),
+            new PackageDependencyEvidenceDeclarationResult.NotApplicable(),
+            new PackageDependencyEvidenceSelection(
+                PackageDependencyEvidenceSelectionStatus.Unavailable,
+                null,
+                null,
+                null,
+                null),
+            null,
+            ProjectRuntimeDependencyRelationships(facts),
+            new PackageDependencyEvidenceProcessingResult.Available(
+                [
+                    PackageDependencyEvidenceProcessingObservation
+                        .RuntimeDependencyProjection,
+                ],
+                [],
+                PackageDependencyEvidencePhaseCompletion.Complete),
+            facts.Target);
     }
 
     private static PackageDependencyEvidenceRoot ProjectRestoredProject(
@@ -1937,6 +2137,62 @@ public static class PackageDependencyEvidenceQuery
                 "Unknown restored-project graph result."),
         };
 
+    private static PackageDependencyEvidenceRelationshipResult.Available
+        ProjectRuntimeDependencyRelationships(RuntimeDependencyFacts facts) =>
+        new(
+            [
+                .. facts.Graph.Packages.Select(package =>
+                    new PackageDependencyEvidenceResolvedPackage(
+                        new PackageDependencyEvidencePackageIdentity
+                            .RuntimeDependencyManifest(package.Identity),
+                        package.Identity.Coordinate,
+                        null)),
+            ],
+            [
+                .. facts.Graph.Edges.Select(edge =>
+                    new PackageDependencyEvidenceRelationship(
+                        new PackageDependencyEvidenceRelationshipIdentity
+                            .RuntimeDependencyManifest(edge.Identity),
+                        ProjectRuntimeDependencyParent(edge.Parent),
+                        new PackageDependencyEvidencePackageIdentity
+                            .RuntimeDependencyManifest(edge.Dependency),
+                        null,
+                        null,
+                        edge.Dependency.Coordinate,
+                        null,
+                        edge.Parent
+                            is RuntimeDependencyGraphParentIdentity.Package
+                                ? PackageDependencyEvidenceAuthorship
+                                    .LibraryDeclared
+                                : PackageDependencyEvidenceAuthorship
+                                    .Unattributed,
+                        null)),
+            ],
+            [
+                .. facts.Graph.Failures.Select(failure =>
+                    new PackageDependencyEvidenceRelationshipFailure
+                        .RuntimeDependencyManifest(failure)),
+            ],
+            facts.Graph.IsComplete
+                ? PackageDependencyEvidencePhaseCompletion.Complete
+                : PackageDependencyEvidencePhaseCompletion.Incomplete);
+
+    private static PackageDependencyEvidenceRelationshipParentIdentity
+        ProjectRuntimeDependencyParent(
+            RuntimeDependencyGraphParentIdentity parent) =>
+        parent switch
+        {
+            RuntimeDependencyGraphParentIdentity.Package package =>
+                new PackageDependencyEvidenceRelationshipParentIdentity.Package(
+                    new PackageDependencyEvidencePackageIdentity
+                        .RuntimeDependencyManifest(package.Identity)),
+            RuntimeDependencyGraphParentIdentity.Library library =>
+                new PackageDependencyEvidenceRelationshipParentIdentity
+                    .RuntimeDependencyLibrary(library.Identity),
+            _ => throw new InvalidOperationException(
+                "Unknown runtime dependency relationship parent."),
+        };
+
     private static PackageDependencyEvidenceRelationshipParentIdentity
         ProjectRelationshipParent(
             PackageDependencyEvidenceRootIdentity.RestoredProject root,
@@ -2228,6 +2484,19 @@ public static class PackageDependencyEvidenceQuery
         {
             throw new ArgumentException(
                 "An authored-project root requires direct project-XML provenance.",
+                nameof(acquisitionForm));
+        }
+    }
+
+    private static void RequireRuntimeDependencyAcquisitionForm(
+        PackageDependencyEvidenceAcquisitionForm acquisitionForm)
+    {
+        if (acquisitionForm
+            != PackageDependencyEvidenceAcquisitionForm
+                .RuntimeDependencyManifest)
+        {
+            throw new ArgumentException(
+                "A runtime dependency root requires runtime-manifest provenance.",
                 nameof(acquisitionForm));
         }
     }

--- a/tests/DotnetInspector.Queries.Tests/PackageDependencyEvidenceQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/PackageDependencyEvidenceQueryTests.cs
@@ -89,6 +89,375 @@ public sealed class PackageDependencyEvidenceQueryTests
     }
 
     [Fact]
+    public void Execute_CurrentRuntimeManifestRetainsProviderIdentityTargetAndProvenance()
+    {
+        string assemblyName =
+            typeof(PackageDependencyEvidenceQueryTests).Assembly.GetName().Name!;
+        RuntimeDependencyFacts facts = RuntimeFacts(
+            File.ReadAllBytes(
+                Path.Combine(
+                    AppContext.BaseDirectory,
+                    $"{assemblyName}.deps.json")));
+        var sourceLabel = new InertString(
+            TextPolicy.Field,
+            "test-host.deps.json");
+        PackageDependencyEvidenceOutcome outcome =
+            PackageDependencyEvidenceQuery.Execute(
+                new PackageDependencyEvidenceRequest(
+                    [
+                        PackageDependencyEvidenceQuery
+                            .CreateRuntimeDependencyManifestInput(
+                                new RuntimeDependencyFactsResult.Available(facts),
+                                sourceLabel: sourceLabel),
+                    ]));
+        PackageDependencyEvidenceRoot root = Assert.Single(outcome.Roots);
+        var identity = Assert.IsType<
+            PackageDependencyEvidenceRootIdentity.RuntimeDependencyManifest>(
+                root.Identity);
+        var provenance = Assert.IsType<
+            PackageDependencyEvidenceRootProvenance.RuntimeDependencyManifest>(
+                root.Provenance);
+        PackageDependencyEvidenceRelationshipResult.Available relationships =
+            Assert.IsType<PackageDependencyEvidenceRelationshipResult.Available>(
+                root.Relationships);
+
+        Assert.Equal(facts.Root, identity.Identity);
+        Assert.Equal(facts.ContentProvenance, provenance.ContentProvenance);
+        Assert.Equal(
+            PackageDependencyEvidenceAcquisitionForm
+                .RuntimeDependencyManifest,
+            provenance.AcquisitionForm);
+        Assert.Equal("test-host.deps.json", provenance.SourceLabel?.ToString());
+        Assert.Equal(
+            PackageDependencyEvidenceInputKind.RuntimeDependencyManifest,
+            root.InputKind);
+        Assert.Equal(
+            PackageDependencyEvidenceDeclarationBasis.NotApplicable,
+            root.DeclarationBasis);
+        Assert.Equal(facts.Target, root.RuntimeTarget);
+        Assert.Null(root.RestoredTarget);
+        Assert.IsType<PackageDependencyEvidenceDeclarationResult.NotApplicable>(
+            root.Declaration);
+        Assert.Equal(
+            PackageDependencyEvidenceSelectionStatus.Unavailable,
+            root.Selection.Status);
+        Assert.Equal(facts.Graph.Packages.Length, relationships.Packages.Length);
+        Assert.Equal(facts.Graph.Edges.Length, relationships.Relationships.Length);
+        Assert.True(relationships.IsComplete);
+        Assert.All(
+            relationships.Packages,
+            package => Assert.IsType<
+                PackageDependencyEvidencePackageIdentity
+                    .RuntimeDependencyManifest>(package.Identity));
+        Assert.All(
+            relationships.Relationships,
+            relationship => Assert.IsType<
+                PackageDependencyEvidenceRelationshipIdentity
+                    .RuntimeDependencyManifest>(relationship.Identity));
+        PackageDependencyEvidenceProcessingResult.Available processing =
+            Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
+                root.Processing);
+        Assert.Equal(
+            [
+                PackageDependencyEvidenceProcessingObservation
+                    .RuntimeDependencyProjection,
+            ],
+            processing.Observations);
+        Assert.True(processing.IsComplete);
+        Assert.Equal(1, outcome.Phases.Declarations.NotApplicable);
+        Assert.Equal(1, outcome.Phases.Relationships.Complete);
+        Assert.Equal(1, outcome.Phases.Processing.Complete);
+    }
+
+    [Fact]
+    public void PackageInput_RuntimeRelationshipsDoNotInventConstraintsRolesOrPruning()
+    {
+        PackageDependencyEvidenceRoot root = NormalizeRuntime(
+            new RuntimeDependencyFactsResult.Available(
+                RuntimeFacts(
+                    """
+                    {
+                      "runtimeTarget": { "name": "net8.0" },
+                      "targets": {
+                        "net8.0": {
+                          "Example.App/1.0.0": {
+                            "dependencies": {
+                              "Example.Package": "1.0.0"
+                            }
+                          },
+                          "Example.Package/1.0.0": {
+                            "dependencies": {
+                              "Example.Transitive": "2.0.0"
+                            }
+                          },
+                          "Example.Transitive/2.0.0": {}
+                        }
+                      },
+                      "libraries": {
+                        "Example.App/1.0.0": { "type": "project" },
+                        "Example.Package/1.0.0": { "type": "package" },
+                        "Example.Transitive/2.0.0": { "type": "package" }
+                      }
+                    }
+                    """)));
+        PackageDependencyEvidenceRelationshipResult.Available relationships =
+            Assert.IsType<PackageDependencyEvidenceRelationshipResult.Available>(
+                root.Relationships);
+        PackageDependencyEvidenceRelationship applicationRelationship =
+            relationships.Relationships.Single(relationship =>
+                relationship.ResolvedCoordinate.PackageId == "example.package");
+        PackageDependencyEvidenceRelationship packageRelationship =
+            relationships.Relationships.Single(relationship =>
+                relationship.ResolvedCoordinate.PackageId
+                    == "example.transitive");
+
+        Assert.IsType<
+            PackageDependencyEvidenceRelationshipParentIdentity
+                .RuntimeDependencyLibrary>(
+                applicationRelationship.Parent);
+        Assert.Equal(
+            PackageDependencyEvidenceAuthorship.Unattributed,
+            applicationRelationship.Authorship);
+        Assert.IsType<
+            PackageDependencyEvidenceRelationshipParentIdentity.Package>(
+                packageRelationship.Parent);
+        Assert.Equal(
+            PackageDependencyEvidenceAuthorship.LibraryDeclared,
+            packageRelationship.Authorship);
+        Assert.All(
+            relationships.Relationships,
+            relationship =>
+            {
+                Assert.Null(relationship.CanonicalRequestedConstraint);
+                Assert.Null(relationship.SourceRequestedConstraintSpelling);
+                Assert.Null(relationship.Role);
+                Assert.Null(relationship.DeclarationAssociation);
+            });
+
+        PackageDependencyEvidenceProcessingResult.Available processing =
+            Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
+                root.Processing);
+        Assert.Equal(
+            [
+                PackageDependencyEvidenceProcessingObservation
+                    .RuntimeDependencyProjection,
+            ],
+            processing.Observations);
+        Assert.DoesNotContain(
+            PackageDependencyEvidenceProcessingObservation
+                .PackagePruningEvaluation,
+            processing.Observations);
+    }
+
+    [Fact]
+    public void Execute_RuntimeIncompleteFactsRetainUsableGraphAndFailures()
+    {
+        PackageDependencyEvidenceRoot root = NormalizeRuntime(
+            new RuntimeDependencyFactsResult.Available(
+                RuntimeFacts(
+                    """
+                    {
+                      "runtimeTarget": { "name": "net8.0" },
+                      "targets": {
+                        "net8.0": {
+                          "Example.App/1.0.0": {
+                            "dependencies": {
+                              "Example.Valid": "1.0.0",
+                              "Example.Missing": "2.0.0"
+                            }
+                          },
+                          "Example.Valid/1.0.0": {}
+                        }
+                      },
+                      "libraries": {
+                        "Example.App/1.0.0": { "type": "project" },
+                        "Example.Valid/1.0.0": { "type": "package" }
+                      }
+                    }
+                    """)));
+        PackageDependencyEvidenceRelationshipResult.Available relationships =
+            Assert.IsType<PackageDependencyEvidenceRelationshipResult.Available>(
+                root.Relationships);
+
+        Assert.False(relationships.IsComplete);
+        Assert.Single(relationships.Packages);
+        Assert.Single(relationships.Relationships);
+        var failure = Assert.IsType<
+            PackageDependencyEvidenceRelationshipFailure
+                .RuntimeDependencyManifest>(
+                Assert.Single(relationships.Failures));
+        Assert.Equal(
+            RuntimeDependencyGraphFailureReason.UnresolvedDependency,
+            failure.Failure.Reason);
+        Assert.Equal(1, failure.Failure.Count);
+        Assert.True(
+            Assert.IsType<PackageDependencyEvidenceProcessingResult.Available>(
+                root.Processing).IsComplete);
+    }
+
+    [Fact]
+    public void Execute_RuntimeCompleteEmptyGraphIsNotUnavailable()
+    {
+        PackageDependencyEvidenceRoot root = NormalizeRuntime(
+            new RuntimeDependencyFactsResult.Available(
+                RuntimeFacts(
+                    """
+                    {
+                      "runtimeTarget": { "name": "net8.0" },
+                      "targets": {
+                        "net8.0": {}
+                      },
+                      "libraries": {}
+                    }
+                    """)));
+        PackageDependencyEvidenceRelationshipResult.Available relationships =
+            Assert.IsType<PackageDependencyEvidenceRelationshipResult.Available>(
+                root.Relationships);
+
+        Assert.True(relationships.IsComplete);
+        Assert.Empty(relationships.Packages);
+        Assert.Empty(relationships.Relationships);
+        Assert.Empty(relationships.Failures);
+    }
+
+    [Fact]
+    public void Compare_RuntimeDeclarationNotApplicableIsDistinctFromIncomplete()
+    {
+        PackageDependencyEvidenceRoot runtime = NormalizeRuntime(
+            new RuntimeDependencyFactsResult.Available(
+                RuntimeFacts(
+                    """
+                    {
+                      "runtimeTarget": { "name": "net8.0" },
+                      "targets": {
+                        "net8.0": {}
+                      },
+                      "libraries": {}
+                    }
+                    """)));
+        PackageDependencyEvidenceRoot package = NormalizePackage(
+            Manifest("""<group targetFramework="net8.0" />"""),
+            PackageDependencyEvidenceAcquisitionForm.DirectNuspec);
+
+        PackageDependencyEvidenceComparison comparison =
+            PackageDependencyEvidenceQuery.Compare(runtime, package);
+
+        Assert.All(
+            [
+                comparison.Core,
+                comparison.Scoped,
+                comparison.SelectedCore,
+                comparison.SelectedScoped,
+            ],
+            result => Assert.Equal(
+                PackageDependencyEvidenceNotComparableReason
+                    .DeclarationNotApplicable,
+                Assert.IsType<
+                    PackageDependencyEvidenceComparisonResult.NotComparable>(
+                        result).Reason));
+    }
+
+    [Fact]
+    public void Execute_RuntimeProviderFailureBecomesFailedRoot()
+    {
+        RuntimeDependencyFactsResult result =
+            RuntimeDependencyFactsQuery.Execute(
+                Encoding.UTF8.GetBytes("{"));
+        PackageDependencyEvidenceOutcome outcome =
+            PackageDependencyEvidenceQuery.Execute(
+                new PackageDependencyEvidenceRequest(
+                    [
+                        PackageDependencyEvidenceQuery
+                            .CreateRuntimeDependencyManifestInput(result),
+                    ]));
+
+        Assert.Empty(outcome.Roots);
+        var failure = Assert.IsType<
+            PackageDependencyEvidenceRootFailure.RuntimeDependencyManifest>(
+                Assert.Single(outcome.FailedRoots));
+        Assert.Equal(
+            RuntimeDependencyFailureReason.MalformedOrDuplicateBearingJson,
+            failure.Failure.Reason);
+        Assert.Equal(
+            PackageDependencyEvidenceRootSetCompletion.Incomplete,
+            outcome.RootSet.Completion);
+        Assert.Equal(0, outcome.RootSet.AdmittedRootCount);
+        Assert.Equal(1, outcome.RootSet.FailedRootCount);
+    }
+
+    [Fact]
+    public void CreateRuntimeDependencyManifestInput_RequiresRuntimeManifestAcquisition()
+    {
+        RuntimeDependencyFactsResult result =
+            new RuntimeDependencyFactsResult.Available(
+                RuntimeFacts(
+                    """
+                    {
+                      "runtimeTarget": { "name": "net8.0" },
+                      "targets": {
+                        "net8.0": {}
+                      },
+                      "libraries": {}
+                    }
+                    """));
+
+        Assert.Throws<ArgumentException>(() =>
+            PackageDependencyEvidenceQuery.CreateRuntimeDependencyManifestInput(
+                result,
+                PackageDependencyEvidenceAcquisitionForm.ProjectAssets));
+    }
+
+    [Fact]
+    public void RuntimeRoot_RequiresExclusiveMatchingTargetEvidence()
+    {
+        RuntimeDependencyFacts facts = RuntimeFacts(
+            """
+            {
+              "runtimeTarget": { "name": "net8.0" },
+              "targets": {
+                "net8.0": {}
+              },
+              "libraries": {}
+            }
+            """);
+        PackageDependencyEvidenceRoot runtime = NormalizeRuntime(
+            new RuntimeDependencyFactsResult.Available(facts));
+        PackageDependencyEvidenceRoot restored = NormalizeRestored(
+            Available(
+                RestoredProjectDependencyFactsQuery.Execute(
+                    File.ReadAllBytes(
+                        FixtureCatalog.RestoredProjectDependencyFacts.AssetPath(
+                            "project.assets.json")),
+                    new RestoredProjectTargetRequest("net11.0"))));
+
+        Assert.Throws<ArgumentException>(() =>
+            new PackageDependencyEvidenceRoot(
+                runtime.Identity,
+                runtime.Provenance,
+                runtime.Display,
+                runtime.Declaration,
+                runtime.Selection,
+                restored.RestoredTarget,
+                runtime.Relationships,
+                runtime.Processing,
+                runtime.RuntimeTarget));
+
+        RuntimeDependencyTarget mismatched =
+            facts.Target with { FrameworkIdentity = "net9.0" };
+        Assert.Throws<ArgumentException>(() =>
+            new PackageDependencyEvidenceRoot(
+                runtime.Identity,
+                runtime.Provenance,
+                runtime.Display,
+                runtime.Declaration,
+                runtime.Selection,
+                null,
+                runtime.Relationships,
+                runtime.Processing,
+                mismatched));
+    }
+
+    [Fact]
     public void Execute_AuthoredSyntaxRetainsTargetsDeclarationsAndProvenance()
     {
         var sourceLabel = new InertString(
@@ -1830,6 +2199,23 @@ public sealed class PackageDependencyEvidenceQueryTests
                                 result,
                                 sourceLabel: sourceLabel),
                     ])).Roots);
+
+    private static PackageDependencyEvidenceRoot NormalizeRuntime(
+        RuntimeDependencyFactsResult result) =>
+        Assert.Single(
+            PackageDependencyEvidenceQuery.Execute(
+                new PackageDependencyEvidenceRequest(
+                    [
+                        PackageDependencyEvidenceQuery
+                            .CreateRuntimeDependencyManifestInput(result),
+                    ])).Roots);
+
+    private static RuntimeDependencyFacts RuntimeFacts(byte[] bytes) =>
+        Assert.IsType<RuntimeDependencyFactsResult.Available>(
+            RuntimeDependencyFactsQuery.Execute(bytes)).Value;
+
+    private static RuntimeDependencyFacts RuntimeFacts(string json) =>
+        RuntimeFacts(Encoding.UTF8.GetBytes(json));
 
     private static AuthoredProjectDependencyFactsResult AuthoredFacts(
         string projectXml) =>


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational
capabilities or compelling user experiences while remaining conventionally
sound, delightfully new or unique, or both.

This change completes #6266 step 5 by adapting typed
`RuntimeDependencyFactsQuery` outcomes into the existing
`PackageDependencyEvidenceQuery` snapshot. The normalized owner now represents
runtime manifests without reparsing `.deps.json` or moving acquisition,
pruning policy, PackageHouse, or presentation into L1 composition.

## Demo

Given runtime facts whose selected target contains an application library, one
runtime package, and one transitive runtime package, the normalized root now
reports:

| Evidence | Normalized result |
| --- | --- |
| Input kind | `RuntimeDependencyManifest` |
| Declaration basis | `NotApplicable` |
| Runtime target | Exact provider-issued framework/RID identity and inert spelling |
| Runtime packages | Provider-issued package identities and resolved coordinates |
| Application-library edge | Opaque runtime-library parent, `Unattributed` authorship |
| Package-parent edge | Package parent, `LibraryDeclared` authorship |
| Requested constraint | Absent rather than reconstructed |
| Direct/transitive role | Absent rather than inferred |
| Processing | Positive `RuntimeDependencyProjection` evidence only |
| Package pruning | Not inferred from missing framework assemblies |

A valid empty runtime graph remains complete-empty relationship evidence. An
incomplete provider graph retains usable packages and edges plus typed
relationship failures. A failed provider outcome becomes a failed root rather
than an anonymous or empty admitted root.

## Implementation

- Extends the existing input, root, provenance, package, parent, edge, and
  failure unions with runtime-manifest variants.
- Adds the `RuntimeDependencyManifest` acquisition form and
  `CreateRuntimeDependencyManifestInput`.
- Retains provider-issued runtime target, semantic root/package/edge identities,
  exact-byte provenance, resolved coordinates, graph completion, and failure
  counts.
- Keeps declaration evidence not applicable and declaration selection
  unavailable.
- Maps package-parent relationships to library-declared authorship and opaque
  non-package parents to unattributed authorship.
- Records runtime projection independently from graph completion and never
  manufactures restore or package-pruning observations.
- Makes declaration comparison with runtime input explicitly not comparable
  because declarations are not applicable, not because they are incomplete.
- Enforces that runtime and restored target evidence are mutually exclusive and
  that a runtime target agrees with its manifest identity.

## Boundary

This slice accepts only `RuntimeDependencyFactsResult`. It does not accept
bytes or paths, locate manifests, reparse JSON, infer an application root,
reconstruct authored constraints, classify direct/transitive role, inspect
assets, evaluate pruning, change PackageHouse, or add CLI/browser acquisition
and rendering.

Package-pruning policy remains #6266 step 6. CLI and inspect-web Browser/Wasm
adoption remain steps 7 and 8.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release -m:1 -p:UseSharedCompilation=false`
  - succeeded before the final non-overlapping inspect-web-only `main`
    integration; 0 errors and 3 existing JS-export fixture warnings
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release --no-restore -- --filter-class '*PackageDependencyEvidenceQueryTests'`
  - 56 passed
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release --no-restore`
  - 2,047 passed on the integrated candidate
- `npx markdownlint-cli docs/design/package-dependency-evidence.md docs/design/runtime-dependency-facts.md`
- `git diff --check origin/main...HEAD`

Completes #6266 step 5.
