### PR TITLE
Fix Inspect Web deployment canary detection

### DIFF
--- a/inspect-web/scripts/verify-async-lowering.cs
+++ b/inspect-web/scripts/verify-async-lowering.cs
@@ -117,7 +117,7 @@ foreach (string assemblyName in contextAssemblies.Order(StringComparer.Ordinal))
         compilerAsyncCount,
         runtimeAsyncCount,
         asyncExports.Count(method =>
-            method.DeclaringType == "InspectionEngine"
+            SimpleTypeName(method.DeclaringType) == "InspectionEngine"
             && method.MethodName == "AsyncLoweringCanary")));
 }
 


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational capabilities or compelling user experiences while remaining conventionally sound and, where valuable, delightfully unique.

## Summary

Restore Inspect Web staging deployment verification after the browser host moved into the `DotnetInspect.Web` namespace.

`MethodClassificationScanner` reports the canary's declaring type as `DotnetInspect.Web.InspectionEngine`. The deployment verifier already normalizes declaring types when matching async `[JSExport]` methods, but its final canary count compared the full name to the unqualified pre-move name. Reuse the same normalization for that count.

## Demo

Before, every staging run since #6507 failed with:

```text
Expected exactly one async InspectionEngine.AsyncLoweringCanary in the compiled context; found 0.
```

After the fix, the exact failing census reports:

```text
InspectWeb async census found 68 exports (41 async) across 7 context-rooted assemblies: compiler=41, runtime=0; canary=compiler.
  DotnetInspect.Web: exports=7, async=1 (compiler=1, runtime=0)
```

The neighboring six facade assemblies remain included, and all 41 async exports retain compiler lowering.

## Validation

- `dotnet run inspect-web/scripts/verify-async-lowering.cs -- inspect-web/DotnetInspect.Web/bin/Release/net11.0/DotnetInspect.Web.dll compiler artifacts/inspect-web-async-census-committed.json`
- `dotnet run --project inspect-web/DotnetInspect.Web.Tests -c Release` — 472 passed
- Fresh Release Browser/Wasm publish completed; the broader deployment verifier passed the async census, generated-facade runtime canary, and published Browser/Wasm facade smoke before reaching an unrelated Bash 3.2 empty-array incompatibility on macOS.
