### PR TITLE
Add candidate payload settlement to package leases

### DIFF
--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -67,7 +67,9 @@ The lease carries the live authority to:
 
 - authorize and settle one caller-pinned package coordinate;
 - discover dependency versions across one explicit source authorization; and
-- acquire one exact manifest through a candidate issued by the same lease.
+- acquire one exact manifest through a candidate issued by the same lease; and
+- acquire one admitted retained payload through a candidate issued by the same
+  lease and caller-supplied authority-scoped package stores.
 
 One lease owns one candidate-issuer identity. It accepts only source results
 whose association and client identity match the exact configured authority
@@ -81,6 +83,15 @@ package stores, artifact content, or Workspace participants. Completed result
 values retain their existing evidence semantics after retirement; no
 PackageHouse receipt stores the live source-settlement lease.
 
+Candidate payload acquisition consults every authorized cache before cold
+acquisition, then tries the same stable local-before-HTTP authority order used
+for candidate manifests. The result preserves the serving configured authority,
+producer identity, retained-content generation, cache/download origin,
+not-found authorities, and attributed failures. The lease does not create or
+select stores: the caller supplies one store per configured authority and
+producer, preserving host choice between filesystem, in-memory Browser/Wasm,
+or another package-owned storage implementation.
+
 This ownership correction preserves the existing `IDisposable` lifetime and
 async operation shapes. It does not define borrowing or transfer across an
 `await` boundary; [#6544](https://github.com/richlander/dotnet-inspect/issues/6544)
@@ -88,10 +99,14 @@ owns that contract. Repository-wide absence of another issuer or the retired
 House-named API remains unverified by user choice.
 
 `PackageSourceSettlementLeaseSettlesManifestAndRetiresWithoutDisposingClient`
-and
+and `PackageSourceSettlementLeaseAcquiresPayloadAndRetiresWithoutDisposingClient`
+are the Release gates for lease retirement, caller-owned resources, retained
+generation, producer, and origin. Together with
 `PackageSourceSettlementLeaseRejectsForeignCandidateAndClientAssociation`
-are the Release gates for retirement, caller-owned resources, candidate
-identity, and exact source association.
+they gate candidate identity and exact source association. Existing
+`ConfiguredPayloadAcquisitionTests` remain the Release gates for cache/source
+ordering, failover, not-found evidence, and typed payload failures through the
+shared candidate-payload implementation.
 
 ## Identity roles
 

--- a/src/DotnetInspector.Packages/DesktopPackageSourceComposition.Payloads.cs
+++ b/src/DotnetInspector.Packages/DesktopPackageSourceComposition.Payloads.cs
@@ -1,38 +1,7 @@
-using System.Collections.ObjectModel;
 using InertText;
 using NuGetFetch;
 
 namespace DotnetInspector.Packages;
-
-/// <summary>An exact payload and its configured authority, or attributed failures.</summary>
-public sealed class ConfiguredPackagePayloadResult
-{
-    internal ConfiguredPackagePayloadResult(
-        ConfiguredPackageAuthority? authority,
-        AcquiredPackageSourcePayload? payload,
-        IReadOnlyList<PackageAuthorityFailure> failures,
-        IReadOnlyList<ConfiguredPackageAuthority>? notFoundAuthorities = null,
-        IReadOnlyList<ConfiguredPackageAuthority>? reportingAuthorities = null,
-        bool selectionUsesOriginalSources = false)
-    {
-        Authority = authority;
-        Payload = payload;
-        Failures = new ReadOnlyCollection<PackageAuthorityFailure>([.. failures]);
-        NotFoundAuthorities = new ReadOnlyCollection<ConfiguredPackageAuthority>(
-            [.. notFoundAuthorities ?? []]);
-        ReportingAuthorities = reportingAuthorities is null
-            ? null
-            : new ReadOnlyCollection<ConfiguredPackageAuthority>([.. reportingAuthorities]);
-        SelectionUsesOriginalSources = selectionUsesOriginalSources;
-    }
-
-    public ConfiguredPackageAuthority? Authority { get; }
-    public AcquiredPackageSourcePayload? Payload { get; }
-    public IReadOnlyList<PackageAuthorityFailure> Failures { get; }
-    public IReadOnlyList<ConfiguredPackageAuthority> NotFoundAuthorities { get; }
-    internal IReadOnlyList<ConfiguredPackageAuthority>? ReportingAuthorities { get; }
-    internal bool SelectionUsesOriginalSources { get; }
-}
 
 public sealed partial class DesktopPackageSourceComposition
 {
@@ -123,7 +92,7 @@ public sealed partial class DesktopPackageSourceComposition
             failures).ConfigureAwait(false);
     }
 
-    private async Task<ConfiguredPackagePayloadResult> AcquireCandidateAsync(
+    private Task<ConfiguredPackagePayloadResult> AcquireCandidateAsync(
         PackageAcquisitionCandidate candidate,
         Func<ConfiguredPackageAuthority, PackageProducerIdentity, IPackageStore> createStore,
         Action<string>? log,
@@ -132,163 +101,15 @@ public sealed partial class DesktopPackageSourceComposition
         IPackagePayloadTransferPolicy? transferPolicy,
         List<PackageAuthorityFailure> failures,
         bool selectionUsesOriginalSources = false)
-    {
-        if (!_sourceLease.OwnsCandidate(candidate))
-        {
-            throw new InvalidOperationException(
-                "The package acquisition candidate belongs to another source composition.");
-        }
-
-        var notFoundAuthorities = new List<ConfiguredPackageAuthority>();
-        try
-        {
-            operation.ThrowIfExpired();
-            List<(AuthorityEntry Entry, IPackageStore Store)> entries = [];
-            foreach (PackageAcquisitionAuthorityEvidence evidence in
-                candidate.Authorities
-                    .OrderBy(evidence =>
-                        evidence.Authority.Kind
-                            == ConfiguredPackageAuthorityKind.LocalFolder
-                            ? 0
-                            : 1)
-                    .ThenBy(
-                        evidence => evidence.Authority.Source.Url,
-                        StringComparer.Ordinal))
-            {
-                operation.ThrowIfExpired();
-                ConfiguredPackageAuthority authority = evidence.Authority;
-                if (!_authoritiesByAssociation.TryGetValue(
-                        authority.Association,
-                        out AuthorityEntry? entry)
-                    || !ReferenceEquals(entry.Authority, authority))
-                {
-                    throw new InvalidOperationException(
-                        "The package acquisition candidate names an unknown or retired configured authority.");
-                }
-                RequireAuthority(entry.Client.Source, entry);
-                IPackageStore store = createStore(entry.Authority, entry.Client.Source.Producer);
-                entries.Add((entry, store));
-            }
-            ConfiguredPackageAuthority[]? selectedAuthorities =
-                candidate.Kind == PackageAcquisitionCandidateKind.Discovered
-                    ? [.. entries.Select(item => item.Entry.Authority)]
-                    : null;
-
-            // Every authorized cache is consulted before cold acquisition.
-            // Stable consultation order is not configured declaration precedence.
-            foreach (var (entry, store) in entries)
-            {
-                operation.ThrowIfExpired();
-                AcquiredPackageSourcePayload? cached =
-                    await PackagePayloadAcquisition.TryGetCachedAsync(
-                        candidate.Coordinate,
-                        entry.Client.Source.Producer.Key,
-                        store,
-                        limits, log, operation.OperationToken).ConfigureAwait(false);
-                operation.ThrowIfExpired();
-                if (cached is not null)
-                {
-                    return new(
-                        entry.Authority,
-                        cached,
-                        failures,
-                        reportingAuthorities: selectedAuthorities,
-                        selectionUsesOriginalSources: selectionUsesOriginalSources);
-                }
-            }
-
-            foreach (var (entry, store) in entries)
-            {
-                operation.ThrowIfExpired();
-                log?.Invoke(
-                    $"Acquiring {candidate.Coordinate.PackageId} {candidate.Coordinate.Version} from "
-                    + $"{PackageSourceDisplay.ForDiagnostics(entry.Source)}.");
-                try
-                {
-                    PackageSourcePayloadResult result =
-                        await PackagePayloadAcquisition.AcquireAuthorizedAsync(
-                            entry.Client,
-                            candidate.Coordinate,
-                            store,
-                            operation,
-                            log, limits, transferPolicy).ConfigureAwait(false);
-                    operation.ThrowIfExpired();
-                    RequireAuthority(entry.Client.Source, entry);
-                    if (result is PackageSourcePayloadResult.Acquired acquired)
-                    {
-                        return new(
-                            entry.Authority,
-                            acquired.Payload,
-                            failures,
-                            notFoundAuthorities,
-                            selectedAuthorities,
-                            selectionUsesOriginalSources);
-                    }
-                    if (result is PackageSourcePayloadResult.Failed failed)
-                    {
-                        RequireAuthority(failed.Failure.Source, entry);
-                        failures.Add(DescribePayloadFailure(entry.Source, failed.Failure));
-                    }
-                    else if (result is PackageSourcePayloadResult.Unavailable unavailable)
-                    {
-                        if (unavailable.IsNotFound)
-                        {
-                            notFoundAuthorities.Add(entry.Authority);
-                        }
-                        else
-                        {
-                            failures.Add(new PackageAuthorityFailure(
-                                PackageSourceDisplay.ForDiagnostics(entry.Source),
-                                PackageAuthorityFailureKind.ResponseRejected,
-                                "The selected source did not supply a payload satisfying the package policy.")
-                            {
-                                ResultSource = entry.Client.Source,
-                            });
-                        }
-                    }
-                }
-                catch (PackageSourceStreamException exception)
-                {
-                    RequireAuthority(exception.ResultSource, entry);
-                    failures.Add(new PackageAuthorityFailure(
-                        PackageSourceDisplay.ForDiagnostics(entry.Source),
-                        ClassifySourceFailure(exception.Kind), exception.Message)
-                    {
-                        ResultSource = exception.ResultSource,
-                        Timeout = exception.Timeout,
-                    });
-                    if (exception.Timeout?.Kind == PackageSourceTimeoutKind.Operation)
-                    {
-                        return new(
-                            null,
-                            null,
-                            failures,
-                            notFoundAuthorities);
-                    }
-                }
-            }
-            operation.ThrowIfExpired();
-            return new(null, null, failures, notFoundAuthorities);
-        }
-        catch (NuGetOperationTimeoutException)
-        {
-            return PayloadOperationTimedOut(
-                operation,
-                failures,
-                notFoundAuthorities);
-        }
-        catch (OperationCanceledException) when (operation.CancellationToken.IsCancellationRequested)
-        {
-            throw new OperationCanceledException(operation.CancellationToken);
-        }
-        catch (OperationCanceledException) when (operation.OperationToken.IsCancellationRequested)
-        {
-            return PayloadOperationTimedOut(
-                operation,
-                failures,
-                notFoundAuthorities);
-        }
-    }
+        => _sourceLease.AcquireCandidatePayloadAsync(
+            candidate,
+            createStore,
+            log,
+            operation,
+            limits,
+            transferPolicy,
+            failures,
+            selectionUsesOriginalSources);
 
     private static PackageAuthorityFailure RequiredProducerUnavailable() =>
         new(
@@ -301,36 +122,18 @@ public sealed partial class DesktopPackageSourceComposition
 
     private static ConfiguredPackagePayloadResult PayloadOperationTimedOut(
         NuGetOperationContext operation,
-        List<PackageAuthorityFailure> failures,
-        IReadOnlyList<ConfiguredPackageAuthority>? notFoundAuthorities = null)
+        List<PackageAuthorityFailure> failures)
     {
         failures.Add(new PackageAuthorityFailure(
-            InertString.Empty, PackageAuthorityFailureKind.Timeout,
+            InertString.Empty,
+            PackageAuthorityFailureKind.Timeout,
             "The package payload operation deadline expired before acquisition completed.")
         {
-            Timeout = new(PackageSourceTimeoutKind.Operation, operation.OperationTimeout),
+            Timeout = new(
+                PackageSourceTimeoutKind.Operation,
+                operation.OperationTimeout),
         });
-        return new(null, null, failures, notFoundAuthorities);
+        return new(null, null, failures);
     }
 
-    private static PackageAuthorityFailure DescribePayloadFailure(
-        PackageSource source, PackageSourceFailure failure) =>
-        new(PackageSourceDisplay.ForDiagnostics(source),
-            ClassifySourceFailure(failure.Kind), failure.Message)
-        {
-            SourceFailure = failure,
-            ResultSource = failure.Source,
-        };
-
-    private static PackageAuthorityFailureKind ClassifySourceFailure(PackageSourceFailureKind kind) =>
-        kind switch
-        {
-            PackageSourceFailureKind.AuthenticationRequired => PackageAuthorityFailureKind.AuthenticationRequired,
-            PackageSourceFailureKind.Timeout => PackageAuthorityFailureKind.Timeout,
-            PackageSourceFailureKind.Unsupported => PackageAuthorityFailureKind.Unsupported,
-            PackageSourceFailureKind.InvalidResponse => PackageAuthorityFailureKind.InvalidResponse,
-            PackageSourceFailureKind.ResponseRejected => PackageAuthorityFailureKind.ResponseRejected,
-            PackageSourceFailureKind.Transport => PackageAuthorityFailureKind.Transport,
-            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
-        };
 }

--- a/src/DotnetInspector.Packages/PackageAcquisitionCandidatePayloads.cs
+++ b/src/DotnetInspector.Packages/PackageAcquisitionCandidatePayloads.cs
@@ -1,0 +1,360 @@
+using System.Collections.ObjectModel;
+using InertText;
+using NuGetFetch;
+
+namespace DotnetInspector.Packages;
+
+/// <summary>An exact payload and its configured authority, or attributed failures.</summary>
+public sealed class ConfiguredPackagePayloadResult
+{
+    internal ConfiguredPackagePayloadResult(
+        ConfiguredPackageAuthority? authority,
+        AcquiredPackageSourcePayload? payload,
+        IReadOnlyList<PackageAuthorityFailure> failures,
+        IReadOnlyList<ConfiguredPackageAuthority>? notFoundAuthorities = null,
+        IReadOnlyList<ConfiguredPackageAuthority>? reportingAuthorities = null,
+        bool selectionUsesOriginalSources = false)
+    {
+        Authority = authority;
+        Payload = payload;
+        Failures = new ReadOnlyCollection<PackageAuthorityFailure>([.. failures]);
+        NotFoundAuthorities = new ReadOnlyCollection<ConfiguredPackageAuthority>(
+            [.. notFoundAuthorities ?? []]);
+        ReportingAuthorities = reportingAuthorities is null
+            ? null
+            : new ReadOnlyCollection<ConfiguredPackageAuthority>(
+                [.. reportingAuthorities]);
+        SelectionUsesOriginalSources = selectionUsesOriginalSources;
+    }
+
+    public ConfiguredPackageAuthority? Authority { get; }
+    public AcquiredPackageSourcePayload? Payload { get; }
+    public IReadOnlyList<PackageAuthorityFailure> Failures { get; }
+    public IReadOnlyList<ConfiguredPackageAuthority> NotFoundAuthorities { get; }
+    internal IReadOnlyList<ConfiguredPackageAuthority>? ReportingAuthorities
+        { get; }
+    internal bool SelectionUsesOriginalSources { get; }
+}
+
+/// <summary>
+/// Acquires admitted retained payloads only through candidates issued by one
+/// package-owned candidate issuer.
+/// </summary>
+internal sealed class PackageAcquisitionCandidatePayloadAcquirer
+{
+    private readonly PackageAcquisitionCandidateIssuer _issuer;
+    private readonly Func<
+        ConfiguredPackageAuthority,
+        IPackageSourceClient> _getClient;
+
+    public PackageAcquisitionCandidatePayloadAcquirer(
+        PackageAcquisitionCandidateIssuer issuer,
+        Func<ConfiguredPackageAuthority, IPackageSourceClient> getClient)
+    {
+        ArgumentNullException.ThrowIfNull(issuer);
+        ArgumentNullException.ThrowIfNull(getClient);
+        _issuer = issuer;
+        _getClient = getClient;
+    }
+
+    public Task<ConfiguredPackagePayloadResult> AcquireAsync(
+        PackageAcquisitionCandidate candidate,
+        Func<
+            ConfiguredPackageAuthority,
+            PackageProducerIdentity,
+            IPackageStore> createStore,
+        Action<string>? log = null,
+        PackagePayloadLimits? limits = null,
+        CancellationToken cancellationToken = default,
+        IPackagePayloadTransferPolicy? transferPolicy = null,
+        NuGetOperationContext? operationContext = null) =>
+        AcquireAsync(
+            candidate,
+            createStore,
+            log,
+            limits,
+            cancellationToken,
+            transferPolicy,
+            operationContext,
+            failures: [],
+            selectionUsesOriginalSources: false);
+
+    internal async Task<ConfiguredPackagePayloadResult> AcquireAsync(
+        PackageAcquisitionCandidate candidate,
+        Func<
+            ConfiguredPackageAuthority,
+            PackageProducerIdentity,
+            IPackageStore> createStore,
+        Action<string>? log,
+        PackagePayloadLimits? limits,
+        CancellationToken cancellationToken,
+        IPackagePayloadTransferPolicy? transferPolicy,
+        NuGetOperationContext? operationContext,
+        List<PackageAuthorityFailure> failures,
+        bool selectionUsesOriginalSources)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(createStore);
+        ArgumentNullException.ThrowIfNull(failures);
+        if (!_issuer.OwnsCandidate(candidate))
+        {
+            throw new InvalidOperationException(
+                "The package acquisition candidate belongs to another issuer.");
+        }
+
+        using NuGetOperationContext? ownedOperation =
+            operationContext is null
+                ? new NuGetOperationContext(cancellationToken)
+                : null;
+        NuGetOperationContext operation =
+            operationContext ?? ownedOperation!;
+        cancellationToken = ResolveInvocationToken(
+            operation,
+            cancellationToken);
+        var notFoundAuthorities = new List<ConfiguredPackageAuthority>();
+        try
+        {
+            operation.ThrowIfExpired();
+            List<(
+                ConfiguredPackageAuthority Authority,
+                IPackageSourceClient Client,
+                IPackageStore Store)> entries = [];
+            foreach (PackageAcquisitionAuthorityEvidence evidence in
+                     PackageAcquisitionCandidateManifestAcquirer
+                         .OrderAuthorities(candidate.Authorities))
+            {
+                operation.ThrowIfExpired();
+                ConfiguredPackageAuthority authority = evidence.Authority;
+                IPackageSourceClient client = _getClient(authority)
+                    ?? throw new InvalidOperationException(
+                        "The package source client factory returned null.");
+                RequireAuthority(client.Source, authority);
+                IPackageStore store = createStore(
+                    authority,
+                    client.Source.Producer)
+                    ?? throw new InvalidOperationException(
+                        "The package store factory returned null.");
+                entries.Add((authority, client, store));
+            }
+            ConfiguredPackageAuthority[]? selectedAuthorities =
+                candidate.Kind == PackageAcquisitionCandidateKind.Discovered
+                    ? [.. entries.Select(item => item.Authority)]
+                    : null;
+
+            // Every authorized cache is consulted before cold acquisition.
+            foreach (var (authority, client, store) in entries)
+            {
+                operation.ThrowIfExpired();
+                AcquiredPackageSourcePayload? cached =
+                    await PackagePayloadAcquisition.TryGetCachedAsync(
+                        candidate.Coordinate,
+                        client.Source.Producer.Key,
+                        store,
+                        limits,
+                        log,
+                        operation.OperationToken).ConfigureAwait(false);
+                operation.ThrowIfExpired();
+                RequireAuthority(client.Source, authority);
+                if (cached is not null)
+                {
+                    return new(
+                        authority,
+                        cached,
+                        failures,
+                        reportingAuthorities: selectedAuthorities,
+                        selectionUsesOriginalSources:
+                            selectionUsesOriginalSources);
+                }
+            }
+
+            foreach (var (authority, client, store) in entries)
+            {
+                operation.ThrowIfExpired();
+                log?.Invoke(
+                    $"Acquiring {candidate.Coordinate.PackageId} "
+                    + $"{candidate.Coordinate.Version} from "
+                    + $"{PackageSourceDisplay.ForDiagnostics(authority.Source)}.");
+                try
+                {
+                    PackageSourcePayloadResult result =
+                        await PackagePayloadAcquisition.AcquireAuthorizedAsync(
+                            client,
+                            candidate.Coordinate,
+                            store,
+                            operation,
+                            log,
+                            limits,
+                            transferPolicy).ConfigureAwait(false);
+                    operation.ThrowIfExpired();
+                    RequireAuthority(client.Source, authority);
+                    if (result is PackageSourcePayloadResult.Acquired acquired)
+                    {
+                        return new(
+                            authority,
+                            acquired.Payload,
+                            failures,
+                            notFoundAuthorities,
+                            selectedAuthorities,
+                            selectionUsesOriginalSources);
+                    }
+                    if (result is PackageSourcePayloadResult.Failed failed)
+                    {
+                        RequireAuthority(
+                            failed.Failure.Source,
+                            authority,
+                            client.Source);
+                        failures.Add(
+                            DescribePayloadFailure(
+                                authority.Source,
+                                failed.Failure));
+                    }
+                    else if (result is PackageSourcePayloadResult.Unavailable
+                             unavailable)
+                    {
+                        if (unavailable.IsNotFound)
+                        {
+                            notFoundAuthorities.Add(authority);
+                        }
+                        else
+                        {
+                            failures.Add(new PackageAuthorityFailure(
+                                PackageSourceDisplay.ForDiagnostics(
+                                    authority.Source),
+                                PackageAuthorityFailureKind.ResponseRejected,
+                                "The selected source did not supply a payload satisfying the package policy.")
+                            {
+                                ResultSource = client.Source,
+                            });
+                        }
+                    }
+                }
+                catch (PackageSourceStreamException exception)
+                {
+                    RequireAuthority(
+                        exception.ResultSource,
+                        authority,
+                        client.Source);
+                    failures.Add(new PackageAuthorityFailure(
+                        PackageSourceDisplay.ForDiagnostics(authority.Source),
+                        ClassifySourceFailure(exception.Kind),
+                        exception.Message)
+                    {
+                        ResultSource = exception.ResultSource,
+                        Timeout = exception.Timeout,
+                    });
+                    if (exception.Timeout?.Kind
+                        == PackageSourceTimeoutKind.Operation)
+                    {
+                        return new(
+                            null,
+                            null,
+                            failures,
+                            notFoundAuthorities);
+                    }
+                }
+            }
+            operation.ThrowIfExpired();
+            return new(null, null, failures, notFoundAuthorities);
+        }
+        catch (NuGetOperationTimeoutException)
+        {
+            return PayloadOperationTimedOut(
+                operation,
+                failures,
+                notFoundAuthorities);
+        }
+        catch (OperationCanceledException)
+            when (operation.CancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(
+                operation.CancellationToken);
+        }
+        catch (OperationCanceledException)
+            when (operation.OperationToken.IsCancellationRequested)
+        {
+            return PayloadOperationTimedOut(
+                operation,
+                failures,
+                notFoundAuthorities);
+        }
+    }
+
+    private static ConfiguredPackagePayloadResult PayloadOperationTimedOut(
+        NuGetOperationContext operation,
+        List<PackageAuthorityFailure> failures,
+        IReadOnlyList<ConfiguredPackageAuthority>? notFoundAuthorities = null)
+    {
+        failures.Add(new PackageAuthorityFailure(
+            InertString.Empty,
+            PackageAuthorityFailureKind.Timeout,
+            "The package payload operation deadline expired before acquisition completed.")
+        {
+            Timeout = new(
+                PackageSourceTimeoutKind.Operation,
+                operation.OperationTimeout),
+        });
+        return new(null, null, failures, notFoundAuthorities);
+    }
+
+    private static PackageAuthorityFailure DescribePayloadFailure(
+        PackageSource source,
+        PackageSourceFailure failure) =>
+        new(
+            PackageSourceDisplay.ForDiagnostics(source),
+            ClassifySourceFailure(failure.Kind),
+            failure.Message)
+        {
+            SourceFailure = failure,
+            ResultSource = failure.Source,
+        };
+
+    private static PackageAuthorityFailureKind ClassifySourceFailure(
+        PackageSourceFailureKind kind) =>
+        kind switch
+        {
+            PackageSourceFailureKind.AuthenticationRequired =>
+                PackageAuthorityFailureKind.AuthenticationRequired,
+            PackageSourceFailureKind.Timeout =>
+                PackageAuthorityFailureKind.Timeout,
+            PackageSourceFailureKind.Unsupported =>
+                PackageAuthorityFailureKind.Unsupported,
+            PackageSourceFailureKind.InvalidResponse =>
+                PackageAuthorityFailureKind.InvalidResponse,
+            PackageSourceFailureKind.ResponseRejected =>
+                PackageAuthorityFailureKind.ResponseRejected,
+            PackageSourceFailureKind.Transport =>
+                PackageAuthorityFailureKind.Transport,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    private static void RequireAuthority(
+        PackageSourceResultIdentity result,
+        ConfiguredPackageAuthority authority,
+        PackageSourceResultIdentity? expectedSource = null)
+    {
+        if (!ReferenceEquals(
+                result.Association,
+                authority.Association)
+            || (expectedSource is not null
+                && !ReferenceEquals(result, expectedSource)))
+        {
+            throw new InvalidOperationException(
+                "The package source result belongs to another configured authority or client.");
+        }
+    }
+
+    private static CancellationToken ResolveInvocationToken(
+        NuGetOperationContext operationContext,
+        CancellationToken invocationToken)
+    {
+        if (invocationToken != default
+            && invocationToken != operationContext.CancellationToken)
+        {
+            throw new ArgumentException(
+                "The invocation token must match the operation context's caller token.",
+                nameof(invocationToken));
+        }
+
+        return operationContext.CancellationToken;
+    }
+}

--- a/src/DotnetInspector.Packages/PackageSourceSettlementLease.cs
+++ b/src/DotnetInspector.Packages/PackageSourceSettlementLease.cs
@@ -47,6 +47,8 @@ public sealed class PackageSourceSettlementLease : IDisposable
         new();
     private readonly PackageAcquisitionCandidateManifestAcquirer
         _manifestAcquirer;
+    private readonly PackageAcquisitionCandidatePayloadAcquirer
+        _payloadAcquirer;
     private int _retired;
 
     internal PackageSourceSettlementLease(
@@ -57,6 +59,9 @@ public sealed class PackageSourceSettlementLease : IDisposable
         _getClient = getClient;
         _createOperationContext = createOperationContext;
         _manifestAcquirer = new(
+            _candidateIssuer,
+            GetClient);
+        _payloadAcquirer = new(
             _candidateIssuer,
             GetClient);
     }
@@ -350,6 +355,65 @@ public sealed class PackageSourceSettlementLease : IDisposable
             candidate,
             cancellationToken,
             operationContext ?? ownedOperation).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Acquires one exact admitted retained payload through a candidate issued
+    /// by this lease.
+    /// </summary>
+    public async Task<ConfiguredPackagePayloadResult>
+        AcquireCandidatePayloadAsync(
+        PackageAcquisitionCandidate candidate,
+        Func<
+            ConfiguredPackageAuthority,
+            PackageProducerIdentity,
+            IPackageStore> createStore,
+        Action<string>? log = null,
+        PackagePayloadLimits? limits = null,
+        CancellationToken cancellationToken = default,
+        IPackagePayloadTransferPolicy? transferPolicy = null,
+        NuGetOperationContext? operationContext = null)
+    {
+        ThrowIfRetired();
+        using NuGetOperationContext? ownedOperation =
+            operationContext is null
+                ? CreateOperationContext(cancellationToken)
+                : null;
+        return await _payloadAcquirer.AcquireAsync(
+            candidate,
+            createStore,
+            log,
+            limits,
+            cancellationToken,
+            transferPolicy,
+            operationContext ?? ownedOperation).ConfigureAwait(false);
+    }
+
+    internal Task<ConfiguredPackagePayloadResult>
+        AcquireCandidatePayloadAsync(
+        PackageAcquisitionCandidate candidate,
+        Func<
+            ConfiguredPackageAuthority,
+            PackageProducerIdentity,
+            IPackageStore> createStore,
+        Action<string>? log,
+        NuGetOperationContext operationContext,
+        PackagePayloadLimits? limits,
+        IPackagePayloadTransferPolicy? transferPolicy,
+        List<PackageAuthorityFailure> failures,
+        bool selectionUsesOriginalSources)
+    {
+        ThrowIfRetired();
+        return _payloadAcquirer.AcquireAsync(
+            candidate,
+            createStore,
+            log,
+            limits,
+            operationContext.CancellationToken,
+            transferPolicy,
+            operationContext,
+            failures,
+            selectionUsesOriginalSources);
     }
 
     public void Dispose() =>

--- a/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
@@ -1755,6 +1755,81 @@ public sealed class PackageHouseContractTests
     }
 
     [Fact]
+    public async Task PackageSourceSettlementLeaseAcquiresPayloadAndRetiresWithoutDisposingClient()
+    {
+        PackageSourceAuthorization authorization =
+            PackageSourceAuthorization.Authorize(
+                [
+                    new PackageSource(
+                        "browser",
+                        "https://browser.example/v3/index.json"),
+                ]);
+        ConfiguredPackageAuthority authority =
+            Assert.Single(authorization.Authorities);
+        TrackingPackageSourceClient? tracking = null;
+        using IPackageSourceClient client =
+            PackageSourceClientFactory.CreateCustom(
+                PackageSourceDescriptor.NuGetGallery,
+                authority.Association,
+                factory =>
+                {
+                    tracking = new TrackingPackageSourceClient(factory);
+                    return tracking;
+                });
+        using PackageSourceSettlementLease lease =
+            PackageSourceSettlementService.IssueLease(_ => client);
+        PackageAcquisitionCandidate candidate =
+            Assert.IsType<PackageAcquisitionCandidate>(
+                lease.ResolvePinnedCandidate(
+                    authorization,
+                    Coordinate).Candidate);
+        var store = new InMemoryPackageStore();
+        byte[] nupkg = TestPackageArchive.Create(
+            (
+                "contoso.json.nuspec",
+                "<package><metadata><id>contoso.json</id><version>1.0.0</version></metadata></package>"u8.ToArray()),
+            ("lib/net10.0/contoso.json.dll", [1, 2, 3]));
+        IPackageContent committed = await store.CommitAsync(
+            Coordinate.PackageId,
+            Coordinate.Version,
+            client.Source.Producer.Key,
+            new MemoryStream(nupkg, writable: false),
+            TestContext.Current.CancellationToken);
+
+        ConfiguredPackagePayloadResult payload =
+            await lease.AcquireCandidatePayloadAsync(
+                candidate,
+                (_, producer) =>
+                {
+                    Assert.Equal(client.Source.Producer, producer);
+                    return store;
+                },
+                cancellationToken:
+                    TestContext.Current.CancellationToken);
+
+        Assert.Same(authority, payload.Authority);
+        AcquiredPackageSourcePayload acquired =
+            Assert.IsType<AcquiredPackageSourcePayload>(payload.Payload);
+        Assert.Same(committed, acquired.Content);
+        Assert.Same(
+            committed.GenerationIdentity,
+            acquired.Content.GenerationIdentity);
+        Assert.Equal(client.Source.Producer.Key, acquired.ProducerKey);
+        Assert.Equal(PackagePayloadOrigin.Cache, acquired.Origin);
+        Assert.Empty(payload.Failures);
+
+        lease.Dispose();
+
+        Assert.False(tracking!.IsDisposed);
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await lease.AcquireCandidatePayloadAsync(
+                candidate,
+                (_, _) => store,
+                cancellationToken:
+                    TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
     public async Task PackageSourceSettlementLeaseRejectsForeignCandidateAndClientAssociation()
     {
         PackageSourceAuthorization authorization =
@@ -1792,6 +1867,18 @@ public sealed class PackageHouseContractTests
             async () => await lease.AcquireCandidateManifestAsync(
                 candidate,
                 TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await lease.AcquireCandidatePayloadAsync(
+                foreignCandidate,
+                (_, _) => new InMemoryPackageStore(),
+                cancellationToken:
+                    TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await lease.AcquireCandidatePayloadAsync(
+                candidate,
+                (_, _) => new InMemoryPackageStore(),
+                cancellationToken:
+                    TestContext.Current.CancellationToken));
     }
 
     private static PackageHouseRequest Request(


### PR DESCRIPTION
Build robust, capable product substrate that is conventionally sound and enables a compelling shared CLI/Browser Platform experience.

## Demo

Before, `PackageSourceSettlementLease` could settle exact candidates and acquire manifests, but retained payload settlement remained private to `DesktopPackageSourceComposition`. A host-neutral consumer such as package-backed Platform realization would have needed to reconstruct that desktop algorithm or fall back to the legacy package resolver.

After, the same lease-issued candidate acquires its admitted retained payload through explicit authority-scoped stores:

```csharp
PackageAcquisitionCandidate candidate = /* issued by this lease */;
ConfiguredPackagePayloadResult result =
    await lease.AcquireCandidatePayloadAsync(
        candidate,
        (authority, producer) => stores.Get(authority, producer),
        cancellationToken: cancellationToken);
```

The result preserves the serving authority, producer, immutable content generation, cache/download origin, not-found authorities, and attributed failures. Existing desktop package acquisition delegates to this implementation, so neighboring CLI package behavior is unchanged.

## Summary

- extract candidate payload acquisition from desktop composition into the package-source settlement owner
- expose candidate payload settlement on `PackageSourceSettlementLease`
- preserve caller ownership of clients, stores, operation contexts, and payloads across lease retirement
- reject foreign candidate issuers and mismatched configured-authority client associations
- document the source ordering, evidence, lifetime, and host-neutral storage contract

Closes #6562. Prerequisite for #6561.

## Compatibility

This adds a host-neutral lease capability without changing candidate identity, source ordering, cache admission, cold-acquisition failover, or existing desktop package behavior. It adds no filesystem or Browser/Wasm dependency.

## Validation

- `dotnet run --project tests/DotnetInspector.Services.Tests -c Release -- --filter-method '*PackageSourceSettlementLease*'` (3 passed)
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release -- --filter-class '*ConfiguredPayloadAcquisitionTests*'` (97 passed)
- `dotnet build dotnet-inspect.slnx -c Release`
- `DOTNET_HOST_PATH=$(command -v dotnet) dotnet run --project eng/DependencyPolicy.Tests -c Release --no-build` (26 passed)
- `dotnet run --project eng/DependencyPolicy -c Release --no-build` (25 rules; 211 projects; 47 assemblies)
- `npx markdownlint-cli docs/design/package-source-model.md`
- `git diff --check`