### PR TITLE
Adopt resource ownership for assembly inspection

### DIFF
--- a/eng/decompiler-gate-skip-projects.txt
+++ b/eng/decompiler-gate-skip-projects.txt
@@ -100,7 +100,6 @@ src/ILInspector.Analysis.App
 src/ILInspector.JsExportSurface
 src/ILInspector.TypeScriptGeneration
 src/Inspector.Artifacts.Local
-src/Inspector.Resources
 src/TsJsExport.Contracts
 src/mdi
 src/runfaster

--- a/eng/dependency-policy.json
+++ b/eng/dependency-policy.json
@@ -301,6 +301,7 @@
         "CSharpText",
         "Inspector.Artifacts",
         "Inspector.Findings",
+        "Inspector.Resources",
         "ILInspector.MetadataPrimitives",
         "InertText"
       ]

--- a/eng/inspect-web-gate-projects.txt
+++ b/eng/inspect-web-gate-projects.txt
@@ -16,6 +16,7 @@ src/DotnetInspector.Services
 src/DotnetInspector.SourceSelection
 src/DotnetInspector.Vocabulary
 src/Inspector.Findings
+src/Inspector.Resources
 src/Inspector.Text
 src/ILInspector.Analysis
 src/ILInspector.CallGraph

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -1,4 +1,5 @@
 using System.Reflection.PortableExecutable;
+using Inspector.Resources;
 using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata;
@@ -13,7 +14,16 @@ namespace ILInspector.Metadata;
 /// per-facet producers, not a god-object. The method-body seam is a sibling session opened over
 /// the same image.
 /// </summary>
-public sealed class AssemblyInspectionSession : IDisposable
+/// <remarks>
+/// Every session carries one synchronous terminal obligation. A session
+/// created by <c>Open</c> owns its image; a session created by
+/// <see cref="Borrow(PdbContext)"/> owns only its session borrow and leaves the
+/// lender's image open.
+/// </remarks>
+[ResourceOwnership]
+public sealed class AssemblyInspectionSession :
+    IDisposable,
+    IResourceSnapshotSource<AssemblyInspectionSession>
 {
     readonly AssemblyImage _image;
     readonly Lazy<MetadataTypeDeclarationProbe.Index>
@@ -75,6 +85,25 @@ public sealed class AssemblyInspectionSession : IDisposable
     /// </summary>
     public static AssemblyInspectionSession Borrow(PdbContext context)
         => new(AssemblyImage.Borrow(context.BorrowedPEReader, context.EnsureAliveForBorrower));
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The callback begins only while this session and any lender backing it
+    /// remain alive.
+    /// </remarks>
+    public TResult Snapshot<TState, TResult>(
+        TState state,
+        ResourceSnapshotCallback<
+            AssemblyInspectionSession,
+            TState,
+            TResult> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        _image.EnsureAlive();
+        return callback(
+            new ReadOnlyResourceSnapshotView<AssemblyInspectionSession>(this),
+            state);
+    }
 
     /// <summary>Whether the image contains managed metadata (false for a native binary).</summary>
     public bool HasMetadata

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\CSharpText\CSharpText.csproj" />
     <ProjectReference Include="..\Inspector.Artifacts\Inspector.Artifacts.csproj" />
     <ProjectReference Include="..\Inspector.Findings\Inspector.Findings.csproj" />
+    <ProjectReference Include="..\Inspector.Resources\Inspector.Resources.csproj" />
     <ProjectReference Include="..\InertText\InertText.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
   </ItemGroup>

--- a/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Reflection.Metadata;
 
+using Inspector.Resources;
 using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata.Tests;
@@ -20,6 +21,105 @@ public class AssemblyInspectionSessionTests
     {
         using var session = AssemblyInspectionSession.Open(SelfPath);
         Assert.True(session.HasMetadata);
+    }
+
+    [Fact]
+    public void ResourceOwnershipContract_IsDeclared()
+    {
+        Assert.NotNull(
+            typeof(AssemblyInspectionSession)
+                .GetCustomAttributes(
+                    typeof(ResourceOwnershipAttribute),
+                    inherit: false)
+                .Single());
+        Assert.Contains(
+            typeof(IResourceSnapshotSource<AssemblyInspectionSession>),
+            typeof(AssemblyInspectionSession).GetInterfaces());
+    }
+
+    [Fact]
+    public void Snapshot_ReturnsDetachedDataFromTheLiveSession()
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+
+        string assemblyName = session.Snapshot(
+            SelfName,
+            static (snapshot, expectedName) =>
+            {
+                Assert.Equal(
+                    expectedName,
+                    snapshot.Value.AssemblyInfo().AssemblyName);
+                return snapshot.Value.AssemblyInfo().AssemblyName
+                    ?? throw new InvalidOperationException(
+                        "The test assembly has no assembly name.");
+            });
+
+        Assert.Equal(SelfName, assemblyName);
+    }
+
+    [Fact]
+    public void Snapshot_PropagatesFailureAndLeavesTheSessionUsable()
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+        var failure = new InvalidOperationException("snapshot failed");
+
+        InvalidOperationException thrown =
+            Assert.Throws<InvalidOperationException>(
+                () => session.Snapshot<object?, object?>(
+                    state: null,
+                    (snapshot, state) =>
+                    {
+                        Assert.True(snapshot.Value.HasMetadata);
+                        Assert.Null(state);
+                        throw failure;
+                    }));
+
+        Assert.Same(failure, thrown);
+        Assert.True(session.HasMetadata);
+    }
+
+    [Fact]
+    public void Snapshot_RejectsDisposedSessionBeforeInvokingCallback()
+    {
+        var session = AssemblyInspectionSession.Open(SelfPath);
+        session.Dispose();
+        bool invoked = false;
+
+        Assert.Throws<ObjectDisposedException>(
+            () => session.Snapshot(
+                state: 0,
+                (snapshot, state) =>
+                {
+                    invoked = true;
+                    return state;
+                }));
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void BorrowedSessionSnapshot_UsesTheLenderLifetime()
+    {
+        using var context = PdbContext.Open(SelfPath);
+        using var session = AssemblyInspectionSession.Borrow(context);
+
+        Assert.Equal(
+            SelfName,
+            session.Snapshot(
+                state: 0,
+                static (snapshot, _) =>
+                    snapshot.Value.AssemblyInfo().AssemblyName));
+
+        context.Dispose();
+        bool invoked = false;
+        Assert.Throws<ObjectDisposedException>(
+            () => session.Snapshot(
+                state: 0,
+                (snapshot, state) =>
+                {
+                    invoked = true;
+                    return state;
+                }));
+        Assert.False(invoked);
     }
 
     [Fact]


### PR DESCRIPTION
`AssemblyInspectionSession` now declares its synchronous resource obligation
and provides an owner-validated snapshot callback over the live session.
Opened sessions own their image; `Borrow(PdbContext)` sessions own only their
disposable borrow and retain the lender's lifetime boundary.

This is slice 2 of the six-slice `AssemblyInspectionSession` ownership pilot.
Parent #6566 has merged, so this slice now targets `main`. Remaining slices add
focused Analysis normalization, one CLI metadata-table consumer, the
corresponding Inspect Web serialization path with `JsExportSurface`
authentication, and the bounded remaining-use inventory.

## Demo

An ordinary opened session can produce detached data without exposing its
`AssemblyImage` or raw readers:

```csharp
using AssemblyInspectionSession session =
    AssemblyInspectionSession.Open(path);

string assemblyName = session.Snapshot(
    state: 0,
    static (snapshot, _) =>
        snapshot.Value.AssemblyInfo().AssemblyName!);
```

The neighboring lender-bound case uses the same contract:

```csharp
using PdbContext context = PdbContext.Open(path);
using AssemblyInspectionSession session =
    AssemblyInspectionSession.Borrow(context);

string? assemblyName = session.Snapshot(
    state: 0,
    static (snapshot, _) =>
        snapshot.Value.AssemblyInfo().AssemblyName);
```

If either the session or its `PdbContext` lender is disposed before
`Snapshot`, the callback is not invoked and `ObjectDisposedException` remains
visible.

## Design basis

`docs/design/resource-ownership-and-borrowing.md` owns the declaration and
synchronous snapshot contract. `docs/design/assembly-inspection-query.md` owns
`AssemblyInspectionSession` as the Metadata inspection seam.

The implementation reuses `AssemblyImage.EnsureAlive()`, which already
distinguishes owned images from `PdbContext`-backed borrows. It introduces no
parallel liveness state, synchronization, serializer dependency, or host
contract.

## Changes

- Mark `AssemblyInspectionSession` with `ResourceOwnershipAttribute`.
- Implement
  `IResourceSnapshotSource<AssemblyInspectionSession>` using the existing
  owner/lender liveness check.
- Add the dependency-free `Inspector.Resources` reference to
  `ILInspector.Metadata` and update its enforced dependency allow list.
- Gate declaration shape, detached results, callback failure propagation,
  disposed-session rejection, and lender-bound rejection.
- Update the generated Inspect Web and Decompiler routing inventories for the
  new transitive dependency.

## Boundaries

- No Analysis normalization or ownership diagnostics.
- No CLI, Queries, Inspect Web, STJ, or TypeScript adoption.
- No async borrow, thread-safety claim, or runtime policing of trusted callback
  behavior.
- No Package Source or PackageHouse ownership adoption; that remains deferred
  until #6560 and #6563 settle.

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release
  Build succeeded

dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build -- \
  --filter-class '*AssemblyInspectionSessionTests'
  15 passed

dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build
  3,076 passed; 3 expected environment/corpus skips

dotnet run --project eng/DependencyPolicy.Tests -c Release --no-build
  28 passed

dotnet run --project eng/DependencyPolicy -c Release --no-build
  26 rules passed; 215 projects and 49 assemblies evaluated

dotnet run eng/test-ci-change-detection.cs -c Release
  passed
```

Closes #6571
