### PR TITLE
Migrate fixture infrastructure tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -257,6 +257,12 @@ suite's IL body and assembly comparison, normalization, member alignment,
 Finding census and matching, compiler-generated ordinal, metadata-graph
 safety, or diff presentation evidence.
 
+`DotnetInspector.FixtureInfrastructure.Tests` is the eighteenth migrated
+adopter. Its required PR command remains unfiltered. This path reuses the
+pinned outcome-level host gate without changing the suite's fixture identity,
+registration, grouping, artifact resolution, source and sidecar paths,
+boundary-axis, or cross-assembly relationship evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/DotnetInspector.FixtureInfrastructure.Tests/DotnetInspector.FixtureInfrastructure.Tests.csproj
+++ b/tests/DotnetInspector.FixtureInfrastructure.Tests/DotnetInspector.FixtureInfrastructure.Tests.csproj
@@ -9,6 +9,7 @@
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This advances robust, conventional test evidence by making stale
`DotnetInspector.FixtureInfrastructure.Tests` selectors fail through the test
platform that owns discovery and filtering.

## Demo

Before this change, the native xUnit host accepts an unmatched method selector
as successful evidence:

```text
DotnetInspector.FixtureInfrastructure.Tests  Total: 0
exit=0
```

With Microsoft Testing Platform selected, the equivalent stale filter fails:

```text
Test run summary: Zero tests ran
  total: 0
exit=8
```

Neighboring fixture-catalog evidence continues to execute normally:

```text
All_FixtureIdsAreUnique                          total: 1   exit=0
BoundaryMetadata_EverySemanticAxisHasFixtureCoverage
                                                  total: 1   exit=0
full suite                                        total: 20  exit=0
```

## Summary

- Select Microsoft Testing Platform for
  `DotnetInspector.FixtureInfrastructure.Tests` through the `xunit.v3`
  integration already pinned by the repository.
- Record the suite as the eighteenth migrated adopter in the xUnit host owner.
- Preserve the unfiltered required-CI command unchanged.
- Preserve fixture identity, registration, grouping, artifact resolution,
  source and sidecar paths, boundary axes, and cross-assembly relationship
  evidence.

## Design basis

`docs/design/xunit-test-host.md` owns repository xUnit host selection and
aggregate zero-test behavior. MTP owns parsing, discovery, filtering,
execution, and exit code `8`; this slice adds no selector parser, runner
library dependency, workflow scan, or output parser.

The fixture catalog retains its existing requirement that solution fixture
artifacts be built before the suite executes. Missing fixture artifacts remain
visible failures; the host migration neither weakens nor duplicates that
domain evidence.

## Validation

- Native unmatched method selector: 0 tests, exit `0`.
- Unmatched MTP method filter: 0 tests, exit `8`.
- `All_FixtureIdsAreUnique`: 1 passed.
- `BoundaryMetadata_EverySemanticAxisHasFixtureCoverage`: 1 passed.
- Full `DotnetInspector.FixtureInfrastructure.Tests` suite: 20 passed.
- Full Release solution build.
- `markdownlint` and `git diff --check`.

Closes the eighteenth migration slice of #5379.
