### PR TITLE
Add platform library population declarations

### DIFF
--- a/docs/design/platform-library-population-declaration.md
+++ b/docs/design/platform-library-population-declaration.md
@@ -16,6 +16,11 @@ The declaration lets the application catalog say that a Workspace is relevant
 to the .NET runtime or ASP.NET Core library population without selecting or
 executing a platform source.
 
+The declaration contract is implemented by
+`DotnetInspector.SourceSelection.PlatformLibraryPopulationDeclaration`.
+Catalog projection, Workspace retention, source realization, and host adoption
+remain in their separately owned slices.
+
 ## Authority and exact claim
 
 **Platform Library Population Declaration** owns:

--- a/src/DotnetInspector.SourceSelection/DotnetInspector.SourceSelection.csproj
+++ b/src/DotnetInspector.SourceSelection/DotnetInspector.SourceSelection.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
+    <ProjectReference Include="../DotnetInspector.Platforms/DotnetInspector.Platforms.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/DotnetInspector.SourceSelection/PlatformLibraryPopulationDeclaration.cs
+++ b/src/DotnetInspector.SourceSelection/PlatformLibraryPopulationDeclaration.cs
@@ -1,0 +1,19 @@
+using DotnetInspector.Platforms;
+
+namespace DotnetInspector.SourceSelection;
+
+/// <summary>
+/// Declares one relevant logical platform library population before realization.
+/// </summary>
+public sealed record PlatformLibraryPopulationDeclaration
+{
+    public PlatformLibraryPopulationDeclaration(PlatformFamily family)
+    {
+        if (!Enum.IsDefined(family))
+            throw new ArgumentOutOfRangeException(nameof(family));
+
+        Family = family;
+    }
+
+    public PlatformFamily Family { get; }
+}

--- a/tests/DotnetInspector.SourceSelection.Tests/PlatformLibraryPopulationDeclarationTests.cs
+++ b/tests/DotnetInspector.SourceSelection.Tests/PlatformLibraryPopulationDeclarationTests.cs
@@ -1,0 +1,44 @@
+using DotnetInspector.Platforms;
+
+namespace DotnetInspector.SourceSelection.Tests;
+
+public sealed class PlatformLibraryPopulationDeclarationTests
+{
+    [Theory]
+    [InlineData(PlatformFamily.DotNetRuntime)]
+    [InlineData(PlatformFamily.AspNetCore)]
+    public void PublicConsumerRetainsExactProductFamily(PlatformFamily family)
+    {
+        var declaration = new PlatformLibraryPopulationDeclaration(family);
+
+        Assert.Equal(family, declaration.Family);
+    }
+
+    [Fact]
+    public void EqualityDependsOnlyOnExactProductFamily()
+    {
+        var runtime = new PlatformLibraryPopulationDeclaration(
+            PlatformFamily.DotNetRuntime);
+        var equalRuntime = new PlatformLibraryPopulationDeclaration(
+            PlatformFamily.DotNetRuntime);
+        var aspNetCore = new PlatformLibraryPopulationDeclaration(
+            PlatformFamily.AspNetCore);
+
+        Assert.Equal(runtime, equalRuntime);
+        Assert.Equal(runtime.GetHashCode(), equalRuntime.GetHashCode());
+        Assert.NotEqual(runtime, aspNetCore);
+        Assert.Equal(2, new HashSet<PlatformLibraryPopulationDeclaration>
+        {
+            runtime,
+            equalRuntime,
+            aspNetCore,
+        }.Count);
+    }
+
+    [Fact]
+    public void UndefinedProductFamilyIsRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new PlatformLibraryPopulationDeclaration((PlatformFamily)2));
+    }
+}


### PR DESCRIPTION
Build robust foundational inspection capabilities by preserving platform
population intent as an exact, resource-free value before any source or target
is selected.

## Demo

The application catalog can now construct the two real product-family
declarations required by its future curated Workspace manifest:

```csharp
var runtime = new PlatformLibraryPopulationDeclaration(
    PlatformFamily.DotNetRuntime);
var aspNetCore = new PlatformLibraryPopulationDeclaration(
    PlatformFamily.AspNetCore);
```

`runtime` means the logical `Microsoft.NETCore.App` population;
`aspNetCore` means the logical `Microsoft.AspNetCore.App` population. Neither
construction probes installed SDKs, packs, paths, caches, or network sources.

A neighboring invalid case is rejected rather than becoming an unknown
success-shaped declaration:

```csharp
new PlatformLibraryPopulationDeclaration((PlatformFamily)2);
// ArgumentOutOfRangeException
```

## Summary

- add the Source Selection-owned
  `PlatformLibraryPopulationDeclaration`;
- retain the existing owner-issued `PlatformFamily` with value equality and
  undefined-family rejection;
- add the direct Source Selection dependency on the package-neutral Platforms
  contract assembly;
- prove both real product families, equality/hash behavior, distinction, and
  invalid-family rejection through the public test consumer; and
- record the implemented declaration while leaving catalog projection,
  Workspace retention, realization, and host adoption in their owned slices.

## Design basis

The normative owner is
`docs/design/platform-library-population-declaration.md`. Its exact claim is
one immutable declaration for either the .NET runtime or ASP.NET Core logical
library population before target, version, source, view, acquisition, or
Workspace admission is selected.

This is the first implementation prerequisite for #6577 and the
Ecosystems-owned curation plan in #6570 / #6012. The next prerequisite is the
lower Queries-owned ecosystem registration declaration; Workspace Scope does
not invent these source-owner currencies.

No TLA+ model is added because this immutable value introduces no lifecycle,
publication, replacement, or concurrency transition.

## Validation

- `dotnet run --project tests/DotnetInspector.SourceSelection.Tests -c Release`
- `npx markdownlint-cli docs/design/platform-library-population-declaration.md`
- `git diff --check`

Closes #6578.
