### PR TITLE
Migrate InertText tests to MTP

### DIFF
--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -263,6 +263,12 @@ pinned outcome-level host gate without changing the suite's fixture identity,
 registration, grouping, artifact resolution, source and sidecar paths,
 boundary-axis, or cross-assembly relationship evidence.
 
+`InertText.Tests` is the nineteenth migrated adopter. Its required PR and
+developer commands remain unfiltered. These paths reuse the pinned
+outcome-level host gate without changing the suite's text-policy, containment,
+lossless and injective encoding, visual-form, truncation, composition, URL
+redaction, or public-surface evidence.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/InertText.Tests/InertText.Tests.csproj
+++ b/tests/InertText.Tests/InertText.Tests.csproj
@@ -10,6 +10,7 @@
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This advances robust, conventional test evidence by making stale
`InertText.Tests` selectors fail through the test platform that owns discovery
and filtering.

## Demo

Before this change, the native xUnit host accepts an unmatched method selector
as successful evidence:

```text
InertText.Tests  Total: 0
exit=0
```

With Microsoft Testing Platform selected, the equivalent stale filter fails:

```text
Test run summary: Zero tests ran
  total: 0
exit=8
```

Neighboring InertText evidence continues to execute normally:

```text
ForPathComponent_ContractVersionPinsCurrentOutput
                                                  total: 1    exit=0
RoundTrip_EveryScalar_RecoversTheOriginal         total: 1    exit=0
full suite                                        total: 428  exit=0
```

## Summary

- Select Microsoft Testing Platform for `InertText.Tests` through the
  `xunit.v3` integration already pinned by the repository.
- Record the suite as the nineteenth migrated adopter in the xUnit host owner.
- Preserve the unfiltered required-CI and developer commands unchanged.
- Preserve text-policy, containment, lossless and injective encoding,
  visual-form, truncation, composition, URL-redaction, and public-surface
  evidence.

## Design basis

`docs/design/xunit-test-host.md` owns repository xUnit host selection and
aggregate zero-test behavior. MTP owns parsing, discovery, filtering,
execution, and exit code `8`; this slice adds no selector parser, runner
library dependency, workflow scan, or output parser.

`InertText.Tests` has only unfiltered supported CI and developer invocations,
so MTP's aggregate non-vacuity result is the complete host-level receipt. The
suite's domain tests remain the owners of containment, recovery, URL-redaction,
and public-surface evidence.

## Validation

- Native unmatched method selector: 0 tests, exit `0`.
- Unmatched MTP method filter: 0 tests, exit `8`.
- `ForPathComponent_ContractVersionPinsCurrentOutput`: 1 passed.
- `RoundTrip_EveryScalar_RecoversTheOriginal`: 1 passed.
- Full `InertText.Tests` suite: 428 passed.
- Full Release solution build.
- `markdownlint` and `git diff --check`.

Closes the nineteenth migration slice of #5379.
