### PR TITLE
Use Metadata declaration semantics for Research targets

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -452,12 +452,13 @@ gates;
 `ResearchTargetDomains_BlockOnlyTheirOwnCensus`,
 `ResearchTargetAttempt_AddressEvidenceMismatchBlocksBeforeCensus`,
 `ResearchTargetAbsence_FailedExtensionContainerBlocksProjectedMember`,
-`ResearchTargetAbsence_UnscopedForwarderFailureBlocksOnlyAbsence`,
+`ResearchTargetDeclaration_UnscopedForwarderFailureRemainsVisible`,
 `ResearchTargetDeclaringType_DistinguishesAbsentFromForwarded`,
 `ResearchTargetDeclaringType_DoesNotInferAbsenceUnderForwarder`,
 `ResearchTargetDeclaringType_DoesNotInferAbsenceFromMalformedExport`,
+`ResearchTargetDeclaringType_UsesMetadataSemanticsForEquivalentForwarders`,
 `ResearchTargetDeclaringType_RejectsFailedExactDuplicate`,
-`ResearchTargetForwarder_RetainedEvidencePrecedesUnscopedFailure`,
+`ResearchTargetForwarder_UnscopedFailureRemainsVisible`,
 `ResearchTargetReferenceOnlyInput_TerminatesWithoutOpening`,
 `ResearchTargetInputValidation_RejectsMismatchedModuleEvidence`,
 `ResearchTargetResolution_StagesEachAdmittedInputOnce`,
@@ -528,7 +529,8 @@ request retains:
 
 - its operation, question, scope, domain, side-local admitted-input identity,
   and side;
-- the exact typed `MemberTargetSelector` and declaring-type intent;
+- the exact typed `MemberTargetSelector` and
+  `MetadataTypeDefinitionName` declaring-type intent;
 - the pinned Metadata API-surface scope it evaluates: public and non-public
   members, Metadata-supported compiler-generated types and fields, Metadata's
   exclusion of synthesized methods, and no member-kind filter;
@@ -586,20 +588,39 @@ Resolution may borrow an implementation input only for the duration of the
 call, and must evaluate all requests for that input from one staged read. Live
 assembly and module identity must agree with the acquisition descriptor and
 Analysis-issued module identity, including the descriptor-bound MVID when one
-is present. Member selection remains Metadata-owned, uses its existing API
-surface including its synthesized-method exclusions, and matches the exact
-declaring-type metadata full name. A potentially covering Metadata inspection
-failure, including an unscoped forwarder failure, prevents Research from
-asserting absence but does not suppress otherwise established local or
-forwarding evidence. Because Metadata projects local extension methods onto
-their receiver types, an owner-scoped failed TypeDef may cover member absence
-on another retained type even though it does not cover that type's declaration
-absence. Retained TypeDefs, exact forwarders, and exact owner-scoped failed
-TypeDefs participate in the declaration census; duplicate exact declarations
-fail as ambiguous. An exact type forwarder, or an intent nested beneath a
-retained root forwarder, makes the target unavailable rather than absent. A
-durable address requires an in-range `MethodDefinition` handle of the validated
-module.
+is present.
+
+Research retains the caller's structured declaring-type intent unchanged and
+asks `MetadataTypeDeclarationProbe` for the local declaration disposition
+before member selection. It does not reconstruct namespace or nested-type
+boundaries from a flattened name and does not reinterpret raw TypeDef or
+ExportedType rows. The final construction validator consumes a second
+Metadata-issued declaration result produced from the same staged reader, so it
+does not trust the resolver's classification and does not reopen the input.
+`Defined` selects the exact Metadata-issued TypeDef token and permits
+`MemberTargetResolver` to inspect that type. `Forwarded` terminates the
+input-local attempt as `Unavailable/DeclaringTypeForwarded`; this includes
+nested forwarding and multiple equivalent same-target forwarder rows that
+Metadata coalesces into one declaration. `Missing` permits
+`DeclaringTypeAbsent` only when no potentially covering Metadata inspection
+failure exists. `Ambiguous` preserves declaration ambiguity, including
+competing targets and definition/forwarder conflicts. `Rejected` and module
+exports remain visible as incomplete Metadata evidence rather than
+success-shaped absence.
+
+After a definition is established, member selection remains Metadata-owned and
+uses its existing API surface, including its synthesized-method exclusions.
+A potentially covering Metadata inspection failure prevents Research from
+asserting member absence. Because Metadata projects local extension methods
+onto their receiver types, an owner-scoped failed TypeDef may cover member
+absence on another retained type even though it does not cover that type's
+declaration absence. A durable address requires an in-range
+`MethodDefinition` handle of the validated module.
+
+`Microsoft.Extensions.DependencyInjection` 10.0.0 is the real-package witness:
+its `net10.0` facade forwards `ServiceCollection` to
+`Microsoft.Extensions.DependencyInjection.Abstractions`. Equivalent duplicate
+rows are a Metadata-supported stress extension of that production shape.
 
 `DeclaringTypeForwarded` is terminal only for this exact input-local attempt.
 It does not decide whether a later workspace-composition step treats the
@@ -607,7 +628,8 @@ forwarder as the compared endpoint or follows it to a terminal implementation
 participant already admitted, or explicitly authorized for supplemental
 admission, by the workspace. That later composition owns the effective
 endpoint choice and retains the Metadata-issued forwarding path as
-supplementary query evidence; it is not implemented or verified by this slice.
+supplementary query evidence. Research does not resolve assembly references,
+select workspace participants, acquire packages, or add admitted inputs.
 
 `Resolved` is terminal only after Research validates that the selected target
 and durable address belong to the same admitted assembly and module. A

--- a/src/DotnetInspector.ResearchQueries/DirectMemberComparisonQuery.cs
+++ b/src/DotnetInspector.ResearchQueries/DirectMemberComparisonQuery.cs
@@ -253,8 +253,18 @@ public static class DirectMemberComparisonQuery
                             tokens.Where(token => token is not null).ToArray(), address.Token) + 1;
                         selector += $":{ordinal}";
                     }
+                    if (type.DefinitionName is not { } definitionName)
+                    {
+                        failure = Failure(
+                            new LocalComparisonQueryFailure.InvalidDesignation(
+                                DirectMemberDesignationFailureKind
+                                    .MetadataSelectionUnavailable,
+                                [.. surface.InspectionFailures]),
+                            side);
+                        return null;
+                    }
                     failure = null;
-                    return new(type.DefinitionName?.ToMetadataFullName() ?? type.FullName,
+                    return new(definitionName,
                         MemberTargetSelector.Parse(selector), role.Value);
                 }
             }
@@ -276,7 +286,7 @@ public static class DirectMemberComparisonQuery
     }
 
     sealed record Selection(
-        string Type,
+        MetadataTypeDefinitionName Type,
         MemberTargetSelector Selector,
         ResearchTargetRelationshipRole Role)
     {

--- a/src/DotnetInspector.ResearchQueries/WorkspaceResearchTargetComposition.cs
+++ b/src/DotnetInspector.ResearchQueries/WorkspaceResearchTargetComposition.cs
@@ -459,8 +459,7 @@ internal static class WorkspaceResearchTargetCompositionValidator
             || resolution.Scopes.Count(scope => ReferenceEquals(scope, request.Scope)) != 1
             || !ReferenceEquals(request.Scope.Question, question)
             || !ReferenceEquals(request.Scope.Id.Operation, resolution.Operation)
-            || !string.Equals(request.Scope.DeclaringTypeFullName,
-                request.DeclaringType.ToMetadataFullName(), StringComparison.Ordinal)
+            || !request.Scope.DeclaringType.Equals(request.DeclaringType)
             || request.Scope.Domains.Count(domain => ReferenceEquals(domain, request.Domain)) != 1
             || !ReferenceEquals(request.Domain.Scope, request.Scope.Id)
             || !ReferenceEquals(request.Census.Domain, request.Domain)
@@ -512,7 +511,7 @@ internal static class WorkspaceResearchTargetCompositionValidator
                         || !ReferenceEquals(target.Input.Question, question)
                         || target.Side != target.Input.Side
                         || target.Kind != scope.Kind
-                        || target.DeclaringTypeFullName != scope.DeclaringTypeFullName
+                        || !ReferenceEquals(target.DeclaringType, scope.DeclaringType)
                         || target.Selector != scope.Selector
                         || !domain.Inputs.Any(input => ReferenceEquals(input.Input, target.Input)))
                         return false;

--- a/src/DotnetInspector.ResearchQueries/WorkspaceResearchTargetPlanningQuery.cs
+++ b/src/DotnetInspector.ResearchQueries/WorkspaceResearchTargetPlanningQuery.cs
@@ -78,7 +78,7 @@ public static class WorkspaceResearchTargetPlanningQuery
             projected.Admission,
             projected.Admission.Inputs.Select(input =>
                 new ResearchTargetInputRoleAssignment(input, ResearchTargetInputRole.Implementation)),
-            [new ResearchCarriedMemberSelection(question, declaringType.ToMetadataFullName(), selector)]);
+            [new ResearchCarriedMemberSelection(question, declaringType, selector)]);
         ResearchTargetPlanningOutcome outcome = ResearchTargetResolver.Resolve(request, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
         return outcome switch

--- a/src/ILInspector.Research/ResearchTargetPlanningRequest.cs
+++ b/src/ILInspector.Research/ResearchTargetPlanningRequest.cs
@@ -50,15 +50,15 @@ public abstract class ResearchMemberSelectionOccurrence
 {
     private protected ResearchMemberSelectionOccurrence(
         ResearchComparisonQuestionId question,
-        string declaringTypeFullName,
+        MetadataTypeDefinitionName declaringType,
         MemberTargetSelector selector,
         ResearchTargetRequestKind kind)
     {
         ArgumentNullException.ThrowIfNull(question);
-        ArgumentException.ThrowIfNullOrWhiteSpace(declaringTypeFullName);
+        ArgumentNullException.ThrowIfNull(declaringType);
         ArgumentNullException.ThrowIfNull(selector);
         Question = question;
-        DeclaringTypeFullName = declaringTypeFullName;
+        DeclaringType = declaringType;
         Selector = selector;
         Kind = kind;
     }
@@ -67,12 +67,12 @@ public abstract class ResearchMemberSelectionOccurrence
     public ResearchComparisonQuestionId Question { get; }
 
     /// <summary>
-    /// The exact declaring-type full name this selection intends. Metadata
-    /// selection runs only against a type definition whose metadata full name
-    /// equals this value; no prefix, suffix, case-insensitive, or display
-    /// spelling recovers it.
+    /// The exact structured declaring-type name this selection intends.
     /// </summary>
-    public string DeclaringTypeFullName { get; }
+    public MetadataTypeDefinitionName DeclaringType { get; }
+
+    /// <summary>The flattened metadata spelling of <see cref="DeclaringType"/>.</summary>
+    public string DeclaringTypeFullName => DeclaringType.ToMetadataFullName();
 
     /// <summary>The exact typed Metadata selector.</summary>
     public MemberTargetSelector Selector { get; }
@@ -94,11 +94,11 @@ public sealed class ResearchCarriedMemberSelection :
 {
     public ResearchCarriedMemberSelection(
         ResearchComparisonQuestionId question,
-        string declaringTypeFullName,
+        MetadataTypeDefinitionName declaringType,
         MemberTargetSelector selector)
         : base(
             question,
-            declaringTypeFullName,
+            declaringType,
             selector,
             ResearchTargetRequestKind.Carried)
     {
@@ -123,13 +123,13 @@ public sealed class ResearchExactAddressMemberSelection :
     public ResearchExactAddressMemberSelection(
         ResearchComparisonQuestionId question,
         ResearchAdmittedInput input,
-        string declaringTypeFullName,
+        MetadataTypeDefinitionName declaringType,
         MemberTargetSelector selector,
         MetadataMethodAddress address,
         ResearchTargetRelationshipRole assertedRole)
         : base(
             question,
-            declaringTypeFullName,
+            declaringType,
             selector,
             ResearchTargetRequestKind.ExactAddress)
     {

--- a/src/ILInspector.Research/ResearchTargetResolution.cs
+++ b/src/ILInspector.Research/ResearchTargetResolution.cs
@@ -419,14 +419,14 @@ public sealed class ResearchTargetRequest
 {
     internal ResearchTargetRequest(
         ResearchTargetRequestId id,
-        string declaringTypeFullName,
+        MetadataTypeDefinitionName declaringType,
         MemberTargetSelector selector,
         ResearchTargetRequestKind kind,
         MetadataMethodAddress? assertedAddress,
         ResearchTargetRelationshipRole? assertedRole)
     {
         Id = id;
-        DeclaringTypeFullName = declaringTypeFullName;
+        DeclaringType = declaringType;
         Selector = selector;
         Kind = kind;
         AssertedAddress = assertedAddress;
@@ -454,8 +454,11 @@ public sealed class ResearchTargetRequest
     /// <summary>The side this request occupies.</summary>
     public ResearchComparisonSide Side => Id.Side;
 
-    /// <summary>The exact declaring-type full-name intent.</summary>
-    public string DeclaringTypeFullName { get; }
+    /// <summary>The exact structured declaring-type intent.</summary>
+    public MetadataTypeDefinitionName DeclaringType { get; }
+
+    /// <summary>The flattened metadata spelling of <see cref="DeclaringType"/>.</summary>
+    public string DeclaringTypeFullName => DeclaringType.ToMetadataFullName();
 
     /// <summary>The exact typed Metadata selector.</summary>
     public MemberTargetSelector Selector { get; }
@@ -633,13 +636,13 @@ public sealed class ResearchTargetScope
 {
     internal ResearchTargetScope(
         ResearchTargetScopeId id,
-        string declaringTypeFullName,
+        MetadataTypeDefinitionName declaringType,
         MemberTargetSelector selector,
         ResearchTargetRequestKind kind,
         ImmutableArray<ResearchTargetDomain> domains)
     {
         Id = id;
-        DeclaringTypeFullName = declaringTypeFullName;
+        DeclaringType = declaringType;
         Selector = selector;
         Kind = kind;
         Domains = domains;
@@ -651,8 +654,11 @@ public sealed class ResearchTargetScope
     /// <summary>The question that parents this scope.</summary>
     public ResearchComparisonQuestionId Question => Id.Question;
 
-    /// <summary>The exact declaring-type full-name intent.</summary>
-    public string DeclaringTypeFullName { get; }
+    /// <summary>The exact structured declaring-type intent.</summary>
+    public MetadataTypeDefinitionName DeclaringType { get; }
+
+    /// <summary>The flattened metadata spelling of <see cref="DeclaringType"/>.</summary>
+    public string DeclaringTypeFullName => DeclaringType.ToMetadataFullName();
 
     /// <summary>The exact typed Metadata selector.</summary>
     public MemberTargetSelector Selector { get; }

--- a/src/ILInspector.Research/ResearchTargetResolutionValidator.cs
+++ b/src/ILInspector.Research/ResearchTargetResolutionValidator.cs
@@ -103,10 +103,7 @@ static class ResearchTargetResolutionValidator
                         population.Operation),
                 "A scope must be parented by the admitted operation and question.");
             Require(
-                string.Equals(
-                    scope.DeclaringTypeFullName,
-                    selection.DeclaringTypeFullName,
-                    StringComparison.Ordinal)
+                ReferenceEquals(scope.DeclaringType, selection.DeclaringType)
                     && scope.Selector == selection.Selector
                     && scope.Kind == selection.Kind,
                 "A scope must retain its selection's exact intent.");
@@ -849,10 +846,7 @@ static class ResearchTargetResolutionValidator
                     && ReferenceEquals(request.Question, input.Question),
                 "A request must be strictly side-, input-, scope-, and domain-local.");
             Require(
-                string.Equals(
-                    request.DeclaringTypeFullName,
-                    selection.DeclaringTypeFullName,
-                    StringComparison.Ordinal)
+                ReferenceEquals(request.DeclaringType, selection.DeclaringType)
                     && request.Selector == selection.Selector
                     && request.Kind == selection.Kind
                     && ReferenceEquals(
@@ -913,6 +907,7 @@ static class ResearchTargetResolutionValidator
                 "An ambiguous domain must block every one of its own requests.");
             Require(
                 evidence.InputEvidence is null
+                    && evidence.ValidationDeclaration is null
                     && evidence.DeclaringType is null
                     && !evidence.TargetResolutionFailed
                     && evidence.MetadataResolution is null,
@@ -931,6 +926,7 @@ static class ResearchTargetResolutionValidator
                 "A reference-only request must terminate Unavailable.");
             Require(
                 evidence.InputEvidence is null
+                    && evidence.ValidationDeclaration is null
                     && evidence.DeclaringType is null
                     && !evidence.TargetResolutionFailed
                     && evidence.MetadataResolution is null,
@@ -947,7 +943,7 @@ static class ResearchTargetResolutionValidator
 
         if (inputEvidence.ReadFailed)
         {
-            RequireNoMetadataResolution(evidence);
+            RequireNoDeclaration(evidence);
             RequireFailure(
                 outcome,
                 ResearchTargetDiagnosticKind.InputUnreadable);
@@ -957,7 +953,7 @@ static class ResearchTargetResolutionValidator
         if (ValidateImage(inputEvidence, input) is
             ResearchTargetDiagnosticKind imageFailure)
         {
-            RequireNoMetadataResolution(evidence);
+            RequireNoDeclaration(evidence);
             RequireFailure(outcome, imageFailure);
             return;
         }
@@ -965,43 +961,13 @@ static class ResearchTargetResolutionValidator
         ApiSurface surface = inputEvidence.Surface
             ?? throw Violation(
                 "A readable validated input must retain its short-lived Metadata surface.");
+        TypeDeclarationResult declaration = evidence.ValidationDeclaration
+            ?? throw Violation(
+                "A readable validated input must retain its Metadata declaration result.");
         string intent = request.DeclaringTypeFullName;
-        List<ApiType> declaringTypes =
-        [
-            .. surface.Types.Where(
-                candidate => string.Equals(
-                    MetadataFullName(candidate),
-                    intent,
-                    StringComparison.Ordinal)),
-        ];
-        int forwarders = surface.TypeForwarders.Count(
-            forwarder => string.Equals(
-                MetadataFullName(forwarder),
-                intent,
-                StringComparison.Ordinal));
-        int failedTypeDefinitions =
-            CountFailedTypeDefinitions(surface, intent);
-        bool nestedUnderForwarder = surface.TypeForwarders.Any(
-            forwarder => IsNestedUnder(
-                intent,
-                MetadataFullName(forwarder)));
-        int exactDeclarations =
-            declaringTypes.Count + forwarders + failedTypeDefinitions;
-        if (exactDeclarations > 1
-            || (declaringTypes.Count + failedTypeDefinitions != 0
-                && nestedUnderForwarder))
+        switch (declaration)
         {
-            RequireNoMetadataResolution(evidence);
-            RequireFailure(
-                outcome,
-                ResearchTargetDiagnosticKind.DeclaringTypeAmbiguous);
-            return;
-        }
-
-        if (declaringTypes.Count == 0)
-        {
-            if (forwarders == 1 || nestedUnderForwarder)
-            {
+            case TypeDeclarationResult.Forwarded:
                 RequireNoMetadataResolution(evidence);
                 Require(
                     outcome is ResearchTargetOutcome.Unavailable
@@ -1012,41 +978,73 @@ static class ResearchTargetResolutionValidator
                     },
                     "Retained forwarding evidence must terminate Unavailable.");
                 return;
-            }
-
-            if (FindPotentiallyCoveringFailure(
-                    surface,
-                    intent,
-                    memberAbsence: false) is not null)
-            {
+            case TypeDeclarationResult.Ambiguous:
+                RequireNoMetadataResolution(evidence);
+                RequireFailure(
+                    outcome,
+                    ResearchTargetDiagnosticKind.DeclaringTypeAmbiguous);
+                return;
+            case TypeDeclarationResult.ExportedFromModule:
+            case TypeDeclarationResult.Rejected:
                 RequireNoMetadataResolution(evidence);
                 RequireFailure(
                     outcome,
                     ResearchTargetDiagnosticKind.IncompleteMetadataSurface);
                 return;
-            }
-
-            Require(
-                outcome is ResearchTargetOutcome.NotFound
+            case TypeDeclarationResult.Missing:
+                RequireNoMetadataResolution(evidence);
+                if (FindPotentiallyCoveringFailure(
+                    surface,
+                    intent,
+                    memberAbsence: false) is not null)
                 {
-                    MetadataDiagnostic: null,
-                    ResearchDiagnostic.Kind:
-                        ResearchTargetDiagnosticKind.DeclaringTypeAbsent,
-                    Candidates.IsEmpty: true,
-                },
-                "A complete surface with no type or forwarder must retain declaring-type absence.");
+                    RequireFailure(
+                        outcome,
+                        ResearchTargetDiagnosticKind.IncompleteMetadataSurface);
+                    return;
+                }
 
-            Require(
-                evidence.DeclaringType is null
-                    && evidence.MetadataResolution is null
-                    && !evidence.TargetResolutionFailed,
-                "A missing declaring type must terminate before Metadata member resolution.");
+                Require(
+                    outcome is ResearchTargetOutcome.NotFound
+                    {
+                        MetadataDiagnostic: null,
+                        ResearchDiagnostic.Kind:
+                            ResearchTargetDiagnosticKind.DeclaringTypeAbsent,
+                        Candidates.IsEmpty: true,
+                    },
+                    "A complete surface with no declaration must retain declaring-type absence.");
+                return;
+            case TypeDeclarationResult.Defined:
+                break;
+            default:
+                throw Violation("Unknown Metadata declaration result.");
+        }
+
+        var defined = (TypeDeclarationResult.Defined)declaration;
+        List<ApiType> declaringTypes =
+        [
+            .. surface.Types.Where(
+                candidate =>
+                    candidate.MetadataToken == defined.Definition.Value),
+        ];
+        if (declaringTypes.Count != 1)
+        {
+            RequireNoMetadataResolution(evidence);
+            RequireFailure(
+                outcome,
+                declaringTypes.Count == 0
+                    && FindPotentiallyCoveringFailure(
+                        surface,
+                        intent,
+                        memberAbsence: false) is not null
+                    ? ResearchTargetDiagnosticKind.IncompleteMetadataSurface
+                    : ResearchTargetDiagnosticKind.ResolutionFailed);
             return;
         }
 
         Require(
             ReferenceEquals(evidence.DeclaringType, declaringTypes[0]),
-            "Metadata resolution must use the exact selected declaring type.");
+            "Metadata resolution must use the exact TypeDef selected by Metadata.");
 
         if (evidence.TargetResolutionFailed)
         {
@@ -1548,17 +1546,6 @@ static class ResearchTargetResolutionValidator
                         && failure.OwningTypeDefinition is not null)
                     || MayAffectType(failure, declaringTypeFullName)));
 
-    static int CountFailedTypeDefinitions(
-        ApiSurface surface,
-        string declaringTypeFullName)
-        => surface.InspectionFailures.Count(
-            failure =>
-                failure.OwningTypeDefinition is { } owner
-                && string.Equals(
-                    owner.ToMetadataFullName(),
-                    declaringTypeFullName,
-                    StringComparison.Ordinal));
-
     static bool MayAffectType(
         ApiSurfaceInspectionFailure failure,
         string declaringTypeFullName)
@@ -1583,17 +1570,6 @@ static class ResearchTargetResolutionValidator
         return true;
     }
 
-    static string MetadataFullName(ApiType type)
-        => type.DefinitionName?.ToMetadataFullName() ?? type.FullName;
-
-    static string MetadataFullName(TypeForwarder forwarder)
-        => forwarder.DefinitionName?.ToMetadataFullName() ?? forwarder.TypeName;
-
-    static bool IsNestedUnder(string candidate, string potentialRoot)
-        => candidate.Length > potentialRoot.Length
-            && candidate.StartsWith(potentialRoot, StringComparison.Ordinal)
-            && candidate[potentialRoot.Length] == '.';
-
     static void RequireFailure(
         ResearchTargetOutcome outcome,
         ResearchTargetDiagnosticKind kind)
@@ -1610,7 +1586,16 @@ static class ResearchTargetResolutionValidator
             evidence.DeclaringType is null
                 && evidence.MetadataResolution is null
                 && !evidence.TargetResolutionFailed,
-            "An input-level terminal outcome must precede Metadata resolution.");
+            "A declaration-level terminal outcome must precede Metadata member resolution.");
+
+    static void RequireNoDeclaration(
+        ResearchTargetValidationEvidence evidence)
+    {
+        Require(
+            evidence.ValidationDeclaration is null,
+            "An input-level terminal outcome must precede Metadata declaration probing.");
+        RequireNoMetadataResolution(evidence);
+    }
 
     /// <summary>
     /// The single terminal arm each bounded Research diagnostic may occupy.

--- a/src/ILInspector.Research/ResearchTargetResolver.cs
+++ b/src/ILInspector.Research/ResearchTargetResolver.cs
@@ -277,7 +277,7 @@ public static class ResearchTargetResolver
                         selection as ResearchExactAddressMemberSelection;
                     ResearchTargetRequest targetRequest = new(
                         new ResearchTargetRequestId(domain.Id, input.Id),
-                        selection.DeclaringTypeFullName,
+                        selection.DeclaringType,
                         selection.Selector,
                         selection.Kind,
                         exact?.Address,
@@ -510,58 +510,64 @@ public static class ResearchTargetResolver
         MetadataReader reader,
         LibraryBodyModuleIdentity module)
     {
-        string intent = planned.Request.DeclaringTypeFullName;
+        MetadataTypeDefinitionName intent = planned.Request.DeclaringType;
+        TypeDeclarationResult declaration =
+            MetadataTypeDeclarationProbe.Probe(reader, intent);
+        // Final validation derives its expectation from a separate normalized
+        // result without reopening the staged input.
+        planned.ValidationDeclaration =
+            MetadataTypeDeclarationProbe.Probe(reader, intent);
+        switch (declaration)
+        {
+            case TypeDeclarationResult.Forwarded:
+                return Unavailable(
+                    ResearchTargetDiagnosticKind.DeclaringTypeForwarded);
+            case TypeDeclarationResult.Ambiguous:
+                return Failed(
+                    ResearchTargetDiagnosticKind.DeclaringTypeAmbiguous);
+            case TypeDeclarationResult.ExportedFromModule:
+            case TypeDeclarationResult.Rejected:
+                return Failed(
+                    ResearchTargetDiagnosticKind.IncompleteMetadataSurface);
+            case TypeDeclarationResult.Missing:
+                if (FindPotentiallyCoveringFailure(
+                    surface,
+                    intent.ToMetadataFullName(),
+                    memberAbsence: false) is not null)
+                {
+                    return Failed(
+                        ResearchTargetDiagnosticKind.IncompleteMetadataSurface);
+                }
+
+                return new ResearchTargetOutcome.NotFound(
+                    metadataDiagnostic: null,
+                    new ResearchTargetDiagnostic(
+                        ResearchTargetDiagnosticKind.DeclaringTypeAbsent),
+                    candidates: []);
+            case TypeDeclarationResult.Defined:
+                break;
+            default:
+                throw new InvalidOperationException(
+                    "Unknown Metadata declaration result.");
+        }
+
+        var defined = (TypeDeclarationResult.Defined)declaration;
         List<ApiType> declaringTypes =
         [
             .. surface.Types.Where(
-                candidate => string.Equals(
-                    MetadataFullName(candidate),
-                    intent,
-                    StringComparison.Ordinal)),
+                candidate =>
+                    candidate.MetadataToken == defined.Definition.Value),
         ];
-        int forwarders = surface.TypeForwarders.Count(
-            forwarder => string.Equals(
-                MetadataFullName(forwarder),
-                intent,
-                StringComparison.Ordinal));
-        int failedTypeDefinitions =
-            CountFailedTypeDefinitions(surface, intent);
-        bool nestedUnderForwarder = surface.TypeForwarders.Any(
-            forwarder => IsNestedUnder(
-                intent,
-                MetadataFullName(forwarder)));
-        int exactDeclarations =
-            declaringTypes.Count + forwarders + failedTypeDefinitions;
-        if (exactDeclarations > 1
-            || (declaringTypes.Count + failedTypeDefinitions != 0
-                && nestedUnderForwarder))
+        if (declaringTypes.Count != 1)
         {
             return Failed(
-                ResearchTargetDiagnosticKind.DeclaringTypeAmbiguous);
-        }
-
-        if (declaringTypes.Count == 0)
-        {
-            if (forwarders == 1 || nestedUnderForwarder)
-            {
-                return Unavailable(
-                    ResearchTargetDiagnosticKind.DeclaringTypeForwarded);
-            }
-
-            if (FindPotentiallyCoveringFailure(
-                    surface,
-                    intent,
-                    memberAbsence: false) is not null)
-            {
-                return Failed(
-                    ResearchTargetDiagnosticKind.IncompleteMetadataSurface);
-            }
-
-            return new ResearchTargetOutcome.NotFound(
-                metadataDiagnostic: null,
-                new ResearchTargetDiagnostic(
-                    ResearchTargetDiagnosticKind.DeclaringTypeAbsent),
-                candidates: []);
+                declaringTypes.Count == 0
+                    && FindPotentiallyCoveringFailure(
+                        surface,
+                        intent.ToMetadataFullName(),
+                        memberAbsence: false) is not null
+                    ? ResearchTargetDiagnosticKind.IncompleteMetadataSurface
+                    : ResearchTargetDiagnosticKind.ResolutionFailed);
         }
 
         ApiType declaring = declaringTypes[0];
@@ -580,7 +586,7 @@ public static class ResearchTargetResolver
                     == ResearchTargetOutcomeKind.NotFound
                 && FindPotentiallyCoveringFailure(
                     surface,
-                    intent,
+                    intent.ToMetadataFullName(),
                     memberAbsence: true) is not null)
             {
                 return Failed(
@@ -712,17 +718,6 @@ public static class ResearchTargetResolver
                         && failure.OwningTypeDefinition is not null)
                     || MayAffectType(failure, declaringTypeFullName)));
 
-    static int CountFailedTypeDefinitions(
-        ApiSurface surface,
-        string declaringTypeFullName)
-        => surface.InspectionFailures.Count(
-            failure =>
-                failure.OwningTypeDefinition is { } owner
-                && string.Equals(
-                    owner.ToMetadataFullName(),
-                    declaringTypeFullName,
-                    StringComparison.Ordinal));
-
     static bool MayAffectType(
         ApiSurfaceInspectionFailure failure,
         string declaringTypeFullName)
@@ -847,17 +842,6 @@ public static class ResearchTargetResolver
             (MethodDefinitionHandle)entity);
     }
 
-    static string MetadataFullName(ApiType type)
-        => type.DefinitionName?.ToMetadataFullName() ?? type.FullName;
-
-    static string MetadataFullName(TypeForwarder forwarder)
-        => forwarder.DefinitionName?.ToMetadataFullName() ?? forwarder.TypeName;
-
-    static bool IsNestedUnder(string candidate, string potentialRoot)
-        => candidate.Length > potentialRoot.Length
-            && candidate.StartsWith(potentialRoot, StringComparison.Ordinal)
-            && candidate[potentialRoot.Length] == '.';
-
     static void Terminate(
         IReadOnlyList<PlannedRequest> requests,
         ResearchTargetDiagnosticKind kind)
@@ -947,7 +931,7 @@ public static class ResearchTargetResolver
             scopes.Add(
                 new ResearchTargetScope(
                     scope.Id,
-                    scope.Selection.DeclaringTypeFullName,
+                    scope.Selection.DeclaringType,
                     scope.Selection.Selector,
                     scope.Selection.Kind,
                     domains.MoveToImmutable()));
@@ -976,6 +960,7 @@ public static class ResearchTargetResolver
                         planned.Input,
                         planned.Role,
                         planned.InputEvidence,
+                        planned.ValidationDeclaration,
                         planned.DeclaringType,
                         planned.MetadataResolution,
                         planned.TargetResolutionFailed,
@@ -1040,6 +1025,8 @@ public static class ResearchTargetResolver
 
         public ResearchTargetInputValidationEvidence? InputEvidence { get; set; }
 
+        public TypeDeclarationResult? ValidationDeclaration { get; set; }
+
         public ApiType? DeclaringType { get; set; }
 
         public MemberTargetResolution? MetadataResolution { get; set; }
@@ -1059,6 +1046,7 @@ internal sealed record ResearchTargetValidationEvidence(
     ResearchAdmittedInput Input,
     ResearchTargetInputRole Role,
     ResearchTargetInputValidationEvidence? InputEvidence,
+    TypeDeclarationResult? ValidationDeclaration,
     ApiType? DeclaringType,
     MemberTargetResolution? MetadataResolution,
     bool TargetResolutionFailed,

--- a/tests/DotnetInspector.Queries.Tests/DirectMemberComparisonQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/DirectMemberComparisonQueryTests.cs
@@ -543,7 +543,8 @@ public sealed class DirectMemberComparisonQueryTests
                     Projected.Admission.Inputs.Select(input =>
                         new ResearchTargetInputRoleAssignment(input, ResearchTargetInputRole.Implementation)),
                     [new ResearchCarriedMemberSelection(Projected.Receipt.Questions[Identity.Question],
-                        "DiffFixtureSample.DiffSample", MemberTargetSelector.Parse("Stable"))]))).Resolution;
+                        TypeName("DiffFixtureSample", "DiffSample"),
+                        MemberTargetSelector.Parse("Stable"))]))).Resolution;
             Pair = Assert.IsType<ResearchDesignatedPairOutcome.Admitted>(
                 ResearchDesignatedPairAdmission.Admit(Projected.Admission, resolution,
                     resolution.Attempts.Single(attempt => ReferenceEquals(attempt.Request.Input,
@@ -558,6 +559,12 @@ public sealed class DirectMemberComparisonQueryTests
         internal ProjectedQueryPopulation Projected { get; }
         internal ResearchDesignatedPair Pair { get; }
         internal LocalComparisonPublication Publication { get; }
+
+        static MetadataTypeDefinitionName TypeName(
+            string @namespace,
+            string name) =>
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(@namespace, [name])).Name;
         public void Dispose() => _index.ReleaseCallGraphCaches();
     }
 

--- a/tests/DotnetInspector.Queries.Tests/WorkspaceResearchTargetCompositionQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceResearchTargetCompositionQueryTests.cs
@@ -250,7 +250,7 @@ public sealed class WorkspaceResearchTargetCompositionQueryTests
         ResearchTargetDomain original = plan.Scope.Domains[0];
         var crossed = new ResearchTargetDomain(original.Id, original.Key,
             original.Inputs, original.ConflictingInputs, otherDomain.Requests, otherDomain.Attempts);
-        var crossedScope = new ResearchTargetScope(plan.Scope.Id, plan.Scope.DeclaringTypeFullName,
+        var crossedScope = new ResearchTargetScope(plan.Scope.Id, plan.Scope.DeclaringType,
             plan.Scope.Selector, plan.Scope.Kind, plan.Scope.Domains.Replace(original, crossed));
         var crossedResolution = new ResearchTargetResolution(plan.Resolution.Operation, [crossedScope]);
         var crossedCensus = crossedResolution.Censuses.Single(census =>
@@ -313,7 +313,7 @@ public sealed class WorkspaceResearchTargetCompositionQueryTests
         // Keep the original operation, selected scope, and census valid, but append
         // a foreign domain inside that scope. A narrow selected census cannot hide it.
         var broadenedScope = new ResearchTargetScope(narrow.Scope.Id,
-            narrow.Scope.DeclaringTypeFullName, narrow.Scope.Selector, narrow.Scope.Kind,
+            narrow.Scope.DeclaringType, narrow.Scope.Selector, narrow.Scope.Kind,
             narrow.Scope.Domains.Add(broader.Scope.Domains[1]));
         var broadened = new ResearchTargetResolution(narrow.Resolution.Operation, [broadenedScope]);
         AssertPreQueryRejected(fixture, narrow.Request(fixture, group: group, resolution: broadened,
@@ -430,7 +430,9 @@ public sealed class WorkspaceResearchTargetCompositionQueryTests
         var failed = Assert.IsType<ResearchTargetPlanningOutcome.Rejected>(ResearchTargetResolver.Resolve(
             new(plan.Projected.Admission, [],
                 [new ResearchCarriedMemberSelection(
-                    plan.Projected.Receipt.Questions[plan.Population.Question], "N.Type", Selector)]),
+                    plan.Projected.Receipt.Questions[plan.Population.Question],
+                    WorkspaceResearchTargetFixture.TypeName,
+                    Selector)]),
             TestContext.Current.CancellationToken));
         Assert.Equal(ResearchTargetPlanningRejectionKind.MissingInputRole, failed.Rejection.Kind);
         // The public facade always supplies total implementation roles and one valid

--- a/tests/DotnetInspector.Queries.Tests/WorkspaceResearchTargetFixture.cs
+++ b/tests/DotnetInspector.Queries.Tests/WorkspaceResearchTargetFixture.cs
@@ -80,14 +80,14 @@ internal sealed class WorkspaceResearchTargetFixture : IDisposable
             MetadataMethodAddress address = MetadataMethodAddress.Create(
                 pe.GetMetadataReader(), MetadataTokens.MethodDefinitionHandle(1));
             selection = [new ResearchExactAddressMemberSelection(
-                question, projected.Admission.Inputs[0], "N.Type", selector, address,
+                question, projected.Admission.Inputs[0], TypeName, selector, address,
                 ResearchTargetRelationshipRole.Method)];
         }
         else
         {
             selection = Enumerable.Range(0, selections).Select(_ =>
                 (ResearchMemberSelectionOccurrence)new ResearchCarriedMemberSelection(
-                    question, "N.Type", selector)).ToArray();
+                    question, TypeName, selector)).ToArray();
         }
         var resolution = Assert.IsType<ResearchTargetPlanningOutcome.Planned>(
             ResearchTargetResolver.Resolve(new(

--- a/tests/ILInspector.Research.Tests/ResearchDesignatedPairTests.cs
+++ b/tests/ILInspector.Research.Tests/ResearchDesignatedPairTests.cs
@@ -137,9 +137,13 @@ public partial class ResearchProducerSessionTests
         var twoQuestions = new SessionFixture(population);
         ResearchTargetResolution crossQuestion = twoQuestions.ResolveSelections(
             new ResearchCarriedMemberSelection(
-                population.Questions[0].Id, SampleType, MemberTargetSelector.Parse("Method")),
+                population.Questions[0].Id,
+                TypeName(SampleType),
+                MemberTargetSelector.Parse("Method")),
             new ResearchCarriedMemberSelection(
-                population.Questions[1].Id, SampleType, MemberTargetSelector.Parse("Method")));
+                population.Questions[1].Id,
+                TypeName(SampleType),
+                MemberTargetSelector.Parse("Method")));
         Assert.Equal(
             ResearchDesignatedPairRejectionKind.CrossQuestion,
             Assert.IsType<ResearchDesignatedPairOutcome.Rejected>(
@@ -155,7 +159,7 @@ public partial class ResearchProducerSessionTests
         var wrongImage = new ResearchExactAddressMemberSelection(
             images.Population.Questions[0].Id,
             images.Population.Inputs[0],
-            bodyType,
+            TypeName(bodyType),
             MemberTargetSelector.Parse("BodyState"),
             Target(Attempt(imageTargets, 0, ResearchComparisonSide.After)).Address!.Value,
             ResearchTargetRelationshipRole.Method);
@@ -163,7 +167,8 @@ public partial class ResearchProducerSessionTests
             wrongImage,
             new ResearchCarriedMemberSelection(
                 images.Population.Questions[0].Id,
-                bodyType, MemberTargetSelector.Parse("BodyState")));
+                TypeName(bodyType),
+                MemberTargetSelector.Parse("BodyState")));
         var wrongOutcome = Assert.IsType<ResearchDesignatedPairOutcome.Unavailable>(
             ResearchDesignatedPairAdmission.Admit(
                 images.Population, wrong,
@@ -218,19 +223,29 @@ public partial class ResearchProducerSessionTests
         SessionFixture drift = SessionFixture.Create(
             Occurrence(FixtureCatalog.ResearchTargetCorrespondenceV1.AssemblyPath()),
             Occurrence(FixtureCatalog.ResearchTargetCorrespondenceV2.AssemblyPath()));
-        ResearchTargetResolution divergent = drift.Resolve("CorrespondenceIdentity.Outer.Inner", "M");
-        Assert.All(divergent.Correspondences, outcome => Assert.Equal(
-            ResearchTargetTaintKind.SelectionDrift,
-            Assert.IsType<ResearchTargetCorrespondenceOutcome.CounterpartUnavailable>(outcome)
-                .Taint.Kind));
+        ResearchComparisonQuestionId driftQuestion =
+            drift.Population.Questions[0].Id;
+        ResearchTargetResolution divergent = drift.ResolveSelections(
+            new ResearchCarriedMemberSelection(
+                driftQuestion,
+                TypeName("CorrespondenceIdentity", "Outer", "Inner"),
+                MemberTargetSelector.Parse("M")),
+            new ResearchCarriedMemberSelection(
+                driftQuestion,
+                TypeName("CorrespondenceIdentity.Outer", "Inner"),
+                MemberTargetSelector.Parse("M")));
+        Assert.Single(
+            divergent.Correspondences
+                .OfType<ResearchTargetCorrespondenceOutcome.BeforeOnly>());
+        Assert.Single(
+            divergent.Correspondences
+                .OfType<ResearchTargetCorrespondenceOutcome.AfterOnly>());
         ResearchDesignatedPair divergentPair = Admit(
             drift, divergent,
             Attempt(divergent, 0, ResearchComparisonSide.Before),
-            Attempt(divergent, 0, ResearchComparisonSide.After));
+            Attempt(divergent, 1, ResearchComparisonSide.After));
         Assert.Equal(2, Complete(new(drift.Population, divergentPair, ResearchProducerCatalog.Kinds))
             .Results.Length);
-        Assert.All(divergent.Correspondences, outcome =>
-            Assert.IsType<ResearchTargetCorrespondenceOutcome.CounterpartUnavailable>(outcome));
     }
 
     [Fact]
@@ -256,7 +271,8 @@ public partial class ResearchProducerSessionTests
         ResearchTargetResolution resolution = ResolveExactPair(
             fixture, SampleType, "Method", "DiffFixtureSample.BodyStateSample", "BodyState",
             new ResearchCarriedMemberSelection(
-                population.Questions[1].Id, "DiffFixtureSample.BodyStateSample",
+                population.Questions[1].Id,
+                TypeName("DiffFixtureSample.BodyStateSample"),
                 MemberTargetSelector.Parse("Missing")));
         ResearchDesignatedPair pair = Admit(
             fixture, resolution,
@@ -500,7 +516,10 @@ public partial class ResearchProducerSessionTests
             return new(
                 attempt.Request.Question,
                 fixture.Population.GetInput(attempt.Request.Input),
-                type, MemberTargetSelector.Parse(selector), target.Address!.Value, target.Role);
+                TypeName(type),
+                MemberTargetSelector.Parse(selector),
+                target.Address!.Value,
+                target.Role);
         }
     }
 }

--- a/tests/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
+++ b/tests/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
@@ -19,6 +19,22 @@ public partial class ResearchProducerSessionTests
     const string SampleType =
         "ILInspector.Research.TargetFixtures.TargetSample";
 
+    static MetadataTypeDefinitionName TypeName(string fullName)
+    {
+        int separator = fullName.LastIndexOf('.');
+        return TypeName(
+            separator < 0 ? "" : fullName[..separator],
+            fullName[(separator + 1)..]);
+    }
+
+    static MetadataTypeDefinitionName TypeName(
+        string @namespace,
+        params string[] segments) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(
+                @namespace,
+                [.. segments])).Name;
+
     [Fact]
     public void ResearchProducerCatalog_AdmitsEveryDeclaredLocalKind()
     {
@@ -1022,7 +1038,7 @@ public partial class ResearchProducerSessionTests
                     .. selections.Select(
                         selection => new ResearchCarriedMemberSelection(
                             Population.Questions[0].Id,
-                            selection.DeclaringType,
+                            TypeName(selection.DeclaringType),
                             selection.Selector)),
                 ]);
 

--- a/tests/ILInspector.Research.Tests/ResearchTargetResolverTests.cs
+++ b/tests/ILInspector.Research.Tests/ResearchTargetResolverTests.cs
@@ -29,6 +29,22 @@ public class ResearchTargetResolverTests
     const string AbsentType = "ILInspector.Research.TargetFixtures.NotHere";
     const string DiffType = "DiffFixtureSample.DiffSample";
 
+    static MetadataTypeDefinitionName TypeName(string fullName)
+    {
+        int separator = fullName.LastIndexOf('.');
+        return TypeName(
+            separator < 0 ? "" : fullName[..separator],
+            fullName[(separator + 1)..]);
+    }
+
+    static MetadataTypeDefinitionName TypeName(
+        string @namespace,
+        params string[] segments) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(
+                @namespace,
+                [.. segments])).Name;
+
     // --------------------------------------------------------------- requests
 
     [Fact]
@@ -234,6 +250,16 @@ public class ResearchTargetResolverTests
             resolved.Target,
             Diagnostic: null,
             resolved.Candidates);
+        using var declarationImage = new PEReader(
+            File.OpenRead(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        TypeDeclarationResult declaration =
+            MetadataTypeDeclarationProbe.Probe(
+                declarationImage.GetMetadataReader(),
+                selection.DeclaringType);
+        TypeDeclarationResult missingDeclaration =
+            MetadataTypeDeclarationProbe.Probe(
+                declarationImage.GetMetadataReader(),
+                TypeName(AbsentType));
         var surface = new ApiSurface();
         surface.Types.Add(resolved.Target.ApiType);
         ResearchTargetInputValidationEvidence inputEvidence = new(
@@ -278,6 +304,7 @@ public class ResearchTargetResolverTests
                     []),
                 researchDiagnostic: null,
                 candidates: []));
+        Rejects(resolved, declarationOverride: missingDeclaration);
         Rejects(resolved, corruptDispositionRequest: true);
         resolved.Target.ApiMember.Member.GetterToken =
             resolved.Target.ApiMember.Member.MetadataToken;
@@ -303,6 +330,7 @@ public class ResearchTargetResolverTests
                 input,
                 ResearchTargetInputRole.Implementation,
                 inputEvidence,
+                declaration,
                 resolved.Target.ApiType,
                 metadata,
                 TargetResolutionFailed: false,
@@ -384,6 +412,7 @@ public class ResearchTargetResolverTests
             ResearchTargetOutcome corrupted,
             bool corruptDispositionRequest = false,
             ResearchTargetInputValidationEvidence? evidenceOverride = null,
+            TypeDeclarationResult? declarationOverride = null,
             bool omitMetadataEvidence = false)
         {
             ResearchTargetAttempt attempt = new(
@@ -414,7 +443,7 @@ public class ResearchTargetResolverTests
                 [attempt]);
             ResearchTargetScope corruptedScope = new(
                 scope.Id,
-                scope.DeclaringTypeFullName,
+                scope.DeclaringType,
                 scope.Selector,
                 scope.Kind,
                 [corruptedDomain]);
@@ -428,6 +457,9 @@ public class ResearchTargetResolverTests
                     input,
                     ResearchTargetInputRole.Implementation,
                     evidenceOverride ?? inputEvidence,
+                    omitMetadataEvidence
+                        ? null
+                        : declarationOverride ?? declaration,
                     omitMetadataEvidence ? null : resolved.Target.ApiType,
                     omitMetadataEvidence ? null : metadata,
                     TargetResolutionFailed: false,
@@ -929,7 +961,12 @@ public class ResearchTargetResolverTests
         var nested = Assert.IsType<
             ResearchTargetCorrespondenceOutcome.Paired>(
                 Assert.Single(
-                    nestedFixture.ResolveDefault(NestedType, "Method")
+                    nestedFixture.ResolveDefault(
+                            TypeName(
+                                "ILInspector.Research.TargetFixtures",
+                                "TargetOuter",
+                                "TargetInner"),
+                            "Method")
                         .Correspondences));
         Assert.Equal(
             ["TargetOuter", "TargetInner"],
@@ -1070,34 +1107,27 @@ public class ResearchTargetResolverTests
                 primitiveName.Before.CorrespondenceKey.BodyIdentity!
                     .ParameterTypes).Kind);
 
-        ResearchTargetResolution nested = fixture.ResolveDefault(
-            "CorrespondenceIdentity.Outer.Inner",
-            "M");
-        ResearchTargetCorrespondenceOutcome.CounterpartUnavailable[] drift =
-        [
-            .. nested.Correspondences
-                .Select(Assert.IsType<
-                    ResearchTargetCorrespondenceOutcome
-                        .CounterpartUnavailable>),
-        ];
-        Assert.Equal(2, drift.Length);
-        Assert.All(
-            drift,
-            outcome => Assert.Equal(
-                ResearchTargetTaintKind.SelectionDrift,
-                outcome.Taint.Kind));
+        ResearchTargetResolution nested = fixture.Resolve(
+            fixture.Carried(
+                0,
+                TypeName("CorrespondenceIdentity", "Outer", "Inner"),
+                MemberTargetSelector.Parse("M")),
+            fixture.Carried(
+                0,
+                TypeName("CorrespondenceIdentity.Outer", "Inner"),
+                MemberTargetSelector.Parse("M")));
+        var beforeOnly = Assert.Single(
+            nested.Correspondences
+                .OfType<ResearchTargetCorrespondenceOutcome.BeforeOnly>());
+        var afterOnly = Assert.Single(
+            nested.Correspondences
+                .OfType<ResearchTargetCorrespondenceOutcome.AfterOnly>());
 
         MetadataTypeDefinitionName? beforeType =
-            drift.Single(outcome =>
-                    outcome.Attempt.Request.Side
-                        == ResearchComparisonSide.Before)
-                .CorrespondenceKey!.BodyIdentity!
+            beforeOnly.Before.CorrespondenceKey.BodyIdentity!
                 .DeclaringType.DefinitionName;
         MetadataTypeDefinitionName? afterType =
-            drift.Single(outcome =>
-                    outcome.Attempt.Request.Side
-                        == ResearchComparisonSide.After)
-                .CorrespondenceKey!.BodyIdentity!
+            afterOnly.After.CorrespondenceKey.BodyIdentity!
                 .DeclaringType.DefinitionName;
         Assert.NotNull(beforeType);
         Assert.NotNull(afterType);
@@ -2092,7 +2122,12 @@ public class ResearchTargetResolverTests
         // name.
         Assert.IsType<ResearchTargetOutcome.Resolved>(
             Assert.Single(
-                fixture.ResolveDefault(NestedType, "Method").Attempts).Outcome);
+                fixture.ResolveDefault(
+                    TypeName(
+                        "ILInspector.Research.TargetFixtures",
+                        "TargetOuter",
+                        "TargetInner"),
+                    "Method").Attempts).Outcome);
         Assert.IsType<ResearchTargetOutcome.NotFound>(
             Assert.Single(
                 fixture.ResolveDefault(
@@ -2124,7 +2159,9 @@ public class ResearchTargetResolverTests
             [(Occurrence(image), null, null)]);
 
         ResearchTargetAttempt forwarded = Assert.Single(
-            fixture.ResolveDefault("N.Outer.Inner", "Method").Attempts);
+            fixture.ResolveDefault(
+                TypeName("N", "Outer", "Inner"),
+                "Method").Attempts);
         var unavailable =
             Assert.IsType<ResearchTargetOutcome.Unavailable>(forwarded.Outcome);
         Assert.Equal(
@@ -2132,7 +2169,9 @@ public class ResearchTargetResolverTests
             unavailable.Diagnostic.Kind);
 
         ResearchTargetAttempt unrelated = Assert.Single(
-            fixture.ResolveDefault("N.Other.Inner", "Method").Attempts);
+            fixture.ResolveDefault(
+                TypeName("N", "Other", "Inner"),
+                "Method").Attempts);
         Assert.Equal(
             ResearchTargetDiagnosticKind.DeclaringTypeAbsent,
             Assert.IsType<ResearchTargetOutcome.NotFound>(unrelated.Outcome)
@@ -2234,6 +2273,33 @@ public class ResearchTargetResolverTests
     }
 
     [Fact]
+    public void ResearchTargetDeclaringType_UsesMetadataSemanticsForEquivalentForwarders()
+    {
+        byte[] image = BuildResearchSurfaceImage(
+            cyclicTypeName: null,
+            duplicateTypeName: null,
+            forwarderTypeName: "Forwarded",
+            forwarderDeclarationCount: 2);
+        using var pe = new PEReader(
+            new MemoryStream(image, writable: false));
+        MetadataTypeDefinitionName intent = TypeName("N", "Forwarded");
+        var declaration = Assert.IsType<TypeDeclarationResult.Forwarded>(
+            MetadataTypeDeclarationProbe.Probe(
+                pe.GetMetadataReader(),
+                intent));
+        Assert.Equal(2, declaration.Declarations.Length);
+
+        TargetFixture fixture = TargetFixture.Create(
+            [(Occurrence(image), null, null)]);
+        var unavailable = Assert.IsType<ResearchTargetOutcome.Unavailable>(
+            Assert.Single(
+                fixture.ResolveDefault(intent, "Method").Attempts).Outcome);
+        Assert.Equal(
+            ResearchTargetDiagnosticKind.DeclaringTypeForwarded,
+            unavailable.Diagnostic.Kind);
+    }
+
+    [Fact]
     public void ResearchTargetDeclaringType_RejectsFailedExactDuplicate()
     {
         byte[] image = BuildFailedExactDuplicateImage();
@@ -2258,7 +2324,7 @@ public class ResearchTargetResolverTests
     }
 
     [Fact]
-    public void ResearchTargetAbsence_UnscopedForwarderFailureBlocksOnlyAbsence()
+    public void ResearchTargetDeclaration_UnscopedForwarderFailureRemainsVisible()
     {
         byte[] image = BuildMalformedForwarderImage();
         ApiSurface surface = ExtractSurface(image);
@@ -2280,22 +2346,16 @@ public class ResearchTargetResolverTests
             ResearchTargetDiagnosticKind.IncompleteMetadataSurface,
             failed.Diagnostic.Kind);
 
-        ResearchTargetResolution resolved =
-            fixture.ResolveDefault("N.C", "M");
-        Assert.IsType<ResearchTargetOutcome.Resolved>(
-            Assert.Single(resolved.Attempts).Outcome);
-        var unavailable = Assert.IsType<
-            ResearchTargetCorrespondenceOutcome.CounterpartUnavailable>(
-                Assert.Single(resolved.Correspondences));
-        Assert.Null(unavailable.StrictKey);
-        Assert.Null(unavailable.CorrespondenceKey);
+        var localFailure = Assert.IsType<ResearchTargetOutcome.Failed>(
+            Assert.Single(
+                fixture.ResolveDefault("N.C", "M").Attempts).Outcome);
         Assert.Equal(
-            ResearchTargetTaintKind.BodyIdentityUnavailable,
-            unavailable.Taint.Kind);
+            ResearchTargetDiagnosticKind.IncompleteMetadataSurface,
+            localFailure.Diagnostic.Kind);
     }
 
     [Fact]
-    public void ResearchTargetForwarder_RetainedEvidencePrecedesUnscopedFailure()
+    public void ResearchTargetForwarder_UnscopedFailureRemainsVisible()
     {
         byte[] image = BuildMalformedForwarderImage(
             includeLocalType: false,
@@ -2310,14 +2370,14 @@ public class ResearchTargetResolverTests
 
         TargetFixture fixture = TargetFixture.Create(
             [(Occurrence(image), null, null)]);
-        var unavailable = Assert.IsType<ResearchTargetOutcome.Unavailable>(
+        var failed = Assert.IsType<ResearchTargetOutcome.Failed>(
             Assert.Single(
                 fixture.ResolveDefault(
                     "N.Forwarded",
                     "M").Attempts).Outcome);
         Assert.Equal(
-            ResearchTargetDiagnosticKind.DeclaringTypeForwarded,
-            unavailable.Diagnostic.Kind);
+            ResearchTargetDiagnosticKind.IncompleteMetadataSurface,
+            failed.Diagnostic.Kind);
     }
 
     [Fact]
@@ -2536,7 +2596,7 @@ public class ResearchTargetResolverTests
                     [
                         new ResearchCarriedMemberSelection(
                             stranger.Questions[0].Id,
-                            SampleType,
+                            TypeName(SampleType),
                             MemberTargetSelector.Parse("Method")),
                     ]),
             [ResearchTargetPlanningRejectionKind.ForeignInput] =
@@ -2547,7 +2607,7 @@ public class ResearchTargetResolverTests
                         new ResearchExactAddressMemberSelection(
                             fixture.Population.Questions[0].Id,
                             stranger.Inputs[0],
-                            SampleType,
+                            TypeName(SampleType),
                             MemberTargetSelector.Parse("Method"),
                             address,
                             ResearchTargetRelationshipRole.Method),
@@ -2594,7 +2654,7 @@ public class ResearchTargetResolverTests
                         new ResearchExactAddressMemberSelection(
                             fixture.Population.Questions[0].Id,
                             admitted,
-                            SampleType,
+                            TypeName(SampleType),
                             MemberTargetSelector.Parse("Method"),
                             address,
                             (ResearchTargetRelationshipRole)77),
@@ -2961,7 +3021,8 @@ public class ResearchTargetResolverTests
         string? duplicateTypeName,
         string? forwarderTypeName = null,
         string? nestedForwarderTypeName = null,
-        string? malformedAssemblyRefExportTypeName = null)
+        string? malformedAssemblyRefExportTypeName = null,
+        int forwarderDeclarationCount = 1)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -3021,6 +3082,7 @@ public class ResearchTargetResolverTests
 
         if (forwarderTypeName is not null)
         {
+            Assert.True(forwarderDeclarationCount >= 1);
             AssemblyReferenceHandle target = metadata.AddAssemblyReference(
                 metadata.GetOrAddString("ForwarderTarget"),
                 new Version(1, 0, 0, 0),
@@ -3028,12 +3090,18 @@ public class ResearchTargetResolverTests
                 publicKeyOrToken: default,
                 flags: default,
                 hashValue: default);
-            ExportedTypeHandle root = metadata.AddExportedType(
-                TypeAttributes.Public | Forwarder,
-                metadata.GetOrAddString("N"),
-                metadata.GetOrAddString(forwarderTypeName),
-                target,
-                typeDefinitionId: 0);
+            ExportedTypeHandle root = default;
+            for (int index = 0; index < forwarderDeclarationCount; index++)
+            {
+                ExportedTypeHandle declaration = metadata.AddExportedType(
+                    TypeAttributes.Public | Forwarder,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString(forwarderTypeName),
+                    target,
+                    typeDefinitionId: 0);
+                if (index == 0)
+                    root = declaration;
+            }
             if (nestedForwarderTypeName is not null)
             {
                 metadata.AddExportedType(
@@ -3690,6 +3758,15 @@ public class ResearchTargetResolverTests
             int questionIndex,
             string declaringType,
             MemberTargetSelector selector)
+            => Carried(
+                questionIndex,
+                TypeName(declaringType),
+                selector);
+
+        public ResearchCarriedMemberSelection Carried(
+            int questionIndex,
+            MetadataTypeDefinitionName declaringType,
+            MemberTargetSelector selector)
             => new(
                 Population.Questions[questionIndex].Id,
                 declaringType,
@@ -3705,7 +3782,7 @@ public class ResearchTargetResolverTests
             => new(
                 Population.Questions[questionIndex].Id,
                 input,
-                declaringType,
+                TypeName(declaringType),
                 MemberTargetSelector.Parse(selector),
                 address,
                 role);
@@ -3719,6 +3796,14 @@ public class ResearchTargetResolverTests
             string declaringType,
             string selector)
             => Resolve(Carried(0, declaringType, selector));
+
+        public ResearchTargetResolution ResolveDefault(
+            MetadataTypeDefinitionName declaringType,
+            string selector)
+            => Resolve(Carried(
+                0,
+                declaringType,
+                MemberTargetSelector.Parse(selector)));
 
         public ResearchTargetPlanningOutcome ResolveRaw(
             IEnumerable<ResearchMemberSelectionOccurrence?> selections,


### PR DESCRIPTION
## Summary

Research target planning now retains `MetadataTypeDefinitionName` and consumes
`MetadataTypeDeclarationProbe` before member selection. Equivalent same-target
forwarder rows therefore use Metadata's normalized declaration semantics
instead of becoming a Research-owned ambiguity.

This is the focused precursor for #6429 and #6437.

## Design basis

`docs/design/implementation-diff.md` owns Research's input-local target
attempts. `docs/design/type-forwarding-resolution.md` owns declaration
classification and forwarding resolution.

Research now:

- carries the structured declaring-type identity through selections, scopes,
  and requests;
- obtains a normalized local declaration result from Metadata;
- permits member selection only for the exact TypeDef token from `Defined`;
- maps `Forwarded` to
  `Unavailable/DeclaringTypeForwarded`, including nested and equivalent
  duplicate declarations; and
- leaves cross-assembly traversal, workspace selection, and acquisition outside
  Research.

The final validator consumes a second Metadata declaration result from the
same staged reader, preserving independent validation without reopening the
input.

## Demo

The real package witness is
`Microsoft.Extensions.DependencyInjection` 10.0.0:

```bash
dotnet run --project src/DotnetInspect.Cli -c Release --no-build -- \
  library Microsoft.Extensions.DependencyInjection \
  --package Microsoft.Extensions.DependencyInjection@10.0.0 \
  --tfm net10.0 -v:d -S "Type Forwarders" -n 20
```

```text
# Microsoft.Extensions.DependencyInjection.dll (net10.0)

## Type Forwarders

| Type | Target Assembly |
| ---- | --------------- |
| Microsoft.Extensions.DependencyInjection.ServiceCollection | Microsoft.Extensions.DependencyInjection.Abstractions |
```

The controlled duplicate-row extension now follows that same declaration
semantics:

```bash
dotnet run --project tests/ILInspector.Research.Tests -c Release --no-build -- \
  --filter-method \
  ILInspector.Research.Tests.ResearchTargetResolverTests.ResearchTargetDeclaringType_UsesMetadataSemanticsForEquivalentForwarders
```

```text
Test run summary: Passed!
  total: 1
  failed: 0
  succeeded: 1
```

What to notice:

- Before, two equivalent forwarder rows became
  `Failed/DeclaringTypeAmbiguous`.
- After, Metadata retains both declaration tokens in one `Forwarded` result and
  Research publishes `Unavailable/DeclaringTypeForwarded`.
- Competing targets and definition/forwarder conflicts remain ambiguous.

## Compatibility

`ResearchCarriedMemberSelection` and
`ResearchExactAddressMemberSelection` now require
`MetadataTypeDefinitionName`. The derived `DeclaringTypeFullName` property
remains available for display. This intentional source change prevents
namespace and nested-type boundaries from being reconstructed from flattened
text.

Malformed or otherwise rejected declaration evidence remains a visible
`IncompleteMetadataSurface` failure. Research does not follow forwarding
targets or acquire additional inputs.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/ILInspector.Research.Tests -c Release`
  - 295 passed
- affected `DotnetInspector.Queries.Tests` classes
  - 90 passed
- `npx markdownlint-cli docs/design/implementation-diff.md`
- `git diff --check`

Closes #6616
