### PR TITLE
Refresh nightly CLI certification expectations

### DIFF
--- a/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
@@ -2843,7 +2843,7 @@ public partial class CommandExecutionTests
             var (exit, output, error) = await RunAppAsync(
                 "vocabulary",
                 "-S",
-                "@Decompiler",
+                "C# *",
                 "--count",
                 "--tips",
                 "q");
@@ -3378,7 +3378,7 @@ public partial class CommandExecutionTests
     [Fact]
     public async Task BareName_PlatformNamespacePrefix_RoutesToTypePrefixBrowse()
     {
-        var (exit, output, error) = await RunAppAsync("System.Text", "--tips", "q", "-n", "12");
+        var (exit, output, error) = await RunAppAsync("System.Text", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("Showing best-effort platform prefix matches for 'System.Text'", error);
@@ -3390,7 +3390,7 @@ public partial class CommandExecutionTests
         // claim is asserted. The claim here is about ROUTING, so it is moved to where the evidence
         // lives rather than dropped.
         var (factExit, factOutput, _) = await RunAppAsync(
-            "System.Text", "--tips", "q", "-n", "12", "-S", SectionNames.ApiInfo);
+            "System.Text", "--tips", "q", "-S", SectionNames.ApiInfo);
 
         Assert.Equal(0, factExit);
         Assert.Contains("| Source | Platform |", factOutput, StringComparison.Ordinal);
@@ -4485,8 +4485,6 @@ public partial class CommandExecutionTests
             "--where",
             "Kind=InvocationExpression",
             "--table",
-            "--rows",
-            "1",
             "--tips",
             "q"
         ];
@@ -9185,7 +9183,7 @@ public partial class CommandExecutionTests
 
         // Structured resolution reaches ParamCollectionAttribute through the
         // platform policy instead of dropping it with the sibling-only probe.
-        Assert.Contains("Types: 90", fieldsOutput, StringComparison.Ordinal);
+        Assert.Contains("Types: 91", fieldsOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("Methods:", fieldsOutput, StringComparison.Ordinal);
 
         // --columns is the same surface and was the case the first fix missed: it does not filter
@@ -9202,7 +9200,7 @@ public partial class CommandExecutionTests
             "type", "--platform", "System.Text.Json", "-v:q", "-S", SectionNames.ApiInfo, "--tips", "q");
 
         Assert.Equal(0, bothExit);
-        Assert.Contains("| Types | 90 |", bothOutput, StringComparison.Ordinal);
+        Assert.Contains("| Types | 91 |", bothOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("Library: System.Text.Json.dll |", bothOutput, StringComparison.Ordinal);
     }
 
@@ -10147,7 +10145,7 @@ public partial class CommandExecutionTests
     public async Task Type_SingleType_SourceFilesSection_RendersTypeSourceUrls()
     {
         var (exit, output, error) = await RunAppAsync(
-            "System.Text.Json.JsonSerializer", "-S", "Source Files", "--tips", "q", "-n", "28");
+            "type", "System.Text.Json.JsonSerializer", "-S", "Source Files", "--tips", "q", "-n", "28");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational
capabilities or compelling user experiences while remaining conventionally
sound, delightfully new, or both.

## Summary

- Align slow CLI certification cases with the intentional commandless
  row-selection envelope: route-only commandless cases no longer request
  non-uniform row gestures, while the source-files case uses explicit `type`
  to retain command-owned `-n`.
- Replace the removed `@Decompiler` vocabulary category with the current
  multi-section `C# *` selection.
- Update the .NET 11 RC1 `System.Text.Json` public-type baseline from 90 to 91.

This changes certification expectations only; product behavior is unchanged.

## Demo

Commandless routing now rejects a row gesture that is not uniform across all
possible implicit routes:

```text
dotnet-inspect System.Text -n 12
```

The routing test therefore exercises the intended route without `-n`. The
neighboring explicit command remains command-owned and supports the row
gesture:

```text
dotnet-inspect type System.Text.Json.JsonSerializer \
  -S "Source Files" -n 28
```

The repaired slow tests preserve both sides of that boundary.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- Six repaired methods: 11 passed
- Complete CLI suite: 7,447 passed, 31 skipped, with five unrelated failures
  reproduced unchanged on a clean current-`main` worktree:
  - stderr-ownership project closure
  - two local-source replay path assertions
  - projected JSON routing inventory
  - case-distinct unresolved-reference inventory
- Final rebase onto `e7572e46d66a8dd064131c6fa66d4230a8405b98`;
  repaired methods revalidated 11/11