### PR TITLE
Run Microsoft.Extensions demos from ASP.NET Core Platform

### DIFF
--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -649,11 +649,12 @@ selection, missing-capability results, and discovery materialization remain
 unchanged. Hosts must not infer executable traversal from a nonempty hint or
 core sequence, a curated set, or the presence of a pack identity.
 
-In particular, `ecosystem.platform` already groups product demos. It can retain
-that identity without pretending that its package-backed demos supply
-platform-source-owned traversal. This slice neither creates a Platform
-package set nor substitutes a `System.*` package prefix for a platform target.
-The catalog can expose the
+Ecosystem grouping and source provenance are orthogonal. `ecosystem.platform`
+groups Runtime Platform demos, while `ecosystem.microsoft-extensions` retains
+the Microsoft.Extensions demos whose exact implementation sources are ASP.NET
+Core Platform libraries. Neither grouping creates a Platform package set,
+changes curated package-set membership, or substitutes a package prefix for a
+Platform target. The catalog can expose the
 [resource-free population declaration](platform-library-population-declaration.md)
 independently; source realization and acquisition remain separate
 prerequisites.
@@ -1147,16 +1148,16 @@ The flat product-demo projection preserves current order and appends Aspire:
 ```text
 Demos
 
-System.Text.Json                     Browse the Runtime Platform API
-Cross-package call graph             Trace calls across three packages
-Serialize call graph                 Trace the Runtime STJ implementation
-Configuration Bind                  Recursive binder call graph
-Options hub                         Inbound fan-in at AddOptions
-DI TryAdd hub                       Keyed/scoped Try* fan-in
-AddHttpClient                       HttpClient factory registration
-JsonElement.GetDecimal              Trace the Runtime number parse path
-Aspire AddPostgres                  PostgreSQL resource registration graph
-Aspire AddRedis                     Redis resource registration graph
+System.Text.Json                    Browse the Runtime Platform API
+Cross-library call graph            Trace calls across three Platform libraries
+Serialize call graph                Trace the Runtime STJ implementation
+Configuration Bind                 Recursive binder call graph
+Options hub                        Inbound fan-in at AddOptions
+DI TryAdd hub                      Keyed/scoped Try* fan-in
+AddHttpClient                      HttpClient factory registration
+JsonElement.GetDecimal             Trace the Runtime number parse path
+Aspire AddPostgres                 PostgreSQL resource registration graph
+Aspire AddRedis                    Redis resource registration graph
 ```
 
 The grouped ecosystem projection uses the same registrations:
@@ -1259,15 +1260,17 @@ gating the generic registry path's no-lookup behavior.
 ten scenario IDs, pack mapping, metadata, and global order without deriving
 expectations from source records.
 `ProductEcosystemPackTests.ExistingDemoSourcesPreserveDonorRecordsAndRunPlans`
-resolves the transferred eight sources and pins their package coordinates,
-navigation shape, type and member selection, section, and run-plan lowering to
-the donor behavior.
+resolves the transferred eight sources and pins their Runtime or ASP.NET Core
+Platform coordinates, navigation shape, type and member selection, section,
+and run-plan lowering to the donor behavior while retaining their ecosystem
+grouping.
 `ProductEcosystemPackTests.AspireDemoSourcesMatchLiteralPinsAndAnchors` gates
 the two exact package IDs, versions, TFMs, types, member anchors, and Call Graph
 bindings.
 `DemoCommandTests.Cli_EveryCallGraphDemo_Table_EmitsNonEmptyRows` gates
 nonempty ordinary CLI Call Graph execution through the existing section
-pipeline, including both Aspire scenarios.
+pipeline, including multi-library ASP.NET Core Platform caller scope and both
+package-backed Aspire scenarios.
 `DemoCommandTests.ListUsesCatalogDescriptorMetadata` and
 `BrowserProductHomeDemosTests.CatalogProjectionUsesEcosystemDescriptorMetadata`
 prove both hosts use application-catalog title and summary even when the

--- a/docs/design/platform-package-pruning.md
+++ b/docs/design/platform-package-pruning.md
@@ -24,7 +24,7 @@ remains a separate effort with its own design; none is specified here.
 
 A project targets `net10.0` and something in its graph depends on
 `System.Text.Json` 9.0.0. The SDK removes that dependency, because the platform
-already supplies `System.Text.Json` 10.0.11. The package is never downloaded,
+already supplies `System.Text.Json` 10.0.12. The package is never downloaded,
 never appears in the assets file, and nothing binds to it. The application uses
 the platform's copy.
 
@@ -169,8 +169,8 @@ The SDK ships the decision as `PackageId|Version` pairs, in the reference
 pack under `data/PackageOverrides.txt`:
 
 ```text
-System.Text.Json|10.0.11
-System.Reflection.Metadata|10.0.11
+System.Text.Json|10.0.12
+System.Reflection.Metadata|10.0.12
 System.Memory|5.0.0
 Microsoft.CSharp|4.7.0
 ```
@@ -524,8 +524,8 @@ Pruning decides package identities. It does not decide assemblies, files,
 types, asset-group selection, or graph policy, and it never compares an
 assembly version with a package version.
 
-The distinction is observable in `System.Text.Json` 10.0.11: the package
-version is 10.0.11 while the assembly version is 10.0.0.0. Comparing the
+The distinction is observable in `System.Text.Json` 10.0.12: the package
+version is 10.0.12 while the assembly version is 10.0.0.0. Comparing the
 assembly reference to the package ceiling would use the wrong identity and
 version currency even though the leading major happens to match.
 
@@ -665,8 +665,8 @@ The first implementation slice is #6239. Its gates live in
 | Family composition decides inventory membership | `FamilyCompositionDecidesInventoryMembership` | implemented — #6239 |
 | Composition refuses mismatched targets and prefers the lower supplied version | `CompositionRefusesMismatchedTargetsAndPrefersTheLowerSuppliedVersion` | implemented — #6239 |
 | An empty inventory subsumes nothing | `EmptyInventorySubsumesNothing` | implemented — #6239 |
-| The browser catalog projects exact pack-owned supply rows | `StjPlatformDemos_JoinExactSupplyAndCatalogEvidence` in `DotnetInspect.Web.Tests` and `platform-index.test.ts` | implemented — first Inspect Web adoption |
-| A demo migrates only when exact policy delegation and explicit implementation-library correspondence both hold | `StjPlatformDemos_JoinExactSupplyAndCatalogEvidence` | implemented — first Inspect Web adoption |
+| The browser catalog projects exact pack-owned supply rows | `StjPlatformDemos_JoinExactSupplyAndCatalogEvidence` and `ExtensionsPlatformDemos_JoinExactSupplyAndCatalogEvidence` in `DotnetInspect.Web.Tests`, plus `platform-index.test.ts` | implemented — Inspect Web adoption |
+| A demo migrates only when exact policy delegation and explicit implementation-library correspondence both hold | `StjPlatformDemos_JoinExactSupplyAndCatalogEvidence` and `ExtensionsPlatformDemos_JoinExactSupplyAndCatalogEvidence` | implemented — Runtime and ASP.NET Core demo adoption |
 | Only an exact selected `ecosystem.platform` registration activates pruning; absent, unselected, and ASP.NET-Core-only registrations do not | `PruningActivation_RequiresSelectedPlatformRegistration` in `DotnetInspector.Queries.Tests` | pending — Workspace pruning adoption under #6012 and #6570 |
 | The selected Platform registration activates comparison only with its associated exact target inventory | `PruningActivation_RequiresExactTargetInventoryCorrespondence` in `DotnetInspector.Queries.Tests` | pending — Workspace pruning adoption under #6012 and #6570 |
 | An acquired exact pack replaces projected supplied versions | `Pruning_ExactPackReplacesProjectedVersions` | pending — projection slice |

--- a/docs/design/platform-package-supply-policy.md
+++ b/docs/design/platform-package-supply-policy.md
@@ -4,9 +4,9 @@
 
 Implemented by #6268 as the policy slice of #6228 effort 1. Inspect Web now
 projects exact reference-pack inventory into its Platform catalog and uses this
-policy to gate the three System.Text.Json demo migrations. Runtime activation
-still consumes an explicit Platform assembly coordinate; this policy does not
-infer one from package identity.
+policy to gate the three System.Text.Json and five Microsoft.Extensions demo
+migrations. Runtime activation still consumes explicit Platform assembly
+coordinates; this policy does not infer them from package identity.
 
 ## Authority and exact claim
 
@@ -123,9 +123,10 @@ adoption to:
 
 Inspect Web's checked-in Platform catalog is the first production projection:
 each exact target carries its pack-owned package supply rows beside, but
-separate from, its library rows. The System.Text.Json demos consume the
-result only as an authoring migration gate and separately require an exact
-`System.Text.Json` implementation-library row.
+separate from, its library rows. The Runtime System.Text.Json and ASP.NET Core
+Microsoft.Extensions demos consume the result only as an authoring migration
+gate and separately require exact implementation-library rows for every
+selected assembly.
 
 [#6266](https://github.com/richlander/dotnet-inspect/issues/6266) separately
 tracks the eight-step package-input evolution. Its step 6 adopts normalized

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -18,7 +18,7 @@ workspaces. Browser home demos execute every selected preset through
 `RunHomeDemo`, apply its typed package or Platform activation, and publish the
 ordinary canonical Browser workspace only after the selected result is ready.
 CLI Platform demos use the same `WorkspaceContextLoader` implementation-pack
-realization before lowering the selected image into the ordinary type/member
+realization before lowering the selected images into the ordinary type/member
 section pipeline.
 Schema version 2, packet format 2, complete view binding, and the restoration
 coordinator defined here are not yet implemented.
@@ -783,12 +783,12 @@ section; CLI and browser encodings consume that plan rather than parsing the
 member selection independently. **The current schema-version-1 home demos bind
 legacy product section display names** through
 `ProductDemoSections` (today: `Methods` for the STJ API tour; `Call
-Graph` primary bind for multi-package and focused graph demos, expanded
+Graph` primary bind for multi-source and focused graph demos, expanded
 at run via `ExpandRunSections` / `DemoScenarioRunner`: Markdown keeps
 `Call Graph` + `Callers`; table/tsv/jsonl select `Callers` when the demo has
 caller scope — MemberCommand re-adds Callers under caller scope, so
 Call Graph-only tabular would silently fall back to a member inventory — and
-select `Call Graph` when it does not, so package-local entry points with empty
+select `Call Graph` when it does not, so single-library entry points with empty
 Callers still emit rows; standalone `--mermaid` keeps `Call Graph`; document
 `--json` fails closed for Call Graph demos until graph sections project into
 that payload.
@@ -824,10 +824,13 @@ their exact canonical facet IDs before Registry resolution.
 (`DemoScenarioRunner`) so `dotnet-inspect demo <id>` returns ordinary section
 output from the existing pipelines; multi-package workspaces encode extra
 package members as `--caller-package` for the call-graph demo. A Platform demo
-retains its exact family, version, framework, and assembly through
-`WorkspaceContextLoader`, then materializes the selected implementation image
-for the existing CLI section renderers; it does not inspect the reference-pack
-stub as the implementation body. **inspect-web** loads home-demo metadata and exact scenario IDs from the
+retains every exact family, version, framework, and assembly coordinate through
+`WorkspaceContextLoader`, then materializes the selected implementation images
+for the existing CLI section renderers. The focused image remains the command
+root; additional selected images enter the ordinary member caller-scope path
+through one temporary directory. The CLI does not inspect reference-pack stubs
+as implementation bodies or fabricate package coordinates for Platform
+members. **inspect-web** loads home-demo metadata and exact scenario IDs from the
 ecosystem catalog through the browser engine (`ListHomeDemos` /
 `RunHomeDemo`; `ResolveHomeDemo` remains a tooling/debug projection).
 Every selected home demo executes through `RunHomeDemo`; the host does not
@@ -848,6 +851,8 @@ package workspaces until Browser has explicit execution support rather than
 silently dropping those bindings. These properties are gated by
 `ToRunPlan_AllProductHomeDemosHaveSupportedBrowserShape`,
 `StjSerializer_RunPlanOwnsTypeOnlyMethodsSelection`,
+`StjPlatformDemos_JoinExactSupplyAndCatalogEvidence`,
+`ExtensionsPlatformDemos_JoinExactSupplyAndCatalogEvidence`,
 `ToRunPlan_DerivesNonFirstFocusForTypeOnlyMethodsView`,
 `ToRunPlan_PlatformCoordinatePreservesSourceNativeFocus`,
 `ToRunPlan_RejectsMixedPackageAndPlatformWorkspace`,
@@ -865,6 +870,10 @@ silently dropping those bindings. These properties are gated by
 `HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph`,
 `PlatformHomeDemoRunCore_ProjectsMethodsWithSourceNativeActivation`, and
 `PlatformHomeDemoRunCore_PreservesContextAcrossEquivalentVersionSpellings`.
+CLI multi-Platform execution and caller-scope preservation are gated by
+`Runner_LowersMultiPlatformCallGraphWithCallerScopeSections`,
+`Cli_DemoCallGraph_Table_EmitsCallersRows`, and the all-demo Mermaid and table
+execution gates.
 
 The Browser host validates the complete typed result before replacing the
 current workspace. Package activation retains the returned coordinates and
@@ -882,23 +891,24 @@ gated by `product-home-demos.test.ts`,
 `spotlight-identity.test.ts`, and the package/Platform Methods and Call Graph
 production-composition cases in `library-hierarchy.spec.ts`.
 
-The System.Text.Json migration is gated by two independent exact facts:
-`PlatformPrunePolicy` reports that the former package pin is subsumed, and the
-same Platform target contains the explicitly selected `System.Text.Json`
-implementation library. Package identity is never treated as assembly
-identity. Demos requesting a version newer than the selected Platform ceiling
-remain package-backed. Microsoft.Extensions migration remains follow-on work,
-and Aspire demos remain package-backed because their libraries are not
-supplied by the Platform.
+The System.Text.Json and Microsoft.Extensions migrations are gated by two
+independent exact facts: `PlatformPrunePolicy` reports that each former package
+pin is subsumed, and the same target independently contains each explicitly
+selected implementation library. Package identity is never treated as assembly
+identity. The three System.Text.Json demos use the Runtime Platform target.
+The five Microsoft.Extensions demos remain owned by the Microsoft.Extensions
+ecosystem while their selected libraries use the ASP.NET Core Platform target;
+ecosystem grouping and source provenance are orthogonal. Demos requesting a
+version newer than the selected Platform ceiling remain package-backed. Aspire
+demos remain package-backed because their libraries are not supplied by the
+Platform.
 Browser package scopes now adapt product-selected, product-realized package
 participants into Browser coordinate/asset provenance; Browser still owns Wasm
 transport, cache/deadline/lifetime policy, and its resource-limit values.
 Residual: (1) bind minted facet IDs to replace the display-name allow list;
-(2) realize definitions via `WorkspaceContextLoader` instead of CLI package/
-`--caller-package` encoding; (3) migrate remaining shipped package coordinates
-that are supplied by an exact Platform target only after inventory, Platform
-catalog, and package discovery jointly establish that classification;
-(4) Call Graph / Callers structured JSON projection remains the shared
+(2) realize package definitions via `WorkspaceContextLoader` instead of CLI
+package/`--caller-package` encoding; (3) Call Graph / Callers structured JSON
+projection remains the shared
 member-pipeline gap
 (Markdown/Mermaid are the faithful graph formats today).
 

--- a/inspect-web/DotnetInspect.Web.Tests/BrowserProductHomeDemosTests.cs
+++ b/inspect-web/DotnetInspect.Web.Tests/BrowserProductHomeDemosTests.cs
@@ -99,18 +99,31 @@ public sealed class BrowserProductHomeDemosTests
     }
 
     [Fact]
-    public void ResolveHomeDemo_ExtensionsCallGraph_ProjectsPackagesAndMemberAnchor()
+    public void ResolveHomeDemo_ExtensionsCallGraph_ProjectsPlatformLibrariesAndMemberAnchor()
     {
         using var document = JsonDocument.Parse(
             DotnetInspect.Web.Interop.Catalog.CatalogExports.ResolveHomeDemo(ProductDemoIds.ExtensionsCallGraph));
         var root = document.RootElement.GetProperty("demo");
         var members = root.GetProperty("workspaceMembers");
         Assert.Equal(3, members.GetArrayLength());
+        Assert.All(
+            members.EnumerateArray(),
+            member =>
+            {
+                Assert.Equal("platform", member.GetProperty("kind").GetString());
+                Assert.Equal("aspnetcore", member.GetProperty("id").GetString());
+                Assert.Equal("10.0.12", member.GetProperty("version").GetString());
+                Assert.Equal("net10.0", member.GetProperty("framework").GetString());
+            });
         Assert.Equal(
-            "Microsoft.Extensions.DependencyInjection.Abstractions",
-            members[0].GetProperty("id").GetString());
-        Assert.Equal("Microsoft.Extensions.Logging", members[1].GetProperty("id").GetString());
-        Assert.Equal("Microsoft.Extensions.Http", members[2].GetProperty("id").GetString());
+            [
+                "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Logging",
+                "Microsoft.Extensions.Http",
+            ],
+            members.EnumerateArray()
+                .Select(member =>
+                    member.GetProperty("assembly").GetString()));
 
         Assert.Equal(0, root.GetProperty("focusTabIndex").GetInt32());
         Assert.Equal("di", root.GetProperty("tabs")[0].GetProperty("id").GetString());
@@ -256,6 +269,135 @@ public sealed class BrowserProductHomeDemosTests
     }
 
     [Fact]
+    public void ExtensionsPlatformDemos_JoinExactSupplyAndCatalogEvidence()
+    {
+        const string packageVersion = "10.0.0";
+        const string platformFamily = "aspnetcore";
+        const string platformFrameworkFamily = "Microsoft.AspNetCore.App";
+        const string platformPack = "aspnetcore.app";
+        const string platformVersion = "10.0.12";
+        const string framework = "net10.0";
+        var expectedAssemblies = new Dictionary<string, string[]>
+        {
+            [ProductDemoIds.ExtensionsCallGraph] =
+            [
+                "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Logging",
+                "Microsoft.Extensions.Http",
+            ],
+            [ProductDemoIds.ConfigBindCallGraph] =
+                ["Microsoft.Extensions.Configuration.Binder"],
+            [ProductDemoIds.OptionsAddCallGraph] =
+                ["Microsoft.Extensions.Options"],
+            [ProductDemoIds.DiTryAddCallGraph] =
+                ["Microsoft.Extensions.DependencyInjection.Abstractions"],
+            [ProductDemoIds.HttpAddHttpClientCallGraph] =
+                ["Microsoft.Extensions.Http"],
+        };
+        (string PackageId, string Assembly)[] mappings =
+        [
+            ("Microsoft.Extensions.Configuration.Binder",
+                "Microsoft.Extensions.Configuration.Binder"),
+            ("Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.DependencyInjection.Abstractions"),
+            ("Microsoft.Extensions.Http",
+                "Microsoft.Extensions.Http"),
+            ("Microsoft.Extensions.Logging",
+                "Microsoft.Extensions.Logging"),
+            ("Microsoft.Extensions.Options",
+                "Microsoft.Extensions.Options"),
+        ];
+
+        using JsonDocument document = JsonDocument.Parse(
+            File.ReadAllText(
+                Path.Combine(
+                    RepositoryRoot(),
+                    "inspect-web",
+                    "assets",
+                    "platform-index.json")));
+        JsonElement target = Assert.Single(
+            document.RootElement
+                .GetProperty("targets")
+                .EnumerateArray(),
+            candidate =>
+                candidate.GetProperty("tfm").GetString() == framework
+                && candidate.GetProperty("version").GetString()
+                    == platformVersion);
+        JsonElement[] supplies =
+        [
+            .. target.GetProperty("supplies").EnumerateArray()
+                .Where(candidate =>
+                    candidate.GetProperty("family").GetString()
+                        == platformFrameworkFamily),
+        ];
+        var inventory = PlatformPruneInventory.FromExactFamily(
+            new PlatformPruneTarget(
+                platformFrameworkFamily,
+                framework,
+                NuGetVersion.Parse(platformVersion)),
+            supplies.Select(supply =>
+                $"{supply.GetProperty("package").GetString()}"
+                + $"|{supply.GetProperty("version").GetString()}"));
+
+        foreach (var mapping in mappings)
+        {
+            PlatformSupplyReceipt receipt = PlatformPrunePolicy.Evaluate(
+                inventory,
+                new PackageCoordinate(
+                    mapping.PackageId,
+                    packageVersion,
+                    framework));
+            Assert.True(receipt.Supply.DelegatesToPlatform);
+            Assert.Equal(platformFrameworkFamily, receipt.Supply.Family);
+            Assert.Equal(
+                NuGetVersion.Parse(packageVersion),
+                receipt.Supply.SuppliedVersion);
+
+            JsonElement supply = Assert.Single(
+                supplies,
+                candidate =>
+                    candidate.GetProperty("package").GetString()
+                        == mapping.PackageId);
+            Assert.Equal(
+                platformPack,
+                supply.GetProperty("pack").GetString());
+            JsonElement library = Assert.Single(
+                target.GetProperty("rows").EnumerateArray(),
+                candidate =>
+                    candidate.GetProperty("pack").GetString()
+                        == platformPack
+                    && candidate.GetProperty("assembly").GetString()
+                        == mapping.Assembly);
+            Assert.True(
+                library.GetProperty("hasImplementation").GetBoolean());
+        }
+
+        foreach (var expected in expectedAssemblies)
+        {
+            BrowserHomeDemoRunPlan plan =
+                BrowserProductHomeDemos.ToRunPlan(
+                    Select(expected.Key).Scenario);
+            BrowserHomeDemoRunRequest.Platform[] requests =
+            [
+                .. plan.Requests.Select(request =>
+                    Assert.IsType<BrowserHomeDemoRunRequest.Platform>(
+                        request)),
+            ];
+            Assert.Equal(
+                expected.Value,
+                requests.Select(request => request.Assembly));
+            Assert.All(
+                requests,
+                request =>
+                {
+                    Assert.Equal(platformFamily, request.Family);
+                    Assert.Equal(platformVersion, request.Version);
+                    Assert.Equal(framework, request.TargetFramework);
+                });
+        }
+    }
+
+    [Fact]
     public void ExtensionsCallGraph_RunPlanOwnsWorkspaceFocusAndMemberSelection()
     {
         BrowserHomeDemoRunPlan plan =
@@ -263,16 +405,22 @@ public sealed class BrowserProductHomeDemosTests
                 Select(ProductDemoIds.ExtensionsCallGraph).Scenario);
 
         Assert.Equal(3, plan.Requests.Length);
-        BrowserPackageRequest[] requests =
+        BrowserHomeDemoRunRequest.Platform[] requests =
         [
             .. plan.Requests.Select(request =>
-                Assert.IsType<BrowserHomeDemoRunRequest.Package>(request).Request),
+                Assert.IsType<BrowserHomeDemoRunRequest.Platform>(request)),
         ];
         Assert.Equal(
             "Microsoft.Extensions.DependencyInjection.Abstractions",
-            requests[0].PackageId);
-        Assert.Equal("10.0.0", requests[0].Version);
-        Assert.Equal("net10.0", requests[0].TargetFramework);
+            requests[0].Assembly);
+        Assert.All(
+            requests,
+            request =>
+            {
+                Assert.Equal("aspnetcore", request.Family);
+                Assert.Equal("10.0.12", request.Version);
+                Assert.Equal("net10.0", request.TargetFramework);
+            });
         Assert.Equal(0, plan.FocusRequestIndex);
         Assert.Equal(
             "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",

--- a/src/DotnetInspect.Cli/Commands/DemoCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/DemoCommand.cs
@@ -173,9 +173,20 @@ public static class DemoCommand
         ApiOptions options)
     {
         ProductDemoRunPlan plan = ProductDemoRunPlan.Create(resolved);
-        WorkspaceMemberCoordinate.PlatformMember? platform = plan.Context.Members
-            .OfType<WorkspaceMemberCoordinate.PlatformMember>()
-            .FirstOrDefault(member => string.Equals(
+        WorkspaceMemberCoordinate.PlatformMember[] platformMembers =
+        [
+            .. plan.Context.Members
+                .OfType<WorkspaceMemberCoordinate.PlatformMember>(),
+        ];
+        if (platformMembers.Length != plan.Context.Members.Count)
+        {
+            CommandError.Write(
+                $"Home demo '{resolved.ScenarioId}' cannot mix package and Platform members.");
+            return 1;
+        }
+
+        WorkspaceMemberCoordinate.PlatformMember? platform =
+            platformMembers.FirstOrDefault(member => string.Equals(
                 member.Assembly,
                 options.PlatformAssembly,
                 StringComparison.OrdinalIgnoreCase));
@@ -193,7 +204,7 @@ public static class DemoCommand
                 new WorkspaceContextInput
                 {
                     Framework = options.Tfm ?? plan.Context.Framework,
-                    Members = [platform],
+                    Members = platformMembers,
                 },
                 new WorkspaceContextLoadOptions
                 {
@@ -220,20 +231,61 @@ public static class DemoCommand
 
         WorkspaceContextLoadOutcome.Loaded loaded =
             (WorkspaceContextLoadOutcome.Loaded)outcome;
-        var implementation = loaded.Members
-            .Select(static member => member.Participant.Assembly)
-            .Single();
+        if (loaded.Members.Length != platformMembers.Length)
+        {
+            CommandError.Write(
+                $"Home demo '{resolved.ScenarioId}' did not load every declared Platform member.");
+            return 1;
+        }
+
         string tempDirectory =
             Directory.CreateTempSubdirectory("inspect-demo-platform").FullName;
         try
         {
-            string assemblyPath = Path.Combine(
-                tempDirectory,
-                $"{platform.Assembly}.dll");
-            await using (Stream sourceStream = implementation.OpenRead())
-            await using (FileStream destination = File.Create(assemblyPath))
+            string? assemblyPath = null;
+            var materializedPaths =
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < loaded.Members.Length; index++)
             {
-                await sourceStream.CopyToAsync(destination);
+                WorkspaceContextMember loadedMember = loaded.Members[index];
+                WorkspaceMemberCoordinate.PlatformMember declared =
+                    platformMembers[index];
+                if (!Equals(loadedMember.Declared, declared))
+                {
+                    CommandError.Write(
+                        $"Home demo '{resolved.ScenarioId}' loaded Platform members out of declaration order.");
+                    return 1;
+                }
+
+                string materializedPath = Path.Combine(
+                    tempDirectory,
+                    $"{declared.Assembly}.dll");
+                if (!materializedPaths.Add(materializedPath))
+                {
+                    CommandError.Write(
+                        $"Home demo '{resolved.ScenarioId}' has Platform members that map to the same local image name.");
+                    return 1;
+                }
+
+                await using (
+                    Stream sourceStream =
+                        loadedMember.Participant.Assembly.OpenRead())
+                await using (
+                    FileStream destination =
+                        File.Create(materializedPath))
+                {
+                    await sourceStream.CopyToAsync(destination);
+                }
+
+                if (Equals(declared, platform))
+                    assemblyPath = materializedPath;
+            }
+
+            if (assemblyPath is null)
+            {
+                CommandError.Write(
+                    $"Home demo '{resolved.ScenarioId}' did not materialize its focused Platform member.");
+                return 1;
             }
 
             var context = new CommandContext(options.Verbose);
@@ -266,7 +318,15 @@ public static class DemoCommand
             return await (options switch
             {
                 MemberOptions member =>
-                    MemberCommand.ExecuteResolvedAsync(member, source, surface),
+                    MemberCommand.ExecuteResolvedAsync(
+                        loaded.Members.Length > 1
+                            ? member with
+                            {
+                                CallerScopeDirectories = [tempDirectory],
+                            }
+                            : member,
+                        source,
+                        surface),
                 TypeOptions type =>
                     TypeCommand.ExecuteResolvedAsync(type, source, surface),
                 _ => throw new InvalidOperationException(
@@ -326,8 +386,9 @@ public static class DemoCommand
 /// <see cref="MemberOptions"/> so run uses the existing section pipeline.
 /// Multi-package workspaces map extra package members to
 /// <see cref="MemberOptions.CallerScopePackages"/> (CLI encoding of the same
-/// closed preset). Platform demos retain their typed coordinate for exact
-/// implementation-pack activation before entering the same section pipeline.
+/// closed preset). Platform demos retain their typed coordinates for exact
+/// implementation-pack activation; additional Platform members enter the
+/// same caller-scope pipeline through one temporary directory.
 /// </summary>
 public static class DemoScenarioRunner
 {
@@ -466,14 +527,18 @@ public static class DemoScenarioRunner
             return false;
 
         // Extra package members become caller-scope packages (CLI encoding of multi-package graph).
-        if (!TryCollectCallerPackages(resolved, context, source.PackagePath, out var callers, out error))
+        if (!TryCollectCallerPackages(context, source.PackagePath, out var callers))
             return false;
+        bool hasCallerScope = callers.Length > 0
+            || HasAdditionalPlatformMembers(
+                context,
+                source.PlatformAssembly);
 
         if (!TryResolveRunSections(
                 section,
                 format,
                 embeddedMermaid,
-                hasCallerScope: callers.Length > 0,
+                hasCallerScope,
                 out var runSections,
                 out error))
             return false;
@@ -670,14 +735,11 @@ public static class DemoScenarioRunner
     }
 
     private static bool TryCollectCallerPackages(
-        ResolvedScenario resolved,
         ResolvedWorkspaceContext context,
         string? primaryPackagePath,
-        out string[] callers,
-        out string? error)
+        out string[] callers)
     {
         callers = [];
-        error = null;
 
         string? primaryId = null;
         if (primaryPackagePath is { Length: > 0 })
@@ -700,10 +762,23 @@ public static class DemoScenarioRunner
                 : member.PackageId);
         }
 
-        // Platform-only extras are not expressible as --caller-package; ignore for this encoding.
-        _ = resolved;
         callers = list.ToArray();
         return true;
+    }
+
+    private static bool HasAdditionalPlatformMembers(
+        ResolvedWorkspaceContext context,
+        string? primaryAssembly)
+    {
+        if (primaryAssembly is null)
+            return false;
+
+        return context.Members
+            .OfType<WorkspaceMemberCoordinate.PlatformMember>()
+            .Any(member => !string.Equals(
+                member.Assembly,
+                primaryAssembly,
+                StringComparison.OrdinalIgnoreCase));
     }
 
     private static TypeOptions ApplyFormat(

--- a/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
+++ b/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
@@ -24,11 +24,11 @@ internal static class ProductEcosystemPacks
         new(
             EcosystemPackIds.MicrosoftExtensions,
             "Microsoft.Extensions",
-            "Microsoft.Extensions package and demo content.",
+            "Microsoft.Extensions package discovery and product demos.",
             200,
             PackageSetIds.MicrosoftExtensions,
             [
-                Demo(ProductDemoIds.ExtensionsCallGraph, "Cross-package call graph", "Trace calls across three packages", 200, CreateExtensionsCallGraphRecords),
+                Demo(ProductDemoIds.ExtensionsCallGraph, "Cross-library call graph", "Trace calls across three Platform libraries", 200, CreateExtensionsCallGraphRecords),
                 Demo(ProductDemoIds.ConfigBindCallGraph, "Configuration Bind", "Recursive binder call graph", 400, CreateConfigBindCallGraphRecords),
                 Demo(ProductDemoIds.OptionsAddCallGraph, "Options hub", "Inbound fan-in at AddOptions", 500, CreateOptionsAddCallGraphRecords),
                 Demo(ProductDemoIds.DiTryAddCallGraph, "DI TryAdd hub", "Keyed/scoped Try* fan-in", 600, CreateDiTryAddCallGraphRecords),
@@ -134,12 +134,21 @@ internal static class ProductEcosystemPacks
     private static InspectionDefinitionRecord[] CreateExtensionsCallGraphRecords()
     {
         const int v = InspectionDefinitionJson.CurrentSchemaVersion;
-        var diAbstractions = Package(
+        var diAbstractions = Platform(
+            "aspnetcore",
             "Microsoft.Extensions.DependencyInjection.Abstractions",
-            "10.0.0",
+            "10.0.12",
             "net10.0");
-        var logging = Package("Microsoft.Extensions.Logging", "10.0.0", "net10.0");
-        var http = Package("Microsoft.Extensions.Http", "10.0.0", "net10.0");
+        var logging = Platform(
+            "aspnetcore",
+            "Microsoft.Extensions.Logging",
+            "10.0.12",
+            "net10.0");
+        var http = Platform(
+            "aspnetcore",
+            "Microsoft.Extensions.Http",
+            "10.0.12",
+            "net10.0");
         return
         [
             new WorkspaceDefinition(
@@ -151,8 +160,8 @@ internal static class ProductEcosystemPacks
                         framework: "net10.0",
                         members: [diAbstractions, logging, http]),
                 ],
-                title: "Extensions cross-package call graph",
-                description: "DI Abstractions + Logging + Http for multi-package call graph."),
+                title: "Extensions cross-library call graph",
+                description: "DI Abstractions + Logging + Http from the ASP.NET Core Platform."),
             new ViewDefinition(
                 v,
                 "try-add-enumerable-call-graph",
@@ -172,8 +181,8 @@ internal static class ProductEcosystemPacks
             new ScenarioDefinition(
                 v,
                 ProductDemoIds.ExtensionsCallGraph,
-                title: "Cross-package call graph",
-                description: "Trace calls across three packages",
+                title: "Cross-library call graph",
+                description: "Trace calls across three Platform libraries",
                 workspace: "extensions-callgraph",
                 context: "extensions",
                 view: "try-add-enumerable-call-graph",
@@ -231,13 +240,17 @@ internal static class ProductEcosystemPacks
     }
 
     /// <summary>
-    /// Single-package dense recursive graph: <c>ConfigurationBinder.Bind</c>.
+    /// Platform-library dense recursive graph: <c>ConfigurationBinder.Bind</c>.
     /// High fan-out into binder internals (arrays, conversion, BindingPoint).
     /// </summary>
     private static InspectionDefinitionRecord[] CreateConfigBindCallGraphRecords()
     {
         const int v = InspectionDefinitionJson.CurrentSchemaVersion;
-        var binder = Package("Microsoft.Extensions.Configuration.Binder", "10.0.0", "net10.0");
+        var binder = Platform(
+            "aspnetcore",
+            "Microsoft.Extensions.Configuration.Binder",
+            "10.0.12",
+            "net10.0");
         return
         [
             new WorkspaceDefinition(
@@ -276,13 +289,17 @@ internal static class ProductEcosystemPacks
     }
 
     /// <summary>
-    /// Single-package inbound hub: <c>AddOptions(IServiceCollection)</c>.
+    /// Platform-library inbound hub: <c>AddOptions(IServiceCollection)</c>.
     /// Sibling Configure/PostConfigure/ValidateOnStart methods fan into the hub.
     /// </summary>
     private static InspectionDefinitionRecord[] CreateOptionsAddCallGraphRecords()
     {
         const int v = InspectionDefinitionJson.CurrentSchemaVersion;
-        var options = Package("Microsoft.Extensions.Options", "10.0.0", "net10.0");
+        var options = Platform(
+            "aspnetcore",
+            "Microsoft.Extensions.Options",
+            "10.0.12",
+            "net10.0");
         return
         [
             new WorkspaceDefinition(
@@ -321,15 +338,16 @@ internal static class ProductEcosystemPacks
     }
 
     /// <summary>
-    /// Package-local inbound hub: <c>TryAdd(IServiceCollection, ServiceDescriptor)</c>.
+    /// Platform-library inbound hub: <c>TryAdd(IServiceCollection, ServiceDescriptor)</c>.
     /// Keyed/scoped/singleton/transient Try* overloads fan into the hub (high fan-in).
     /// </summary>
     private static InspectionDefinitionRecord[] CreateDiTryAddCallGraphRecords()
     {
         const int v = InspectionDefinitionJson.CurrentSchemaVersion;
-        var di = Package(
+        var di = Platform(
+            "aspnetcore",
             "Microsoft.Extensions.DependencyInjection.Abstractions",
-            "10.0.0",
+            "10.0.12",
             "net10.0");
         return
         [
@@ -376,7 +394,11 @@ internal static class ProductEcosystemPacks
     private static InspectionDefinitionRecord[] CreateHttpAddHttpClientCallGraphRecords()
     {
         const int v = InspectionDefinitionJson.CurrentSchemaVersion;
-        var http = Package("Microsoft.Extensions.Http", "10.0.0", "net10.0");
+        var http = Platform(
+            "aspnetcore",
+            "Microsoft.Extensions.Http",
+            "10.0.12",
+            "net10.0");
         return
         [
             new WorkspaceDefinition(

--- a/tests/DotnetInspect.Cli.Tests/DemoCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/DemoCommandTests.cs
@@ -165,7 +165,7 @@ public class DemoCommandTests
     }
 
     [Fact]
-    public void Runner_LowersCallGraphToMemberSectionWithCallerPackages()
+    public void Runner_LowersMultiPlatformCallGraphWithCallerScopeSections()
     {
         var resolved = ResolveDemo(ProductDemoIds.ExtensionsCallGraph);
         Assert.True(DemoScenarioRunner.TryCreateOptions(resolved, OutputFormat.Markdown, noHeader: false, out var options, out var error), error);
@@ -173,9 +173,12 @@ public class DemoCommandTests
         Assert.Equal(
             "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
             member.TypeName);
+        Assert.Null(member.PackagePath);
         Assert.Equal(
-            "Microsoft.Extensions.DependencyInjection.Abstractions@10.0.0",
-            member.PackagePath);
+            "Microsoft.Extensions.DependencyInjection.Abstractions",
+            member.PlatformAssembly);
+        Assert.Equal("aspnetcore@10.0.12", member.PlatformFramework);
+        Assert.Equal("net10.0", member.Tfm);
         Assert.Equal("74b6b4b321", member.MemberDigest);
         Assert.Contains("TryAddEnumerable", member.MemberFilter);
         Assert.Contains("method", member.KindFilter);
@@ -186,8 +189,7 @@ public class DemoCommandTests
                 SectionNames.Callers,
             },
             member.IncludeSections);
-        Assert.Contains("Microsoft.Extensions.Logging@10.0.0", member.CallerScopePackages);
-        Assert.Contains("Microsoft.Extensions.Http@10.0.0", member.CallerScopePackages);
+        Assert.Empty(member.CallerScopePackages);
     }
 
     [Fact]
@@ -273,7 +275,10 @@ public class DemoCommandTests
             member.IncludeSections);
         Assert.Equal([SectionNames.Callers], Assert.IsType<string[]>(member.Select));
         Assert.True(member.Tabular);
-        Assert.NotEmpty(member.CallerScopePackages);
+        Assert.Empty(member.CallerScopePackages);
+        Assert.Equal(
+            "Microsoft.Extensions.DependencyInjection.Abstractions",
+            member.PlatformAssembly);
     }
 
     [Fact]

--- a/tests/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
+++ b/tests/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
@@ -174,7 +174,7 @@ public sealed class ProductEcosystemPackTests
         var expected = new[]
         {
             (100, ProductDemoIds.StjSerializer, EcosystemPackIds.Platform, "System.Text.Json", "Browse the Runtime Platform API"),
-            (200, ProductDemoIds.ExtensionsCallGraph, EcosystemPackIds.MicrosoftExtensions, "Cross-package call graph", "Trace calls across three packages"),
+            (200, ProductDemoIds.ExtensionsCallGraph, EcosystemPackIds.MicrosoftExtensions, "Cross-library call graph", "Trace calls across three Platform libraries"),
             (300, ProductDemoIds.StjSerializeCallGraph, EcosystemPackIds.Platform, "Serialize call graph", "Trace the Runtime STJ implementation"),
             (400, ProductDemoIds.ConfigBindCallGraph, EcosystemPackIds.MicrosoftExtensions, "Configuration Bind", "Recursive binder call graph"),
             (500, ProductDemoIds.OptionsAddCallGraph, EcosystemPackIds.MicrosoftExtensions, "Options hub", "Inbound fan-in at AddOptions"),
@@ -215,13 +215,19 @@ public sealed class ProductEcosystemPackTests
         Assert.Same(stj.Navigation!.FocusTab, stjPlan.Focus);
         Assert.Null(stjPlan.Member);
 
-        AssertCallGraph(
+        AssertPlatformCallGraph(
             ProductDemoIds.ExtensionsCallGraph,
+            "aspnetcore",
             "Microsoft.Extensions.DependencyInjection.Abstractions",
             "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
             "74b6b4b321",
             "TryAddEnumerable",
-            expectedMemberCount: 3);
+            expectedAssemblies:
+            [
+                "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Logging",
+                "Microsoft.Extensions.Http",
+            ]);
         AssertPlatformCallGraph(
             ProductDemoIds.StjSerializeCallGraph,
             "runtime",
@@ -229,26 +235,30 @@ public sealed class ProductEcosystemPackTests
             "System.Text.Json.JsonSerializer",
             "1dc14dd1fb",
             "Serialize");
-        AssertCallGraph(
+        AssertPlatformCallGraph(
             ProductDemoIds.ConfigBindCallGraph,
+            "aspnetcore",
             "Microsoft.Extensions.Configuration.Binder",
             "Microsoft.Extensions.Configuration.ConfigurationBinder",
             "a6a6257f65",
             "Bind");
-        AssertCallGraph(
+        AssertPlatformCallGraph(
             ProductDemoIds.OptionsAddCallGraph,
+            "aspnetcore",
             "Microsoft.Extensions.Options",
             "Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions",
             "1e6bfaf2ae",
             "AddOptions");
-        AssertCallGraph(
+        AssertPlatformCallGraph(
             ProductDemoIds.DiTryAddCallGraph,
+            "aspnetcore",
             "Microsoft.Extensions.DependencyInjection.Abstractions",
             "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
             "6ce164c602",
             "TryAdd");
-        AssertCallGraph(
+        AssertPlatformCallGraph(
             ProductDemoIds.HttpAddHttpClientCallGraph,
+            "aspnetcore",
             "Microsoft.Extensions.Http",
             "Microsoft.Extensions.DependencyInjection.HttpClientFactoryServiceCollectionExtensions",
             "5c44566d15",
@@ -362,7 +372,8 @@ public sealed class ProductEcosystemPackTests
         string anchor,
         string memberName,
         string platformVersion = "10.0.12",
-        string framework = "net10.0")
+        string framework = "net10.0",
+        IReadOnlyList<string>? expectedAssemblies = null)
     {
         ResolvedScenario scenario = Select(scenarioId);
         AssertPlatformAndNavigation(
@@ -370,7 +381,8 @@ public sealed class ProductEcosystemPackTests
             family,
             assembly,
             platformVersion,
-            framework);
+            framework,
+            expectedAssemblies);
         Assert.Equal(type, scenario.View!.Type);
         Assert.Equal(anchor, scenario.View.MemberAnchor);
         Assert.Equal($"method:{memberName}", scenario.View.MemberKey);
@@ -443,24 +455,37 @@ public sealed class ProductEcosystemPackTests
         string family,
         string assembly,
         string platformVersion,
-        string framework)
+        string framework,
+        IReadOnlyList<string>? expectedAssemblies = null)
     {
         Assert.True(scenario.CreatesAssemblyContextGroup);
-        WorkspaceMemberCoordinate.PlatformMember member =
-            Assert.IsType<WorkspaceMemberCoordinate.PlatformMember>(
-                Assert.Single(scenario.SelectedContext!.Members));
-        Assert.Equal(family, member.Family);
-        Assert.Equal(assembly, member.Assembly);
-        Assert.Equal(platformVersion, member.Version);
-        Assert.Equal(framework, member.Framework);
+        string[] assemblies =
+            [.. expectedAssemblies ?? [assembly]];
+        WorkspaceMemberCoordinate.PlatformMember[] members =
+        [
+            .. scenario.SelectedContext!.Members.Select(member =>
+                Assert.IsType<WorkspaceMemberCoordinate.PlatformMember>(
+                    member)),
+        ];
+        Assert.Equal(assemblies.Length, members.Length);
+        Assert.Equal(assemblies, members.Select(member => member.Assembly));
+        Assert.All(
+            members,
+            member =>
+            {
+                Assert.Equal(family, member.Family);
+                Assert.Equal(platformVersion, member.Version);
+                Assert.Equal(framework, member.Framework);
+            });
 
         Assert.NotNull(scenario.Navigation);
-        Assert.Single(scenario.Navigation!.Tabs);
+        Assert.Equal(assemblies.Length, scenario.Navigation!.Tabs.Count);
         Assert.Equal(0, scenario.Navigation.FocusIndex);
         WorkspaceMemberCoordinate.PlatformMember focus =
             Assert.IsType<WorkspaceMemberCoordinate.PlatformMember>(
                 scenario.Navigation.FocusTab.Coordinate);
-        Assert.Equal(member, focus);
+        Assert.Equal(members[0], focus);
+        Assert.Equal(assembly, focus.Assembly);
     }
 
     private static WorkspaceMemberCoordinate.PackageMember Package(


### PR DESCRIPTION
Build robust, capable product demos that use the same source .NET applications
would use, while preserving explicit ecosystem identity and exact evidence.

## Summary

- migrate the five Microsoft.Extensions demos from overlapping `10.0.0`
  package inputs to exact ASP.NET Core Platform `10.0.12` implementation
  libraries without moving them out of the Microsoft.Extensions ecosystem
- require both exact `PackageOverrides.txt` supply evidence and an independent
  implementation-library catalog row for each package/assembly mapping
- extend CLI Platform demo execution to materialize every selected
  implementation image and pass peer libraries through the existing
  caller-scope directory path
- keep the two Aspire demos package-backed and update the owning design status,
  execution contract, and current .NET 10 pruning examples

## Demo

The cross-library demo now names Platform libraries and finds callers from both
peer assemblies:

```text
$ dotnet-inspect demo extensions-callgraph --table
Source                                                 Caller
Microsoft.Extensions.DependencyInjection.Abstractions  ...TryAddEnumerable(...)
Microsoft.Extensions.Http                              ...AddHttpClient(...)
Microsoft.Extensions.Http                              ...AddHttpClient(...)
Microsoft.Extensions.Logging                           ...AddLogging(...)
```

The catalog describes the source shape directly:

```text
extensions-callgraph  Cross-library call graph  Trace calls across three Platform libraries
```

The neighboring Aspire demo remains package-backed:

```text
Type: Aspire.Hosting.RedisBuilderExtensions | Package: Aspire.Hosting.Redis |
Version: 13.5.3 | TFM: net8.0 |
Library: lib/net8.0/Aspire.Hosting.Redis.dll | Source: NuGet
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.Ecosystems.Tests -c Release`
  — 89 passed
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --
  --filter-class '*DemoCommandTests'` — 61 passed
- `dotnet run --project inspect-web/DotnetInspect.Web.Tests -c Release --
  -class DotnetInspect.Web.Tests.BrowserProductHomeDemosTests` — 26 passed
- `npm run build` and `npm run analyze` in `inspect-web`
- `markdownlint` on all changed design documents

Part of #6228 and #6013.
