### PR TITLE
Inspect Web: add routed Diagnostics for current-session evidence

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -1340,15 +1340,38 @@ The data bar does not contain:
 - an API-surface label; or
 - an expansion toggle.
 
-Diagnostics opens as a full-bleed surface and may include:
+Diagnostics opens at `/diagnostics` as a routed full-bleed surface. Settings
+and Spotlight Commands expose the route; the Application menu does not. The
+destination receives focus on its single `Diagnostics` level-one heading, and
+Back restores the preceding routed surface without discarding its retained
+Workspace. A direct entry falls back to Home.
 
-- runtime and Wasm state;
+The first implemented Diagnostics snapshot contains only evidence already
+issued for the current browser session:
+
+- loading, ready, or failed Browser/Wasm runtime state;
+- download, startup, precompute, and total startup measurements;
+- framework asset count, transferred bytes, and decoded bytes;
+- exact product version, full linked commit, UTC build timestamp, and
+  Browser/Wasm host; and
+- aggregate package, resident-payload, Workspace, and resident-byte cache
+  statistics.
+
+Runtime, build, and package-cache absence or failure remain visible in the same
+route geometry. A cache-statistics failure does not preserve prior counts as an
+undisclosed successful snapshot. Runtime spans the wide layout, with Build and
+Package cache in equal columns below it. The same content becomes one vertical
+scroller on a narrow viewport without page-level horizontal overflow. The
+full-bleed route does not repeat the persistent data bar.
+
+Later owner-adoption work may add:
+
 - network operations and typed failures;
-- exact build provenance;
 - package-source health;
-- candidate and payload cache contents;
+- candidate and payload cache-entry inventory;
 - coordinate, producer, size, and persistence for each cache entry;
-- cache limits and eviction state; and
+- cache limits and eviction state;
+- a support-report copy action; and
 - owner-authorized cache-management actions.
 
 Diagnostics consumes owner-issued data and actions. It does not infer package

--- a/inspect-web/DotnetInspect.Web.Tests/BrowserStaticWebAppConfigTests.cs
+++ b/inspect-web/DotnetInspect.Web.Tests/BrowserStaticWebAppConfigTests.cs
@@ -20,12 +20,13 @@ public class BrowserStaticWebAppConfigTests
             .. config.RootElement.GetProperty("routes").EnumerateArray(),
         ];
 
-        Assert.Equal(5, routes.Length);
+        Assert.Equal(6, routes.Length);
         AssertRoute(routes[0], "/");
         AssertRoute(routes[1], "/index.html");
         AssertRoute(routes[2], "/credits", "/index.html");
         AssertRoute(routes[3], "/demos", "/index.html");
-        AssertRoute(routes[4], "/query", "/index.html");
+        AssertRoute(routes[4], "/diagnostics", "/index.html");
+        AssertRoute(routes[5], "/query", "/index.html");
         Assert.Equal(
             "dotnet-isolated:8.0",
             config.RootElement

--- a/inspect-web/README.md
+++ b/inspect-web/README.md
@@ -2044,9 +2044,30 @@ The line presents app version, linked short commit, concise UTC build date,
 applicable acquisition producer, and the same CLI-tool and agent-skill links
 used on Home. Package acquisition supplies a compact producer label; the data
 bar renders that display text without parsing an endpoint. Runtime/Wasm state,
-timings, cache inventory, assembly/framework duplication, and management
-actions belong to the separate full-bleed Diagnostics surface rather than the
+timings, cache evidence, assembly/framework duplication, and management actions
+belong to the separate full-bleed Diagnostics surface rather than the
 persistent row.
+
+The routed `/diagnostics` surface is available from Settings and the Spotlight
+Commands scope. `src/diagnostics-view.ts` owns its typed pure rendering and
+Back/product bindings; `src/diagnostics-route.ts` owns route recognition and
+the in-app history marker. The first snapshot presents current Browser/Wasm
+loading, ready, or failed state; startup phase measurements and framework-byte
+totals; exact build provenance; and the aggregate package-cache statistics
+issued by the engine. Missing build data and runtime or cache failures remain
+visible rather than becoming zeroes or retained successful counts. The route
+does not appear in the Application menu and does not repeat the data bar.
+
+`test/diagnostics-view.test.ts`, `test/diagnostics-route.test.ts`,
+`test/settings-panel.test.ts`, `test/command-bar.test.ts`, and
+`test/entry-routes.test.ts` gate the typed snapshot, escaping, entry controls,
+history marker, and static hosting inventory. The Diagnostics cases in
+`browser/library-hierarchy.spec.ts` exercise Settings and Spotlight routing,
+destination focus, Back restoration, loading and failure states, package-cache
+failure disclosure, and the 390-pixel vertical layout against the built app.
+Network history, package-source health, cache-entry inventory and limits,
+support-report generation, eviction state, and cache-management actions remain
+future owner-adoption work.
 
 The workbench subject hierarchy is **Package → Library → Type → Member**.
 Package owns coordinate-wide inventory, documents, and NuGet dependencies.

--- a/inspect-web/browser/library-hierarchy.spec.ts
+++ b/inspect-web/browser/library-hierarchy.spec.ts
@@ -827,7 +827,7 @@ test("Diagnostics opens from Settings and Spotlight without entering the Applica
   await expect(page.locator("#inspector-panel h1")).toBeFocused();
 });
 
-test("Diagnostics retains its route geometry while runtime evidence loads on a narrow viewport", async ({
+test("Diagnostics retains its route geometry while Build evidence loads on a narrow viewport", async ({
   page,
 }, testInfo) => {
   await page.setViewportSize({ width: 390, height: 720 });
@@ -835,8 +835,8 @@ test("Diagnostics retains its route geometry while runtime evidence loads on a n
   await page.goto("/diagnostics");
 
   await expect(page.locator("#diagnostics-heading")).toHaveText("Diagnostics");
-  await expect(page.locator(".diagnostics-runtime-state-loading"))
-    .toContainText("engine loading");
+  await expect(page.locator(".diagnostics-runtime-state-ready"))
+    .toContainText("engine ready");
   await expect(page.locator(".diagnostics-card")).toHaveCount(3);
   expect(await page.evaluate(() =>
     document.documentElement.scrollWidth <= document.documentElement.clientWidth
@@ -851,8 +851,6 @@ test("Diagnostics retains its route geometry while runtime evidence loads on a n
   await expect(page.locator("html"))
     .toHaveAttribute("data-build-identity-pending", "true");
   await releaseFacade(page, "finish-build-identity");
-  await expect(page.locator(".diagnostics-runtime-state-ready"))
-    .toContainText("engine ready");
   await expect(page.locator(".diagnostics-card")
     .filter({ has: page.locator("#diagnostics-build-heading") }))
     .toContainText("fixture");
@@ -876,6 +874,50 @@ test("Diagnostics retains its route geometry while runtime evidence loads on a n
   await page.locator("#diagnostics-back").click();
   await expect(page).toHaveURL("/");
   await expect(page.locator("main h1")).toBeFocused();
+});
+
+test("Diagnostics Back keeps Home heading focus through a later Build rerender", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page, { buildIdentity: "pending" });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator("html"))
+    .toHaveAttribute("data-build-identity-pending", "true");
+  await page.locator("#diagnostics-back").click();
+  await expect(page).toHaveURL("/");
+  await expect(page.locator("main h1")).toBeFocused();
+
+  await releaseFacade(page, "finish-build-identity");
+  await expect(page.locator(".data-bar-product"))
+    .toContainText("dotnet-inspect vfixture");
+  await expect(page.locator("main h1")).toBeFocused();
+});
+
+test("Diagnostics starts runtime and cache evidence while Build identity is pending", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page, {
+    buildIdentity: "pending",
+    cachePending: true,
+  });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator("html"))
+    .toHaveAttribute("data-build-identity-pending", "true");
+  await expect(page.locator(".diagnostics-runtime-state-ready"))
+    .toContainText("engine ready");
+  await expect(page.locator("html"))
+    .toHaveAttribute("data-package-cache-stats-pending", "true");
+
+  await releaseFacade(page, "finish-build-identity");
+  await releaseFacade(page, "finish-package-cache-stats");
+  await expect(page.locator(".diagnostics-card")
+    .filter({ has: page.locator("#diagnostics-build-heading") }))
+    .toContainText("fixture");
+  await expect(page.locator(".diagnostics-card")
+    .filter({ has: page.locator("#diagnostics-cache-heading") }))
+    .toContainText("Packages");
 });
 
 test("Diagnostics cache refresh does not reclaim relinquished heading focus", async ({

--- a/inspect-web/browser/library-hierarchy.spec.ts
+++ b/inspect-web/browser/library-hierarchy.spec.ts
@@ -151,6 +151,7 @@ interface HomeDemoFixture {
 interface DiagnosticsFixture {
   buildIdentity?: "ready" | "pending" | "failed";
   cacheFailure?: boolean;
+  cachePending?: boolean;
 }
 
 // Exercise the production composition root and bindings with deterministic facade
@@ -358,7 +359,12 @@ async function installFacades(
         return { activated: true, superseded: false,
           package: await queryPackage(coordinate.package, coordinate.version, coordinate.framework) };
       }
-      export function packageCacheStats() {
+      export async function packageCacheStats() {
+        if (diagnosticsOptions.cachePending) {
+          document.documentElement.dataset.packageCacheStatsPending = "true";
+          await new Promise(resolve => document.addEventListener(
+            "finish-package-cache-stats", resolve, { once: true }));
+        }
         if (diagnosticsOptions.cacheFailure) throw new Error("Cache storage offline");
         return { packages: 1, resident: 1, workspaces: 1, residentBytes: 0 };
       }
@@ -787,10 +793,16 @@ test("Diagnostics opens from Settings and Spotlight without entering the Applica
     fullPage: true,
   });
 
+  await page.locator("#diagnostics-product").click();
+  await expect(page).toHaveURL("/");
+  await expect(page.locator("main h1")).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/diagnostics$/);
+  await expect(page.locator("#diagnostics-heading")).toBeFocused();
   await page.locator("#diagnostics-back").click();
   await expect(page).toHaveURL(/package=Example\.Package/);
-  await expect(page.locator("#inspector-panel h1"))
-    .toHaveText("Example.Package");
+  await expect(page.locator("#inspector-panel h1")).toBeFocused();
 
   await page.keyboard.press("Control+k");
   await expect(page.locator("#spotlight-input")).toBeFocused();
@@ -800,8 +812,7 @@ test("Diagnostics opens from Settings and Spotlight without entering the Applica
   await expect(page).toHaveURL(/\/diagnostics$/);
   await expect(page.locator("#diagnostics-heading")).toBeFocused();
   await page.locator("#diagnostics-back").click();
-  await expect(page.locator("#inspector-panel h1"))
-    .toHaveText("Example.Package");
+  await expect(page.locator("#inspector-panel h1")).toBeFocused();
 });
 
 test("Diagnostics retains its route geometry while runtime evidence loads on a narrow viewport", async ({
@@ -852,6 +863,34 @@ test("Diagnostics retains its route geometry while runtime evidence loads on a n
     .toBe(true);
   await page.locator("#diagnostics-back").click();
   await expect(page).toHaveURL("/");
+  await expect(page.locator("main h1")).toBeFocused();
+});
+
+test("Diagnostics cache refresh does not reclaim relinquished heading focus", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page, { cachePending: true });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator("#diagnostics-heading")).toBeFocused();
+  await expect(page.locator("html"))
+    .toHaveAttribute("data-package-cache-stats-pending", "true");
+  await page.evaluate(() => {
+    const app = document.querySelector("#app");
+    if (!app) throw new Error("Missing application root");
+    const observer = new MutationObserver(() => {
+      const back = document.querySelector<HTMLButtonElement>(
+        "#diagnostics-back");
+      if (!back) return;
+      observer.disconnect();
+      back.focus();
+    });
+    observer.observe(app, { childList: true, subtree: true });
+  });
+
+  await releaseFacade(page, "finish-package-cache-stats");
+  await expect(page.locator("#diagnostics-back")).toBeFocused();
+  await expect(page.locator(".diagnostics-inline-loading")).toHaveCount(0);
 });
 
 test("Diagnostics keeps startup and package-cache failures visible in place", async ({

--- a/inspect-web/browser/library-hierarchy.spec.ts
+++ b/inspect-web/browser/library-hierarchy.spec.ts
@@ -148,6 +148,11 @@ interface HomeDemoFixture {
   results: Readonly<Record<string, BrowserHomeDemoRunResult>>;
 }
 
+interface DiagnosticsFixture {
+  buildIdentity?: "ready" | "pending" | "failed";
+  cacheFailure?: boolean;
+}
+
 // Exercise the production composition root and bindings with deterministic facade
 // responses. Codec and participant-query behavior have separate engine outcome gates.
 async function installFacades(
@@ -160,6 +165,7 @@ async function installFacades(
   opportunities: "ready" | "long" | "empty" | "partial" | "partial-empty" | "query-error" | "deferred" = "ready",
   analysis: "ready" | "long" | "empty" | "partial" | "partial-empty" | "query-error" | "deferred" = "ready",
   homeDemos?: HomeDemoFixture,
+  diagnostics: DiagnosticsFixture = {},
 ) {
   const catalogTarget: PlatformCatalogTarget = {
     ...platformTarget,
@@ -226,19 +232,34 @@ async function installFacades(
     }`;
   const modules: Record<string, string> = {
     host: `
+      const diagnosticsOptions = ${JSON.stringify(diagnostics)};
       export async function createRuntime() { return {}; }
       export function configureHost() {}
       export async function runEntryPoint() { return 0; }
       export function registerEpochWorkReporter() {}
       export async function drainEpochWorkReporter() {}
       export function unregisterEpochWorkReporter() {}
-      export function buildIdentity() {
-        return { version: "fixture", commit: null, builtAtUtc: null, commitUrl: null };
+      export async function buildIdentity() {
+        if (diagnosticsOptions.buildIdentity === "pending") {
+          document.documentElement.dataset.buildIdentityPending = "true";
+          await new Promise(resolve => document.addEventListener(
+            "finish-build-identity", resolve, { once: true }));
+        }
+        if (diagnosticsOptions.buildIdentity === "failed") {
+          throw new Error("Build identity unavailable");
+        }
+        return {
+          version: "fixture",
+          commit: "0123456789abcdef0123456789abcdef01234567",
+          builtAtUtc: "2026-01-23T15:41:12Z",
+          commitUrl: "https://github.com/richlander/dotnet-inspect/commit/0123456789abcdef0123456789abcdef01234567",
+        };
       }`,
     package: `
       ${surfaceLookup}
       const platformTarget = ${JSON.stringify(catalogTarget)};
       const platformOptions = ${JSON.stringify(platform ?? {})};
+      const diagnosticsOptions = ${JSON.stringify(diagnostics)};
       let warmupAttempts = 0;
       export async function getPlatformVersions(tfm) {
         document.documentElement.dataset.platformVersionsRequest = tfm;
@@ -338,6 +359,7 @@ async function installFacades(
           package: await queryPackage(coordinate.package, coordinate.version, coordinate.framework) };
       }
       export function packageCacheStats() {
+        if (diagnosticsOptions.cacheFailure) throw new Error("Cache storage offline");
         return { packages: 1, resident: 1, workspaces: 1, residentBytes: 0 };
       }
       export function listPackageQueryFacets() { return { facets: [] }; }
@@ -717,6 +739,147 @@ async function releaseFacade(page: Page, name: string): Promise<void> {
 }
 
 const root = "/?package=Example.Package&version=1.0.0&framework=net10.0#pkg";
+
+async function installDiagnosticsFacades(
+  page: Page,
+  diagnostics: DiagnosticsFixture = {},
+): Promise<void> {
+  await installFacades(
+    page,
+    surface,
+    [],
+    "ready",
+    "ready",
+    undefined,
+    "ready",
+    "ready",
+    undefined,
+    diagnostics);
+}
+
+test("Diagnostics opens from Settings and Spotlight without entering the Application menu", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await installDiagnosticsFacades(page);
+  await page.goto(root);
+  await expect(page.locator("#inspector-panel h1"))
+    .toHaveText("Example.Package");
+
+  await page.locator("#application-menu-button").click();
+  await expect(page.locator("#application-menu"))
+    .not.toContainText("Diagnostics");
+  await page.locator('[data-application-action="settings"]').click();
+  await page.locator("#settings-diagnostics-open").click();
+
+  await expect(page).toHaveURL(/\/diagnostics$/);
+  await expect(page.locator("#diagnostics-heading")).toBeFocused();
+  await expect(page.locator("#diagnostics-runtime-heading"))
+    .toHaveText("Runtime startup");
+  await expect(page.locator(".diagnostics-runtime-state-ready"))
+    .toContainText("engine ready");
+  await expect(page.locator("#diagnostics-build-heading")).toHaveText("Build");
+  await expect(page.locator("#diagnostics-cache-heading"))
+    .toHaveText("Package cache");
+  await expect(page.locator(".data-bar")).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath("diagnostics-wide.png"),
+    fullPage: true,
+  });
+
+  await page.locator("#diagnostics-back").click();
+  await expect(page).toHaveURL(/package=Example\.Package/);
+  await expect(page.locator("#inspector-panel h1"))
+    .toHaveText("Example.Package");
+
+  await page.keyboard.press("Control+k");
+  await expect(page.locator("#spotlight-input")).toBeFocused();
+  await page.locator("#spotlight-input").fill("diagnostics");
+  await page.getByRole("option").filter({ hasText: "diagnostics" }).click();
+
+  await expect(page).toHaveURL(/\/diagnostics$/);
+  await expect(page.locator("#diagnostics-heading")).toBeFocused();
+  await page.locator("#diagnostics-back").click();
+  await expect(page.locator("#inspector-panel h1"))
+    .toHaveText("Example.Package");
+});
+
+test("Diagnostics retains its route geometry while runtime evidence loads on a narrow viewport", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 720 });
+  await installDiagnosticsFacades(page, { buildIdentity: "pending" });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator("#diagnostics-heading")).toHaveText("Diagnostics");
+  await expect(page.locator(".diagnostics-runtime-state-loading"))
+    .toContainText("engine loading");
+  await expect(page.locator(".diagnostics-card")).toHaveCount(3);
+  expect(await page.evaluate(() =>
+    document.documentElement.scrollWidth <= document.documentElement.clientWidth
+    && document.body.scrollWidth <= document.body.clientWidth))
+    .toBe(true);
+
+  const cardTops = await page.locator(".diagnostics-card").evaluateAll(cards =>
+    cards.map(card => card.getBoundingClientRect().top));
+  expect(cardTops[0]).toBeLessThan(cardTops[1]!);
+  expect(cardTops[1]).toBeLessThan(cardTops[2]!);
+
+  await expect(page.locator("html"))
+    .toHaveAttribute("data-build-identity-pending", "true");
+  await releaseFacade(page, "finish-build-identity");
+  await expect(page.locator(".diagnostics-runtime-state-ready"))
+    .toContainText("engine ready");
+  await expect(page.locator(".diagnostics-card")
+    .filter({ has: page.locator("#diagnostics-build-heading") }))
+    .toContainText("fixture");
+  await page.screenshot({
+    path: testInfo.outputPath("diagnostics-narrow-top.png"),
+    fullPage: false,
+  });
+  await page.locator(".diagnostics-main").evaluate(element => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect(page.locator("#diagnostics-cache-heading")).toBeInViewport();
+  await expect(page.locator("#diagnostics-back")).toBeInViewport();
+  await page.screenshot({
+    path: testInfo.outputPath("diagnostics-narrow-end.png"),
+    fullPage: false,
+  });
+  expect(await page.evaluate(() =>
+    document.documentElement.scrollWidth <= document.documentElement.clientWidth
+    && document.body.scrollWidth <= document.body.clientWidth))
+    .toBe(true);
+  await page.locator("#diagnostics-back").click();
+  await expect(page).toHaveURL("/");
+});
+
+test("Diagnostics keeps startup and package-cache failures visible in place", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page, { buildIdentity: "failed" });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator(".diagnostics-runtime-state-failed"))
+    .toContainText("did not start");
+  await expect(page.locator(".diagnostics-failure-detail"))
+    .not.toBeEmpty();
+  await expect(page.locator(".diagnostics-inline-failed"))
+    .toContainText("inspection engine did not start");
+  await expect(page).toHaveURL(/\/diagnostics$/);
+});
+
+test("Diagnostics discloses a package-cache statistics failure", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page, { cacheFailure: true });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator(".diagnostics-runtime-state-ready"))
+    .toContainText("engine ready");
+  await expect(page.locator(".diagnostics-inline-failed"))
+    .toContainText("Cache storage offline");
+});
 
 const peerSurface: BrowserPackageSurface = {
   ...surface,

--- a/inspect-web/browser/library-hierarchy.spec.ts
+++ b/inspect-web/browser/library-hierarchy.spec.ts
@@ -149,6 +149,7 @@ interface HomeDemoFixture {
 }
 
 interface DiagnosticsFixture {
+  runtimeFailure?: boolean;
   buildIdentity?: "ready" | "pending" | "failed";
   cacheFailure?: boolean;
   cachePending?: boolean;
@@ -234,12 +235,23 @@ async function installFacades(
   const modules: Record<string, string> = {
     host: `
       const diagnosticsOptions = ${JSON.stringify(diagnostics)};
-      export async function createRuntime() { return {}; }
+      export async function createRuntime() {
+        if (diagnosticsOptions.runtimeFailure) {
+          throw new Error("Runtime unavailable");
+        }
+        return {};
+      }
       export function configureHost() {}
       export async function runEntryPoint() { return 0; }
       export function registerEpochWorkReporter() {}
       export async function drainEpochWorkReporter() {}
       export function unregisterEpochWorkReporter() {}
+      export async function asyncLoweringCanary() {
+        if (diagnosticsOptions.runtimeFailure) {
+          throw new Error("Runtime unavailable");
+        }
+        return "inspect-web-async-lowering-ok";
+      }
       export async function buildIdentity() {
         if (diagnosticsOptions.buildIdentity === "pending") {
           document.documentElement.dataset.buildIdentityPending = "true";
@@ -893,6 +905,40 @@ test("Diagnostics cache refresh does not reclaim relinquished heading focus", as
   await expect(page.locator(".diagnostics-inline-loading")).toHaveCount(0);
 });
 
+test("Diagnostics treats a refreshed history entry as direct", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page);
+  await page.goto(root);
+  await page.locator("#application-menu-button").click();
+  await page.locator('[data-application-action="settings"]').click();
+  await page.locator("#settings-diagnostics-open").click();
+  await expect(page).toHaveURL(/\/diagnostics$/);
+
+  await page.reload();
+  await expect(page.locator("#diagnostics-heading")).toBeFocused();
+  await page.locator("#diagnostics-back").click();
+  await expect(page).toHaveURL("/");
+  await page.goForward();
+  await expect(page).toHaveURL("/");
+});
+
+test("Diagnostics renders absent framework timing as unavailable", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page);
+  await page.goto("/diagnostics");
+  await expect(page.locator(".diagnostics-runtime-state-ready")).toBeVisible();
+
+  const runtimeCard = page.locator(".diagnostics-runtime-card");
+  const factValue = (label: string) =>
+    runtimeCard.getByText(label, { exact: true }).locator("..").locator("dd");
+  await expect(factValue("Download")).toHaveText("Unavailable");
+  await expect(factValue("Framework assets")).toHaveText("Unavailable");
+  await expect(factValue("Transferred")).toHaveText("Unavailable");
+  await expect(factValue("Decoded")).toHaveText("Unavailable");
+});
+
 test("Diagnostics preserves commit-link focus through cache refresh", async ({
   page,
 }) => {
@@ -913,16 +959,36 @@ test("Diagnostics preserves commit-link focus through cache refresh", async ({
 test("Diagnostics keeps startup and package-cache failures visible in place", async ({
   page,
 }) => {
-  await installDiagnosticsFacades(page, { buildIdentity: "failed" });
+  await installDiagnosticsFacades(page, { runtimeFailure: true });
   await page.goto("/diagnostics");
 
   await expect(page.locator(".diagnostics-runtime-state-failed"))
     .toContainText("did not start");
   await expect(page.locator(".diagnostics-failure-detail"))
     .not.toBeEmpty();
-  await expect(page.locator(".diagnostics-inline-failed"))
+  const cacheCard = page.locator(".diagnostics-card")
+    .filter({ has: page.locator("#diagnostics-cache-heading") });
+  await expect(cacheCard.locator(".diagnostics-inline-failed"))
     .toContainText("inspection engine did not start");
   await expect(page).toHaveURL(/\/diagnostics$/);
+});
+
+test("Diagnostics isolates a build-identity failure from runtime and cache", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page, { buildIdentity: "failed" });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator(".diagnostics-runtime-state-ready"))
+    .toContainText("engine ready");
+  const buildCard = page.locator(".diagnostics-card")
+    .filter({ has: page.locator("#diagnostics-build-heading") });
+  await expect(buildCard.locator(".diagnostics-inline-failed"))
+    .toContainText("Product build identity is unavailable");
+  const cacheCard = page.locator(".diagnostics-card")
+    .filter({ has: page.locator("#diagnostics-cache-heading") });
+  await expect(cacheCard).toContainText("Packages");
+  await expect(cacheCard.locator(".diagnostics-inline-failed")).toHaveCount(0);
 });
 
 test("Diagnostics discloses a package-cache statistics failure", async ({

--- a/inspect-web/browser/library-hierarchy.spec.ts
+++ b/inspect-web/browser/library-hierarchy.spec.ts
@@ -893,6 +893,23 @@ test("Diagnostics cache refresh does not reclaim relinquished heading focus", as
   await expect(page.locator(".diagnostics-inline-loading")).toHaveCount(0);
 });
 
+test("Diagnostics preserves commit-link focus through cache refresh", async ({
+  page,
+}) => {
+  await installDiagnosticsFacades(page, { cachePending: true });
+  await page.goto("/diagnostics");
+
+  await expect(page.locator("html"))
+    .toHaveAttribute("data-package-cache-stats-pending", "true");
+  const commitLink = page.locator("#diagnostics-commit");
+  await commitLink.focus();
+  await expect(commitLink).toBeFocused();
+
+  await releaseFacade(page, "finish-package-cache-stats");
+  await expect(commitLink).toBeFocused();
+  await expect(page.locator(".diagnostics-inline-loading")).toHaveCount(0);
+});
+
 test("Diagnostics keeps startup and package-cache failures visible in place", async ({
   page,
 }) => {

--- a/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/inspect-web/browser/workspace-titlebar-harness.ts
@@ -969,6 +969,10 @@ workbenchShellBinding =
   bindWorkbenchShell(document, workbenchShellActions);
 bindSettingsPanel(document, {
   onClose: () => setApplicationDialog(null),
+  onOpenDiagnostics: () => {
+    document.body.dataset.diagnosticsOpened = "true";
+    setApplicationDialog(null);
+  },
   onOpen: () => setApplicationDialog("settings"),
   onTasteClear() {},
   onTasteToggle() {},

--- a/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1476,7 +1476,8 @@ test("the Application menu owns global actions and modal focus return", async ({
     "data-drill-in",
     "true");
   await page.keyboard.press("Shift+Tab");
-  await expect(page.getByRole("button", { name: "Light" })).toBeFocused();
+  await expect(page.getByRole("button", { name: "Open Diagnostics" }))
+    .toBeFocused();
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog", { name: "Settings" })).toBeHidden();
   await expect(button).toBeFocused();

--- a/inspect-web/src/command-bar.ts
+++ b/inspect-web/src/command-bar.ts
@@ -48,6 +48,7 @@ const ROOT_COMMANDS: readonly CommandDefinition[] = [
   ["framework", "select a target framework", "choice"],
   ["find", "search the current package", "text"],
   ["clear", "clear the current filter", "none"],
+  ["diagnostics", "open browser session Diagnostics", "none"],
   ["share", "copy a link to this selection", "none"],
   ["settings", "open application settings", "none"],
   ["keyboard help", "show keyboard commands", "none"],

--- a/inspect-web/src/diagnostics-route.ts
+++ b/inspect-web/src/diagnostics-route.ts
@@ -1,0 +1,36 @@
+import {
+  isRoutedEntryPath,
+  ROUTED_ENTRY_PATHS,
+} from "./entry-routes.ts";
+
+export const DIAGNOSTICS_PATH = ROUTED_ENTRY_PATHS.diagnostics;
+
+const DIAGNOSTICS_HISTORY_KEY = "inspectWebDiagnosticsEntry";
+
+function historyRecord(value: unknown): Record<string, unknown> {
+  const record: Record<string, unknown> = {};
+  if (typeof value !== "object" || value === null) return record;
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key === "string") record[key] = Reflect.get(value, key);
+  }
+  return record;
+}
+
+export function isDiagnosticsPath(pathname: string): boolean {
+  return isRoutedEntryPath(pathname, DIAGNOSTICS_PATH);
+}
+
+export function diagnosticsHistoryState(
+  currentState: unknown,
+): Record<string, unknown> {
+  return {
+    ...historyRecord(currentState),
+    [DIAGNOSTICS_HISTORY_KEY]: true,
+  };
+}
+
+export function isDiagnosticsHistoryEntry(state: unknown): boolean {
+  return typeof state === "object"
+    && state !== null
+    && Reflect.get(state, DIAGNOSTICS_HISTORY_KEY) === true;
+}

--- a/inspect-web/src/diagnostics-route.ts
+++ b/inspect-web/src/diagnostics-route.ts
@@ -6,6 +6,7 @@ import {
 export const DIAGNOSTICS_PATH = ROUTED_ENTRY_PATHS.diagnostics;
 
 const DIAGNOSTICS_HISTORY_KEY = "inspectWebDiagnosticsEntry";
+const DIAGNOSTICS_HISTORY_TOKEN = globalThis.crypto.randomUUID();
 
 function historyRecord(value: unknown): Record<string, unknown> {
   const record: Record<string, unknown> = {};
@@ -25,12 +26,13 @@ export function diagnosticsHistoryState(
 ): Record<string, unknown> {
   return {
     ...historyRecord(currentState),
-    [DIAGNOSTICS_HISTORY_KEY]: true,
+    [DIAGNOSTICS_HISTORY_KEY]: DIAGNOSTICS_HISTORY_TOKEN,
   };
 }
 
 export function isDiagnosticsHistoryEntry(state: unknown): boolean {
   return typeof state === "object"
     && state !== null
-    && Reflect.get(state, DIAGNOSTICS_HISTORY_KEY) === true;
+    && Reflect.get(state, DIAGNOSTICS_HISTORY_KEY)
+      === DIAGNOSTICS_HISTORY_TOKEN;
 }

--- a/inspect-web/src/diagnostics-view.ts
+++ b/inspect-web/src/diagnostics-view.ts
@@ -188,7 +188,7 @@ function buildCardHtml(
     );
     const commit = identity.commit?.trim() ?? "";
     const commitHtml = commit && identity.commitUrl
-      ? `<a href="${escapeHtml(identity.commitUrl)}" target="_blank" rel="noopener noreferrer"><code>${escapeHtml(commit)}</code></a>`
+      ? `<a id="diagnostics-commit" href="${escapeHtml(identity.commitUrl)}" target="_blank" rel="noopener noreferrer"><code>${escapeHtml(commit)}</code></a>`
       : commit
         ? `<code>${escapeHtml(commit)}</code>`
         : undefined;

--- a/inspect-web/src/diagnostics-view.ts
+++ b/inspect-web/src/diagnostics-view.ts
@@ -51,6 +51,7 @@ export interface DiagnosticsViewModel {
 
 export interface DiagnosticsViewActions {
   onBack: () => void;
+  onHome: () => void;
 }
 
 function formatDuration(milliseconds: number): string {
@@ -289,12 +290,12 @@ export function bindDiagnosticsView(
   root: ParentNode,
   actions: DiagnosticsViewActions,
 ): void {
-  const activateBack = (event: Event) => {
+  const activate = (action: () => void) => (event: Event) => {
     event.preventDefault();
-    actions.onBack();
+    action();
   };
   root.querySelector<HTMLElement>("#diagnostics-product")
-    ?.addEventListener("click", activateBack);
+    ?.addEventListener("click", activate(actions.onHome));
   root.querySelector<HTMLButtonElement>("#diagnostics-back")
-    ?.addEventListener("click", activateBack);
+    ?.addEventListener("click", activate(actions.onBack));
 }

--- a/inspect-web/src/diagnostics-view.ts
+++ b/inspect-web/src/diagnostics-view.ts
@@ -1,0 +1,300 @@
+import { fmtBytes } from "./data-bar.ts";
+import type { BrowserBuildIdentity } from "./facades/inspect-web-host.d.ts";
+import type { BrowserPackageCacheStats } from "./facades/inspect-web-package.d.ts";
+import { renderBrand } from "./brand.ts";
+
+export interface RuntimeStartupDiagnostics {
+  downloadMs: number;
+  startupMs: number;
+  precomputeMs: number;
+  totalMs: number;
+  transfer: number;
+  decoded: number;
+  assets: number;
+}
+
+export type DiagnosticsRuntimeState =
+  | {
+      kind: "loading";
+      message: string;
+    }
+  | {
+      kind: "ready";
+      message: string;
+      diagnostics: RuntimeStartupDiagnostics | null;
+    }
+  | {
+      kind: "failed";
+      message: string;
+      detail: string | null;
+    };
+
+export type DiagnosticsPackageCacheState =
+  | {
+      kind: "loading";
+    }
+  | {
+      kind: "ready";
+      stats: BrowserPackageCacheStats;
+    }
+  | {
+      kind: "failed";
+      message: string;
+    };
+
+export interface DiagnosticsViewModel {
+  runtime: DiagnosticsRuntimeState;
+  buildIdentity: BrowserBuildIdentity | null;
+  packageCache: DiagnosticsPackageCacheState;
+  capturedAtUtc: string;
+}
+
+export interface DiagnosticsViewActions {
+  onBack: () => void;
+}
+
+function formatDuration(milliseconds: number): string {
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) return "Unavailable";
+  if (milliseconds < 1000) return `${Math.round(milliseconds)} ms`;
+  const seconds = milliseconds / 1000;
+  return `${seconds.toFixed(seconds < 10 ? 2 : 1)} s`;
+}
+
+function formatInteger(value: number): string {
+  return Number.isFinite(value) && value >= 0
+    ? Math.round(value).toLocaleString("en-US")
+    : "Unavailable";
+}
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return "Unavailable";
+  return value === 0 ? "0 B" : fmtBytes(value);
+}
+
+function formatUtcTimestamp(value: string): string {
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return "Unavailable";
+  return timestamp.toLocaleString("en-US", {
+    day: "numeric",
+    hour: "numeric",
+    hour12: true,
+    minute: "2-digit",
+    month: "short",
+    second: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+    year: "numeric",
+  });
+}
+
+function factHtml(
+  label: string,
+  value: string,
+  escapeHtml: (value: string) => string,
+  options: { className?: string; valueHtml?: string } = {},
+): string {
+  const className = options.className
+    ? ` diagnostics-fact-${options.className}`
+    : "";
+  return `<div class="diagnostics-fact${className}">
+    <dt>${escapeHtml(label)}</dt>
+    <dd>${options.valueHtml ?? escapeHtml(value)}</dd>
+  </div>`;
+}
+
+function phaseWidth(value: number, total: number): string {
+  if (!Number.isFinite(value) || value <= 0 || total <= 0) return "0";
+  return Math.max(0, Math.min(100, value / total * 100)).toFixed(3);
+}
+
+function runtimeCardHtml(
+  runtime: DiagnosticsRuntimeState,
+  escapeHtml: (value: string) => string,
+): string {
+  const stateClass = ` diagnostics-runtime-${runtime.kind}`;
+
+  let body = "";
+  if (runtime.kind === "ready" && runtime.diagnostics) {
+    const diagnostics = runtime.diagnostics;
+    const measuredTotal = Math.max(
+      diagnostics.downloadMs + diagnostics.startupMs + diagnostics.precomputeMs,
+      diagnostics.totalMs,
+      0,
+    );
+    body = `<div class="diagnostics-card-body">
+      <div class="diagnostics-total">
+        <span>Total startup</span>
+        <strong>${escapeHtml(formatDuration(diagnostics.totalMs))}</strong>
+      </div>
+      <div class="diagnostics-phase-bar" aria-label="Startup phases">
+        <span class="diagnostics-phase-download" style="--diagnostics-phase-width:${phaseWidth(diagnostics.downloadMs, measuredTotal)}%"></span>
+        <span class="diagnostics-phase-startup" style="--diagnostics-phase-width:${phaseWidth(diagnostics.startupMs, measuredTotal)}%"></span>
+        <span class="diagnostics-phase-precompute" style="--diagnostics-phase-width:${phaseWidth(diagnostics.precomputeMs, measuredTotal)}%"></span>
+      </div>
+      <dl class="diagnostics-phase-legend" aria-label="Startup phase legend">
+        ${factHtml("Download", formatDuration(diagnostics.downloadMs), escapeHtml, { className: "phase-download" })}
+        ${factHtml("Start runtime", formatDuration(diagnostics.startupMs), escapeHtml, { className: "phase-startup" })}
+        ${factHtml("Prepare inspection", formatDuration(diagnostics.precomputeMs), escapeHtml, { className: "phase-precompute" })}
+      </dl>
+      <dl class="diagnostics-facts diagnostics-runtime-facts">
+      ${factHtml("Framework assets", formatInteger(diagnostics.assets), escapeHtml)}
+      ${factHtml("Transferred", formatBytes(diagnostics.transfer), escapeHtml)}
+      ${factHtml("Decoded", formatBytes(diagnostics.decoded), escapeHtml)}
+      </dl>
+    </div>`;
+  } else if (runtime.kind === "ready") {
+    body = `<p class="diagnostics-unavailable">Startup measurements are unavailable for this session.</p>`;
+  } else if (runtime.kind === "failed" && runtime.detail) {
+    body = `<pre class="diagnostics-failure-detail">${escapeHtml(runtime.detail)}</pre>`;
+  } else {
+    body = `<div class="diagnostics-progress" aria-hidden="true"><span></span></div>`;
+  }
+
+  return `<section class="diagnostics-card diagnostics-runtime-card${stateClass}" aria-labelledby="diagnostics-runtime-heading">
+    <div class="diagnostics-card-head">
+      <h2 id="diagnostics-runtime-heading">Runtime startup</h2>
+      <span class="diagnostics-owner">Browser Performance API</span>
+    </div>
+    ${body}
+  </section>`;
+}
+
+function runtimeStateHtml(
+  runtime: DiagnosticsRuntimeState,
+  escapeHtml: (value: string) => string,
+): string {
+  const title = runtime.kind === "ready"
+    ? "Browser inspection engine ready"
+    : runtime.kind === "failed"
+      ? "Browser inspection engine failed"
+      : "Browser inspection engine loading";
+  return `<div class="diagnostics-runtime-state diagnostics-runtime-state-${runtime.kind}" role="status">
+    <span class="diagnostics-runtime-dot" aria-hidden="true"></span>
+    <strong>${title}</strong>
+    <span>${escapeHtml(runtime.message)}</span>
+  </div>`;
+}
+
+function buildCardHtml(
+  identity: BrowserBuildIdentity | null,
+  escapeHtml: (value: string) => string,
+): string {
+  const facts = [];
+  if (identity) {
+    const version = identity.version.trim();
+    facts.push(
+      factHtml("Version", version || "Unavailable", escapeHtml),
+    );
+    const commit = identity.commit?.trim() ?? "";
+    const commitHtml = commit && identity.commitUrl
+      ? `<a href="${escapeHtml(identity.commitUrl)}" target="_blank" rel="noopener noreferrer"><code>${escapeHtml(commit)}</code></a>`
+      : commit
+        ? `<code>${escapeHtml(commit)}</code>`
+        : undefined;
+    const commitOptions = commitHtml ? { valueHtml: commitHtml } : {};
+    facts.push(
+      factHtml("Commit", commit || "Unavailable", escapeHtml, commitOptions),
+      factHtml(
+        "Built",
+        identity.builtAtUtc
+          ? formatUtcTimestamp(identity.builtAtUtc)
+          : "Unavailable",
+        escapeHtml,
+      ),
+    );
+  } else {
+    facts.push(
+      factHtml("Build identity", "Unavailable", escapeHtml),
+    );
+  }
+  facts.push(factHtml("Host", "Browser / WebAssembly", escapeHtml));
+
+  return `<section class="diagnostics-card" aria-labelledby="diagnostics-build-heading">
+    <div class="diagnostics-card-head">
+      <h2 id="diagnostics-build-heading">Build</h2>
+      <span class="diagnostics-owner">Host identity</span>
+    </div>
+    <dl class="diagnostics-facts">${facts.join("")}</dl>
+  </section>`;
+}
+
+function cacheCardHtml(
+  cache: DiagnosticsPackageCacheState,
+  escapeHtml: (value: string) => string,
+): string {
+  let body = "";
+  if (cache.kind === "ready") {
+    body = `<dl class="diagnostics-facts">
+      ${factHtml("Packages", formatInteger(cache.stats.packages), escapeHtml)}
+      ${factHtml("Resident payloads", formatInteger(cache.stats.resident), escapeHtml)}
+      ${factHtml("Workspaces", formatInteger(cache.stats.workspaces), escapeHtml)}
+      ${factHtml("Resident bytes", formatBytes(cache.stats.residentBytes), escapeHtml, { className: "emphasis" })}
+    </dl>`;
+  } else if (cache.kind === "failed") {
+    body = `<div class="diagnostics-inline-state diagnostics-inline-failed">
+      <span aria-hidden="true">!</span>
+      <p>${escapeHtml(cache.message)}</p>
+    </div>`;
+  } else {
+    body = `<div class="diagnostics-inline-state">
+      <span class="diagnostics-inline-spinner" aria-hidden="true"></span>
+      <p>Reading aggregate package-cache statistics.</p>
+    </div>`;
+  }
+
+  return `<section class="diagnostics-card" aria-labelledby="diagnostics-cache-heading">
+    <div class="diagnostics-card-head">
+      <h2 id="diagnostics-cache-heading">Package cache</h2>
+      <span class="diagnostics-owner">Browser package workspace</span>
+    </div>
+    ${body}
+  </section>`;
+}
+
+export function diagnosticsViewHtml(
+  model: DiagnosticsViewModel,
+  escapeHtml: (value: string) => string,
+): string {
+  return `<div class="diagnostics-view">
+    <header class="diagnostics-header">
+      ${renderBrand({
+        ariaLabel: "dotnet-inspect workspace",
+        href: "/",
+        id: "diagnostics-product",
+      })}
+      <button id="diagnostics-back" class="diagnostics-back" type="button">
+        Back
+      </button>
+    </header>
+    <main class="diagnostics-main">
+      <header class="diagnostics-title">
+        <div>
+          <p class="diagnostics-eyebrow">Current browser session</p>
+          <h1 id="diagnostics-heading" tabindex="-1">Diagnostics</h1>
+          <p>Runtime, build, and local package-cache evidence for this tab. Inspection runs locally in your browser.</p>
+        </div>
+        <p class="diagnostics-captured">Captured ${escapeHtml(formatUtcTimestamp(model.capturedAtUtc))}</p>
+      </header>
+      ${runtimeStateHtml(model.runtime, escapeHtml)}
+      <div class="diagnostics-grid">
+        ${runtimeCardHtml(model.runtime, escapeHtml)}
+        ${buildCardHtml(model.buildIdentity, escapeHtml)}
+        ${cacheCardHtml(model.packageCache, escapeHtml)}
+      </div>
+    </main>
+  </div>`;
+}
+
+export function bindDiagnosticsView(
+  root: ParentNode,
+  actions: DiagnosticsViewActions,
+): void {
+  const activateBack = (event: Event) => {
+    event.preventDefault();
+    actions.onBack();
+  };
+  root.querySelector<HTMLElement>("#diagnostics-product")
+    ?.addEventListener("click", activateBack);
+  root.querySelector<HTMLButtonElement>("#diagnostics-back")
+    ?.addEventListener("click", activateBack);
+}

--- a/inspect-web/src/diagnostics-view.ts
+++ b/inspect-web/src/diagnostics-view.ts
@@ -4,13 +4,13 @@ import type { BrowserPackageCacheStats } from "./facades/inspect-web-package.d.t
 import { renderBrand } from "./brand.ts";
 
 export interface RuntimeStartupDiagnostics {
-  downloadMs: number;
+  downloadMs: number | null;
   startupMs: number;
   precomputeMs: number;
   totalMs: number;
-  transfer: number;
-  decoded: number;
-  assets: number;
+  transfer: number | null;
+  decoded: number | null;
+  assets: number | null;
 }
 
 export type DiagnosticsRuntimeState =
@@ -42,9 +42,22 @@ export type DiagnosticsPackageCacheState =
       message: string;
     };
 
+export type DiagnosticsBuildState =
+  | {
+      kind: "loading";
+    }
+  | {
+      kind: "ready";
+      identity: BrowserBuildIdentity;
+    }
+  | {
+      kind: "failed";
+      message: string;
+    };
+
 export interface DiagnosticsViewModel {
   runtime: DiagnosticsRuntimeState;
-  buildIdentity: BrowserBuildIdentity | null;
+  build: DiagnosticsBuildState;
   packageCache: DiagnosticsPackageCacheState;
   capturedAtUtc: string;
 }
@@ -54,21 +67,24 @@ export interface DiagnosticsViewActions {
   onHome: () => void;
 }
 
-function formatDuration(milliseconds: number): string {
-  if (!Number.isFinite(milliseconds) || milliseconds < 0) return "Unavailable";
+function formatDuration(milliseconds: number | null): string {
+  if (milliseconds === null
+    || !Number.isFinite(milliseconds)
+    || milliseconds < 0) return "Unavailable";
   if (milliseconds < 1000) return `${Math.round(milliseconds)} ms`;
   const seconds = milliseconds / 1000;
   return `${seconds.toFixed(seconds < 10 ? 2 : 1)} s`;
 }
 
-function formatInteger(value: number): string {
-  return Number.isFinite(value) && value >= 0
+function formatInteger(value: number | null): string {
+  return value !== null && Number.isFinite(value) && value >= 0
     ? Math.round(value).toLocaleString("en-US")
     : "Unavailable";
 }
 
-function formatBytes(value: number): string {
-  if (!Number.isFinite(value) || value < 0) return "Unavailable";
+function formatBytes(value: number | null): string {
+  if (value === null || !Number.isFinite(value) || value < 0)
+    return "Unavailable";
   return value === 0 ? "0 B" : fmtBytes(value);
 }
 
@@ -103,8 +119,11 @@ function factHtml(
   </div>`;
 }
 
-function phaseWidth(value: number, total: number): string {
-  if (!Number.isFinite(value) || value <= 0 || total <= 0) return "0";
+function phaseWidth(value: number | null, total: number): string {
+  if (value === null
+    || !Number.isFinite(value)
+    || value <= 0
+    || total <= 0) return "0";
   return Math.max(0, Math.min(100, value / total * 100)).toFixed(3);
 }
 
@@ -118,7 +137,9 @@ function runtimeCardHtml(
   if (runtime.kind === "ready" && runtime.diagnostics) {
     const diagnostics = runtime.diagnostics;
     const measuredTotal = Math.max(
-      diagnostics.downloadMs + diagnostics.startupMs + diagnostics.precomputeMs,
+      (diagnostics.downloadMs ?? 0)
+        + diagnostics.startupMs
+        + diagnostics.precomputeMs,
       diagnostics.totalMs,
       0,
     );
@@ -177,11 +198,13 @@ function runtimeStateHtml(
 }
 
 function buildCardHtml(
-  identity: BrowserBuildIdentity | null,
+  build: DiagnosticsBuildState,
   escapeHtml: (value: string) => string,
 ): string {
-  const facts = [];
-  if (identity) {
+  let body = "";
+  if (build.kind === "ready") {
+    const facts = [];
+    const { identity } = build;
     const version = identity.version.trim();
     facts.push(
       factHtml("Version", version || "Unavailable", escapeHtml),
@@ -203,19 +226,26 @@ function buildCardHtml(
         escapeHtml,
       ),
     );
+    facts.push(factHtml("Host", "Browser / WebAssembly", escapeHtml));
+    body = `<dl class="diagnostics-facts">${facts.join("")}</dl>`;
+  } else if (build.kind === "failed") {
+    body = `<div class="diagnostics-inline-state diagnostics-inline-failed">
+      <span aria-hidden="true">!</span>
+      <p>${escapeHtml(build.message)}</p>
+    </div>`;
   } else {
-    facts.push(
-      factHtml("Build identity", "Unavailable", escapeHtml),
-    );
+    body = `<div class="diagnostics-inline-state">
+      <span class="diagnostics-inline-spinner" aria-hidden="true"></span>
+      <p>Reading product build identity.</p>
+    </div>`;
   }
-  facts.push(factHtml("Host", "Browser / WebAssembly", escapeHtml));
 
   return `<section class="diagnostics-card" aria-labelledby="diagnostics-build-heading">
     <div class="diagnostics-card-head">
       <h2 id="diagnostics-build-heading">Build</h2>
       <span class="diagnostics-owner">Host identity</span>
     </div>
-    <dl class="diagnostics-facts">${facts.join("")}</dl>
+    ${body}
   </section>`;
 }
 
@@ -279,7 +309,7 @@ export function diagnosticsViewHtml(
       ${runtimeStateHtml(model.runtime, escapeHtml)}
       <div class="diagnostics-grid">
         ${runtimeCardHtml(model.runtime, escapeHtml)}
-        ${buildCardHtml(model.buildIdentity, escapeHtml)}
+        ${buildCardHtml(model.build, escapeHtml)}
         ${cacheCardHtml(model.packageCache, escapeHtml)}
       </div>
     </main>

--- a/inspect-web/src/diagnostics-view.ts
+++ b/inspect-web/src/diagnostics-view.ts
@@ -22,6 +22,7 @@ export type DiagnosticsRuntimeState =
       kind: "ready";
       message: string;
       diagnostics: RuntimeStartupDiagnostics | null;
+      measurementsPending: boolean;
     }
   | {
       kind: "failed";
@@ -163,6 +164,11 @@ function runtimeCardHtml(
       ${factHtml("Transferred", formatBytes(diagnostics.transfer), escapeHtml)}
       ${factHtml("Decoded", formatBytes(diagnostics.decoded), escapeHtml)}
       </dl>
+    </div>`;
+  } else if (runtime.kind === "ready" && runtime.measurementsPending) {
+    body = `<div class="diagnostics-inline-state">
+      <span class="diagnostics-inline-spinner" aria-hidden="true"></span>
+      <p>Finishing startup measurements.</p>
     </div>`;
   } else if (runtime.kind === "ready") {
     body = `<p class="diagnostics-unavailable">Startup measurements are unavailable for this session.</p>`;

--- a/inspect-web/src/dotnet-inspect.ts
+++ b/inspect-web/src/dotnet-inspect.ts
@@ -1021,6 +1021,7 @@ const initialState = {
   loadingMessage: "Starting browser inspection engine…",
   loadingSubtitle: "",
   engineReady: false,
+  engineRuntimeReady: false,
   engineStartupFailed: false,
   engineStatus: "Loading browser WebAssembly…",
   error: "",
@@ -1122,6 +1123,7 @@ let packageCacheStatsRequest = 0;
 let diagnosticsHeadingFocusPending = false;
 let diagnosticsDestinationFocusPending = false;
 let diagnosticsDestinationFocusScheduled = false;
+let diagnosticsDestinationFocusGeneration: number | null = null;
 let platformLibraryRetry: RetryAction = null;
 let platformCatalogRetry: RetryAction = null;
 
@@ -1437,6 +1439,7 @@ function captureRetainedHostState() {
     settingsReturn: state.settingsReturn,
     keyboardHelp: state.keyboardHelp,
     engineReady: state.engineReady,
+    engineRuntimeReady: state.engineRuntimeReady,
     engineStartupFailed: state.engineStartupFailed,
     engineStatus: state.engineStatus,
     diag: state.diag,
@@ -10244,6 +10247,21 @@ function bindHomeEvents() {
   bindHomeShell(document, homeShellActions);
   spotlight.bind(document, "inline");
   if (diagnosticsDestinationFocusPending) return;
+  const destinationFocusGeneration = diagnosticsDestinationFocusGeneration;
+  if (destinationFocusGeneration !== null) {
+    afterCurrentNavigationFrame(() => {
+      if (diagnosticsDestinationFocusGeneration
+        !== destinationFocusGeneration) return;
+      if (documentFocusGeneration !== destinationFocusGeneration) {
+        diagnosticsDestinationFocusGeneration = null;
+        return;
+      }
+      if (focusLevelOneHeading()) {
+        diagnosticsDestinationFocusGeneration = documentFocusGeneration;
+      }
+    });
+    return;
+  }
   afterCurrentNavigationFrame(() => {
     const input =
       document.querySelector<HTMLInputElement>("#spotlight-input");
@@ -10750,11 +10768,12 @@ function diagnosticsRuntimeState(): DiagnosticsRuntimeState {
       detail: state.errorDetail || state.error || null,
     };
   }
-  if (state.engineReady) {
+  if (state.engineRuntimeReady) {
     return {
       kind: "ready",
       message: ".NET is running in WebAssembly and ready for inspection.",
       diagnostics: state.diag,
+      measurementsPending: !state.engineReady,
     };
   }
   return {
@@ -10859,7 +10878,8 @@ function openDiagnosticsRoute() {
   state.diagnosticsCapturedAtUtc = new Date().toISOString();
   diagnosticsHeadingFocusPending = true;
   diagnosticsDestinationFocusPending = false;
-  if (state.engineReady) {
+  diagnosticsDestinationFocusGeneration = null;
+  if (state.engineRuntimeReady) {
     state.packageCacheStatsStatus = "loading";
     state.packageCacheStatsError = "";
   }
@@ -10867,7 +10887,7 @@ function openDiagnosticsRoute() {
     DIAGNOSTICS_PATH,
     diagnosticsHistoryState(history.state));
   render();
-  if (state.engineReady) refreshPackageStats();
+  if (state.engineRuntimeReady) refreshPackageStats();
 }
 
 function closeDiagnosticsRoute() {
@@ -10937,7 +10957,9 @@ function scheduleDiagnosticsDestinationFocus() {
     if (!heading) return;
     diagnosticsDestinationFocusPending = false;
     if (focusGeneration !== documentFocusGeneration) return;
-    focusLevelOneHeading();
+    if (focusLevelOneHeading()) {
+      diagnosticsDestinationFocusGeneration = documentFocusGeneration;
+    }
   });
 }
 
@@ -15002,6 +15024,7 @@ function isStyleOption(value: unknown): value is StyleOption {
 function showEngineFailure(error: unknown) {
   state.loading = false;
   state.engineReady = false;
+  state.engineRuntimeReady = false;
   state.engineStartupFailed = true;
   state.engineStatus = "";
   state.error =
@@ -15020,9 +15043,29 @@ function showEngineFailure(error: unknown) {
   if (!state.credits) render();
 }
 
+async function loadBuildIdentity() {
+  try {
+    state.buildIdentity = await engineClient.host.buildIdentity();
+    state.buildIdentityStatus = "ready";
+  } catch (error) {
+    state.buildIdentity = null;
+    state.buildIdentityStatus = "failed";
+    state.buildIdentityError =
+      `Product build identity is unavailable: ${errorMessage(error)}`;
+    console.error("Product build identity is unavailable.", error);
+  }
+  if (isDiagnosticsPath(location.pathname)) {
+    state.diagnosticsCapturedAtUtc = new Date().toISOString();
+    render();
+  } else if (state.engineReady && !state.credits) {
+    render();
+  }
+}
+
 async function bootstrap() {
   state.loading = !state.home;
   state.engineReady = false;
+  state.engineRuntimeReady = false;
   state.engineStartupFailed = false;
   state.engineStatus = "Loading browser WebAssembly…";
   state.buildIdentity = null;
@@ -15042,18 +15085,14 @@ async function bootstrap() {
     };
     reportEngineStatus("Loading .NET WebAssembly…");
     await startEngine(window.location.origin);
-    reportEngineStatus("Reading package assemblies…");
-    try {
-      state.buildIdentity = await engineClient.host.buildIdentity();
-      state.buildIdentityStatus = "ready";
-    } catch (error) {
-      state.buildIdentity = null;
-      state.buildIdentityStatus = "failed";
-      state.buildIdentityError =
-        `Product build identity is unavailable: ${errorMessage(error)}`;
-      console.error("Product build identity is unavailable.", error);
-    }
     const tEngine = performance.now();
+    state.engineRuntimeReady = true;
+    reportEngineStatus("Reading package assemblies…");
+    void loadBuildIdentity();
+    if (isDiagnosticsPath(location.pathname)) {
+      state.loading = false;
+      refreshPackageStats();
+    }
     try {
       const vocabulary = await engineClient.catalog.listVocabulary();
       const sections = vocabulary?.sections || [];
@@ -15104,8 +15143,7 @@ async function bootstrap() {
     if (isDiagnosticsPath(location.pathname)) {
       state.loading = false;
       state.diag = computeDiagnostics(tStart, tEngine, performance.now());
-      diagnosticsHeadingFocusPending = true;
-      refreshPackageStats();
+      render();
       return;
     }
     if (state.home) {
@@ -15916,6 +15954,7 @@ window.addEventListener("popstate", () => {
   if (dismissedAnnotatedSourceModal) render({ synchronizeUrl: false });
   if (isDiagnosticsPath(location.pathname)) {
     diagnosticsDestinationFocusPending = false;
+    diagnosticsDestinationFocusGeneration = null;
     clearNavigationError();
     state.packageQueryOpen = false;
     packageQueryController.cancel();
@@ -15924,12 +15963,12 @@ window.addEventListener("popstate", () => {
     state.loading = false;
     state.diagnosticsCapturedAtUtc = new Date().toISOString();
     diagnosticsHeadingFocusPending = true;
-    if (state.engineReady) {
+    if (state.engineRuntimeReady) {
       state.packageCacheStatsStatus = "loading";
       state.packageCacheStatsError = "";
     }
     render();
-    if (state.engineReady) refreshPackageStats();
+    if (state.engineRuntimeReady) refreshPackageStats();
     return;
   }
   if (isPackageQueryPath(location.pathname)) {

--- a/inspect-web/src/dotnet-inspect.ts
+++ b/inspect-web/src/dotnet-inspect.ts
@@ -10788,7 +10788,9 @@ function renderDiagnosticsPage() {
   const focusTargetId = diagnosticsHeadingFocusPending
     || activeId === "diagnostics-heading"
     ? "diagnostics-heading"
-    : activeId === "diagnostics-product" || activeId === "diagnostics-back"
+    : activeId === "diagnostics-product"
+      || activeId === "diagnostics-commit"
+      || activeId === "diagnostics-back"
       ? activeId
       : null;
   state.diagnosticsCapturedAtUtc ??= new Date().toISOString();

--- a/inspect-web/src/dotnet-inspect.ts
+++ b/inspect-web/src/dotnet-inspect.ts
@@ -440,6 +440,19 @@ import {
   fmtBytes,
 } from "./data-bar.ts";
 import {
+  DIAGNOSTICS_PATH,
+  diagnosticsHistoryState,
+  isDiagnosticsHistoryEntry,
+  isDiagnosticsPath,
+} from "./diagnostics-route.ts";
+import {
+  bindDiagnosticsView,
+  diagnosticsViewHtml,
+  type DiagnosticsPackageCacheState,
+  type DiagnosticsRuntimeState,
+  type RuntimeStartupDiagnostics,
+} from "./diagnostics-view.ts";
+import {
   bindCreditsPanel,
   isCreditsPath,
   renderCreditsPage,
@@ -851,16 +864,6 @@ interface RecentPackage {
   framework: string;
 }
 
-interface Diagnostics {
-  downloadMs: number;
-  startupMs: number;
-  precomputeMs: number;
-  totalMs: number;
-  transfer: number;
-  decoded: number;
-  assets: number;
-}
-
 let spotlightCache: SpotlightCache | null = null;
 const HOME_BOT_ANIMATION_DURATION_MS = 5500;
 const DEFAULT_REQUESTED_FRAMEWORK = "net10.0";
@@ -1026,6 +1029,10 @@ const initialState = {
   diag: null,
   buildIdentity: null,
   packageCacheStats: null,
+  packageCacheStatsStatus: "idle" as
+    "idle" | "loading" | "ready" | "failed",
+  packageCacheStatsError: "",
+  diagnosticsCapturedAtUtc: null,
 };
 
 interface StateOverrides {
@@ -1076,9 +1083,11 @@ interface StateOverrides {
   styleOptions: StyleOption[] | null;
   history: string[];
   retryAction: ErrorRetryAction;
-  diag: Diagnostics | null;
+  diag: RuntimeStartupDiagnostics | null;
   buildIdentity: BrowserBuildIdentity | null;
   packageCacheStats: BrowserPackageCacheStats | null;
+  packageCacheStatsStatus: "idle" | "loading" | "ready" | "failed";
+  diagnosticsCapturedAtUtc: string | null;
   packageQueryState: PackageQueryState;
   packageQueryFacets: QueryFacetTerm[];
   packageQueryAssemblyPatterns: QueryAssemblyPatternDescriptor[];
@@ -1105,6 +1114,8 @@ type FailedWorkspaceUrlState = WorkspaceUrlPreservation & (
 let failedWorkspaceUrlState: FailedWorkspaceUrlState | null = null;
 let packageQueryWorkspaceFocusNavigationSeq: number | null = null;
 let packageQueryHandoffNavigationSeq: number | null = null;
+let packageCacheStatsRequest = 0;
+let diagnosticsHeadingFocusPending = false;
 let platformLibraryRetry: RetryAction = null;
 let platformCatalogRetry: RetryAction = null;
 
@@ -1425,6 +1436,9 @@ function captureRetainedHostState() {
     diag: state.diag,
     buildIdentity: state.buildIdentity,
     packageCacheStats: state.packageCacheStats,
+    packageCacheStatsStatus: state.packageCacheStatsStatus,
+    packageCacheStatsError: state.packageCacheStatsError,
+    diagnosticsCapturedAtUtc: state.diagnosticsCapturedAtUtc,
   };
 }
 
@@ -2504,12 +2518,18 @@ const initialLocation = initialWorkspace.visible;
 // its workspace directly.
 state.credits = isCreditsPath(location.pathname);
 state.packageQueryOpen = isPackageQueryPath(location.pathname);
+const diagnosticsOpen = isDiagnosticsPath(location.pathname);
 const productHomeDemosOpen = isProductHomeDemosPath(location.pathname);
+if (diagnosticsOpen) {
+  state.diagnosticsCapturedAtUtc = new Date().toISOString();
+  diagnosticsHeadingFocusPending = true;
+}
 if (state.packageQueryOpen) {
   applyPackageQueryHistory(history.state);
 }
 state.home = state.credits
-  || (!state.packageQueryOpen
+  || (!diagnosticsOpen
+    && !state.packageQueryOpen
     && !productHomeDemosOpen
     && !initialLocation.package
     && !initialWorkspace.hasWorkspaceState
@@ -4325,6 +4345,11 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   workbenchShellBinding?.disconnect();
   workbenchShellBinding = null;
 
+  if (isDiagnosticsPath(location.pathname)) {
+    loadingBotSrc = null;
+    renderDiagnosticsPage();
+    return;
+  }
   // The Metadata Explorer is a full-bleed "browse the database" view layered over the
   // package workbench. Like Settings it owns no URL and renders first, returning to the
   // Metadata lens on close.
@@ -7257,6 +7282,7 @@ function bindScopeBarEvents() {
 function bindSettingsPanelEvents() {
   bindSettingsPanel(document, {
     onClose: closeSettings,
+    onOpenDiagnostics: openDiagnosticsRoute,
     onOpen: openSettings,
     onTasteClear: clearTaste,
     onTasteToggle: toggleTaste,
@@ -9089,9 +9115,17 @@ function executeCommand(
   value: string,
   result: CommandPaletteResult | null = null,
 ) {
+  const [verb, ...rest] = value.split(/\s+/);
+  if (verb === "diagnostics" && rest.length === 0) {
+    state.history = [
+      value,
+      ...state.history.filter(item => item !== value),
+    ].slice(0, 5);
+    openDiagnosticsRoute();
+    return undefined;
+  }
   const pkg = currentPackage();
   beginSpotlightNavigation();
-  const [verb, ...rest] = value.split(/\s+/);
   const argument = rest.join(" ");
   let operation;
   if (verb === "type") {
@@ -10693,6 +10727,124 @@ function renderCreditsView() {
     onClose: goHome,
     onToggleTheme: toggleCreditsTheme,
   });
+}
+
+function diagnosticsRuntimeState(): DiagnosticsRuntimeState {
+  if (state.engineStartupFailed) {
+    return {
+      kind: "failed",
+      message: "The browser inspection engine did not start.",
+      detail: state.errorDetail || state.error || null,
+    };
+  }
+  if (state.engineReady) {
+    return {
+      kind: "ready",
+      message: ".NET is running in WebAssembly and ready for inspection.",
+      diagnostics: state.diag,
+    };
+  }
+  return {
+    kind: "loading",
+    message: state.engineStatus
+      || state.loadingMessage
+      || "Starting the browser inspection engine.",
+  };
+}
+
+function diagnosticsPackageCacheState(): DiagnosticsPackageCacheState {
+  if (state.engineStartupFailed) {
+    return {
+      kind: "failed",
+      message: "Package-cache statistics are unavailable because the inspection engine did not start.",
+    };
+  }
+  if (state.packageCacheStatsStatus === "failed") {
+    return {
+      kind: "failed",
+      message: state.packageCacheStatsError
+        || "Package-cache statistics are unavailable.",
+    };
+  }
+  if (state.packageCacheStatsStatus === "ready"
+    && state.packageCacheStats) {
+    return {
+      kind: "ready",
+      stats: state.packageCacheStats,
+    };
+  }
+  return { kind: "loading" };
+}
+
+function renderDiagnosticsPage() {
+  const restoreHeadingFocus = diagnosticsHeadingFocusPending
+    || document.activeElement?.id === "diagnostics-heading";
+  state.diagnosticsCapturedAtUtc ??= new Date().toISOString();
+  document.title = "Diagnostics · dotnet-inspect";
+  app.innerHTML = diagnosticsViewHtml({
+    runtime: diagnosticsRuntimeState(),
+    buildIdentity: state.buildIdentity,
+    packageCache: diagnosticsPackageCacheState(),
+    capturedAtUtc: state.diagnosticsCapturedAtUtc,
+  }, value => escapeHtml(value));
+  bindDiagnosticsView(document, {
+    onBack: closeDiagnosticsRoute,
+  });
+  if (restoreHeadingFocus) {
+    requestAnimationFrame(() => {
+      if (!isDiagnosticsPath(location.pathname)) return;
+      diagnosticsHeadingFocusPending = false;
+      focusLevelOneHeading();
+    });
+  }
+}
+
+function openDiagnosticsRoute() {
+  dismissModalsForRoutedNavigation();
+  navigationSequence.begin();
+  packageQueryController.cancel();
+  state.packageQueryOpen = false;
+  state.credits = false;
+  state.home = false;
+  state.diagnosticsCapturedAtUtc = new Date().toISOString();
+  diagnosticsHeadingFocusPending = true;
+  if (state.engineReady) {
+    state.packageCacheStatsStatus = "loading";
+    state.packageCacheStatsError = "";
+  }
+  workspaceLocation.push(
+    DIAGNOSTICS_PATH,
+    diagnosticsHistoryState(history.state));
+  render();
+  if (state.engineReady) refreshPackageStats();
+}
+
+function closeDiagnosticsRoute() {
+  if (isDiagnosticsHistoryEntry(history.state)) {
+    history.back();
+    return;
+  }
+  replaceDiagnosticsWithHome();
+}
+
+function replaceDiagnosticsWithHome() {
+  navigationSequence.begin();
+  state.loading = false;
+  state.memberCallGraphSeq++;
+  state.memberCallGraphExpanding = false;
+  invalidateGraphMemberNavigation();
+  clearNavigationError();
+  if (!clearWorkspaceRouteFailure()) {
+    render();
+    return;
+  }
+  state.packageQueryOpen = false;
+  packageQueryController.cancel();
+  state.credits = false;
+  state.home = true;
+  spotlight.reset();
+  workspaceLocation.replace("/", history.state);
+  render();
 }
 
 function focusPackageQueryInput() {
@@ -14849,6 +15001,13 @@ async function bootstrap() {
     }
     state.engineReady = true;
     state.engineStatus = "";
+    if (isDiagnosticsPath(location.pathname)) {
+      state.loading = false;
+      state.diag = computeDiagnostics(tStart, tEngine, performance.now());
+      diagnosticsHeadingFocusPending = true;
+      refreshPackageStats();
+      return;
+    }
     if (state.home) {
       // Engine is warm and search is ready; show the intro/home page without loading a package.
       state.loading = false;
@@ -14890,7 +15049,7 @@ function computeDiagnostics(
   tStart: number,
   tEngine: number,
   tReady: number,
-): Diagnostics {
+): RuntimeStartupDiagnostics {
   const assets = performance.getEntriesByType("resource")
     .filter((entry): entry is PerformanceResourceTiming =>
       entry instanceof PerformanceResourceTiming
@@ -14910,7 +15069,7 @@ function computeDiagnostics(
     downloadMs: hasAssets ? lastEnd - firstStart : 0,
     startupMs: hasAssets ? Math.max(0, tEngine - lastEnd) : tEngine - tStart,
     precomputeMs: tReady - tEngine,
-    totalMs: tReady,
+    totalMs: tReady - tStart,
     transfer,
     decoded,
     assets: assets.length
@@ -14918,13 +15077,28 @@ function computeDiagnostics(
 }
 
 function refreshPackageStats() {
+  const request = ++packageCacheStatsRequest;
+  state.packageCacheStatsStatus = "loading";
+  state.packageCacheStatsError = "";
+  if (isDiagnosticsPath(location.pathname)) render();
   void inspectPackageCacheStats().then(
     stats => {
+      if (request !== packageCacheStatsRequest) return undefined;
       state.packageCacheStats = stats;
+      state.packageCacheStatsStatus = "ready";
+      state.diagnosticsCapturedAtUtc = new Date().toISOString();
+      if (isDiagnosticsPath(location.pathname)) render();
       return undefined;
     },
-    () => {
-      // Keep the last known counts; a stats read failure must not disrupt inspection.
+    (error: unknown) => {
+      if (request !== packageCacheStatsRequest) return undefined;
+      state.packageCacheStats = null;
+      state.packageCacheStatsStatus = "failed";
+      state.packageCacheStatsError =
+        `Package-cache statistics are unavailable: ${errorMessage(error)}`;
+      state.diagnosticsCapturedAtUtc = new Date().toISOString();
+      console.error("Package-cache statistics are unavailable.", error);
+      if (isDiagnosticsPath(location.pathname)) render();
       return undefined;
     },
   );
@@ -15054,6 +15228,10 @@ async function openFreshWorkspaceLink(
 }
 
 async function navigateInAppUrl(url: URL) {
+  if (isDiagnosticsPath(url.pathname)) {
+    openDiagnosticsRoute();
+    return;
+  }
   if (isCreditsPath(url.pathname)) {
     openCredits();
     return;
@@ -15623,7 +15801,8 @@ window.addEventListener("popstate", () => {
   const unavailableGlobalWorkspace =
     historyWorkspaceReferenced
     && !historyWorkspaceAvailable
-    && (isPackageQueryPath(location.pathname)
+    && (isDiagnosticsPath(location.pathname)
+      || isPackageQueryPath(location.pathname)
       || isCreditsPath(location.pathname)
       || isProductHomeDemosPath(location.pathname));
   if (unavailableGlobalWorkspace) {
@@ -15631,6 +15810,23 @@ window.addEventListener("popstate", () => {
       !publishFreshEmptyWorkspaceFromHistory(location.href);
   }
   if (dismissedAnnotatedSourceModal) render({ synchronizeUrl: false });
+  if (isDiagnosticsPath(location.pathname)) {
+    clearNavigationError();
+    state.packageQueryOpen = false;
+    packageQueryController.cancel();
+    state.credits = false;
+    state.home = false;
+    state.loading = false;
+    state.diagnosticsCapturedAtUtc = new Date().toISOString();
+    diagnosticsHeadingFocusPending = true;
+    if (state.engineReady) {
+      state.packageCacheStatsStatus = "loading";
+      state.packageCacheStatsError = "";
+    }
+    render();
+    if (state.engineReady) refreshPackageStats();
+    return;
+  }
   if (isPackageQueryPath(location.pathname)) {
     clearNavigationError();
     applyPackageQueryHistory(history.state);

--- a/inspect-web/src/dotnet-inspect.ts
+++ b/inspect-web/src/dotnet-inspect.ts
@@ -1116,6 +1116,8 @@ let packageQueryWorkspaceFocusNavigationSeq: number | null = null;
 let packageQueryHandoffNavigationSeq: number | null = null;
 let packageCacheStatsRequest = 0;
 let diagnosticsHeadingFocusPending = false;
+let diagnosticsDestinationFocusPending = false;
+let diagnosticsDestinationFocusScheduled = false;
 let platformLibraryRetry: RetryAction = null;
 let platformCatalogRetry: RetryAction = null;
 
@@ -4345,6 +4347,10 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   workbenchShellBinding?.disconnect();
   workbenchShellBinding = null;
 
+  if (diagnosticsDestinationFocusPending
+    && !isDiagnosticsPath(location.pathname)) {
+    queueMicrotask(scheduleDiagnosticsDestinationFocus);
+  }
   if (isDiagnosticsPath(location.pathname)) {
     loadingBotSrc = null;
     renderDiagnosticsPage();
@@ -10231,6 +10237,7 @@ function bindHomeEvents() {
   bindSettingsPanelEvents();
   bindHomeShell(document, homeShellActions);
   spotlight.bind(document, "inline");
+  if (diagnosticsDestinationFocusPending) return;
   afterCurrentNavigationFrame(() => {
     const input =
       document.querySelector<HTMLInputElement>("#spotlight-input");
@@ -10777,8 +10784,13 @@ function diagnosticsPackageCacheState(): DiagnosticsPackageCacheState {
 }
 
 function renderDiagnosticsPage() {
-  const restoreHeadingFocus = diagnosticsHeadingFocusPending
-    || document.activeElement?.id === "diagnostics-heading";
+  const activeId = document.activeElement?.id;
+  const focusTargetId = diagnosticsHeadingFocusPending
+    || activeId === "diagnostics-heading"
+    ? "diagnostics-heading"
+    : activeId === "diagnostics-product" || activeId === "diagnostics-back"
+      ? activeId
+      : null;
   state.diagnosticsCapturedAtUtc ??= new Date().toISOString();
   document.title = "Diagnostics · dotnet-inspect";
   app.innerHTML = diagnosticsViewHtml({
@@ -10789,12 +10801,25 @@ function renderDiagnosticsPage() {
   }, value => escapeHtml(value));
   bindDiagnosticsView(document, {
     onBack: closeDiagnosticsRoute,
+    onHome: openDiagnosticsHome,
   });
-  if (restoreHeadingFocus) {
+  if (focusTargetId) {
+    const focusGeneration = documentFocusGeneration;
     requestAnimationFrame(() => {
-      if (!isDiagnosticsPath(location.pathname)) return;
-      diagnosticsHeadingFocusPending = false;
-      focusLevelOneHeading();
+      if (!isDiagnosticsPath(location.pathname)) {
+        diagnosticsHeadingFocusPending = false;
+        return;
+      }
+      if (focusGeneration !== documentFocusGeneration) {
+        diagnosticsHeadingFocusPending = false;
+        return;
+      }
+      if (focusTargetId === "diagnostics-heading") {
+        diagnosticsHeadingFocusPending = false;
+        focusLevelOneHeading();
+        return;
+      }
+      document.getElementById(focusTargetId)?.focus({ preventScroll: true });
     });
   }
 }
@@ -10808,6 +10833,7 @@ function openDiagnosticsRoute() {
   state.home = false;
   state.diagnosticsCapturedAtUtc = new Date().toISOString();
   diagnosticsHeadingFocusPending = true;
+  diagnosticsDestinationFocusPending = false;
   if (state.engineReady) {
     state.packageCacheStatsStatus = "loading";
     state.packageCacheStatsError = "";
@@ -10820,11 +10846,17 @@ function openDiagnosticsRoute() {
 }
 
 function closeDiagnosticsRoute() {
+  diagnosticsDestinationFocusPending = true;
   if (isDiagnosticsHistoryEntry(history.state)) {
     history.back();
     return;
   }
   replaceDiagnosticsWithHome();
+}
+
+function openDiagnosticsHome() {
+  diagnosticsDestinationFocusPending = true;
+  goHome();
 }
 
 function replaceDiagnosticsWithHome() {
@@ -10856,6 +10888,31 @@ function afterCurrentNavigationFrame(action: () => void) {
   const navigationSeq = navigationSequence.current();
   requestAnimationFrame(() => {
     if (navigationSequence.isCurrent(navigationSeq)) action();
+  });
+}
+
+function scheduleDiagnosticsDestinationFocus() {
+  if (!diagnosticsDestinationFocusPending
+    || diagnosticsDestinationFocusScheduled
+    || isDiagnosticsPath(location.pathname)) {
+    return;
+  }
+  const navigationSeq = navigationSequence.current();
+  const focusGeneration = documentFocusGeneration;
+  diagnosticsDestinationFocusScheduled = true;
+  requestAnimationFrame(() => {
+    diagnosticsDestinationFocusScheduled = false;
+    if (!diagnosticsDestinationFocusPending) return;
+    if (!navigationSequence.isCurrent(navigationSeq)
+      || isDiagnosticsPath(location.pathname)) {
+      diagnosticsDestinationFocusPending = false;
+      return;
+    }
+    const heading = document.querySelector<HTMLElement>("main h1");
+    if (!heading) return;
+    diagnosticsDestinationFocusPending = false;
+    if (focusGeneration !== documentFocusGeneration) return;
+    focusLevelOneHeading();
   });
 }
 
@@ -15776,6 +15833,10 @@ function dismissModalsForRoutedNavigation() {
 
 window.addEventListener("popstate", () => {
   void (async () => {
+  if (!isDiagnosticsPath(location.pathname)
+    && document.querySelector(".diagnostics-view")) {
+    diagnosticsDestinationFocusPending = true;
+  }
   const leftPackageQueryHandoff = currentPackageQueryHandoff();
   const navigationSeq = navigationSequence.begin();
   let leftPackageQueryForWorkspaceSuccessor = false;
@@ -15811,6 +15872,7 @@ window.addEventListener("popstate", () => {
   }
   if (dismissedAnnotatedSourceModal) render({ synchronizeUrl: false });
   if (isDiagnosticsPath(location.pathname)) {
+    diagnosticsDestinationFocusPending = false;
     clearNavigationError();
     state.packageQueryOpen = false;
     packageQueryController.cancel();

--- a/inspect-web/src/dotnet-inspect.ts
+++ b/inspect-web/src/dotnet-inspect.ts
@@ -450,6 +450,7 @@ import {
   diagnosticsViewHtml,
   type DiagnosticsPackageCacheState,
   type DiagnosticsRuntimeState,
+  type DiagnosticsBuildState,
   type RuntimeStartupDiagnostics,
 } from "./diagnostics-view.ts";
 import {
@@ -1028,6 +1029,8 @@ const initialState = {
   retryAction: null,
   diag: null,
   buildIdentity: null,
+  buildIdentityStatus: "loading" as "loading" | "ready" | "failed",
+  buildIdentityError: "",
   packageCacheStats: null,
   packageCacheStatsStatus: "idle" as
     "idle" | "loading" | "ready" | "failed",
@@ -1085,6 +1088,7 @@ interface StateOverrides {
   retryAction: ErrorRetryAction;
   diag: RuntimeStartupDiagnostics | null;
   buildIdentity: BrowserBuildIdentity | null;
+  buildIdentityStatus: "loading" | "ready" | "failed";
   packageCacheStats: BrowserPackageCacheStats | null;
   packageCacheStatsStatus: "idle" | "loading" | "ready" | "failed";
   diagnosticsCapturedAtUtc: string | null;
@@ -1437,6 +1441,8 @@ function captureRetainedHostState() {
     engineStatus: state.engineStatus,
     diag: state.diag,
     buildIdentity: state.buildIdentity,
+    buildIdentityStatus: state.buildIdentityStatus,
+    buildIdentityError: state.buildIdentityError,
     packageCacheStats: state.packageCacheStats,
     packageCacheStatsStatus: state.packageCacheStatsStatus,
     packageCacheStatsError: state.packageCacheStatsError,
@@ -10783,6 +10789,23 @@ function diagnosticsPackageCacheState(): DiagnosticsPackageCacheState {
   return { kind: "loading" };
 }
 
+function diagnosticsBuildState(): DiagnosticsBuildState {
+  if (state.buildIdentityStatus === "failed") {
+    return {
+      kind: "failed",
+      message: state.buildIdentityError
+        || "Product build identity is unavailable.",
+    };
+  }
+  if (state.buildIdentityStatus === "ready" && state.buildIdentity) {
+    return {
+      kind: "ready",
+      identity: state.buildIdentity,
+    };
+  }
+  return { kind: "loading" };
+}
+
 function renderDiagnosticsPage() {
   const activeId = document.activeElement?.id;
   const focusTargetId = diagnosticsHeadingFocusPending
@@ -10797,7 +10820,7 @@ function renderDiagnosticsPage() {
   document.title = "Diagnostics · dotnet-inspect";
   app.innerHTML = diagnosticsViewHtml({
     runtime: diagnosticsRuntimeState(),
-    buildIdentity: state.buildIdentity,
+    build: diagnosticsBuildState(),
     packageCache: diagnosticsPackageCacheState(),
     capturedAtUtc: state.diagnosticsCapturedAtUtc,
   }, value => escapeHtml(value));
@@ -14987,6 +15010,12 @@ function showEngineFailure(error: unknown) {
   state.errorDetail = error instanceof Error
     ? error.stack || error.message
     : String(error);
+  if (state.buildIdentityStatus !== "ready") {
+    state.buildIdentity = null;
+    state.buildIdentityStatus = "failed";
+    state.buildIdentityError =
+      "Product build identity is unavailable because the inspection engine did not start.";
+  }
   state.retryAction = () => window.location.reload();
   if (!state.credits) render();
 }
@@ -14996,6 +15025,9 @@ async function bootstrap() {
   state.engineReady = false;
   state.engineStartupFailed = false;
   state.engineStatus = "Loading browser WebAssembly…";
+  state.buildIdentity = null;
+  state.buildIdentityStatus = "loading";
+  state.buildIdentityError = "";
   state.error = "";
   state.retryAction = null;
   render();
@@ -15011,7 +15043,16 @@ async function bootstrap() {
     reportEngineStatus("Loading .NET WebAssembly…");
     await startEngine(window.location.origin);
     reportEngineStatus("Reading package assemblies…");
-    state.buildIdentity = await engineClient.host.buildIdentity();
+    try {
+      state.buildIdentity = await engineClient.host.buildIdentity();
+      state.buildIdentityStatus = "ready";
+    } catch (error) {
+      state.buildIdentity = null;
+      state.buildIdentityStatus = "failed";
+      state.buildIdentityError =
+        `Product build identity is unavailable: ${errorMessage(error)}`;
+      console.error("Product build identity is unavailable.", error);
+    }
     const tEngine = performance.now();
     try {
       const vocabulary = await engineClient.catalog.listVocabulary();
@@ -15125,13 +15166,13 @@ function computeDiagnostics(
   }
   const hasAssets = assets.length > 0 && Number.isFinite(firstStart);
   return {
-    downloadMs: hasAssets ? lastEnd - firstStart : 0,
+    downloadMs: hasAssets ? lastEnd - firstStart : null,
     startupMs: hasAssets ? Math.max(0, tEngine - lastEnd) : tEngine - tStart,
     precomputeMs: tReady - tEngine,
     totalMs: tReady - tStart,
-    transfer,
-    decoded,
-    assets: assets.length
+    transfer: hasAssets ? transfer : null,
+    decoded: hasAssets ? decoded : null,
+    assets: hasAssets ? assets.length : null
   };
 }
 

--- a/inspect-web/src/engine-worker-client.ts
+++ b/inspect-web/src/engine-worker-client.ts
@@ -175,6 +175,20 @@ function startFailureReason(
     : reason.kind;
 }
 
+function registerEngineWorkerCanaryAdapter(host: EngineWorkerHost) {
+  return host.registerOperation({
+    kind: engineWorkerCanaryKind,
+    allowance: { kind: "unbounded" },
+    encodeInput: (input: string) => engineWorkerText.decode(input),
+    value: engineWorkerText,
+    error: engineWorkerText,
+    diagnostic: engineWorkerText,
+    progress: engineWorkerText,
+    mapPreparationError: error => error,
+    boundaryErrors: engineWorkerBoundaryErrors,
+  });
+}
+
 function packageQueryRequest(
   searchText: string,
   facetIdsJson: string,
@@ -556,17 +570,7 @@ export function bindPackageQueryFacade(
 // migration or a claim that application operations already run in this Worker.
 export function createEngineWorkerProbe(options: EngineWorkerProbeOptions) {
   const host = createHost(options);
-  const adapter = host.registerOperation({
-    kind: engineWorkerCanaryKind,
-    allowance: { kind: "unbounded" },
-    encodeInput: (input: string) => engineWorkerText.decode(input),
-    value: engineWorkerText,
-    error: engineWorkerText,
-    diagnostic: engineWorkerText,
-    progress: engineWorkerText,
-    mapPreparationError: error => error,
-    boundaryErrors: engineWorkerBoundaryErrors,
-  });
+  const adapter = registerEngineWorkerCanaryAdapter(host);
   const typeSourceAdapter = registerEngineWorkerTypeSourceAdapter(host);
   const page = createOperationAuthorityPage();
   const cpu = bindEngineWorkerCpuProbe(host, page, options.operationDiagnostic);
@@ -635,6 +639,27 @@ export function createProductionEngineWorkerClient(
   }
 
   const authority = createSharedEngineOperationAuthority();
+  const readinessAdapter = registerEngineWorkerCanaryAdapter(host);
+  const readinessSession = authority.page.createSession<
+    string, string, string, string, WorkerRuntimePreparationError
+  >({
+    feature: { publish: () => undefined },
+    diagnostic: { report: options.operationDiagnostic },
+  });
+  const readiness = readinessSession.start("", readinessAdapter);
+  const ready = (async () => {
+    if (readiness.kind !== "started") {
+      throw new Error(
+        `Engine readiness probe refused: ${startFailureReason(readiness.reason)}.`);
+    }
+    const outcome = await readiness.handle.outcome;
+    await readiness.handle.quiesced;
+    if (outcome.kind === "succeeded") return;
+    if (outcome.kind === "failed") {
+      throw new Error(`Engine readiness probe failed: ${outcome.error}`);
+    }
+    throw new Error(`Engine readiness probe was canceled: ${outcome.reason}.`);
+  })();
   const startup = bindEngineWorkerStartupClient(
     host,
     options.operationDiagnostic,
@@ -656,6 +681,9 @@ export function createProductionEngineWorkerClient(
     authority,
   );
   const identity = startup.host.buildIdentity();
+  // The eager startup read may settle before the page awaits it. Observe that
+  // rejection now; the retained promise still rejects to the Build consumer.
+  void identity.catch(() => undefined);
   const client: EngineClient = {
     host: {
       buildIdentity: () => identity,
@@ -680,8 +708,9 @@ export function createProductionEngineWorkerClient(
   return {
     host,
     client,
-    ready: identity.then(() => undefined),
+    ready,
     dispose() {
+      readinessSession.dispose();
       packageQuery.dispose();
       typeSource.dispose();
       host.dispose();

--- a/inspect-web/src/entry-routes.ts
+++ b/inspect-web/src/entry-routes.ts
@@ -1,6 +1,7 @@
 export const ROUTED_ENTRY_PATHS = {
   credits: "/credits",
   demos: "/demos",
+  diagnostics: "/diagnostics",
   packageQuery: "/query",
 } as const;
 
@@ -9,6 +10,7 @@ export const ENTRY_DOCUMENT_PATHS = [
   "/index.html",
   ROUTED_ENTRY_PATHS.credits,
   ROUTED_ENTRY_PATHS.demos,
+  ROUTED_ENTRY_PATHS.diagnostics,
   ROUTED_ENTRY_PATHS.packageQuery,
 ] as const;
 

--- a/inspect-web/src/settings-panel.ts
+++ b/inspect-web/src/settings-panel.ts
@@ -39,6 +39,7 @@ export function reconcileStyleTaste(
 
 export interface SettingsPanelBindingActions {
   onClose: () => void;
+  onOpenDiagnostics: () => void;
   onOpen: (from: "home" | "workbench") => void;
   onTasteClear: () => void;
   onTasteToggle: (taste: string) => void;
@@ -55,6 +56,9 @@ export function bindSettingsPanel(
   root.querySelector("#home-settings")?.addEventListener(
     "click",
     () => actions.onOpen("home"));
+  root.querySelector("#settings-diagnostics-open")?.addEventListener(
+    "click",
+    actions.onOpenDiagnostics);
   const backdrop = root.querySelector<HTMLElement>("#settings-backdrop");
   backdrop?.addEventListener("click", event => {
     if (event.target === backdrop) actions.onClose();
@@ -165,6 +169,16 @@ export function renderSettingsView(options: RenderSettingsViewOptions): string {
               ${activeCount
                 ? '<button id="settings-taste-clear" type="button" class="settings-reset">Reset to default</button>'
                 : '<span class="settings-muted">Default · opcode-faithful</span>'}
+            </div>
+          </section>
+
+          <section class="settings-section">
+            <div class="settings-section-head">
+              <h2>Diagnostics</h2>
+              <p>View runtime, build, and aggregate package-cache evidence for this browser session.</p>
+            </div>
+            <div class="settings-control">
+              <button id="settings-diagnostics-open" type="button" class="settings-reset">Open Diagnostics</button>
             </div>
           </section>
         </div>

--- a/inspect-web/src/styles.css
+++ b/inspect-web/src/styles.css
@@ -3657,3 +3657,433 @@ kbd {
 :root[data-theme="light"] .annotated-source-code .token.attribute,
 :root[data-theme="light"] .annotated-source-code .token.namespace,
 :root[data-theme="light"] .annotated-source-code .token.preprocessor { color: #6c4d91; }
+
+/* Routed Diagnostics surface */
+.diagnostics-view {
+  width: 100%;
+  height: 100vh;
+  min-width: 0;
+  display: grid;
+  grid-template-rows: 52px minmax(0, 1fr);
+  overflow: hidden;
+  background:
+    radial-gradient(900px 520px at 86% -12%, var(--shell-accent-soft), transparent 62%),
+    var(--bg);
+}
+
+.diagnostics-header {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-right: 20px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--chrome) 88%, transparent);
+}
+
+.diagnostics-header .brand { height: 100%; }
+
+.diagnostics-back {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  background: var(--panel-raised);
+  color: var(--muted);
+  font: 11px var(--mono);
+}
+
+.diagnostics-back:hover,
+.diagnostics-back:focus-visible {
+  border-color: var(--shell-accent);
+  color: var(--text);
+}
+
+.diagnostics-main {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: clamp(24px, 4vw, 52px);
+}
+
+.diagnostics-title {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 28px;
+  margin-bottom: 24px;
+}
+
+.diagnostics-eyebrow {
+  margin: 0;
+  color: var(--shell-accent);
+  font: 10px var(--mono);
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.diagnostics-title h1 {
+  width: fit-content;
+  margin: 7px 0 0;
+  font-size: clamp(30px, 4vw, 46px);
+  letter-spacing: -.035em;
+}
+
+#diagnostics-heading:focus-visible {
+  outline-color: var(--shell-accent);
+  outline-offset: 3px;
+}
+
+.diagnostics-title > div > p:last-child {
+  max-width: 67ch;
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.diagnostics-runtime-state {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 13px 15px;
+  border: 1px solid color-mix(in srgb, var(--shell-accent) 45%, var(--line));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--shell-accent) 8%, var(--panel));
+}
+
+.diagnostics-runtime-state-ready {
+  border-color: color-mix(in srgb, var(--green) 45%, var(--line));
+  background: color-mix(in srgb, var(--green) 8%, var(--panel));
+}
+
+.diagnostics-runtime-state-failed {
+  border-color: color-mix(in srgb, var(--red, #d97070) 45%, var(--line));
+  background: color-mix(in srgb, var(--red, #d97070) 8%, var(--panel));
+}
+
+.diagnostics-runtime-dot {
+  width: 9px;
+  height: 9px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--shell-accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--shell-accent) 14%, transparent);
+}
+
+.diagnostics-runtime-state-ready .diagnostics-runtime-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--green) 14%, transparent);
+}
+
+.diagnostics-runtime-state-failed .diagnostics-runtime-dot {
+  background: var(--red, #d97070);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--red, #d97070) 14%, transparent);
+}
+
+.diagnostics-runtime-state strong { font: 12px var(--mono); }
+.diagnostics-runtime-state > span:last-child { color: var(--muted); font-size: 12px; }
+
+.diagnostics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  align-items: start;
+}
+
+.diagnostics-card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 94%, transparent);
+}
+
+.diagnostics-runtime-card { grid-column: 1 / -1; }
+
+.diagnostics-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel-raised);
+}
+
+.diagnostics-card-head h2 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.diagnostics-owner {
+  color: var(--dim);
+  font: 10px var(--mono);
+}
+
+.diagnostics-card-body { padding: 16px; }
+
+.diagnostics-total {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.diagnostics-total span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.diagnostics-total strong {
+  font: 24px var(--mono);
+}
+
+.diagnostics-phase-download { background: var(--shell-accent-fill); }
+.diagnostics-phase-startup { background: var(--blue); }
+.diagnostics-phase-precompute { background: var(--green); }
+
+.diagnostics-phase-bar {
+  height: 14px;
+  display: flex;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background: var(--code-bg);
+}
+
+.diagnostics-phase-bar span {
+  width: var(--diagnostics-phase-width);
+  min-width: 0;
+}
+
+.diagnostics-phase-legend {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 10px 0 0;
+}
+
+.diagnostics-phase-legend .diagnostics-fact {
+  display: block;
+  padding: 0;
+  border: 0;
+}
+
+.diagnostics-phase-legend .diagnostics-fact dt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.diagnostics-phase-legend .diagnostics-fact dt::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 2px;
+}
+
+.diagnostics-fact-phase-download dt::before { background: var(--shell-accent-fill); }
+.diagnostics-fact-phase-startup dt::before { background: var(--blue); }
+.diagnostics-fact-phase-precompute dt::before { background: var(--green); }
+
+.diagnostics-phase-legend .diagnostics-fact dd {
+  margin-top: 3px;
+  font-size: 12px;
+  text-align: left;
+}
+
+.diagnostics-facts {
+  margin: 0;
+  padding: 16px;
+}
+
+.diagnostics-fact {
+  display: grid;
+  grid-template-columns: minmax(104px, .7fr) minmax(0, 1.3fr);
+  gap: 16px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.diagnostics-fact:first-child { padding-top: 0; }
+.diagnostics-fact:last-child { padding-bottom: 0; border-bottom: 0; }
+
+.diagnostics-fact dt {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.diagnostics-fact dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  font: 11px/1.45 var(--mono);
+  text-align: right;
+}
+
+.diagnostics-fact a {
+  color: var(--shell-accent);
+  font-size: 10px;
+  text-underline-offset: 3px;
+}
+
+.diagnostics-fact code {
+  color: inherit;
+  font: inherit;
+}
+
+.diagnostics-runtime-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 0;
+  margin-top: 18px;
+}
+
+.diagnostics-runtime-facts .diagnostics-fact {
+  display: block;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg);
+}
+
+.diagnostics-runtime-facts .diagnostics-fact dt {
+  color: var(--dim);
+  font: 10px var(--mono);
+  text-transform: uppercase;
+}
+
+.diagnostics-runtime-facts .diagnostics-fact dd {
+  margin-top: 6px;
+  font-size: 15px;
+  text-align: left;
+}
+
+.diagnostics-unavailable {
+  margin: 16px;
+  color: var(--dim);
+  font: 12px/1.5 var(--mono);
+}
+
+.diagnostics-failure-detail {
+  max-height: 220px;
+  margin: 16px;
+  padding: 12px;
+  overflow: auto;
+  border: 1px solid color-mix(in srgb, var(--red, #d97070) 35%, var(--line));
+  border-radius: 5px;
+  background: var(--code-bg);
+  color: var(--muted);
+  font: 11px/1.55 var(--mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.diagnostics-progress {
+  height: 4px;
+  margin: 18px 16px 16px;
+  overflow: hidden;
+  border-radius: 3px;
+  background: var(--code-bg);
+}
+
+.diagnostics-progress span {
+  width: 36%;
+  height: 100%;
+  display: block;
+  background: var(--shell-accent-fill);
+  animation: diagnostics-progress 1.4s ease-in-out infinite alternate;
+}
+
+@keyframes diagnostics-progress {
+  from { transform: translateX(-20%); }
+  to { transform: translateX(200%); }
+}
+
+.diagnostics-inline-state {
+  min-height: 92px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px;
+  color: var(--muted);
+}
+
+.diagnostics-inline-state p { margin: 0; font-size: 12px; }
+
+.diagnostics-inline-spinner {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  border: 2px solid var(--line-strong);
+  border-top-color: var(--shell-accent);
+  border-radius: 50%;
+  animation: diagnostics-spin .8s linear infinite;
+}
+
+.diagnostics-inline-failed {
+  color: var(--red, #d97070);
+}
+
+.diagnostics-inline-failed > span {
+  width: 20px;
+  height: 20px;
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--red, #d97070) 14%, transparent);
+  font: 11px var(--mono);
+}
+
+@keyframes diagnostics-spin {
+  to { transform: rotate(360deg); }
+}
+
+.diagnostics-captured {
+  flex: none;
+  margin: 0;
+  color: var(--dim);
+  font: 10px var(--mono);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diagnostics-progress span,
+  .diagnostics-inline-spinner { animation: none; }
+}
+
+@media (max-width: 760px) {
+  .diagnostics-view { grid-template-rows: 48px minmax(0, 1fr); }
+  .diagnostics-header { padding-right: 10px; }
+  .diagnostics-header .brand { width: auto; padding-right: 10px; }
+  .diagnostics-main { padding: 22px 14px 36px; }
+  .diagnostics-title { display: block; margin-bottom: 18px; }
+  .diagnostics-captured { margin-top: 12px; }
+  .diagnostics-runtime-state { align-items: flex-start; flex-wrap: wrap; }
+  .diagnostics-runtime-state > span:last-child {
+    flex-basis: calc(100% - 19px);
+    margin-left: 19px;
+  }
+  .diagnostics-grid { grid-template-columns: minmax(0, 1fr); }
+  .diagnostics-runtime-card { grid-column: auto; }
+  .diagnostics-runtime-facts { grid-template-columns: minmax(0, 1fr); }
+  .diagnostics-phase-legend { grid-template-columns: minmax(0, 1fr); gap: 6px; }
+  .diagnostics-phase-legend .diagnostics-fact {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 14px;
+  }
+  .diagnostics-phase-legend .diagnostics-fact dd { margin-top: 0; text-align: right; }
+  .diagnostics-card-head { align-items: flex-start; }
+}

--- a/inspect-web/staticwebapp.config.json
+++ b/inspect-web/staticwebapp.config.json
@@ -34,6 +34,13 @@
       }
     },
     {
+      "route": "/diagnostics",
+      "rewrite": "/index.html",
+      "headers": {
+        "Cache-Control": "no-cache, no-store, must-revalidate"
+      }
+    },
+    {
       "route": "/query",
       "rewrite": "/index.html",
       "headers": {

--- a/inspect-web/test/command-bar.test.ts
+++ b/inspect-web/test/command-bar.test.ts
@@ -49,6 +49,7 @@ test("the empty command scope offers the root command grammar", () => {
       "framework",
       "find",
       "clear",
+      "diagnostics",
       "share",
       "settings",
       "keyboard help",
@@ -198,6 +199,7 @@ test("trailing whitespace preserves completed command arguments", () => {
     ["framework net9.0 ", "framework net9.0"],
     ["types kind ", "types kind"],
     ["clear ", "clear"],
+    ["diagnostics ", "diagnostics"],
     ["share ", "share"],
     ["settings ", "settings"],
     ["keyboard help ", "keyboard help"],
@@ -212,6 +214,7 @@ test("trailing whitespace preserves completed command arguments", () => {
   for (const invalid of [
     "show metadata extra ",
     "clear clear",
+    "diagnostics extra",
     "share share ",
     "settings settings ",
     "keyboard help extra ",

--- a/inspect-web/test/diagnostics-route.test.ts
+++ b/inspect-web/test/diagnostics-route.test.ts
@@ -15,8 +15,16 @@ test("Diagnostics recognizes hosted entry paths", () => {
 
 test("Diagnostics marks in-app history without discarding retained state", () => {
   const state = diagnosticsHistoryState({ retainedWorkspaceId: "workspace-1" });
+  const marker = Object.entries(state)
+    .find(([key]) => key !== "retainedWorkspaceId");
 
   assert.equal(state.retainedWorkspaceId, "workspace-1");
+  assert.ok(marker);
+  assert.equal(typeof marker[1], "string");
   assert.equal(isDiagnosticsHistoryEntry(state), true);
+  assert.equal(isDiagnosticsHistoryEntry({
+    ...state,
+    [marker[0]]: "previous-document",
+  }), false);
   assert.equal(isDiagnosticsHistoryEntry({}), false);
 });

--- a/inspect-web/test/diagnostics-route.test.ts
+++ b/inspect-web/test/diagnostics-route.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  diagnosticsHistoryState,
+  isDiagnosticsHistoryEntry,
+  isDiagnosticsPath,
+} from "../src/diagnostics-route.ts";
+
+test("Diagnostics recognizes hosted entry paths", () => {
+  assert.equal(isDiagnosticsPath("/diagnostics"), true);
+  assert.equal(isDiagnosticsPath("/diagnostics/"), true);
+  assert.equal(isDiagnosticsPath("/diagnostics/index.html"), false);
+  assert.equal(isDiagnosticsPath("/query"), false);
+});
+
+test("Diagnostics marks in-app history without discarding retained state", () => {
+  const state = diagnosticsHistoryState({ retainedWorkspaceId: "workspace-1" });
+
+  assert.equal(state.retainedWorkspaceId, "workspace-1");
+  assert.equal(isDiagnosticsHistoryEntry(state), true);
+  assert.equal(isDiagnosticsHistoryEntry({}), false);
+});

--- a/inspect-web/test/diagnostics-view.test.ts
+++ b/inspect-web/test/diagnostics-view.test.ts
@@ -18,6 +18,7 @@ const ready: DiagnosticsViewModel = {
   runtime: {
     kind: "ready",
     message: ".NET is running in this browser.",
+    measurementsPending: false,
     diagnostics: {
       downloadMs: 1010,
       startupMs: 522,
@@ -73,6 +74,7 @@ test("Diagnostics distinguishes valid zero bytes from unavailable values", () =>
     runtime: {
       kind: "ready",
       message: "Ready.",
+      measurementsPending: false,
       diagnostics: {
         downloadMs: 0,
         startupMs: 0,
@@ -120,12 +122,31 @@ test("Diagnostics keeps loading and unavailable data visible without zeroes", ()
   assert.doesNotMatch(html, />0</);
 });
 
+test("Diagnostics reports runtime readiness while startup measurements finish", () => {
+  const html = diagnosticsViewHtml({
+    ...ready,
+    runtime: {
+      kind: "ready",
+      message: "Ready.",
+      diagnostics: null,
+      measurementsPending: true,
+    },
+  }, escapeHtml);
+
+  assert.match(html, /Browser inspection engine ready/);
+  assert.match(html, /Finishing startup measurements\./);
+  assert.doesNotMatch(
+    html,
+    /Startup measurements are unavailable for this session\./);
+});
+
 test("Diagnostics renders unavailable framework evidence and build failure", () => {
   const html = diagnosticsViewHtml({
     ...ready,
     runtime: {
       kind: "ready",
       message: "Ready.",
+      measurementsPending: false,
       diagnostics: {
         downloadMs: null,
         startupMs: 522,

--- a/inspect-web/test/diagnostics-view.test.ts
+++ b/inspect-web/test/diagnostics-view.test.ts
@@ -28,11 +28,14 @@ const ready: DiagnosticsViewModel = {
       assets: 42,
     },
   },
-  buildIdentity: {
-    version: "1.2.3",
-    commit: "0123456789abcdef0123456789abcdef01234567",
-    builtAtUtc: "2026-01-23T15:41:12Z",
-    commitUrl: "https://github.com/richlander/dotnet-inspect/commit/0123456789abcdef0123456789abcdef01234567",
+  build: {
+    kind: "ready",
+    identity: {
+      version: "1.2.3",
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      builtAtUtc: "2026-01-23T15:41:12Z",
+      commitUrl: "https://github.com/richlander/dotnet-inspect/commit/0123456789abcdef0123456789abcdef01234567",
+    },
   },
   packageCache: {
     kind: "ready",
@@ -101,7 +104,9 @@ test("Diagnostics keeps loading and unavailable data visible without zeroes", ()
       kind: "loading",
       message: "Starting <runtime>.",
     },
-    buildIdentity: null,
+    build: {
+      kind: "loading",
+    },
     packageCache: {
       kind: "loading",
     },
@@ -109,10 +114,39 @@ test("Diagnostics keeps loading and unavailable data visible without zeroes", ()
   }, escapeHtml);
 
   assert.match(html, /Starting &lt;runtime&gt;\./);
-  assert.match(html, /Build identity/);
-  assert.match(html, />Unavailable</);
+  assert.match(html, /Reading product build identity\./);
+  assert.match(html, /Captured Unavailable/);
   assert.match(html, /Reading aggregate package-cache statistics\./);
   assert.doesNotMatch(html, />0</);
+});
+
+test("Diagnostics renders unavailable framework evidence and build failure", () => {
+  const html = diagnosticsViewHtml({
+    ...ready,
+    runtime: {
+      kind: "ready",
+      message: "Ready.",
+      diagnostics: {
+        downloadMs: null,
+        startupMs: 522,
+        precomputeMs: 308,
+        totalMs: 830,
+        transfer: null,
+        decoded: null,
+        assets: null,
+      },
+    },
+    build: {
+      kind: "failed",
+      message: "Build <identity> unavailable.",
+    },
+  }, escapeHtml);
+
+  assert.match(html, /Download[\s\S]*Unavailable/);
+  assert.match(html, /Framework assets[\s\S]*Unavailable/);
+  assert.match(html, /Transferred[\s\S]*Unavailable/);
+  assert.match(html, /Decoded[\s\S]*Unavailable/);
+  assert.match(html, /Build &lt;identity&gt; unavailable\./);
 });
 
 test("Diagnostics renders explicit runtime and cache failures with escaped detail", () => {

--- a/inspect-web/test/diagnostics-view.test.ts
+++ b/inspect-web/test/diagnostics-view.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindDiagnosticsView,
+  diagnosticsViewHtml,
+  type DiagnosticsViewModel,
+} from "../src/diagnostics-view.ts";
+import { fakeDom } from "./fake-dom.ts";
+
+const escapeHtml = (value: string) => value
+  .replaceAll("&", "&amp;")
+  .replaceAll("<", "&lt;")
+  .replaceAll(">", "&gt;")
+  .replaceAll('"', "&quot;")
+  .replaceAll("'", "&#039;");
+
+const ready: DiagnosticsViewModel = {
+  runtime: {
+    kind: "ready",
+    message: ".NET is running in this browser.",
+    diagnostics: {
+      downloadMs: 1010,
+      startupMs: 522,
+      precomputeMs: 308,
+      totalMs: 1840,
+      transfer: 3_100_000,
+      decoded: 9_800_000,
+      assets: 42,
+    },
+  },
+  buildIdentity: {
+    version: "1.2.3",
+    commit: "0123456789abcdef0123456789abcdef01234567",
+    builtAtUtc: "2026-01-23T15:41:12Z",
+    commitUrl: "https://github.com/richlander/dotnet-inspect/commit/0123456789abcdef0123456789abcdef01234567",
+  },
+  packageCache: {
+    kind: "ready",
+    stats: {
+      packages: 7,
+      resident: 5,
+      workspaces: 2,
+      residentBytes: 12_582_912,
+    },
+  },
+  capturedAtUtc: "2026-01-23T15:45:00Z",
+};
+
+test("Diagnostics renders runtime, build, and package-cache evidence in order", () => {
+  const html = diagnosticsViewHtml(ready, escapeHtml);
+
+  assert.ok(html.indexOf(">Runtime startup<") < html.indexOf(">Build<"));
+  assert.ok(html.indexOf(">Build<") < html.indexOf(">Package cache<"));
+  assert.match(html, /Download/);
+  assert.match(html, /1\.01 s/);
+  assert.match(html, /Framework assets/);
+  assert.match(html, />42</);
+  assert.match(html, /0123456789abcdef0123456789abcdef01234567/);
+  assert.match(html, /Browser \/ WebAssembly/);
+  assert.match(html, /Resident payloads/);
+  assert.match(html, /12 MB/);
+  assert.match(html, /Startup phase legend/);
+  assert.match(html, /Browser Performance API/);
+});
+
+test("Diagnostics distinguishes valid zero bytes from unavailable values", () => {
+  const html = diagnosticsViewHtml({
+    ...ready,
+    runtime: {
+      kind: "ready",
+      message: "Ready.",
+      diagnostics: {
+        downloadMs: 0,
+        startupMs: 0,
+        precomputeMs: 0,
+        totalMs: 0,
+        transfer: 0,
+        decoded: 0,
+        assets: 0,
+      },
+    },
+    packageCache: {
+      kind: "ready",
+      stats: {
+        packages: 0,
+        resident: 0,
+        workspaces: 0,
+        residentBytes: 0,
+      },
+    },
+  }, escapeHtml);
+
+  assert.match(html, /0 B/);
+  assert.match(html, />0</);
+});
+
+test("Diagnostics keeps loading and unavailable data visible without zeroes", () => {
+  const html = diagnosticsViewHtml({
+    runtime: {
+      kind: "loading",
+      message: "Starting <runtime>.",
+    },
+    buildIdentity: null,
+    packageCache: {
+      kind: "loading",
+    },
+    capturedAtUtc: "not-a-date",
+  }, escapeHtml);
+
+  assert.match(html, /Starting &lt;runtime&gt;\./);
+  assert.match(html, /Build identity/);
+  assert.match(html, />Unavailable</);
+  assert.match(html, /Reading aggregate package-cache statistics\./);
+  assert.doesNotMatch(html, />0</);
+});
+
+test("Diagnostics renders explicit runtime and cache failures with escaped detail", () => {
+  const html = diagnosticsViewHtml({
+    ...ready,
+    runtime: {
+      kind: "failed",
+      message: "Browser inspection engine failed.",
+      detail: "<script>alert(1)</script>",
+    },
+    packageCache: {
+      kind: "failed",
+      message: "Cache <offline>.",
+    },
+  }, escapeHtml);
+
+  assert.match(html, /diagnostics-runtime-failed/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /Cache &lt;offline&gt;\./);
+  assert.doesNotMatch(html, /<script>/);
+});
+
+test("Diagnostics binds product and Back controls to the same route action", () => {
+  const listeners = new Map<string, EventListener>();
+  const root = {
+    querySelector(selector: string) {
+      return selector === "#diagnostics-product" || selector === "#diagnostics-back"
+        ? {
+            addEventListener(_type: string, listener: EventListener) {
+              listeners.set(selector, listener);
+            },
+          }
+        : null;
+    },
+  };
+  let calls = 0;
+
+  bindDiagnosticsView(fakeDom.parentNode(root), { onBack: () => calls++ });
+  const event = fakeDom.event({ preventDefault() {} });
+  listeners.get("#diagnostics-product")?.(event);
+  listeners.get("#diagnostics-back")?.(event);
+
+  assert.equal(calls, 2);
+});

--- a/inspect-web/test/diagnostics-view.test.ts
+++ b/inspect-web/test/diagnostics-view.test.ts
@@ -56,6 +56,7 @@ test("Diagnostics renders runtime, build, and package-cache evidence in order", 
   assert.match(html, /Framework assets/);
   assert.match(html, />42</);
   assert.match(html, /0123456789abcdef0123456789abcdef01234567/);
+  assert.match(html, /id="diagnostics-commit"/);
   assert.match(html, /Browser \/ WebAssembly/);
   assert.match(html, /Resident payloads/);
   assert.match(html, /12 MB/);

--- a/inspect-web/test/diagnostics-view.test.ts
+++ b/inspect-web/test/diagnostics-view.test.ts
@@ -134,7 +134,7 @@ test("Diagnostics renders explicit runtime and cache failures with escaped detai
   assert.doesNotMatch(html, /<script>/);
 });
 
-test("Diagnostics binds product and Back controls to the same route action", () => {
+test("Diagnostics binds product Home and Back as distinct route actions", () => {
   const listeners = new Map<string, EventListener>();
   const root = {
     querySelector(selector: string) {
@@ -147,12 +147,15 @@ test("Diagnostics binds product and Back controls to the same route action", () 
         : null;
     },
   };
-  let calls = 0;
+  const calls: string[] = [];
 
-  bindDiagnosticsView(fakeDom.parentNode(root), { onBack: () => calls++ });
+  bindDiagnosticsView(fakeDom.parentNode(root), {
+    onBack: () => calls.push("back"),
+    onHome: () => calls.push("home"),
+  });
   const event = fakeDom.event({ preventDefault() {} });
   listeners.get("#diagnostics-product")?.(event);
   listeners.get("#diagnostics-back")?.(event);
 
-  assert.equal(calls, 2);
+  assert.deepEqual(calls, ["home", "back"]);
 });

--- a/inspect-web/test/settings-panel.test.ts
+++ b/inspect-web/test/settings-panel.test.ts
@@ -64,6 +64,7 @@ class FakeRoot {
         "one:#home-settings",
         "one:#settings-backdrop",
         "one:#settings-close",
+        "one:#settings-diagnostics-open",
         "one:#settings-dialog",
         "one:#settings-taste-clear",
       ].sort());
@@ -73,6 +74,7 @@ class FakeRoot {
 function recordingActions(calls: string[]): SettingsPanelBindingActions {
   return {
     onClose: () => calls.push("close"),
+    onOpenDiagnostics: () => calls.push("diagnostics"),
     onOpen: from => calls.push(`open:${from}`),
     onTasteClear: () => calls.push("clear"),
     onTasteToggle: taste => calls.push(`taste:${taste}`),
@@ -136,6 +138,8 @@ test("settings bindings dispatch valid settings-page controls", () => {
   const missingTaste = new FakeElement();
   root.addAll(".settings-taste [data-taste]", taste, missingTaste);
   const clear = root.add("#settings-taste-clear", new FakeElement());
+  const diagnostics =
+    root.add("#settings-diagnostics-open", new FakeElement());
   const calls: string[] = [];
   bindSettingsPanel(
     fakeDom.parentNode(root),
@@ -149,6 +153,7 @@ test("settings bindings dispatch valid settings-page controls", () => {
   taste.dispatch("change");
   missingTaste.dispatch("change");
   clear.dispatch("click");
+  diagnostics.dispatch("click");
 
   assert.deepEqual(calls, [
     "close",
@@ -156,6 +161,7 @@ test("settings bindings dispatch valid settings-page controls", () => {
     "theme:light",
     "taste:readable-locals",
     "clear",
+    "diagnostics",
   ]);
 });
 
@@ -178,6 +184,24 @@ test("style catalog groups render tiers, byte-divergent badges, and checked stat
   assert.match(html, /data-taste="readable-locals" checked/);
   assert.doesNotMatch(html, /data-taste="expanded-braces" checked/);
   assert.match(html, /oracle/);
+});
+
+test("settings renders the routed Diagnostics entry", () => {
+  const html = renderSettingsView({
+    theme: "dark",
+    settingsReturn: "workbench",
+    styleCatalog: {
+      styleTiers,
+      styleOptions,
+      styleCatalogError: "",
+      taste: [],
+    },
+    escapeHtml,
+  });
+
+  assert.match(html, /<h2>Diagnostics<\/h2>/);
+  assert.match(html, /id="settings-diagnostics-open"/);
+  assert.match(html, /Open Diagnostics/);
 });
 
 test("style catalog groups escape untrusted tier and option text", () => {

--- a/inspect-web/test/spotlight-identity.test.ts
+++ b/inspect-web/test/spotlight-identity.test.ts
@@ -611,6 +611,12 @@ const deploySource = readFileSync(
 const dataBarSource = readFileSync(
   new URL("../src/data-bar.ts", import.meta.url),
   "utf8");
+const diagnosticsViewSource = readFileSync(
+  new URL("../src/diagnostics-view.ts", import.meta.url),
+  "utf8");
+const diagnosticsRouteSource = readFileSync(
+  new URL("../src/diagnostics-route.ts", import.meta.url),
+  "utf8");
 const spotlightSource = readFileSync(
   new URL("../src/spotlight.ts", import.meta.url),
   "utf8");
@@ -1928,9 +1934,10 @@ test("typed settings panel owns its rendered control bindings", () => {
   assert.equal(innerSettingsCall.arguments.length, 2);
   assertIdentifierArgument(innerSettingsCall, 0, "document", "bindSettingsPanel");
   const actions = objectArgument(innerSettingsCall, 1, "bindSettingsPanel");
-  assert.equal(actions.properties.length, 5);
+  assert.equal(actions.properties.length, 6);
   const settingsActions: readonly (readonly [string, string])[] = [
     ["onClose", "closeSettings"],
+    ["onOpenDiagnostics", "openDiagnosticsRoute"],
     ["onOpen", "openSettings"],
     ["onTasteClear", "clearTaste"],
     ["onTasteToggle", "toggleTaste"],
@@ -2266,7 +2273,7 @@ test("annotated source Escape and history ownership track the mounted surface", 
     ?? "";
   assert.match(
     popstate,
-    /const dismissedAnnotatedSourceModal = dismissModalsForRoutedNavigation\(\);\s*invalidateMemberDestinationWork\(state\);[\s\S]*if \(dismissedAnnotatedSourceModal\) render\(\{ synchronizeUrl: false \}\);\s*if \(isPackageQueryPath/);
+    /const dismissedAnnotatedSourceModal = dismissModalsForRoutedNavigation\(\);\s*invalidateMemberDestinationWork\(state\);[\s\S]*if \(dismissedAnnotatedSourceModal\) render\(\{ synchronizeUrl: false \}\);\s*if \(isDiagnosticsPath/);
   assert.match(
     appSource,
     /function render\(options: \{ synchronizeUrl\?: boolean \} = \{\}\)[\s\S]*if \(productDemosRouteVisible\) \{\s*document\.title = "Demos — dotnet-inspect";\s*\} else if \(options\.synchronizeUrl !== false\) \{\s*syncUrl\(\);\s*\}/);
@@ -2492,6 +2499,30 @@ test("data bar shows versioned linked build provenance", () => {
   assert.match(
     deploySource,
     /-getProperty:VersionPrefix[\s\S]*-p:VersionPrefix="\$version"[\s\S]*-p:SourceRevisionId="\$GITHUB_SHA"[\s\S]*-p:BuildTimestampUtc="\$built_at"/);
+});
+
+test("Diagnostics is a routed typed surface outside the Application menu", () => {
+  assert.match(
+    appSource,
+    /if \(isDiagnosticsPath\(location\.pathname\)\) \{\s*loadingBotSrc = null;\s*renderDiagnosticsPage\(\);\s*return;/);
+  assert.match(
+    appSource,
+    /function renderDiagnosticsPage\(\)[\s\S]*diagnosticsViewHtml\(\{[\s\S]*bindDiagnosticsView\(document/);
+  assert.doesNotMatch(appSource, /class="diagnostics-/);
+  assert.match(
+    diagnosticsViewSource,
+    /<h1 id="diagnostics-heading" tabindex="-1">Diagnostics<\/h1>/);
+  assert.match(
+    diagnosticsViewSource,
+    /runtimeCardHtml\(model\.runtime[\s\S]*buildCardHtml\(model\.buildIdentity[\s\S]*cacheCardHtml\(model\.packageCache/);
+  assert.match(
+    diagnosticsRouteSource,
+    /DIAGNOSTICS_PATH = ROUTED_ENTRY_PATHS\.diagnostics[\s\S]*isRoutedEntryPath\(pathname, DIAGNOSTICS_PATH\)/);
+  const applicationMenu =
+    shellControlsSource.match(
+      /export function renderApplicationMenu\([\s\S]*?\n}/)?.[0]
+    ?? "";
+  assert.doesNotMatch(applicationMenu, /Diagnostics|diagnostics/);
 });
 
 test("bootstrap reconciles persisted style choices with the product catalog", () => {
@@ -2867,7 +2898,7 @@ test("initial workspace packet resolution waits for the engine phase", () => {
     /const initialWorkspace = workspaceLocation\.preflightCurrent\(\);\s*const initialLocation = initialWorkspace\.visible/);
   assert.match(
     appSource,
-    /state\.packageQueryOpen = isPackageQueryPath\(location\.pathname\);[\s\S]*const productHomeDemosOpen = isProductHomeDemosPath\(location\.pathname\);[\s\S]*state\.home = state\.credits\s*\|\| \(!state\.packageQueryOpen\s*&& !productHomeDemosOpen\s*&& !initialLocation\.package\s*&& !initialWorkspace\.hasWorkspaceState\s*&& !initialLocation\.routeFailure\)/);
+    /state\.packageQueryOpen = isPackageQueryPath\(location\.pathname\);[\s\S]*const diagnosticsOpen = isDiagnosticsPath\(location\.pathname\);[\s\S]*const productHomeDemosOpen = isProductHomeDemosPath\(location\.pathname\);[\s\S]*state\.home = state\.credits\s*\|\| \(!diagnosticsOpen\s*&& !state\.packageQueryOpen\s*&& !productHomeDemosOpen\s*&& !initialLocation\.package\s*&& !initialWorkspace\.hasWorkspaceState\s*&& !initialLocation\.routeFailure\)/);
   const restore = appSource.match(
     /async function restoreInitialWorkspace\(\)[\s\S]*?\n}\n\nfunction isStyleTier/)?.[0]
     ?? "";

--- a/inspect-web/test/spotlight-identity.test.ts
+++ b/inspect-web/test/spotlight-identity.test.ts
@@ -2472,7 +2472,9 @@ test("dependency graph render identity includes truncation and navigation", () =
 });
 
 test("data bar shows versioned linked build provenance", () => {
-  assert.match(appSource, /state\.buildIdentity = await engineClient\.host\.buildIdentity\(\)/);
+  assert.match(
+    appSource,
+    /state\.buildIdentity = await engineClient\.host\.buildIdentity\(\);[\s\S]*state\.buildIdentityStatus = "ready";[\s\S]*state\.buildIdentityStatus = "failed"/);
   assert.equal(appSource.match(/\bdataBarHtml\(\{/g)?.length, 4);
   assert.match(
     appSource,
@@ -2514,7 +2516,7 @@ test("Diagnostics is a routed typed surface outside the Application menu", () =>
     /<h1 id="diagnostics-heading" tabindex="-1">Diagnostics<\/h1>/);
   assert.match(
     diagnosticsViewSource,
-    /runtimeCardHtml\(model\.runtime[\s\S]*buildCardHtml\(model\.buildIdentity[\s\S]*cacheCardHtml\(model\.packageCache/);
+    /runtimeCardHtml\(model\.runtime[\s\S]*buildCardHtml\(model\.build[\s\S]*cacheCardHtml\(model\.packageCache/);
   assert.match(
     diagnosticsRouteSource,
     /DIAGNOSTICS_PATH = ROUTED_ENTRY_PATHS\.diagnostics[\s\S]*isRoutedEntryPath\(pathname, DIAGNOSTICS_PATH\)/);

--- a/inspect-web/test/spotlight-identity.test.ts
+++ b/inspect-web/test/spotlight-identity.test.ts
@@ -2474,7 +2474,7 @@ test("dependency graph render identity includes truncation and navigation", () =
 test("data bar shows versioned linked build provenance", () => {
   assert.match(
     appSource,
-    /state\.buildIdentity = await engineClient\.host\.buildIdentity\(\);[\s\S]*state\.buildIdentityStatus = "ready";[\s\S]*state\.buildIdentityStatus = "failed"/);
+    /async function loadBuildIdentity\(\) \{[\s\S]*state\.buildIdentity = await engineClient\.host\.buildIdentity\(\);[\s\S]*state\.buildIdentityStatus = "ready";[\s\S]*state\.buildIdentityStatus = "failed"/);
   assert.equal(appSource.match(/\bdataBarHtml\(\{/g)?.length, 4);
   assert.match(
     appSource,


### PR DESCRIPTION
dotnet-inspect builds robust, capable inspection experiences that are
conventionally sound, delightfully useful, or both. This change turns the
approved Diagnostics proposal into the first production routed experience for
current-session browser evidence.

The new `/diagnostics` surface composes existing typed runtime, build, and
aggregate package-cache evidence without adopting an IDE/workbench model or
inventing unavailable diagnostic facts.

## Demo

### Wide

![Wide routed Diagnostics surface](https://github.com/user-attachments/assets/e0e7b12e-bc11-40c8-99dc-7f8785ed14db)

### Narrow: initial position

![Narrow Diagnostics surface at the top](https://github.com/user-attachments/assets/f9f90cf1-bf87-44e7-bd45-f70fb764da07)

### Narrow: build and cache evidence

![Narrow Diagnostics surface at the end](https://github.com/user-attachments/assets/54044916-399e-4729-92a0-b00aeef202d8)

The routed page is available from both the focused Settings action and the
`diagnostics` Spotlight command. It keeps a retained Workspace intact, supports
browser and visible Back navigation, focuses its heading on entry, and uses one
internal vertical scroller at narrow widths.

## What changed

- Added one typed Diagnostics route and one pure markup owner.
- Presented runtime state, startup phases, exact build identity, and aggregate
  package-cache statistics with explicit loading, failure, unavailable, and
  valid-zero states.
- Added Settings and Spotlight entry while keeping Diagnostics out of the
  Application menu.
- Preserved routed history, direct-entry Back behavior, heading focus across
  refreshes, and retained Workspace state.
- Added deterministic unit, structural, static-hosting, and full-app Firefox
  coverage for wide, narrow, loading, startup-failure, and cache-failure cases.

Later owner-adoption slices may add operation history, package-source health,
cache-entry inventory and limits, support reports, or cache-management actions.
This renderer does not infer or mock those contracts.

## Validation

- `npm test`
- `npm run analyze`
- `npm run build`
- `npx playwright test browser/library-hierarchy.spec.ts --project=firefox --grep Diagnostics`
- `npx markdownlint-cli inspect-web/README.md docs/design/inspect-web-surface-composition.md`
- `git diff --check`

Closes #6642
