### PR TITLE
Restore CoreCLR Web correctness without R2R

### DIFF
--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -180,9 +180,7 @@ jobs:
                   targetFramework: $target_framework,
                   configuration: {
                     asyncLowering: "runtime",
-                    publishReadyToRun: true,
-                    publishReadyToRunComposite: false,
-                    readyToRunContainer: "wasm",
+                    publishReadyToRun: false,
                     wasmBuildNative: false
                   },
                   workload: {
@@ -205,6 +203,7 @@ jobs:
         run: |
           npm ci
           npm run build
+          npx playwright install --with-deps firefox
           grep -q '<script type="importmap"></script>' dist/index.html
           grep -Eq '<link rel="preload" id="webassembly"[[:space:]]*/?>' dist/index.html
 
@@ -251,8 +250,7 @@ jobs:
             -p:BuildTimestampUtc="$built_at" \
             -p:Features=runtime-async=on \
             -p:UseMonoRuntime=false \
-            -p:PublishReadyToRun=true \
-            -p:PublishReadyToRunComposite=false \
+            -p:PublishReadyToRun=false \
             -p:WasmBuildNative=false \
             -p:WasmNestedPublishAppDependsOn= \
             -p:WasmEnableExceptionHandling=true \
@@ -264,11 +262,6 @@ jobs:
             artifacts/inspect-web-coreclr-runtime-cohort/workload-list.txt \
             artifacts/inspect-web-coreclr-runtime-cohort/runtime-cohort.json \
             artifacts/inspect-web-coreclr-publish/runtime-cohort/
-          node inspect-web/scripts/verify-coreclr-r2r-publication.ts \
-            --record \
-            artifacts/inspect-web-coreclr-publish/wwwroot \
-            inspect-web/DotnetInspect.Web/obj/Release/net11.0/R2R \
-            artifacts/inspect-web-coreclr-publish/runtime-cohort
 
       - name: Verify runtime-async deployment
         shell: bash
@@ -280,6 +273,13 @@ jobs:
               artifacts/inspect-web-coreclr-publish/wwwroot \
               artifacts/inspect-web-coreclr-publish/async-lowering.json \
               artifacts/inspect-web-runtime-async-receipts
+
+      - name: Test CoreCLR package operation
+        shell: bash
+        run: |
+          INSPECT_WEB_PACKAGE_ADOPTION_SITE=artifacts/inspect-web-coreclr-publish/wwwroot \
+            eng/test-inspect-web-package-adoption-gate.sh \
+              --grep 'drives the production opening, join, occurrence, and rejection contracts'
 
       - name: Publish MSDL managed API
         run: >
@@ -401,11 +401,6 @@ jobs:
           cohort=artifacts/inspect-web-coreclr-publish/runtime-cohort
           test -f "$cohort/dotnet-info.txt"
           test -f "$cohort/workload-list.txt"
-          node inspect-web/scripts/verify-coreclr-r2r-publication.ts \
-            --verify \
-            "$site" \
-            inspect-web/DotnetInspect.Web/obj/Release/net11.0/R2R \
-            "$cohort"
           jq -e '
             .schema == 2
             and .sdk == {
@@ -424,27 +419,9 @@ jobs:
             and .targetFramework == "net11.0"
             and .configuration == {
               asyncLowering: "runtime",
-              publishReadyToRun: true,
-              publishReadyToRunComposite: false,
-              readyToRunContainer: "wasm",
+              publishReadyToRun: false,
               wasmBuildNative: false
             }
-            and .readyToRun.evidenceFile == "ready-to-run-assets.json"
-            and (.readyToRun.evidenceSha256 | test("^[0-9a-f]{64}$"))
-            and .readyToRun.format == "crossgen2-webassembly"
-            and .readyToRun.mode == "per-assembly"
-            and .readyToRun.publishedManagedAssetCount > 0
-            and .readyToRun.readyToRunAssetCount
-              == (.readyToRun.publishedManagedAssetCount - 3)
-            and .readyToRun.readyToRunBytes > 0
-            and .readyToRun.inspectWebApplicationAssetCount == 8
-            and .readyToRun.ilOnlyAssets == [
-              "System.ComponentModel.wasm",
-              "System.Xml.Linq.wasm",
-              "System.wasm"
-            ]
-            and all(.readyToRun.frameworkPayload[];
-              .fileCount > 0 and .bytes > 0)
             and .workload == {
               id: "wasm-tools",
               manifestVersion: "12.0.100-alpha.1.26459.112",
@@ -611,11 +588,6 @@ jobs:
           cohort=artifacts/inspect-web-coreclr-publish/runtime-cohort
           test -f "$cohort/dotnet-info.txt"
           test -f "$cohort/workload-list.txt"
-          node inspect-web/scripts/verify-coreclr-r2r-publication.ts \
-            --verify \
-            "$site" \
-            inspect-web/DotnetInspect.Web/obj/Release/net11.0/R2R \
-            "$cohort"
           jq -e '
             .schema == 2
             and .sdk == {
@@ -634,27 +606,9 @@ jobs:
             and .targetFramework == "net11.0"
             and .configuration == {
               asyncLowering: "runtime",
-              publishReadyToRun: true,
-              publishReadyToRunComposite: false,
-              readyToRunContainer: "wasm",
+              publishReadyToRun: false,
               wasmBuildNative: false
             }
-            and .readyToRun.evidenceFile == "ready-to-run-assets.json"
-            and (.readyToRun.evidenceSha256 | test("^[0-9a-f]{64}$"))
-            and .readyToRun.format == "crossgen2-webassembly"
-            and .readyToRun.mode == "per-assembly"
-            and .readyToRun.publishedManagedAssetCount > 0
-            and .readyToRun.readyToRunAssetCount
-              == (.readyToRun.publishedManagedAssetCount - 3)
-            and .readyToRun.readyToRunBytes > 0
-            and .readyToRun.inspectWebApplicationAssetCount == 8
-            and .readyToRun.ilOnlyAssets == [
-              "System.ComponentModel.wasm",
-              "System.Xml.Linq.wasm",
-              "System.wasm"
-            ]
-            and all(.readyToRun.frameworkPayload[];
-              .fileCount > 0 and .bytes > 0)
             and .workload == {
               id: "wasm-tools",
               manifestVersion: "12.0.100-alpha.1.26459.112",

--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Test CoreCLR package operation
         shell: bash
         run: |
-          INSPECT_WEB_PACKAGE_ADOPTION_SITE=artifacts/inspect-web-coreclr-publish/wwwroot \
+          INSPECT_WEB_PACKAGE_ADOPTION_SITE="$GITHUB_WORKSPACE/artifacts/inspect-web-coreclr-publish/wwwroot" \
             eng/test-inspect-web-package-adoption-gate.sh \
               --grep 'drives the production opening, join, occurrence, and rejection contracts'
 

--- a/docs/inspect-web-runtime-performance.md
+++ b/docs/inspect-web-runtime-performance.md
@@ -219,10 +219,12 @@ Each .NET 12 deployment must use one exact, coherent SDK and workload cohort.
 A floating daily or a stable SDK combined with separately overridden runtime
 packages is not comparable evidence.
 
-The non-ReadyToRun CoreCLR deployment pins the runtime-main cohort:
+The CoreCLR deployment pins the runtime-main cohort:
 
-- SDK `12.0.100-alpha.1.26454.116`;
-- runtime and browser workload packs `12.0.0-alpha.1.26454.116`; and
+- SDK `12.0.100-alpha.1.26459.112`;
+- runtime and browser workload packs `12.0.0-alpha.1.26459.112`;
+- dotnet/dotnet VMR source commit
+  `7792b064d8573a30d8527944de8184b7e108837e`; and
 - workload feed
   `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12/nuget/v3/index.json`.
 
@@ -240,47 +242,59 @@ receipt that binds the SDK, runtime, workload manifest and packs, feeds, target
 framework, runtime-async lowering, and non-ReadyToRun configuration. It also
 records the pinned CoreCLR pack's native JavaScript and Wasm hashes, which must
 equal the published runtime assets. The same receipt is verified before
-artifact upload and again before deployment.
+artifact upload and again before deployment. Before upload, the focused
+package-adoption canary opens a deterministic local package through the
+published production Worker and `QueryPackage` operation. Build identity and
+the async-lowering canary are not sufficient deployment evidence by
+themselves.
 
-ReadyToRun publication must additionally record:
+The earlier `12.0.100-alpha.1.26454.116` non-ReadyToRun cohort produced the
+accepted baseline run `34439612493`. The later cohort remains pinned after the
+ReadyToRun trial so the rejected optimization is the only configuration
+removed.
 
-- `PublishReadyToRun=true`;
-- non-composite per-assembly output;
-- proof that published application and framework assets are the Crossgen2 Wasm
-  images;
-- compressed and uncompressed `/_framework/` size; and
-- the same runtime-async deployment and browser correctness gates used by the
-  non-ReadyToRun CoreCLR deployment.
+### Rejected ReadyToRun trial
 
-The ReadyToRun CoreCLR deployment pins the later runtime-main cohort:
+Promotion run `34559349236` deployed product commit
+`e7572e46d66a8dd064131c6fa66d4230a8405b98` with non-composite application
+ReadyToRun. Crossgen2 produced 71 of 74 managed assets, including all eight
+application assets and `System.Private.CoreLib`. The artifact passed build
+identity, runtime-async, asset-identity, and publication-shape checks.
 
-- SDK `12.0.100-alpha.1.26459.112`;
-- runtime and browser workload packs `12.0.0-alpha.1.26459.112`;
-- dotnet/dotnet VMR source commit
-  `7792b064d8573a30d8527944de8184b7e108837e`; and
-- the same `dotnet12` workload feed used by the non-ReadyToRun cohort.
+The first one-sample production preflight rejected that configuration before
+the five-sample budget was spent. Mono completed the pinned workload, while
+CoreCLR reached Worker readiness and then failed the first package query with:
 
-This cohort follows the same `net11.0` workload and .NET 12 CoreCLR composition
-as the non-ReadyToRun deployment, but sets `PublishReadyToRun=true` and
-`PublishReadyToRunComposite=false`. Its Crossgen2 output uses per-assembly Wasm
-containers in the canonical `R2R/` directory. The publication gate parses the
-SDK-owned runtime asset inventory and requires every emitted Crossgen2 file to
-have the WebAssembly magic number and to be byte-identical to its fingerprinted
-published asset. It also requires every `DotnetInspect.Web*` application asset
-and `System.Private.CoreLib` to be in that ReadyToRun set, rejects orphaned
-Crossgen2 outputs, and records the remaining IL-only managed assets explicitly.
-For the initial candidate, Crossgen2 emits 71 of 74 managed assets, including
-all eight application assets; `System.ComponentModel`, `System`, and
-`System.Xml.Linq` are the three recorded framework facades without Crossgen2
-outputs.
+```text
+Fatal error.
+Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code.
+```
 
-The artifact carries the complete per-assembly manifest and its digest in the
-runtime cohort receipt. The same gate replays before artifact upload and before
-deployment. The receipt also records uncompressed, Brotli, gzip, and total
-`/_framework/` file counts and byte sizes. The replacement-head current-source
-publication measured 77,180,680 uncompressed bytes, 16,593,730 Brotli bytes,
-and 22,981,185 gzip bytes; deployed artifacts remain authoritative because
-fingerprints and compression can change with application code.
+The same commit and cohort succeeded locally with
+`PublishReadyToRun=false` and reproduced the fatal error with
+`PublishReadyToRun=true`. Making only
+`DotnetInspect.Web.Interop.Package` IL-only did not change the failure. A direct
+generated-facade invocation exposed mismatched
+`WasmDelayLoadHelper`/`WasmR2RToInterpreterThunk` dispatch beginning in
+`NuGetFetch.PackageSourceOperation.CaptureAsync<T>`; interpreting `NuGetFetch`
+revealed another failing generic async dispatch in
+`BrowserPackageWorkspace.RunPackageOperationAsync<T>`. Selective exclusions
+therefore do not provide a viable application configuration.
+
+This is the same CoreCLR-Wasm R2R thunk/signature-mismatch family tracked by
+[dotnet/runtime#129622](https://github.com/dotnet/runtime/issues/129622) and
+[dotnet/runtime#129857](https://github.com/dotnet/runtime/issues/129857), but
+the pinned later cohort still reproduces the product failure. The public
+CoreCLR comparison consequently uses the later .NET 12 cohort without
+ReadyToRun. No R2R performance trend point exists because correctness is a
+precondition for measurement.
+
+Any future ReadyToRun publication must additionally record non-composite
+per-assembly output, prove that published assets are the Crossgen2 Wasm images,
+record compressed and uncompressed `/_framework/` size, and pass the same
+focused production-Worker package operation before deployment. The retained
+publication verifier can produce that evidence, but it does not make R2R a
+supported deployment configuration.
 
 The earlier runtime-main cohort had a Linux path-casing defect: Crossgen2 wrote
 `R2R/` while the browser packaging target probed `r2r/`.

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -59,7 +59,7 @@ internal static class PromotionWorkflowContract
         """;
     private const string CoreClrPackageOperationCheck =
         """
-        INSPECT_WEB_PACKAGE_ADOPTION_SITE=artifacts/inspect-web-coreclr-publish/wwwroot \
+        INSPECT_WEB_PACKAGE_ADOPTION_SITE="$GITHUB_WORKSPACE/artifacts/inspect-web-coreclr-publish/wwwroot" \
           eng/test-inspect-web-package-adoption-gate.sh \
             --grep 'drives the production opening, join, occurrence, and rejection contracts'
         """;

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -57,6 +57,12 @@ internal static class PromotionWorkflowContract
           artifacts/inspect-web-compiler-publish/async-lowering.json \
           artifacts/inspect-web-coreclr-publish/async-lowering.json
         """;
+    private const string CoreClrPackageOperationCheck =
+        """
+        INSPECT_WEB_PACKAGE_ADOPTION_SITE=artifacts/inspect-web-coreclr-publish/wwwroot \
+          eng/test-inspect-web-package-adoption-gate.sh \
+            --grep 'drives the production opening, join, occurrence, and rejection contracts'
+        """;
     internal static void AssertMutations(string repository)
     {
         string promotionPath = Path.Combine(
@@ -326,16 +332,16 @@ internal static class PromotionWorkflowContract
             "CoreCLR staging contract accepted runtime verification without its mapped cohort feeds.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
-            "            -p:PublishReadyToRun=true \\\n",
+            "            -p:PublishReadyToRun=false \\\n",
             "",
             ValidateCoreClrStaging,
             "CoreCLR staging contract accepted implicit ReadyToRun behavior.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
-            "            -p:PublishReadyToRunComposite=false \\\n",
+            "            eng/test-inspect-web-package-adoption-gate.sh \\\n",
             "",
             ValidateCoreClrStaging,
-            "CoreCLR staging contract accepted implicit composite ReadyToRun behavior.");
+            "CoreCLR staging contract accepted a skipped package operation.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
             "            -p:WasmBuildNative=false \\\n",
@@ -1184,7 +1190,7 @@ internal static class PromotionWorkflowContract
 
         YamlSequenceNode publishSteps =
             GetRequiredSequence(publishJob, "steps", "CoreCLR jobs.publish");
-        if (publishSteps.Children.Count != 14)
+        if (publishSteps.Children.Count != 15)
         {
             throw new InvalidOperationException(
                 "CoreCLR publish must build and deploy the promoted product identity.");
@@ -1423,9 +1429,7 @@ internal static class PromotionWorkflowContract
                     targetFramework: $target_framework,
                     configuration: {
                       asyncLowering: "runtime",
-                      publishReadyToRun: true,
-                      publishReadyToRunComposite: false,
-                      readyToRunContainer: "wasm",
+                      publishReadyToRun: false,
                       wasmBuildNative: false
                     },
                     workload: {
@@ -1467,6 +1471,7 @@ internal static class PromotionWorkflowContract
                 ["run"] =
                     "npm ci\n" +
                     "npm run build\n" +
+                    "npx playwright install --with-deps firefox\n" +
                     "grep -q '<script type=\"importmap\"></script>' dist/index.html\n" +
                     "grep -Eq '<link rel=\"preload\" id=\"webassembly\"[[:space:]]*/?>' dist/index.html\n",
             },
@@ -1529,8 +1534,7 @@ internal static class PromotionWorkflowContract
               -p:BuildTimestampUtc="$built_at" \
               -p:Features=runtime-async=on \
               -p:UseMonoRuntime=false \
-              -p:PublishReadyToRun=true \
-              -p:PublishReadyToRunComposite=false \
+              -p:PublishReadyToRun=false \
               -p:WasmBuildNative=false \
               -p:WasmNestedPublishAppDependsOn= \
               -p:WasmEnableExceptionHandling=true \
@@ -1542,11 +1546,6 @@ internal static class PromotionWorkflowContract
               artifacts/inspect-web-coreclr-runtime-cohort/workload-list.txt \
               artifacts/inspect-web-coreclr-runtime-cohort/runtime-cohort.json \
               artifacts/inspect-web-coreclr-publish/runtime-cohort/
-            node inspect-web/scripts/verify-coreclr-r2r-publication.ts \
-              --record \
-              artifacts/inspect-web-coreclr-publish/wwwroot \
-              inspect-web/DotnetInspect.Web/obj/Release/net11.0/R2R \
-              artifacts/inspect-web-coreclr-publish/runtime-cohort
             """;
         if (GetRequiredScalar(
                 publish,
@@ -1566,10 +1565,35 @@ internal static class PromotionWorkflowContract
             RuntimeAsyncDeploymentCheck,
             "runtime-async deployment verification step");
 
-        ValidateManagedApiPublish(
+        YamlMappingNode packageOperation =
             RequireStep(
                 publishSteps,
                 8,
+                "Test CoreCLR package operation",
+                "CoreCLR jobs.build");
+        RequireExactKeys(
+            packageOperation,
+            ["name", "shell", "run"],
+            "CoreCLR package operation step");
+        RequireScalarValue(
+            packageOperation,
+            "shell",
+            "bash",
+            "CoreCLR package operation step");
+        if (GetRequiredScalar(
+                packageOperation,
+                "run",
+                "CoreCLR package operation step").TrimEnd()
+            != CoreClrPackageOperationCheck)
+        {
+            throw new InvalidOperationException(
+                "CoreCLR package operation does not match the trusted contract.");
+        }
+
+        ValidateManagedApiPublish(
+            RequireStep(
+                publishSteps,
+                9,
                 "Publish MSDL managed API",
                 "CoreCLR jobs.build"),
             "artifacts/inspect-web-coreclr-publish/api",
@@ -1578,7 +1602,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode buildVerify =
             RequireStep(
                 publishSteps,
-                9,
+                10,
                 "Verify CoreCLR site artifact",
                 "CoreCLR jobs.build");
         ValidateCoreClrArtifactVerification(
@@ -1588,7 +1612,7 @@ internal static class PromotionWorkflowContract
         ValidateAsyncDeploymentCheck(
             RequireStep(
                 publishSteps,
-                10,
+                11,
                 "Compare compiler-async and runtime-async receipts",
                 "CoreCLR jobs.build"),
             PairedAsyncDeploymentCheck,
@@ -1597,7 +1621,7 @@ internal static class PromotionWorkflowContract
         YamlMappingNode upload =
             RequireStep(
                 publishSteps,
-                11,
+                12,
                 "Upload CoreCLR staged site artifact",
                 "CoreCLR jobs.build");
         RequireExactKeys(
@@ -1627,14 +1651,14 @@ internal static class PromotionWorkflowContract
         YamlMappingNode deployVerify =
             RequireStep(
                 publishSteps,
-                12,
+                13,
                 "Verify CoreCLR staged site artifact");
         ValidateCoreClrArtifactVerification(
             deployVerify,
             "CoreCLR staging artifact verification step");
 
         YamlMappingNode deployStep =
-            RequireStep(publishSteps, 13, "Deploy to CoreCLR staging");
+            RequireStep(publishSteps, 14, "Deploy to CoreCLR staging");
         RequireExactKeys(
             deployStep,
             ["name", "uses", "with"],
@@ -1906,11 +1930,6 @@ internal static class PromotionWorkflowContract
               cohort={{publishRoot}}/runtime-cohort
               test -f "$cohort/dotnet-info.txt"
               test -f "$cohort/workload-list.txt"
-              node inspect-web/scripts/verify-coreclr-r2r-publication.ts \
-                --verify \
-                "$site" \
-                inspect-web/DotnetInspect.Web/obj/Release/net11.0/R2R \
-                "$cohort"
               jq -e '
                 .schema == 2
                 and .sdk == {
@@ -1929,27 +1948,9 @@ internal static class PromotionWorkflowContract
                 and .targetFramework == "net11.0"
                 and .configuration == {
                   asyncLowering: "runtime",
-                  publishReadyToRun: true,
-                  publishReadyToRunComposite: false,
-                  readyToRunContainer: "wasm",
+                  publishReadyToRun: false,
                   wasmBuildNative: false
                 }
-                and .readyToRun.evidenceFile == "ready-to-run-assets.json"
-                and (.readyToRun.evidenceSha256 | test("^[0-9a-f]{64}$"))
-                and .readyToRun.format == "crossgen2-webassembly"
-                and .readyToRun.mode == "per-assembly"
-                and .readyToRun.publishedManagedAssetCount > 0
-                and .readyToRun.readyToRunAssetCount
-                  == (.readyToRun.publishedManagedAssetCount - 3)
-                and .readyToRun.readyToRunBytes > 0
-                and .readyToRun.inspectWebApplicationAssetCount == 8
-                and .readyToRun.ilOnlyAssets == [
-                  "System.ComponentModel.wasm",
-                  "System.Xml.Linq.wasm",
-                  "System.wasm"
-                ]
-                and all(.readyToRun.frameworkPayload[];
-                  .fileCount > 0 and .bytes > 0)
                 and .workload == {
                   id: "wasm-tools",
                   manifestVersion: "{{CoreClrDotnetSdkVersion}}",

--- a/inspect-web/README.md
+++ b/inspect-web/README.md
@@ -2319,29 +2319,28 @@ provenance before publication.
 That cohort's browser workload still targets `net11.0`; the runtime is .NET 12
 CoreCLR even though the application graph retains its current target framework.
 The workflow enables `runtime-async=on` across this application graph and
-applies the `UseMonoRuntime=false`, `PublishReadyToRun=true`,
-`PublishReadyToRunComposite=false`, `WasmBuildNative=false`,
-`WasmNestedPublishAppDependsOn=`, and `WasmEnableExceptionHandling=true`
+applies the `UseMonoRuntime=false`, `PublishReadyToRun=false`,
+`WasmBuildNative=false`, `WasmNestedPublishAppDependsOn=`, and
+`WasmEnableExceptionHandling=true`
 overrides. This exercises runtime async only in the CoreCLR comparison
 deployment; Mono staging and ordinary non-AOT builds retain classic async
-lowering. Crossgen2 emits non-composite per-assembly Wasm images into `R2R/`.
-`verify-coreclr-r2r-publication.ts` requires each emitted image to be a
-WebAssembly module and byte-identical to the corresponding fingerprinted
-published asset. It requires all eight `DotnetInspect.Web*` assets and
-`System.Private.CoreLib` to be ReadyToRun, rejects orphaned outputs, and records
-the three framework facades without Crossgen2 output as IL-only. The artifact
-carries that complete per-assembly manifest, its digest, exact `dotnet --info`,
-the installed workload list, uncompressed and compressed `/_framework/` sizes,
-and a machine-readable SDK/runtime/workload receipt. That receipt also
-identifies the exact CoreCLR browser runtime asset bytes, which must match the
-published native JavaScript and Wasm. The workflow regenerates and verifies the
-ReadyToRun evidence, receipt, and CoreCLR-specific `GetDotNetRuntimeHeap` hook
-before artifact upload and again before deployment. Before the CoreCLR artifact
-crosses the upload boundary, the workflow compares its schema-5 runtime receipt
-with the triggering Mono run's schema-5 compiler receipt. This comparison is
-intentionally cross-toolchain: generated facade contracts and async-lowering
-evidence must remain equivalent between the .NET 11 Mono build and .NET 12
-CoreCLR build.
+lowering. The non-composite ReadyToRun trial is rejected because the first real
+package operation fatally entered a mismatched CoreCLR-Wasm R2R thunk even
+though build identity and the async-lowering canary succeeded. The deployment
+therefore runs a focused package-adoption test through the published production
+Worker before upload; it opens a deterministic local package through
+`QueryPackage`, so a runtime that initializes but cannot execute product work
+never reaches Azure deployment.
+
+The artifact carries exact `dotnet --info`, the installed workload list, and a
+machine-readable SDK/runtime/workload receipt. That receipt identifies the
+CoreCLR browser runtime asset bytes, which must match the published native
+JavaScript and Wasm, and records `PublishReadyToRun=false`. Before the CoreCLR
+artifact crosses the upload boundary, the workflow compares its schema-5
+runtime receipt with the triggering Mono run's schema-5 compiler receipt. This
+comparison is intentionally cross-toolchain: generated facade contracts and
+async-lowering evidence must remain equivalent between the .NET 11 Mono build
+and .NET 12 CoreCLR build.
 
 Both deployment builds import `InspectWebAsyncLoweringReceipt.targets`. Every
 project that reaches `CoreCompile` fails unless its exact `Features` property


### PR DESCRIPTION
Build robust, capable Inspect Web runtime evidence by requiring the deployed runtime to execute real product work before it is accepted.

## Summary

Restore the CoreCLR comparison site to the pinned .NET 12 cohort without ReadyToRun. The promoted R2R artifact initialized successfully but fatally failed its first package operation through a mismatched CoreCLR-Wasm R2R thunk.

Add the existing deterministic package-adoption scenario to the CoreCLR deployment before artifact upload. It drives `QueryPackage` through the published production Worker, closing the gap left by build identity and the narrow async-lowering canary.

This advances #6077. It does not claim R2R performance evidence: correctness failed before the five-sample comparison could begin.

## Demo

Before, the focused product-operation canary against the R2R artifact fails:

```text
Error: page.evaluate: index out of bounds
Fatal error.
Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code.
1 failed
```

After, the same current-source artifact published with `PublishReadyToRun=false` completes:

```text
[1/1] artifact-backed package scope adoption over real Wasm
1 passed (19.8s)
Artifact-backed package scope adoption Browser/Wasm gate passed.
```

The neighboring runtime-async and exact SDK/runtime/workload receipt checks remain unchanged.

## Evidence

- Production R2R at commit `e7572e46d66a8dd064131c6fa66d4230a8405b98`: first package query fails fatally.
- Local R2R with the same commit and cohort: reproduces the fatal error.
- Local non-R2R with the same commit and cohort: package query succeeds.
- Local R2R with only `DotnetInspect.Web.Interop.Package` interpreted: still fails.
- Direct facade stack: mismatched `WasmDelayLoadHelper` / `WasmR2RToInterpreterThunk` dispatch begins in generic async package paths.
- Focused package-adoption gate: R2R fails; same-cohort non-R2R passes.

The behavior is consistent with the CoreCLR-Wasm R2R thunk/signature-mismatch family tracked by dotnet/runtime#129622 and dotnet/runtime#129857.

## Compatibility

The .NET 12 SDK, runtime/workload packs, VMR provenance, runtime async lowering, target framework, native runtime bytes, and production promotion cadence remain pinned. Only application ReadyToRun is disabled. The retained R2R publication verifier remains available for a future corrected cohort.

## Validation

- `dotnet run eng/test-ci-change-detection.cs -c Release`
- `npm run build`
- `npx markdownlint-cli docs/inspect-web-runtime-performance.md inspect-web/README.md`
- Exact .NET 12 non-R2R publish with SDK/runtime `12.0.100-alpha.1.26459.112`
- Focused published production-Worker package-adoption canary