### PR TITLE
Adopt Package Source ownership in PackageHouse

### DIFF
--- a/docs/design/package-house.md
+++ b/docs/design/package-house.md
@@ -25,7 +25,8 @@ through their package and Workspace paths.
 
 The current host-neutral implementation floor is `PackageHouse` in
 `DotnetInspector.Packages`. It executes exact and typed selecting `Settle` and
-`Acquire` requests through one Package Source Model-issued settlement lease.
+`Acquire` requests by consuming one Package Source Model-issued operation
+lease.
 `DesktopPackageSourceComposition` still constructs desktop capabilities and
 exposes the shipping compatibility surface; routing that surface through the
 House is the next separately reviewed adapter slice. `Realize`, pruning,
@@ -140,18 +141,19 @@ PackageHouse does not accept transport URLs, rendered dependency rows, asset
 paths, assembly names, or package labels as substitutes for those typed
 inputs.
 
-## Source-settlement lease
+## Package Source operation lease
 
-PackageHouse is the clearing house where source-owner-issued leases are
-acquired or borrowed and source-owner receipts are settled. For the first
-operational slice in
-[#6477](https://github.com/richlander/dotnet-inspect/issues/6477), the Package
-Source Model issues one `PackageSourceSettlementLease` over an injected
-configured-authority-to-`IPackageSourceClient` capability and a lower-owner
-operation-context factory. PackageHouse consumes that lease; it does not mint,
-rename, or reinterpret it.
+PackageHouse consumes one already-issued `PackageSourceOperationLease` for each
+operation. The Package Source Model issues that resource from its root
+settlement lifetime over host-supplied configured-authority clients.
+PackageHouse does not issue, rename, wrap, retain, or publish either lease.
 
-The lease owns one package acquisition candidate-issuer identity. It settles:
+The operation lease owns one package acquisition candidate-issuer identity and
+one lower-owner operation context. PackageHouse owns the exact lease throughout
+settlement, complete discovery, selection, and payload acquisition, including
+every asynchronous suspension. It releases the lease synchronously on every
+terminal result, invalid request or plan, unsupported profile, cancellation,
+timeout, and exception. The lease settles:
 
 - caller-pinned exact candidate authorization;
 - complete version discovery across one explicit discovery contract and
@@ -166,26 +168,21 @@ the exact configured-authority association and the exact client that performed
 the operation. PackageHouse neither discovers a broader authority set nor
 reconstructs source identity from endpoints.
 
-When a caller omits `NuGetOperationContext`, the lease uses that injected
-factory and disposes the created context after the settlement. A
-caller-supplied context remains caller-owned.
-
-Retiring the lease rejects new settlement and candidate use. Completed
-candidate, discovery, manifest, failure, and timeout evidence remains valid as
-data after retirement. Retirement does not dispose source clients,
-authentication contexts, transports, caller-supplied `NuGetOperationContext`
-instances, payload streams, package stores, artifact content, or Workspace
-participants.
+Releasing the operation lease ends its context and root registration.
+Completed candidate, discovery, failure, timeout, receipt, and payload evidence
+remains valid as data after release. Results and receipts retain no live source
+lease authority. Release does not dispose source clients, authentication
+contexts, transports, payload streams, package stores, artifact content, or
+Workspace participants.
 
 `DesktopPackageSourceComposition` owns its desktop capabilities and supplies
 them to one Package Source Model-issued settlement lease for its lifetime.
 Browser/Wasm and query adapters supply their host-created clients through the
 same lease contract.
 
-The current step-4 floor routes exact and selecting settlement and acquisition
-through this substrate. Borrowing or transfer across an `await` boundary
-remains owned by
-[#6544](https://github.com/richlander/dotnet-inspect/issues/6544).
+This is the adopted PackageHouse operation-ownership step 12b under
+[#6544](https://github.com/richlander/dotnet-inspect/issues/6544). Library
+ownership and `Realize` adoption remain separate focused steps.
 
 ## Package demand
 
@@ -262,9 +259,12 @@ not own graph scheduling, cycle termination, depth, or traversal work budgets.
 
 The current `PackageHouse.ExecuteAsync` floor supports `Settle` and `Acquire`.
 One `PackageHouse` instance retains the host's package-source authorization and
-an optional `PackagePayloadAcquisitionPlan`. Each operation separately accepts
-the request and explicitly receives the source-settlement lease, caller
-cancellation, and optional request-matched operation context. `Realize` is
+an optional `PackagePayloadAcquisitionPlan`. Each invocation accepts the
+request and consumes one request-deadline-matched
+`PackageSourceOperationLease` by ordinary resource-parameter ownership
+transfer. Caller cancellation and the operation ceiling are carried only by
+the lease's Package Source-owned context. House operation declarations accept
+only deadlines representable by that lower-owner context. `Realize` is
 rejected until the realization owner is composed in its adoption step.
 
 Execution returns the `PackageHouseSettlement` union. Both arms carry one
@@ -282,8 +282,8 @@ The host supplies:
 - any permitted package input capability;
 - network and local-source permission;
 - cache and payload limits;
-- one owner-issued package operation context;
-- caller cancellation; and
+- one owner-issued package source operation lease carrying caller cancellation
+  and request/operation deadlines; and
 - any policy generation required by the focused owners.
 
 The plan is capability, not result. Registration does not prove a source
@@ -293,14 +293,10 @@ or a payload is authorized.
 The current execution floor binds stable host capabilities to the
 `PackageHouse` instance. `PackagePayloadAcquisitionPlan` groups the
 authority-and-producer-scoped store provider, payload limits, transfer policy,
-and payload diagnostics. It carries no source-settlement lease, operation
-context, payload, or release obligation and does not take ownership of stores
-returned by its provider. The resource-owner-issued
-`PackageSourceSettlementLease` and any caller-owned operation context remain
-explicit invocation inputs rather than hidden fields of a House-named plan.
-This is the current Package Source Model compatibility lifetime, not a claim
-that its async use has completed the declaration and Analysis adoption tracked
-by #6544.
+and payload diagnostics. It carries no source lease, operation context,
+payload, or release obligation and does not take ownership of stores returned
+by its provider. The resource-owner-issued operation lease remains an explicit
+consumed invocation input rather than a hidden field of a House-named plan.
 
 One House operation consumes one shared operation identity and ceiling across
 all selected authorities, source routes, compatibility requests, payload
@@ -723,13 +719,13 @@ authority-bearing package evidence under their owner contracts. PackageHouse
 applies the same candidate, version, pruning, and realization semantics while
 retaining their distinct producer and transport provenance.
 
-### Retired source-settlement lease retains evidence
+### Released source operation retains evidence
 
-A Package Source Model-issued lease issues an exact candidate and settles a
-manifest failure. The host retires the lease. The candidate and failure retain
-their existing evidence semantics, but another candidate resolution or
-manifest operation through that lease is rejected. The source client remains
-alive because its host, not PackageHouse, owns it.
+A Package Source Model-issued operation lease issues an exact candidate and
+settles a manifest failure. Its consumer releases the operation. The candidate
+and failure retain their existing evidence semantics, but another candidate
+resolution or manifest operation through that lease is rejected. The source
+client remains alive because its host, not PackageHouse, owns it.
 
 ### Direct library bypasses PackageHouse
 
@@ -803,9 +799,10 @@ every supported host that uses it.
 | Execution floor | Exact and typed selecting `Settle` and `Acquire` operations produce closed House results; `Realize` remains unavailable until its owner is composed. |
 | Request association | A result retains the exact demand, operation, target context, and owner-issued settlement identity without reconstructing them from display values. |
 | Terminal evidence | Every terminal arm retains the same immutable evidence envelope, completed receipts, and typed failures; direct and owner-adapted operation timeouts cannot produce success. |
-| Source lease authority | One lease owns one candidate issuer; candidates from another lease and clients or results from another configured-authority association are rejected. |
-| Source lease retirement | Retirement rejects new source settlement while completed source evidence remains readable. |
-| Source capability ownership | Retiring a package-source settlement lease does not dispose caller-owned clients or caller-supplied operation contexts. |
+| Source lease authority | One operation lease owns one candidate issuer; candidates from another root generation and clients or results from another configured-authority association are rejected. |
+| Source operation ownership | House execution releases its transferred operation after success, typed failure, invalid plan or deadline, unsupported profile, caller cancellation, operation timeout, and source exception; root settlement can then complete. |
+| Source result independence | House results, decisions, candidates, evidence, receipts, and acquired payloads retain no operation lease or live source authority. |
+| Source capability ownership | Releasing an operation or settling its root does not dispose caller-owned clients, stores, or retained payload content. |
 | Source completeness | Partial authority evidence cannot settle latest, wildcard, range, or authoritative absence, and cannot reach package-store or payload work. |
 | Pruning order | `Subsumed` skips payload acquisition and every other pruning state cannot issue platform delegation. |
 | Pruning correspondence | Platform delegation consumes the policy-issued inventory/coordinate/supply receipt, compares the coordinate through the package owner's normalization, and matches the actual supplier family and exact target version. |

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -90,14 +90,13 @@ without defining a third Package Source resource or retaining a root or
 operation-lease borrow across `await`. The root implements only
 `IAsyncDisposable`.
 
-PackageHouse retains its existing execution signature until
-[#6622](https://github.com/richlander/dotnet-inspect/issues/6622). Its internal
-compatibility bridge registers awaited work against the root generation and
-never disposes a caller-supplied `NuGetOperationContext`. This is not
-PackageHouse operation-lease ownership adoption. Existing direct source
-adapters likewise retain the root only through this scoped compatibility path
-until their owning consumers adopt transferred operation leases. Calls without
-an external context own a fresh operation lease, while existing
+PackageHouse adopts operation-lease ownership in
+[#6622](https://github.com/richlander/dotnet-inspect/issues/6622). Each House
+execution consumes one request-matched operation lease, owns it across every
+asynchronous suspension, and releases it on every terminal path. Existing
+direct source adapters retain the root only through the scoped compatibility
+path until their owning consumers adopt transferred operation leases. Calls
+without an external context own a fresh operation lease, while existing
 external-context calls use the internal registered-work bridge. Desktop
 composition owns the root and awaits root quiescence before releasing its
 clients.
@@ -162,12 +161,13 @@ The operation lease:
 
 Public asynchronous Package Source operations use the operation lease rather
 than accepting a root lease, an independently supplied operation context, or
-both. The lease may transfer to PackageHouse or package-backed Platform, but
-their exact acceptance, terminal-path release, and result-handoff obligations
-belong to [#6622](https://github.com/richlander/dotnet-inspect/issues/6622) and
-the package-backed
-[Platform design](package-backed-platform-realization.md), respectively. A
-direct Package Source consumer may own the lease lexically for one operation.
+both. PackageHouse consumes the lease under
+[#6622](https://github.com/richlander/dotnet-inspect/issues/6622); its exact
+acceptance, terminal-path release, and result-handoff obligations belong to
+the [PackageHouse design](package-house.md). Package-backed Platform adoption
+belongs to the
+[Platform design](package-backed-platform-realization.md). A direct Package
+Source consumer may own the lease lexically for one operation.
 
 ### Awaited work
 

--- a/src/DotnetInspector.Packages/PackageHouse.cs
+++ b/src/DotnetInspector.Packages/PackageHouse.cs
@@ -77,307 +77,263 @@ public sealed class PackageHouse
     }
 
     /// <summary>
-    /// Settles one exact or selecting request through a source-owner lease.
-    /// The caller owns the lease, any supplied operation context, all stores,
-    /// and any returned payload.
+    /// Consumes one source operation lease to settle an exact or selecting
+    /// request. Stores and any returned payload remain caller-owned.
     /// </summary>
-    /// <remarks>
-    /// This preserves the current Package Source Model lifetime contract.
-    /// Declared ownership effects for async lease use remain a focused
-    /// adoption under the resource-ownership tracker.
-    /// </remarks>
-    public async Task<PackageHouseSettlement> ExecuteAsync(
+    public Task<PackageHouseSettlement> ExecuteAsync(
         PackageHouseRequest request,
-        PackageSourceSettlementLease sourceLease,
-        CancellationToken cancellationToken = default,
-        NuGetOperationContext? operationContext = null)
+        PackageSourceOperationLease sourceOperation)
     {
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(sourceLease);
-        if (request.Operation.Profile
-            == PackageHouseOperationProfile.Realize)
-        {
-            throw new NotSupportedException(
-                "This PackageHouse execution slice supports Settle and Acquire operations.");
-        }
-        if (request.Operation.Profile
-                == PackageHouseOperationProfile.Acquire
-            && _payloadAcquisition is null)
-        {
-            throw new InvalidOperationException(
-                "An Acquire operation requires an authority-scoped package store capability.");
-        }
-        if (operationContext is not null
-            && (operationContext.RequestTimeout
-                    != request.Operation.RequestTimeout
-                || operationContext.OperationTimeout
-                    != request.Operation.OperationTimeout))
-        {
-            throw new ArgumentException(
-                "The supplied operation context deadlines must match the PackageHouse request.",
-                nameof(operationContext));
-        }
+        ArgumentNullException.ThrowIfNull(sourceOperation);
+        return ExecuteCoreAsync(request, sourceOperation);
+    }
 
-        using NuGetOperationContext? ownedOperation =
-            operationContext is null
-                ? new(
-                    request.Operation.RequestTimeout,
-                    request.Operation.OperationTimeout,
-                    cancellationToken)
-                : null;
-        NuGetOperationContext operation =
-            operationContext ?? ownedOperation!;
-        cancellationToken = operation.ResolveInvocationToken(
-            cancellationToken);
-        try
+    private async Task<PackageHouseSettlement> ExecuteCoreAsync(
+        PackageHouseRequest request,
+        PackageSourceOperationLease sourceOperation)
+    {
+        using (sourceOperation)
         {
-            operation.ThrowIfExpired();
-            return request.Demand switch
+            ArgumentNullException.ThrowIfNull(request);
+            if (request.Operation.Profile
+                == PackageHouseOperationProfile.Realize)
             {
-                PackageHouseDemand.Exact exact =>
-                    await ExecuteExactAsync(
+                throw new NotSupportedException(
+                    "This PackageHouse execution slice supports Settle and Acquire operations.");
+            }
+            if (request.Operation.Profile
+                    == PackageHouseOperationProfile.Acquire
+                && _payloadAcquisition is null)
+            {
+                throw new InvalidOperationException(
+                    "An Acquire operation requires an authority-scoped package store capability.");
+            }
+            if (sourceOperation.RequestTimeout
+                    != request.Operation.RequestTimeout
+                || sourceOperation.OperationTimeout
+                    != request.Operation.OperationTimeout)
+            {
+                throw new ArgumentException(
+                    "The Package Source operation deadlines must match the PackageHouse request.",
+                    nameof(sourceOperation));
+            }
+
+            try
+            {
+                sourceOperation.ThrowIfExpired();
+                PackageSourceAuthorization authorization;
+                PackageHouseDecisionReceipt decision;
+                PackageAcquisitionCandidate candidate;
+                List<PackageHouseFailure> failures;
+
+                switch (request.Demand)
+                {
+                    case PackageHouseDemand.Exact exact:
+                        authorization =
+                            _sourceAuthorization.AuthorizeSourcesFor(
+                                exact.Coordinate.PackageId);
+                        sourceOperation.ThrowIfExpired();
+                        PackageAcquisitionCandidateResult candidateResult =
+                            sourceOperation.ResolvePinnedCandidate(
+                                authorization,
+                                exact.Coordinate);
+                        sourceOperation.ThrowIfExpired();
+                        failures = AdaptFailures(
+                            request,
+                            candidateResult.Failures);
+                        if (candidateResult.Candidate
+                            is not { } exactCandidate)
+                        {
+                            decision =
+                                PackageHouseDecisionReceipt.Stop(
+                                    request,
+                                    exact.Coordinate);
+                            PackageHouseEvidence evidence = new(
+                                request,
+                                decision,
+                                failures: failures);
+                            return ResourceFree(
+                                CreateCandidateTerminalResult(
+                                    candidateResult,
+                                    authorization,
+                                    evidence));
+                        }
+
+                        candidate = exactCandidate;
+                        decision =
+                            PackageHouseDecisionReceipt.RetainPackage(
+                                request,
+                                candidate.Coordinate,
+                                candidate);
+                        break;
+
+                    case PackageHouseDemand.Selecting selecting:
+                        PackageVersionSelectionRequest selection =
+                            selecting.Request;
+                        authorization =
+                            _sourceAuthorization.AuthorizeSourcesFor(
+                                selection.PackageId);
+                        sourceOperation.ThrowIfExpired();
+                        PackageVersionDiscoveryContract
+                            discoveryContract =
+                                PackageVersionDiscoveryContract.Create(
+                                    selection.Discovery
+                                        .IncludePrerelease,
+                                    includeUnlisted: false,
+                                    limit: null);
+                        PackageVersionDiscoveryResult discovery =
+                            await sourceOperation
+                                .DiscoverVersionsAsync(
+                                    selection.PackageId,
+                                    authorization,
+                                    discoveryContract)
+                                .ConfigureAwait(false);
+                        failures = AdaptFailures(
+                            request,
+                            discovery.Failures);
+                        if (discovery.Failures.Any(
+                                failure => failure.Timeout?.Kind
+                                    == PackageSourceTimeoutKind
+                                        .Operation))
+                        {
+                            return OperationTimedOut(
+                                request,
+                                failures);
+                        }
+                        try
+                        {
+                            sourceOperation.ThrowIfExpired();
+                        }
+                        catch (NuGetOperationTimeoutException)
+                        {
+                            return OperationTimedOut(
+                                request,
+                                failures);
+                        }
+                        PackageVersionResolutionReceipt resolution =
+                            PackageVersionSelectionResolver.Resolve(
+                                selection,
+                                discovery,
+                                PackageVersionDiscoveryFreshness
+                                    .RefreshedForRequest);
+                        try
+                        {
+                            sourceOperation.ThrowIfExpired();
+                        }
+                        catch (NuGetOperationTimeoutException)
+                        {
+                            return OperationTimedOut(
+                                request,
+                                failures);
+                        }
+                        if (resolution
+                            is not PackageVersionResolutionReceipt
+                                .Resolved resolved)
+                        {
+                            decision =
+                                PackageHouseDecisionReceipt.Stop(
+                                    request,
+                                    versionResolution: resolution);
+                            PackageHouseEvidence evidence = new(
+                                request,
+                                decision,
+                                failures: failures);
+                            return ResourceFree(
+                                CreateResolutionTerminalResult(
+                                    resolution,
+                                    evidence));
+                        }
+
+                        candidate = resolved.Candidate;
+                        decision =
+                            PackageHouseDecisionReceipt
+                                .RetainSelectedPackage(
+                                    request,
+                                    resolved);
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(
+                            nameof(request),
+                            request.Demand,
+                            "Unknown PackageHouse demand.");
+                }
+
+                if (request.Operation.Profile
+                    == PackageHouseOperationProfile.Settle)
+                {
+                    return ResourceFree(
+                        new PackageHouseResult.Settled(
+                            new PackageHouseEvidence(
+                                request,
+                                decision,
+                                failures: failures)));
+                }
+
+                PackagePayloadAcquisitionPlan payloadAcquisition =
+                    _payloadAcquisition
+                    ?? throw new InvalidOperationException(
+                        "An Acquire operation requires a payload acquisition plan.");
+                ConfiguredPackagePayloadResult payloadResult =
+                    await sourceOperation
+                        .AcquireCandidatePayloadAsync(
+                            candidate,
+                            payloadAcquisition.GetStore,
+                            log: payloadAcquisition.Log,
+                            limits: payloadAcquisition.Limits,
+                            transferPolicy:
+                                payloadAcquisition.TransferPolicy)
+                        .ConfigureAwait(false);
+                failures.AddRange(
+                    AdaptFailures(request, payloadResult.Failures));
+                if (payloadResult.Payload is not { } payload)
+                {
+                    PackageHouseEvidence evidence = new(
                         request,
-                        exact,
-                        sourceLease,
-                        cancellationToken,
-                        operation).ConfigureAwait(false),
-                PackageHouseDemand.Selecting selecting =>
-                    await ExecuteSelectingAsync(
-                        request,
-                        selecting,
-                        sourceLease,
-                        cancellationToken,
-                        operation).ConfigureAwait(false),
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(request),
-                    request.Demand,
-                    "Unknown PackageHouse demand."),
-            };
-        }
-        catch (NuGetOperationTimeoutException)
-        {
-            return OperationTimedOut(request);
-        }
-        catch (OperationCanceledException)
-            when (operation.CancellationToken.IsCancellationRequested)
-        {
-            throw new OperationCanceledException(
-                operation.CancellationToken);
-        }
-        catch (OperationCanceledException)
-            when (operation.OperationToken.IsCancellationRequested)
-        {
-            return OperationTimedOut(request);
-        }
-    }
+                        decision,
+                        failures: failures);
+                    return ResourceFree(
+                        CreatePayloadTerminalResult(
+                            candidate,
+                            payloadResult,
+                            evidence));
+                }
 
-    private async Task<PackageHouseSettlement> ExecuteExactAsync(
-        PackageHouseRequest request,
-        PackageHouseDemand.Exact exact,
-        PackageSourceSettlementLease sourceLease,
-        CancellationToken cancellationToken,
-        NuGetOperationContext operation)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        operation.ThrowIfExpired();
-        PackageSourceAuthorization authorization =
-            _sourceAuthorization.AuthorizeSourcesFor(
-                exact.Coordinate.PackageId);
-        cancellationToken.ThrowIfCancellationRequested();
-        operation.ThrowIfExpired();
-        PackageAcquisitionCandidateResult candidateResult =
-            sourceLease.ResolvePinnedCandidate(
-                authorization,
-                exact.Coordinate);
-        operation.ThrowIfExpired();
-        List<PackageHouseFailure> failures =
-            AdaptFailures(request, candidateResult.Failures);
-        if (candidateResult.Candidate is not { } candidate)
-        {
-            PackageHouseDecisionReceipt decision =
-                PackageHouseDecisionReceipt.Stop(
-                    request,
-                    exact.Coordinate);
-            PackageHouseEvidence evidence = new(
-                request,
-                decision,
-                failures: failures);
-            return ResourceFree(
-                CreateCandidateTerminalResult(
-                    candidateResult,
-                    authorization,
-                    evidence));
-        }
-
-        PackageHouseDecisionReceipt retained =
-            PackageHouseDecisionReceipt.RetainPackage(
-                request,
-                candidate.Coordinate,
-                candidate);
-        if (request.Operation.Profile
-            == PackageHouseOperationProfile.Settle)
-        {
-            return ResourceFree(
-                new PackageHouseResult.Settled(
-                    new PackageHouseEvidence(
-                        request,
-                        retained,
-                        failures: failures)));
-        }
-
-        return await AcquireAsync(
-            request,
-            retained,
-            candidate,
-            sourceLease,
-            cancellationToken,
-            operation,
-            failures).ConfigureAwait(false);
-    }
-
-    private async Task<PackageHouseSettlement>
-        ExecuteSelectingAsync(
-        PackageHouseRequest request,
-        PackageHouseDemand.Selecting selecting,
-        PackageSourceSettlementLease sourceLease,
-        CancellationToken cancellationToken,
-        NuGetOperationContext operation)
-    {
-        PackageVersionSelectionRequest selection =
-            selecting.Request;
-        cancellationToken.ThrowIfCancellationRequested();
-        operation.ThrowIfExpired();
-        PackageSourceAuthorization authorization =
-            _sourceAuthorization.AuthorizeSourcesFor(
-                selection.PackageId);
-        cancellationToken.ThrowIfCancellationRequested();
-        operation.ThrowIfExpired();
-        PackageVersionDiscoveryContract discoveryContract =
-            PackageVersionDiscoveryContract.Create(
-                selection.Discovery.IncludePrerelease,
-                includeUnlisted: false,
-                limit: null);
-        PackageVersionDiscoveryResult discovery =
-            await sourceLease.DiscoverVersionsAsync(
-                selection.PackageId,
-                authorization,
-                discoveryContract,
-                cancellationToken,
-                operation).ConfigureAwait(false);
-        PackageVersionResolutionReceipt resolution =
-            PackageVersionSelectionResolver.Resolve(
-                selection,
-                discovery,
-                PackageVersionDiscoveryFreshness
-                    .RefreshedForRequest);
-        List<PackageHouseFailure> failures =
-            AdaptFailures(request, discovery.Failures);
-        cancellationToken.ThrowIfCancellationRequested();
-        try
-        {
-            operation.ThrowIfExpired();
-        }
-        catch (NuGetOperationTimeoutException)
-        {
-            return SelectingOperationTimedOut(
-                request,
-                resolution,
-                failures);
-        }
-        if (resolution
-            is not PackageVersionResolutionReceipt.Resolved resolved)
-        {
-            PackageHouseDecisionReceipt decision =
-                PackageHouseDecisionReceipt.Stop(
-                    request,
-                    versionResolution: resolution);
-            PackageHouseEvidence evidence = new(
-                request,
-                decision,
-                failures: failures);
-            return ResourceFree(
-                CreateResolutionTerminalResult(
-                    resolution,
-                    evidence));
-        }
-
-        PackageHouseDecisionReceipt retained =
-            PackageHouseDecisionReceipt.RetainSelectedPackage(
-                request,
-                resolved);
-        if (request.Operation.Profile
-            == PackageHouseOperationProfile.Settle)
-        {
-            return ResourceFree(
-                new PackageHouseResult.Settled(
-                    new PackageHouseEvidence(
-                        request,
-                        retained,
-                        failures: failures)));
-        }
-
-        return await AcquireAsync(
-            request,
-            retained,
-            resolved.Candidate,
-            sourceLease,
-            cancellationToken,
-            operation,
-            failures).ConfigureAwait(false);
-    }
-
-    private async Task<PackageHouseSettlement> AcquireAsync(
-        PackageHouseRequest request,
-        PackageHouseDecisionReceipt decision,
-        PackageAcquisitionCandidate candidate,
-        PackageSourceSettlementLease sourceLease,
-        CancellationToken cancellationToken,
-        NuGetOperationContext operation,
-        List<PackageHouseFailure> failures)
-    {
-        PackagePayloadAcquisitionPlan payloadAcquisition =
-            _payloadAcquisition
-            ?? throw new InvalidOperationException(
-                "An Acquire operation requires a payload acquisition plan.");
-        ConfiguredPackagePayloadResult payloadResult =
-            await sourceLease.AcquireCandidatePayloadAsync(
-                candidate,
-                payloadAcquisition.GetStore,
-                log: payloadAcquisition.Log,
-                limits: payloadAcquisition.Limits,
-                cancellationToken: cancellationToken,
-                transferPolicy: payloadAcquisition.TransferPolicy,
-                operationContext: operation).ConfigureAwait(false);
-        failures.AddRange(
-            AdaptFailures(request, payloadResult.Failures));
-        if (payloadResult.Payload is not { } payload)
-        {
-            PackageHouseEvidence evidence = new(
-                request,
-                decision,
-                failures: failures);
-            return ResourceFree(
-                CreatePayloadTerminalResult(
+                PackageHouseAcquisitionReceipt acquisition = new(
+                    decision,
                     candidate,
-                    payloadResult,
-                    evidence));
-        }
+                    payloadResult.Authority!,
+                    payloadResult.Source!,
+                    payload.Origin,
+                    payload.Content.GenerationIdentity);
+                PackageHouseEvidence settledEvidence = new(
+                    request,
+                    decision,
+                    acquisition,
+                    failures: failures);
+                return new PackageHouseSettlement.Acquired(
+                    new PackageHouseResult.Settled(
+                        settledEvidence),
+                    payload);
+            }
+            catch (NuGetOperationTimeoutException)
+            {
+                return OperationTimedOut(request);
+            }
+            catch (OperationCanceledException)
+            {
+                try
+                {
+                    sourceOperation.ThrowIfExpired();
+                }
+                catch (NuGetOperationTimeoutException)
+                {
+                    return OperationTimedOut(request);
+                }
 
-        PackageHouseAcquisitionReceipt acquisition = new(
-            decision,
-            candidate,
-            payloadResult.Authority!,
-            payloadResult.Source!,
-            payload.Origin,
-            payload.Content.GenerationIdentity);
-        PackageHouseEvidence settledEvidence = new(
-            request,
-            decision,
-            acquisition,
-            failures: failures);
-        return new PackageHouseSettlement.Acquired(
-            new PackageHouseResult.Settled(settledEvidence),
-            payload);
+                throw;
+            }
+        }
     }
 
     private static PackageHouseResult CreateCandidateTerminalResult(
@@ -511,43 +467,19 @@ public sealed class PackageHouse
         new(TextPolicy.Field, text);
 
     private static PackageHouseSettlement OperationTimedOut(
-        PackageHouseRequest request)
+        PackageHouseRequest request,
+        IEnumerable<PackageHouseFailure>? existingFailures = null)
     {
+        var failures = existingFailures is null
+            ? new List<PackageHouseFailure>()
+            : [.. existingFailures];
         PackageHouseFailure.Timeout timeout = new(
             request.Operation.Identity,
             PackageHouseTimeoutKind.Operation,
             request.Operation.OperationTimeout);
+        failures.Add(timeout);
         PackageHouseEvidence evidence = new(
             request,
-            failures: [timeout]);
-        return ResourceFree(
-            new PackageHouseResult.Failed(
-                evidence,
-                Reason("The PackageHouse operation deadline expired.")));
-    }
-
-    private static PackageHouseSettlement SelectingOperationTimedOut(
-        PackageHouseRequest request,
-        PackageVersionResolutionReceipt resolution,
-        List<PackageHouseFailure> failures)
-    {
-        PackageHouseDecisionReceipt decision = resolution switch
-        {
-            PackageVersionResolutionReceipt.Resolved resolved =>
-                PackageHouseDecisionReceipt.RetainSelectedPackage(
-                    request,
-                    resolved),
-            _ => PackageHouseDecisionReceipt.Stop(
-                request,
-                versionResolution: resolution),
-        };
-        failures.Add(new PackageHouseFailure.Timeout(
-            request.Operation.Identity,
-            PackageHouseTimeoutKind.Operation,
-            request.Operation.OperationTimeout));
-        PackageHouseEvidence evidence = new(
-            request,
-            decision,
             failures: failures);
         return ResourceFree(
             new PackageHouseResult.Failed(

--- a/src/DotnetInspector.Packages/PackageHouseRequest.cs
+++ b/src/DotnetInspector.Packages/PackageHouseRequest.cs
@@ -100,6 +100,13 @@ public sealed class PackageHouseOperation
                 timeout,
                 "A PackageHouse timeout must be finite and positive.");
         }
+        if (timeout > NuGetOperationContext.MaximumTimeout)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                timeout,
+                $"A PackageHouse timeout cannot exceed {NuGetOperationContext.MaximumTimeout}.");
+        }
     }
 }
 

--- a/src/DotnetInspector.Packages/PackageSourceOperationLease.cs
+++ b/src/DotnetInspector.Packages/PackageSourceOperationLease.cs
@@ -24,6 +24,10 @@ public sealed class PackageSourceOperationLease : IDisposable
         _context = context;
     }
 
+    internal TimeSpan RequestTimeout => _context.RequestTimeout;
+
+    internal TimeSpan OperationTimeout => _context.OperationTimeout;
+
     /// <summary>Checks the shared caller cancellation and operation ceiling.</summary>
     public void ThrowIfExpired()
     {

--- a/src/NuGetFetch/NuGetFetchOptions.cs
+++ b/src/NuGetFetch/NuGetFetchOptions.cs
@@ -5,9 +5,6 @@ namespace NuGetFetch;
 /// </summary>
 public sealed record NuGetFetchOptions
 {
-    private static readonly TimeSpan MaximumCancellationTimeout =
-        TimeSpan.FromMilliseconds(uint.MaxValue - 1d);
-
     /// <summary>
     /// Default maximum size of a service-index, version-index, or search-response body.
     /// </summary>
@@ -136,7 +133,7 @@ public sealed record NuGetFetchOptions
         TimeSpan requestTimeout)
     {
         ValidateTimeout(requestTimeout, nameof(requestTimeout));
-        if (requestTimeout > MaximumCancellationTimeout / 4)
+        if (requestTimeout > NuGetOperationContext.MaximumTimeout / 4)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(requestTimeout),
@@ -243,12 +240,12 @@ public sealed record NuGetFetchOptions
                 "The timeout must be positive.");
         }
 
-        if (timeout > MaximumCancellationTimeout)
+        if (timeout > NuGetOperationContext.MaximumTimeout)
         {
             throw new ArgumentOutOfRangeException(
                 parameterName,
                 timeout,
-                $"The timeout cannot exceed {MaximumCancellationTimeout}.");
+                $"The timeout cannot exceed {NuGetOperationContext.MaximumTimeout}.");
         }
     }
 }

--- a/src/NuGetFetch/NuGetOperationContext.cs
+++ b/src/NuGetFetch/NuGetOperationContext.cs
@@ -18,6 +18,13 @@ public sealed class NuGetOperationContext : IDisposable
     private int _disposeState;
 
     /// <summary>
+    /// Gets the largest timeout representable by the operation cancellation
+    /// mechanism.
+    /// </summary>
+    public static TimeSpan MaximumTimeout { get; } =
+        TimeSpan.FromMilliseconds(uint.MaxValue - 1d);
+
+    /// <summary>
     /// Creates a context with default request and operation deadlines.
     /// </summary>
     public NuGetOperationContext(

--- a/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageHouseContractTests.cs
@@ -801,6 +801,20 @@ public sealed class PackageHouseContractTests
             operation.Identity,
             PackageHouseOperation.Create(
                 PackageHouseOperationProfile.Acquire).Identity);
+
+        PackageHouseOperation maximum = PackageHouseOperation.Create(
+            PackageHouseOperationProfile.Settle,
+            NuGetOperationContext.MaximumTimeout,
+            NuGetOperationContext.MaximumTimeout);
+        Assert.Equal(
+            NuGetOperationContext.MaximumTimeout,
+            maximum.RequestTimeout);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => PackageHouseOperation.Create(
+                PackageHouseOperationProfile.Settle,
+                NuGetOperationContext.MaximumTimeout
+                    + TimeSpan.FromTicks(1),
+                NuGetOperationContext.MaximumTimeout));
     }
 
     [Fact]

--- a/tests/DotnetInspector.Services.Tests/PackageHouseExecutionTests.cs
+++ b/tests/DotnetInspector.Services.Tests/PackageHouseExecutionTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using DotnetInspector.Packages;
 using NuGetFetch;
 
@@ -26,8 +27,9 @@ public sealed class PackageHouseExecutionTests
         PackageHouseSettlement settlement =
             await house.ExecuteAsync(
                 request,
-                environment.Lease,
-                TestContext.Current.CancellationToken);
+                environment.IssueOperation(
+                    request,
+                    TestContext.Current.CancellationToken));
 
         PackageHouseSettlement.ResourceFree resourceFree =
             Assert.IsType<PackageHouseSettlement.ResourceFree>(
@@ -39,6 +41,7 @@ public sealed class PackageHouseExecutionTests
         Assert.Equal(0, stores);
         Assert.Equal(0, environment.Clients[0].VersionRequests);
         Assert.Equal(0, environment.Clients[0].PayloadRequests);
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -54,8 +57,9 @@ public sealed class PackageHouseExecutionTests
         PackageHouseSettlement settlement =
             await house.ExecuteAsync(
                 request,
-                environment.Lease,
-                TestContext.Current.CancellationToken);
+                environment.IssueOperation(
+                    request,
+                    TestContext.Current.CancellationToken));
 
         PackageHouseSettlement.Acquired acquired =
             Assert.IsType<PackageHouseSettlement.Acquired>(
@@ -75,6 +79,7 @@ public sealed class PackageHouseExecutionTests
         Assert.Equal(payload.Origin, acquisition.Origin);
         Assert.Equal(payload.ProducerKey, acquisition.Producer.Key);
         Assert.Equal(1, environment.Clients[0].PayloadRequests);
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -90,14 +95,16 @@ public sealed class PackageHouseExecutionTests
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => house.ExecuteAsync(
                     request,
-                    environment.Lease,
-                    TestContext.Current.CancellationToken));
+                    environment.IssueOperation(
+                        request,
+                        TestContext.Current.CancellationToken)));
 
         Assert.Contains(
             "package store capability",
             exception.Message,
             StringComparison.Ordinal);
         Assert.Equal(0, environment.Clients[0].PayloadRequests);
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -118,8 +125,9 @@ public sealed class PackageHouseExecutionTests
         PackageHouseSettlement settlement =
             await house.ExecuteAsync(
                 request,
-                environment.Lease,
-                TestContext.Current.CancellationToken);
+                environment.IssueOperation(
+                    request,
+                    TestContext.Current.CancellationToken));
 
         Assert.IsType<PackageHouseResult.Settled>(
             settlement.Result);
@@ -160,8 +168,9 @@ public sealed class PackageHouseExecutionTests
         PackageHouseSettlement settlement =
             await house.ExecuteAsync(
                 request,
-                environment.Lease,
-                TestContext.Current.CancellationToken);
+                environment.IssueOperation(
+                    request,
+                    TestContext.Current.CancellationToken));
 
         Assert.IsType<PackageHouseResult.Incomplete>(
             settlement.Result);
@@ -171,6 +180,7 @@ public sealed class PackageHouseExecutionTests
         Assert.All(
             environment.Clients,
             client => Assert.Equal(0, client.PayloadRequests));
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -187,18 +197,20 @@ public sealed class PackageHouseExecutionTests
             PackageHouseOperation.Create(
                 PackageHouseOperationProfile.Settle));
 
+        PackageHouseRequest absentRequest = CreateRequest();
         PackageHouseSettlement notFound =
             await absent.CreateHouse().ExecuteAsync(
-                CreateRequest(),
-                absent.Lease,
-                cancellationToken:
-                    TestContext.Current.CancellationToken);
+                absentRequest,
+                absent.IssueOperation(
+                    absentRequest,
+                    TestContext.Current.CancellationToken));
+        PackageHouseRequest prereleaseRequest = CreateRequest();
         PackageHouseSettlement noMatch =
             await prerelease.CreateHouse().ExecuteAsync(
-                CreateRequest(),
-                prerelease.Lease,
-                cancellationToken:
-                    TestContext.Current.CancellationToken);
+                prereleaseRequest,
+                prerelease.IssueOperation(
+                    prereleaseRequest,
+                    TestContext.Current.CancellationToken));
 
         Assert.IsType<PackageHouseResult.NotFound>(
             notFound.Result);
@@ -207,25 +219,40 @@ public sealed class PackageHouseExecutionTests
     }
 
     [Fact]
-    public async Task SuppliedOperationDeadlinesMustMatchRequest()
+    public async Task OperationDeadlinesMustMatchRequest()
     {
         await using HouseEnvironment environment = HouseEnvironment.Create(
             new SourceBehavior([Version]));
         PackageHouseRequest request = ExactRequest(
             PackageHouseOperationProfile.Settle);
-        using var operation = new NuGetOperationContext(
-            request.Operation.RequestTimeout
-                + TimeSpan.FromSeconds(1),
-            request.Operation.OperationTimeout,
-            TestContext.Current.CancellationToken);
+        PackageSourceOperationLease operation =
+            environment.Root.IssueOperationLease(
+                TestContext.Current.CancellationToken,
+                request.Operation.RequestTimeout
+                    + TimeSpan.FromSeconds(1),
+                request.Operation.OperationTimeout);
 
         await Assert.ThrowsAsync<ArgumentException>(
             () => environment.CreateHouse().ExecuteAsync(
                 request,
-                environment.Lease,
-                cancellationToken:
-                    TestContext.Current.CancellationToken,
-                operationContext: operation));
+                operation));
+        await environment.AssertRootSettledAsync();
+    }
+
+    [Fact]
+    public async Task NullRequestReleasesTransferredOperation()
+    {
+        await using HouseEnvironment environment = HouseEnvironment.Create(
+            new SourceBehavior([Version]));
+        PackageSourceOperationLease operation =
+            environment.Root.IssueOperationLease(
+                TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => environment.CreateHouse().ExecuteAsync(
+                null!,
+                operation));
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -255,12 +282,14 @@ public sealed class PackageHouseExecutionTests
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => environment.CreateHouse().ExecuteAsync(
                     request,
-                    environment.Lease,
-                    cancellationToken: cancellation.Token));
+                    environment.IssueOperation(
+                        request,
+                        cancellation.Token)));
 
         Assert.Equal(
             cancellation.Token,
             exception.CancellationToken);
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -286,12 +315,13 @@ public sealed class PackageHouseExecutionTests
         PackageHouseSettlement settlement =
             await environment.CreateHouse().ExecuteAsync(
                 request,
-                environment.Lease,
-                cancellationToken:
-                    TestContext.Current.CancellationToken);
+                environment.IssueOperation(
+                    request,
+                    TestContext.Current.CancellationToken));
 
         Assert.IsType<PackageHouseResult.Failed>(
             settlement.Result);
+        Assert.Null(settlement.Result.Decision);
         Assert.Contains(
             settlement.Result.Evidence.Failures,
             failure =>
@@ -303,6 +333,9 @@ public sealed class PackageHouseExecutionTests
                     } authority
                 && authority.Failure.Timeout.Duration
                     == request.Operation.OperationTimeout);
+        Assert.IsType<PackageHouseFailure.Timeout>(
+            settlement.Result.Evidence.Failures.Last());
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -319,10 +352,10 @@ public sealed class PackageHouseExecutionTests
                 requestTimeout: TimeSpan.FromSeconds(1),
                 operationTimeout:
                     TimeSpan.FromMilliseconds(20)));
-        using var operation = new NuGetOperationContext(
-            request.Operation.RequestTimeout,
-            request.Operation.OperationTimeout,
-            TestContext.Current.CancellationToken);
+        PackageSourceOperationLease operation =
+            environment.IssueOperation(
+                request,
+                TestContext.Current.CancellationToken);
         await Task.Delay(
             TimeSpan.FromMilliseconds(60),
             TestContext.Current.CancellationToken);
@@ -330,10 +363,7 @@ public sealed class PackageHouseExecutionTests
         PackageHouseSettlement settlement =
             await environment.CreateHouse().ExecuteAsync(
                 request,
-                environment.Lease,
-                cancellationToken:
-                    TestContext.Current.CancellationToken,
-                operationContext: operation);
+                operation);
 
         Assert.IsType<PackageHouseResult.Failed>(
             settlement.Result);
@@ -342,6 +372,7 @@ public sealed class PackageHouseExecutionTests
             Assert.Single(
                 settlement.Result.Evidence.Failures));
         Assert.Equal(0, environment.Clients[0].VersionRequests);
+        await environment.AssertRootSettledAsync();
     }
 
     [Fact]
@@ -358,9 +389,9 @@ public sealed class PackageHouseExecutionTests
         PackageHouseSettlement settlement =
             await environment.CreateHouse().ExecuteAsync(
                 request,
-                environment.Lease,
-                cancellationToken:
-                    TestContext.Current.CancellationToken);
+                environment.IssueOperation(
+                    request,
+                    TestContext.Current.CancellationToken));
         PackageHouseDecisionReceipt decision =
             Assert.IsType<PackageHouseDecisionReceipt>(
                 settlement.Result.Decision);
@@ -386,6 +417,102 @@ public sealed class PackageHouseExecutionTests
             Assert.Single(failed.Evidence.Failures));
     }
 
+    [Fact]
+    public async Task UnsupportedRealizeReleasesTransferredOperation()
+    {
+        await using HouseEnvironment environment = HouseEnvironment.Create(
+            new SourceBehavior([Version]));
+        var request = new PackageHouseRequest(
+            new PackageHouseDemand.Exact(
+                PackageSourceCoordinate.Create(
+                    PackageId,
+                    Version)),
+            PackageHouseOperation.Create(
+                PackageHouseOperationProfile.Realize),
+            PackageHouseTargetContext.Exact("net10.0"),
+            PackageHouseAssetSelectionKind.Compile);
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => environment.CreateHouse().ExecuteAsync(
+                request,
+                environment.IssueOperation(
+                    request,
+                    TestContext.Current.CancellationToken)));
+
+        await environment.AssertRootSettledAsync();
+    }
+
+    [Fact]
+    public async Task ThrownSourceExceptionReleasesTransferredOperation()
+    {
+        var expected =
+            new InvalidDataException("Source failed after invocation.");
+        await using HouseEnvironment environment = HouseEnvironment.Create(
+            new SourceBehavior(
+                [Version],
+                BeforeVersions: (_, _) =>
+                    Task.FromException(expected)));
+        var request = new PackageHouseRequest(
+            new PackageHouseDemand.Selecting(
+                new PackageVersionSelectionRequest.LatestStable(
+                    PackageId)),
+            PackageHouseOperation.Create(
+                PackageHouseOperationProfile.Settle));
+
+        Assert.Same(
+            expected,
+            await Assert.ThrowsAsync<InvalidDataException>(
+                () => environment.CreateHouse().ExecuteAsync(
+                    request,
+                    environment.IssueOperation(
+                        request,
+                        TestContext.Current.CancellationToken))));
+        await environment.AssertRootSettledAsync();
+    }
+
+    [Fact]
+    public void ResultsAndReceiptsRetainNoSourceLeaseAuthority()
+    {
+        Type[] resourceTypes =
+        [
+            typeof(PackageSourceOperationLease),
+            typeof(PackageSourceSettlementLease),
+        ];
+        Type[] resultAndReceiptTypes =
+        [
+            typeof(PackageHouseSettlement),
+            .. typeof(PackageHouseSettlement)
+                .GetNestedTypes(BindingFlags.Public),
+            typeof(PackageHouseResult),
+            .. typeof(PackageHouseResult)
+                .GetNestedTypes(BindingFlags.Public),
+            typeof(PackageHouseDecisionReceipt),
+            typeof(PackageHouseAcquisitionReceipt),
+            typeof(PackageHouseEvidence),
+            typeof(PackageHouseFailure),
+            .. typeof(PackageHouseFailure)
+                .GetNestedTypes(BindingFlags.Public),
+            typeof(PackageAcquisitionCandidate),
+            typeof(PackageAcquisitionCandidateCorrespondence),
+            typeof(PackageVersionResolutionReceipt),
+            .. typeof(PackageVersionResolutionReceipt)
+                .GetNestedTypes(BindingFlags.Public),
+            typeof(AcquiredPackageSourcePayload),
+        ];
+
+        Assert.All(
+            resultAndReceiptTypes,
+            type => Assert.DoesNotContain(
+                type.GetFields(
+                    BindingFlags.Instance
+                    | BindingFlags.Public
+                    | BindingFlags.NonPublic),
+                field => resourceTypes.Any(
+                    resource =>
+                        resource.IsAssignableFrom(
+                            field.FieldType))));
+    }
+
     private static PackageHouseRequest ExactRequest(
         PackageHouseOperationProfile profile) =>
         new(
@@ -408,19 +535,19 @@ public sealed class PackageHouseExecutionTests
     {
         private HouseEnvironment(
             FixedAuthorization authorization,
-            PackageSourceSettlementLease lease,
+            PackageSourceSettlementLease root,
             IReadOnlyList<HouseSourceClient> clients,
             IReadOnlyList<IPackageSourceClient> ownedClients)
         {
             Authorization = authorization;
-            Lease = lease;
+            Root = root;
             Clients = clients;
             OwnedClients = ownedClients;
         }
 
         public FixedAuthorization Authorization { get; }
 
-        public PackageSourceSettlementLease Lease { get; }
+        public PackageSourceSettlementLease Root { get; }
 
         public IReadOnlyList<HouseSourceClient> Clients { get; }
 
@@ -495,9 +622,24 @@ public sealed class PackageHouseExecutionTests
                     ? null
                     : new PackagePayloadAcquisitionPlan(getStore));
 
+        public PackageSourceOperationLease IssueOperation(
+            PackageHouseRequest request,
+            CancellationToken cancellationToken) =>
+            Root.IssueOperationLease(
+                cancellationToken,
+                request.Operation.RequestTimeout,
+                request.Operation.OperationTimeout);
+
+        public async Task AssertRootSettledAsync()
+        {
+            ValueTask settlement = Root.DisposeAsync();
+            Assert.True(settlement.IsCompletedSuccessfully);
+            await settlement;
+        }
+
         public async ValueTask DisposeAsync()
         {
-            await Lease.DisposeAsync();
+            await Root.DisposeAsync();
             foreach (IPackageSourceClient client in OwnedClients)
             {
                 client.Dispose();


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that provide foundational
capabilities or compelling user experiences while remaining conventionally
sound, delightfully new, or both.

## Summary

Adopt Package Source operation ownership in PackageHouse. Each House execution
now consumes one already-issued `PackageSourceOperationLease`, owns it through
every synchronous and asynchronous source step, and releases it on every
terminal path.

- remove the root settlement lease, caller cancellation, and optional
  `NuGetOperationContext` from `PackageHouse.ExecuteAsync`;
- validate that the transferred operation lease carries the request's exact
  deadlines;
- preserve exact authorization, complete discovery, selection, payload, typed
  failure, and retained-content behavior;
- publish no selection decision when the operation timeout is established
  before or during resolution;
- keep decisions, candidates, evidence, receipts, and payload results free of
  live source authority.

PackageHouse does not issue, rename, wrap, retain, or publish the source-owned
lease. Library ownership and `Realize` remain separate adoption steps.

## Demo

```csharp
PackageSourceOperationLease sourceOperation =
    sourceRoot.IssueOperationLease(
        cancellationToken,
        request.Operation.RequestTimeout,
        request.Operation.OperationTimeout);

PackageHouseSettlement settlement =
    await house.ExecuteAsync(request, sourceOperation);
```

After `ExecuteAsync` returns or throws, the transferred operation has been
released and root settlement can complete. This includes successful settle or
acquire, typed source failure, missing acquisition policy, deadline mismatch,
caller cancellation, operation timeout, unsupported `Realize`, and source
exceptions.

The neighboring acquired-payload case keeps its caller-owned retained content
and exact resource-free acquisition receipt after the source operation is
released.

## Ownership contract

- An ordinary `PackageSourceOperationLease` parameter transfers ownership into
  `PackageHouse.ExecuteAsync`.
- One private async core owns the lease; PackageHouse uses its instance
  receivers as synchronous borrows for source operations.
- The lease owns the lower-level `NuGetOperationContext`; PackageHouse sees
  only the deadline facts required for request correspondence.
- Discovery-level or post-selection operation timeout produces a typed failed
  result without an unproven decision receipt.
- `PackagePayloadAcquisitionPlan` remains stable host policy and contains no
  source lease or release obligation.

## Stack

This is PackageHouse step 12b of #6544's 18-step ownership adoption plan.

- **Parent:** #6630 — Package Source operation ownership implementation
- **Current slice:** PackageHouse adoption tracked by #6622
- **Later:** Library ownership in PackageHouse and package-backed Platform
  adoption remain separately owned.

Closes #6622.

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project tests/DotnetInspector.Services.Tests -c Release -- \
  --filter-class '*PackageHouseExecutionTests' '*PackageHouseContractTests'
  66 passed
dotnet run --project tests/DotnetInspector.Services.Tests -c Release --no-build
  1414 passed, 2 skipped
dotnet run --project tests/NuGetFetch.Tests -c Release --no-build
  1136 passed, 11 skipped
npx markdownlint-cli \
  docs/design/package-house.md \
  docs/design/package-source-model.md
git diff --check
```

SDK: `11.0.100-rc.1.26425.128`.
