### PR TITLE
Adapt prefix candidate pages to observed yield

### DIFF
--- a/docs/design/package-prefix-candidate-stream.md
+++ b/docs/design/package-prefix-candidate-stream.md
@@ -64,12 +64,20 @@ Empty filtered pages are valid: they do not prove source exhaustion.
   JSON remain failures; semantically invalid entries inside the syntactically
   valid, unconsumed `versions` property do not invalidate a prefix candidate.
 
-Gallery still requests 100 raw rows per page, advances by the raw response
-count, and applies its existing 3,000 maximum skip and 100-page client ceiling.
-Metadata byte limits, repeat-page rejection, candidate limits, and exact
-manifest validation remain in force. One retained source page is permitted;
-this does not promise one network row per Browser credit or avoid scanning
-nonmatching candidates to establish the next match.
+Gallery candidate pages initially request 20 raw rows. When a completed raw
+page admits fewer than half as many new literal-prefix matches as raw rows, the
+next request doubles monotonically through 40 and 80 to the existing 100-row
+ceiling. Dense prefixes therefore retain a 20-row acquisition window, while
+sparse prefixes recover the established scan throughput. Materialized prefix
+search retains 100-row requests because its caller has already requested one
+aggregate rather than demand-driven pages.
+
+Pagination advances by the raw response count and retains the existing 3,000
+maximum skip and 100-page client ceiling. Metadata byte limits, repeat-page
+rejection, candidate limits, and exact manifest validation remain in force.
+One retained source page is permitted; this does not promise one network row
+per Browser credit or avoid scanning nonmatching candidates to establish the
+next match.
 
 ## Work and deadline ownership
 
@@ -96,13 +104,13 @@ behavioral reference.
 
 ## Evidence and non-claims
 
-`PackagePrefixSearchTests` gates demand, order, filtering, limits, late failures,
-cancellation, idle-time exclusion, cumulative active budget, caller-context
-ownership, top-level metadata preservation, version-history omission, and
-top-level identity failure. `PackageProfileQueryTests` gates manifest work
-before later search pages, disposal, and partial-result accounting.
-`PackageQueryTests` gates the consumer's existing limits and failure projection.
-These gates run in Release.
+`PackagePrefixSearchTests` gates demand, order, filtering, adaptive request
+sizes, limits, late failures, cancellation, idle-time exclusion, cumulative
+active budget, caller-context ownership, top-level metadata preservation,
+version-history omission, and top-level identity failure.
+`PackageProfileQueryTests` gates manifest work before later search pages,
+disposal, and partial-result accounting. `PackageQueryTests` gates the
+consumer's existing limits and failure projection. These gates run in Release.
 
 The pathological case is a useful first page followed by a blocked or failed
 second page: the first manifest result must already be observable, and the
@@ -116,8 +124,19 @@ production projection transfers only the prototype's top-level-field selection;
 it continues to use the existing source client, request containment, result
 factory, and page contract.
 
+The adaptive-page prototype at `724774adf` ran the same published Browser
+artifact and NativeAOT comparator three times for twelve prefixes on both
+fernie and merritt. The first request was 20 rows in all 72 Browser samples,
+and all samples paused at the initial 20-match credit. `AWSSDK.*` row-20
+latency fell from 7.920 to 2.468 seconds on fernie and from 6.120 to 1.672
+seconds on merritt; descendant-process RSS growth fell from about 75 to 31 MB
+and from about 78 to 40 MB respectively. The sparse `Grpc.*` witness grew to
+100-row requests and completed source exhaustion within 0.4 seconds of the
+fixed-100 baseline on both hosts.
+
 This slice does not claim a fixed first-row latency, reduce NuGet round-trip
-time, reduce the 100-row raw page size, yield individual candidates before one
-raw page completes, parallelize manifests, virtualize the DOM, or move Wasm into
-a Worker. The production measurements in #5816 explain the motivation, not a
-deterministic latency guarantee.
+time, yield individual candidates before one raw page completes, isolate
+decompression from JSON processing, parallelize manifests, virtualize the DOM,
+or change the Worker credit protocol. The production measurements in #5816
+explain the motivation and observed result, not a deterministic latency
+guarantee.

--- a/src/NuGetFetch/SearchService.cs
+++ b/src/NuGetFetch/SearchService.cs
@@ -8,6 +8,7 @@ namespace NuGetFetch;
 /// </summary>
 public partial class SearchService
 {
+    private const int InitialPrefixCandidatePageSize = 20;
     private const int PrefixSearchPageSize = 100;
     private const int MaxPrefixSearchPages = 100;
     private readonly HttpClient _client;
@@ -376,6 +377,9 @@ public partial class SearchService
             new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _observedResults =
             new(StringComparer.OrdinalIgnoreCase);
+        private int _pageSize = includeVersionHistory
+            ? PrefixSearchPageSize
+            : InitialPrefixCandidatePageSize;
         private int _skip;
         private int _pageNumber;
 
@@ -396,14 +400,14 @@ public partial class SearchService
                 ? await service.SearchPageAsync(
                     prefix,
                     _skip,
-                    PrefixSearchPageSize,
+                    _pageSize,
                     prerelease,
                     auth,
                     operation).ConfigureAwait(false)
                 : await service.SearchPrefixCandidatePageAsync(
                     prefix,
                     _skip,
-                    PrefixSearchPageSize,
+                    _pageSize,
                     prerelease,
                     auth,
                     operation).ConfigureAwait(false);
@@ -436,6 +440,12 @@ public partial class SearchService
             if (!madeProgress)
                 throw new InvalidOperationException(
                     "NuGet search pagination repeated a page without making progress.");
+
+            if (!includeVersionHistory
+                && matches.Count * 2 < page.Count)
+            {
+                _pageSize = Math.Min(_pageSize * 2, PrefixSearchPageSize);
+            }
 
             _skip += page.Count;
             if (!IsCompleted)

--- a/tests/NuGetFetch.Tests/PackagePrefixSearchTests.cs
+++ b/tests/NuGetFetch.Tests/PackagePrefixSearchTests.cs
@@ -51,6 +51,41 @@ public sealed class PackagePrefixSearchTests
         AssertRequests(handler, [0, 1, 2], prerelease);
     }
 
+    [Fact]
+    public async Task Gallery_CandidatePagesStartSmallAndGrowAfterLowPrefixYield()
+    {
+        string[] firstPage = Enumerable.Range(0, 20)
+            .Select(index => $"Contoso.Dense.{index}").ToArray();
+        string[] sparsePage =
+        [
+            .. Enumerable.Range(0, 4)
+                .Select(index => $"Contoso.Sparse.{index}"),
+            .. Enumerable.Range(0, 16)
+                .Select(index => $"Other.Package.{index}"),
+        ];
+        string[] emptyFilteredPage = Enumerable.Range(16, 40)
+            .Select(index => $"Other.Package.{index}").ToArray();
+        var handler = new PagingHandler(
+            JsonPage(firstPage),
+            JsonPage(sparsePage),
+            JsonPage(emptyFilteredPage),
+            JsonPage());
+        using IPackageSourceClient source = PackageSourceClientFactory.CreateGallery(
+            PackageSourceAssociation.Create(), handler);
+
+        await foreach (PackageSourceOperationResult<PackageSearchResult> _ in
+            source.SearchByPrefixPagesAsync(
+                Prefix,
+                cancellationToken: TestContext.Current.CancellationToken))
+        {
+        }
+
+        AssertRequests(
+            handler,
+            skips: [0, 20, 40, 80],
+            takes: [20, 20, 40, 80]);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -113,7 +148,7 @@ public sealed class PackagePrefixSearchTests
         Assert.Equal(["Contoso.Zulu", "contoso.Alpha"],
             first.Matches.Select(match => match.Metadata.Id));
         Assert.All(first.Matches, match => Assert.Equal("1.0.0", match.Metadata.Version));
-        AssertRequests(handler, [0, 4, 7]);
+        AssertRequests(handler, [0, 4, 7], takes: [20, 20, 40]);
     }
 
     [Fact]
@@ -248,11 +283,11 @@ public sealed class PackagePrefixSearchTests
         Assert.True(await enumerator.MoveNextAsync());
         AssertPage(source, enumerator.Current, PackageSearchTruncationReason.None,
             "contoso.Match");
-        AssertRequests(handler, [0, 2]);
+        AssertRequests(handler, [0, 2], takes: [20, 40]);
         Assert.True(await enumerator.MoveNextAsync());
         AssertPage(source, enumerator.Current, PackageSearchTruncationReason.None);
         Assert.False(await enumerator.MoveNextAsync());
-        AssertRequests(handler, [0, 2, 3]);
+        AssertRequests(handler, [0, 2, 3], takes: [20, 40, 40]);
     }
 
     [Theory]
@@ -342,7 +377,7 @@ public sealed class PackagePrefixSearchTests
         Assert.True(await enumerator.MoveNextAsync());
         AssertFailure(source, enumerator.Current, PackageSourceFailureKind.InvalidResponse);
         Assert.False(await enumerator.MoveNextAsync());
-        AssertRequests(handler, [0, 100]);
+        AssertRequests(handler, [0, 100], takes: [20, 40]);
     }
 
     [Theory]
@@ -378,8 +413,22 @@ public sealed class PackagePrefixSearchTests
         }
 
         Assert.False(await enumerator.MoveNextAsync());
-        AssertRequests(handler,
-            Enumerable.Range(0, pageCount).Select(page => page * rawPageSize).ToArray());
+        int[] takes = rawPageSize == 100
+            ? Enumerable.Range(0, pageCount)
+                .Select(page => page switch
+                {
+                    0 => 20,
+                    1 => 40,
+                    2 => 80,
+                    _ => 100,
+                })
+                .ToArray()
+            : Enumerable.Repeat(20, pageCount).ToArray();
+        AssertRequests(
+            handler,
+            Enumerable.Range(0, pageCount)
+                .Select(page => page * rawPageSize).ToArray(),
+            takes: takes);
     }
 
     [Fact]
@@ -598,7 +647,10 @@ public sealed class PackagePrefixSearchTests
         Assert.Equal(streamedIds, aggregate.Matches.Select(match => match.Metadata.Id));
         int[] skips = take == 3 ? [0, 2] : [0, 2, 5];
         AssertRequests(streamingHandler, skips);
-        AssertRequests(materializedHandler, skips);
+        AssertRequests(
+            materializedHandler,
+            skips,
+            takes: Enumerable.Repeat(100, skips.Length).ToArray());
     }
 
     [Fact]
@@ -616,7 +668,7 @@ public sealed class PackagePrefixSearchTests
                 Prefix,
                 cancellationToken: TestContext.Current.CancellationToken),
             PackageSourceFailureKind.InvalidResponse);
-        AssertRequests(handler, [0, 1]);
+        AssertRequests(handler, [0, 1], takes: [100, 100]);
     }
 
     private static PackageSearchResult AssertPage(
@@ -657,13 +709,17 @@ public sealed class PackagePrefixSearchTests
     private static void AssertRequests(
         PagingHandler handler,
         int[] skips,
-        bool prerelease = false)
+        bool prerelease = false,
+        int[]? takes = null)
     {
+        takes ??= Enumerable.Repeat(20, skips.Length).ToArray();
+        Assert.Equal(skips.Length, takes.Length);
         Assert.Equal(
-            skips.Select(skip =>
+            skips.Zip(takes, (skip, take) =>
                 $"{GallerySearch}?q={Uri.EscapeDataString(Prefix)}"
                 + $"&skip={skip.ToString(CultureInfo.InvariantCulture)}"
-                + $"&take=100&prerelease={(prerelease ? "true" : "false")}&semVerLevel=2.0.0"),
+                + $"&take={take.ToString(CultureInfo.InvariantCulture)}"
+                + $"&prerelease={(prerelease ? "true" : "false")}&semVerLevel=2.0.0"),
             handler.Requests.Select(uri => uri.AbsoluteUri));
     }
 


### PR DESCRIPTION
Build robust, capable Package Query experiences that are conventionally sound
and provide a compelling, responsive path from broad package discovery to
inspection.

## Summary

Start demand-driven NuGet prefix candidate pages at 20 raw Search rows, then
double monotonically through 40 and 80 to the existing 100-row ceiling when a
page admits fewer than half as many new literal-prefix matches as raw rows.

This aligns dense first-window acquisition with the CLI and Browser's initial
20-match demand while preserving sparse-prefix scan throughput. Materialized
prefix search retains its existing 100-row requests. Provider order, literal
filtering, case-insensitive deduplication, raw-count `skip` accounting, source
limits, failure behavior, and the Worker credit protocol are unchanged.

## Demo

Three fresh-process samples per prefix and host compared the existing fixed-100
published Browser path, this adaptive published Browser artifact, and the
incremental NativeAOT `take=20` prototype.

| Prefix and host | Fixed 100 | Adaptive | NativeAOT | Adaptive / native |
| --- | ---: | ---: | ---: | ---: |
| `AWSSDK.*`, fernie | 7,920 ms | 2,468 ms | 647 ms | 3.81x |
| `AWSSDK.*`, merritt | 6,120 ms | 1,672 ms | 611 ms | 2.74x |
| `System.*`, fernie | 1,477 ms | 1,059 ms | 359 ms | 2.95x |
| `System.*`, merritt | 683 ms | 540 ms | 333 ms | 1.62x |
| `Azure.*`, fernie | 1,670 ms | 1,187 ms | 348 ms | 3.41x |
| `Azure.*`, merritt | 669 ms | 548 ms | 304 ms | 1.80x |

All 72 adaptive Browser samples began with `take=20`, used one Worker, and
paused at exactly 20 visible packages until viewport pressure. Across twelve
prefixes, adaptive Browser row-20 latency was 1.01-2.74x NativeAOT on merritt
and 1.69-3.81x on fernie.

For `AWSSDK.*`, the first response fell from about 1.61 MB gzip to 371 KB.
Median descendant-process RSS growth fell from about 75 to 31 MB on fernie and
from about 78 to 40 MB on merritt.

The sparse `Grpc.*` witness grew `20, 40, 80, 100`, used 23 requests rather
than 20, and established its 24-match exhaustion in 7.169 seconds on fernie
versus 7.556 seconds before, and 5.592 seconds on merritt versus 5.400 seconds
before.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/NuGetFetch.Tests -c Release`
  - 1,041 passed, 11 environment/platform skips
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release -- --filter-class '*PackageQueryTests' '*PackageProfileQueryTests'`
  - 58 passed
- `npx markdownlint-cli docs/design/package-prefix-candidate-stream.md`
- 72 exact-artifact production Browser Worker samples across fernie and
  merritt, plus 72 same-host NativeAOT samples

Tracks #5816.
