### PR TITLE
Specify source integrity audit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -205,6 +205,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [C# Memory-Safety Declaration Spelling](design/csharp-memory-safety-spelling.md) | Proposed CSharp-owned spelling of caller contracts independently from pointer syntax and body-context requirements. |
 | [Source Finding Producers](design/source-finding-producers.md) | How source-derived Findings are produced. |
 | [Source Availability Audit](design/source-availability-audit.md) | Operation-scoped source reachability and origin-validated positive reuse. |
+| [Source Integrity Audit](design/source-integrity-audit.md) | Operation-scoped SourceLink body verification and immutable positive reuse. |
 | [Untrusted Data Threat Model](design/untrusted-data-threat-model.md) | Trust boundaries, existing controls, and the security-scope rationale for untrusted internet-origin data. |
 | [Finding Adoption](design/finding-adoption.md) | How Analysis, Findings, and Research compose. |
 | [Call Graph Projection](design/call-graph-projection.md) | Projecting the inspection graph into a call graph. |

--- a/docs/design/source-integrity-audit.md
+++ b/docs/design/source-integrity-audit.md
@@ -1,0 +1,240 @@
+# Source integrity audit
+
+Status: Implemented existing contract
+
+## Decision
+
+`SourceIntegrityService` owns whether one source-document census provides
+sufficient current or reusable checksum-authenticated body evidence to classify
+each eligible non-embedded compiler source observation as exact,
+line-ending-normalized, mismatched, or unverifiable for the current integrity
+audit.
+
+The audit is an operation-scoped checksum fold. It does not prove repository
+completeness, authorship, or permanent source availability.
+
+This document specifies an existing host-neutral service. It introduces no new
+capability, shared substrate, host, architecture, or rendering path. CLI
+library and package `SourceLink: Integrity` views are its current consumers. A
+browser/Wasm host may use the same service without a persistent cache.
+
+## Motivating production scenario
+
+The nuget.org `System.Text.Json` package is a canonical production consumer:
+
+```console
+dotnet-inspect package System.Text.Json -S "SourceLink: Integrity"
+```
+
+The command acquires package PDB evidence, downloads compiler source documents,
+and reports exact, line-ending-normalized, mismatched, and unverifiable counts.
+The deterministic gates use controlled bodies and transport timing because a
+published package cannot reliably reproduce cancellation at the body-completion
+boundary.
+
+## Owners and boundaries
+
+The service consumes, but does not redefine, these owner-issued facts:
+
+- [Source finding producers](source-finding-producers.md) owns the
+  source-document census, storage kind, resolved URL, authored path, checksum
+  algorithm, and canonical checksum spelling.
+- `PdbSourceHouse.VerifyChecksum` owns SHA1/SHA256 verification and the exact,
+  line-ending-normalized, mismatch, unavailable, and unsupported verdicts.
+- `SourceLinkUrls` owns immutable-content recognition.
+- `SourceFetchOriginValidator` applies the SourceLink provenance rule for
+  final-origin admission.
+- `HttpRetryHelper` owns retried, timeout-bound, size-bounded GET acquisition
+  and its typed outcomes.
+- `CoreCache` owns generic persistence, and `ISourceLinkQueryCache` is the
+  optional host adapter.
+- `SourceIntegrityQuery` owns typed query composition.
+- CLI library and package sections own presentation and package aggregation.
+
+`SourceFetch` and selected-member or type source acquisition are adjacent but
+outside this decision. They return authenticated source bytes to different
+consumers and have their own content-store behavior.
+
+## Census and denominator
+
+The input is one completed source-document census. The audit first selects C#,
+Visual Basic, and F# observations by canonical path.
+
+Embedded observations are outside this audit's denominator. Their bytes are
+carried in the portable PDB rather than acquired through the SourceLink URL
+path owned here.
+
+Every other selected observation contributes exactly one primary verdict:
+
+```text
+Verified + Mismatched + Unverifiable
+  = non-embedded compiler source observations
+```
+
+`LineEndingNormalized` is a disclosed subset of `Verified`, not a fifth
+primary verdict. Empty, non-compiler-only, and embedded-only censuses therefore
+produce zero counts.
+
+Repeated URLs or checksums do not collapse compiler observations. Each
+observation remains in the denominator even when it consumes the same reusable
+integrity evidence.
+
+## Classification
+
+The service classifies observations in this order:
+
+1. Non-compiler observations and embedded observations are outside the
+   denominator.
+2. A non-embedded compiler observation without a resolved URL, checksum,
+   checksum algorithm, or HTTP(S) scheme is unverifiable without network or
+   cache work.
+3. An admitted reusable immutable `verified` observation is exact.
+4. An admitted reusable immutable `normalized` observation is
+   line-ending-normalized.
+5. Otherwise, the service requests the source body through the owned bounded
+   GET operation.
+6. Cancellation observed after acquisition propagates before checksum
+   verification, classification, or publication.
+7. A changed final origin, unavailable response, transport failure, timeout,
+   or oversized body is unverifiable.
+8. `PdbSourceHouse.VerifyChecksum` classifies acquired bytes.
+9. Exact and line-ending-normalized results are verified; only the latter
+   increments `LineEndingNormalized`.
+10. A mismatch increments `Mismatched` and records the authored document path.
+11. An unavailable or unsupported checksum verdict is unverifiable.
+
+Mismatched authored paths are reported in ordinal order. Operational
+diagnostics must not include artifact-authored URLs or paths; presentation may
+render the separately typed `MismatchedFiles`.
+
+## Final-origin and body admission
+
+The service supplies `SourceFetchOriginValidator` to the header-first body
+operation. For an attributable SourceLink request, the final response URL must
+preserve the complete repository and revision origin before any body is read.
+An unattributed requested URL carries no repository provenance claim and
+remains admissible under that owner's rule.
+
+Each body is limited to `SourceFetch.MaxSourceDownloadSize`, currently 16 MB.
+The limit applies when `Content-Length` is present and while reading decoded
+bytes when it is absent. Size and transport mechanics remain owned and gated by
+`HttpRetryHelper`; this service owns only their `Unverifiable`
+classification.
+
+## Checksum evidence
+
+The checksum algorithm and expected bytes come from the portable PDB census.
+Metadata recognizes SHA1 and SHA256 and emits their names as `SHA1` or
+`SHA256`; SourceLink findings emit the checksum as canonical uppercase
+hexadecimal.
+
+`PdbSourceHouse.VerifyChecksum` first checks the exact acquired bytes. If that
+fails and the content contains line endings, it checks LF and CRLF
+normalizations. A normalized match is useful compatibility evidence but remains
+separately disclosed; it is not relabeled as an exact byte match.
+
+Only `Mismatch` means fetched, final-origin-admitted bytes failed a supported
+checksum. Missing metadata, an unsupported checksum, or acquisition failure is
+`Unverifiable`, not mismatch.
+
+## Cache subject and reuse
+
+The cache subject is:
+
+```text
+(source-integrity-v2, immutable resolved URL,
+ producer-issued checksum algorithm, canonical checksum, verification kind)
+```
+
+The current key spelling is:
+
+```text
+<resolved URL>|<SHA1-or-SHA256>|<canonical checksum>
+```
+
+This spelling is unambiguous under the producer contract: the recognized
+algorithm names are closed, and each is followed by a fixed-length hexadecimal
+checksum. The `verified` and `normalized` extensions preserve the distinct
+verdict.
+
+Only recognized immutable URLs are eligible for lookup or publication.
+Checksum-authenticated exact and line-ending-normalized observations may be
+reused without expiry because the subject names both immutable content and the
+expected checksum. Mutable URL positives are verified again on every audit.
+
+The marker value is an opaque presence token. Mismatches, unavailable or
+unsupported inputs, acquisition failures, origin rejection, oversize bodies,
+and cancellation publish nothing. There is no negative integrity entry.
+
+## Failure and cancellation
+
+The HTTP helper converts expected response, transport, timeout, and body-limit
+conditions into typed acquisition outcomes. The integrity service converts
+those outcomes into `Unverifiable` observations and content-free diagnostics.
+
+Unexpected exceptions are not evidence about source integrity. They propagate
+out of the service so `SourceIntegrityQuery` can return its typed `Failed`
+outcome instead of presenting a success-shaped `Available` summary.
+
+The caller's cancellation token governs network and body work. Cancellation
+observed after acquisition or checksum computation propagates before result
+classification or cache publication. It is not translated into an integrity
+verdict.
+
+## Concurrency and ordering
+
+The service verifies eligible observations with maximum concurrency 16.
+Completion order does not affect the summary: counters are atomic and mismatch
+paths are sorted ordinally.
+
+The persistent cache is per integrity subject across audits. Concurrent
+observations may duplicate acquisition before either publishes; the contract
+does not promise single-flight behavior.
+
+## Pathological cases
+
+The contract-defining cases are:
+
+- exact immutable content publishes `verified` and is reused;
+- normalized immutable content publishes `normalized`, is reused, and remains
+  separately counted;
+- mutable content is acquired and verified on every audit;
+- changed-origin and typed acquisition failures are unverifiable and publish
+  nothing;
+- cancellation becoming visible as body acquisition completes propagates and
+  publishes nothing;
+- an unexpected acquisition exception fails rather than returning an
+  unverifiable success-shaped summary; and
+- embedded and non-compiler observations stay outside the denominator while
+  every other compiler observation contributes one primary verdict.
+
+## Required gates
+
+`SourceLinkQueryServiceTests` must gate:
+
+- mixed exact, mismatch, unverifiable, embedded, and non-compiler accounting;
+- immutable exact and normalized category, key, extension, permanent lookup,
+  publication, and reuse;
+- mutable positive non-reuse;
+- no publication after final-origin rejection or typed acquisition failure;
+- cancellation after body completion but before verification and publication;
+  and
+- propagation of an unexpected exception.
+
+`PdbSourceHouseTests` owns checksum and line-ending-normalization matrices.
+`SourceLinkProvenanceTests` owns immutable URL recognition and final-origin
+admission. `HttpRetryHelperTests` owns retry, timeout, streaming, and decoded
+body-limit mechanics. This service consumes those gates rather than duplicating
+their internal cases.
+
+## Non-claims
+
+This decision does not claim:
+
+- source authorship, repository completeness, or permanent availability;
+- integrity for embedded or non-compiler documents;
+- exact byte identity for a line-ending-normalized result;
+- provenance for URLs outside recognized origin grammars;
+- reusable evidence for mutable URLs or failed operations;
+- single-flight acquisition; or
+- selected-member, selected-type, or local-repository source behavior.

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -581,7 +581,7 @@ empty snapshot is a cache miss rather than authoritative candidate metadata.
 | Symbol miss markers | `$LOCAL_APP_DATA/dotnet-inspect/symbol-misses/` | 1 day | dotnet-inspect |
 | Verified SourceLink bytes | `$LOCAL_APP_DATA/dotnet-inspect/source-bytes-v2/` | Permanent when the caller's checksum validator accepts the bytes | dotnet-inspect |
 | [SourceLink availability markers](source-availability-audit.md#cache-subject-and-reuse) | `$LOCAL_APP_DATA/dotnet-inspect/source-audit-v2/` | Permanent for immutable positives, 1 day for mutable positives; no persisted misses | dotnet-inspect |
-| SourceLink integrity markers | `$LOCAL_APP_DATA/dotnet-inspect/source-integrity-v2/` | Permanent for immutable checksum-verified results | dotnet-inspect |
+| [SourceLink integrity markers](source-integrity-audit.md#cache-subject-and-reuse) | `$LOCAL_APP_DATA/dotnet-inspect/source-integrity-v2/` | Permanent for immutable exact or line-ending-normalized results; no mutable or negative entries | dotnet-inspect |
 
 The app package cache carries a `{source}` segment because cached content is
 scoped to the source that supplied it; see

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -334,9 +334,10 @@ network requests.
   availability reuse. Origin-validated positives are permanent only for
   recognized immutable commit-pinned URLs and otherwise retain a one-day TTL.
   Non-success results lack final-origin evidence and remain operation-local.
-- Integrity positives are cached permanently only when the provenance grammar
-  establishes an immutable commit-pinned GitHub or Azure DevOps URL. Integrity
-  results for unknown hosts and moving or ambiguous selectors are not cached.
+- [Source integrity audit](design/source-integrity-audit.md) owns checksum
+  classification and reuse. Exact and line-ending-normalized positives are
+  permanent only when the provenance grammar establishes an immutable
+  commit-pinned URL. Mutable positives and failed operations are not cached.
 - The target bare-library effective catalog may persist successful
   package/platform section summaries under its versioned semantic key. The
   slice-5 successor keys on retained assembly content plus complete typed

--- a/src/DotnetInspector.Services/SourceIntegrityService.cs
+++ b/src/DotnetInspector.Services/SourceIntegrityService.cs
@@ -98,45 +98,31 @@ public static class SourceIntegrityService
                         return;
                     }
 
-                    byte[]? body;
-                    try
-                    {
-                        HttpRetryHelper.HttpBodyFetchResult fetch =
-                            await HttpRetryHelper.GetBytesAfterHeadersWithRetryAsync(
-                                httpClient,
+                    HttpRetryHelper.HttpBodyFetchResult fetch =
+                        await HttpRetryHelper.GetBytesAfterHeadersWithRetryAsync(
+                            httpClient,
+                            document.ResolvedUrl!,
+                            response => SourceFetchOriginValidator.Validate(
                                 document.ResolvedUrl!,
-                                response => SourceFetchOriginValidator.Validate(
-                                    document.ResolvedUrl!,
-                                    response.RequestMessage?.RequestUri?.AbsoluteUri).IsAllowed,
-                                log: null,
-                                cancellationToken: ct,
-                                trafficKind: NetworkTrafficKind.SourceIntegrity,
-                                maxDownloadSize: SourceFetch.MaxSourceDownloadSize)
-                                .ConfigureAwait(false);
-                        if (fetch.Status
-                            == HttpRetryHelper.HttpBodyFetchStatus.ResponseRejected)
-                        {
-                            log?.Invoke(
-                                "Could not verify the final SourceLink response origin.");
-                            body = null;
-                        }
-                        else if (fetch.Bytes is { } bytes)
-                        {
-                            body = bytes;
-                        }
-                        else
-                        {
-                            log?.Invoke("Source integrity fetch failed.");
-                            body = null;
-                        }
+                                response.RequestMessage?.RequestUri?.AbsoluteUri).IsAllowed,
+                            log: null,
+                            cancellationToken: ct,
+                            trafficKind: NetworkTrafficKind.SourceIntegrity,
+                            maxDownloadSize: SourceFetch.MaxSourceDownloadSize)
+                            .ConfigureAwait(false);
+                    ct.ThrowIfCancellationRequested();
+                    if (fetch.Status
+                        == HttpRetryHelper.HttpBodyFetchStatus.ResponseRejected)
+                    {
+                        log?.Invoke(
+                            "Could not verify the final SourceLink response origin.");
                     }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    else if (fetch.Bytes is null)
                     {
                         log?.Invoke("Source integrity fetch failed.");
-                        body = null;
                     }
 
-                    if (body == null)
+                    if (fetch.Bytes is not { } body)
                     {
                         Interlocked.Increment(ref unverifiable);
                         return;
@@ -144,6 +130,7 @@ public static class SourceIntegrityService
 
                     SourceChecksumVerification verification =
                         PdbSourceHouse.VerifyChecksum(document, body);
+                    ct.ThrowIfCancellationRequested();
                     if (verification == SourceChecksumVerification.Exact)
                     {
                         Interlocked.Increment(ref verified);

--- a/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
+++ b/tests/DotnetInspector.Services.Tests/SourceLinkQueryServiceTests.cs
@@ -88,6 +88,170 @@ public class SourceLinkQueryServiceTests
     }
 
     [Fact]
+    public async Task Integrity_ImmutableExactEvidenceIsReused()
+    {
+        const string Url =
+            "https://raw.githubusercontent.com/example/repo/"
+            + "0123456789abcdef0123456789abcdef01234567/src/a.cs";
+        byte[] body = "exact source"u8.ToArray();
+        string checksum = Convert.ToHexString(SHA256.HashData(body));
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(body),
+            };
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+
+        SourceIntegritySummary initial = await SourceIntegrityService.InspectAsync(
+            [Document("/src/A.cs", url: Url, checksum: checksum)],
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+        SourceIntegritySummary repeated = await SourceIntegrityService.InspectAsync(
+            [Document("/src/A.cs", url: Url, checksum: checksum)],
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, initial.Verified);
+        Assert.Equal(1, repeated.Verified);
+        Assert.Equal(1, requests);
+        Assert.Equal(["verified", "normalized", "verified"],
+            cache.Lookups.Select(static lookup => lookup.Extension));
+        Assert.All(cache.Lookups, lookup =>
+        {
+            Assert.Equal("source-integrity-v2", lookup.Category);
+            Assert.Equal($"{Url}|SHA256|{checksum}", lookup.Key);
+            Assert.Null(lookup.MaxAge);
+        });
+        Assert.Equal(
+            new CacheWrite(
+                "source-integrity-v2",
+                $"{Url}|SHA256|{checksum}",
+                "1",
+                "verified"),
+            Assert.Single(cache.Writes));
+    }
+
+    [Fact]
+    public async Task Integrity_ImmutableNormalizedEvidenceIsReused()
+    {
+        const string Url =
+            "https://raw.githubusercontent.com/example/repo/"
+            + "0123456789abcdef0123456789abcdef01234567/src/a.cs";
+        byte[] expected = "first\nsecond\n"u8.ToArray();
+        byte[] served = "first\r\nsecond\r\n"u8.ToArray();
+        string checksum = Convert.ToHexString(SHA256.HashData(expected));
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(served),
+            };
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+
+        SourceIntegritySummary initial = await SourceIntegrityService.InspectAsync(
+            [Document("/src/A.cs", url: Url, checksum: checksum)],
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+        SourceIntegritySummary repeated = await SourceIntegrityService.InspectAsync(
+            [Document("/src/A.cs", url: Url, checksum: checksum)],
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, initial.Verified);
+        Assert.Equal(1, initial.LineEndingNormalized);
+        Assert.Equal(1, repeated.Verified);
+        Assert.Equal(1, repeated.LineEndingNormalized);
+        Assert.Equal(1, requests);
+        Assert.Equal(
+            ["verified", "normalized", "verified", "normalized"],
+            cache.Lookups.Select(static lookup => lookup.Extension));
+        Assert.Equal(
+            new CacheWrite(
+                "source-integrity-v2",
+                $"{Url}|SHA256|{checksum}",
+                "1",
+                "normalized"),
+            Assert.Single(cache.Writes));
+    }
+
+    [Fact]
+    public async Task Integrity_MutablePositiveIsVerifiedOnEveryAudit()
+    {
+        const string Url = "https://example.test/src/a.cs";
+        byte[] body = "exact source"u8.ToArray();
+        string checksum = Convert.ToHexString(SHA256.HashData(body));
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(body),
+            };
+        }));
+        RecordingSourceLinkQueryCache cache = new();
+        SourceDocumentObservation[] documents =
+            [Document("/src/A.cs", url: Url, checksum: checksum)];
+
+        SourceIntegritySummary initial = await SourceIntegrityService.InspectAsync(
+            documents,
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+        SourceIntegritySummary repeated = await SourceIntegrityService.InspectAsync(
+            documents,
+            client,
+            cache,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, initial.Verified);
+        Assert.Equal(1, repeated.Verified);
+        Assert.Equal(2, requests);
+        Assert.Empty(cache.Lookups);
+        Assert.Empty(cache.Writes);
+    }
+
+    [Fact]
+    public async Task Integrity_DuplicateObservationsRemainInTheDenominator()
+    {
+        const string Url = "https://example.test/src/a.cs";
+        byte[] body = "exact source"u8.ToArray();
+        string checksum = Convert.ToHexString(SHA256.HashData(body));
+        int requests = 0;
+        using var client = new HttpClient(new StubHandler(_ =>
+        {
+            Interlocked.Increment(ref requests);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(body),
+            };
+        }));
+        SourceDocumentObservation observation =
+            Document("/src/A.cs", url: Url, checksum: checksum);
+
+        SourceIntegritySummary result = await SourceIntegrityService.InspectAsync(
+            [observation, observation],
+            client,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.Verified);
+        Assert.Equal(0, result.Mismatched);
+        Assert.Equal(0, result.Unverifiable);
+        Assert.Equal(2, requests);
+    }
+
+    [Fact]
     public async Task Availability_DoesNotCountCrossOriginRedirectAsReachable()
     {
         const string Url =
@@ -356,6 +520,7 @@ public class SourceLinkQueryServiceTests
             + "?api-version=7.1&versionType=commit"
             + "&version=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&path=/A.cs";
         var content = new TrackingContent(body);
+        RecordingSourceLinkQueryCache cache = new();
         using var client = new HttpClient(new StubHandler(_ =>
             new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -374,6 +539,7 @@ public class SourceLinkQueryServiceTests
                     checksum: Convert.ToHexString(SHA256.HashData(body)))
             ],
             client,
+            cache,
             log: logs.Add,
             cancellationToken: TestContext.Current.CancellationToken);
 
@@ -381,6 +547,7 @@ public class SourceLinkQueryServiceTests
         Assert.Equal(0, result.Mismatched);
         Assert.Equal(1, result.Unverifiable);
         Assert.Equal(0, content.ReadCount);
+        Assert.Empty(cache.Writes);
         Assert.DoesNotContain(logs, message => message.Contains(Url, StringComparison.Ordinal));
         Assert.DoesNotContain(
             logs,
@@ -391,10 +558,13 @@ public class SourceLinkQueryServiceTests
     [Fact]
     public async Task Integrity_FailureDiagnosticsDoNotEchoArtifactUrls()
     {
-        const string Url = "https://example.test/secret.cs";
+        const string Url =
+            "https://raw.githubusercontent.com/example/secret/"
+            + "0123456789abcdef0123456789abcdef01234567/src/secret.cs";
         List<string> logs = [];
         using var client = new HttpClient(
             new ThrowingHandler($"transport exposed {Url}"));
+        RecordingSourceLinkQueryCache cache = new();
 
         SourceIntegritySummary result = await SourceIntegrityService.InspectAsync(
             [
@@ -404,16 +574,71 @@ public class SourceLinkQueryServiceTests
                     checksum: Convert.ToHexString(SHA256.HashData("expected"u8)))
             ],
             client,
+            cache,
             log: logs.Add,
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, result.Unverifiable);
         Assert.Contains("Source integrity fetch failed.", logs);
+        Assert.Empty(cache.Writes);
         Assert.DoesNotContain(logs, message => message.Contains(Url, StringComparison.Ordinal));
         Assert.DoesNotContain(
             logs,
             message => message.Contains("/src/Secret.cs", StringComparison.Ordinal));
         Assert.DoesNotContain(logs, message => message.Contains("https://", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Integrity_CancellationAfterBodyDoesNotPublishEvidence()
+    {
+        const string Url =
+            "https://raw.githubusercontent.com/example/repo/"
+            + "0123456789abcdef0123456789abcdef01234567/src/a.cs";
+        byte[] body = "exact source"u8.ToArray();
+        using CancellationTokenSource cancellation = new();
+        using var client = new HttpClient(new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new CancellationAtEofContent(body, cancellation),
+            }));
+        RecordingSourceLinkQueryCache cache = new();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => SourceIntegrityService.InspectAsync(
+                [
+                    Document(
+                        "/src/A.cs",
+                        url: Url,
+                        checksum: Convert.ToHexString(SHA256.HashData(body)))
+                ],
+                client,
+                cache,
+                cancellationToken: cancellation.Token));
+
+        Assert.Empty(cache.Writes);
+    }
+
+    [Fact]
+    public async Task Integrity_UnexpectedFailureEscapesTheAudit()
+    {
+        const string Url = "https://example.test/source.cs";
+        using var client = new HttpClient(
+            new UnexpectedThrowingHandler(new InvalidOperationException("unexpected")));
+        RecordingSourceLinkQueryCache cache = new();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SourceIntegrityService.InspectAsync(
+                [
+                    Document(
+                        "/src/A.cs",
+                        url: Url,
+                        checksum: Convert.ToHexString(SHA256.HashData("expected"u8)))
+                ],
+                client,
+                cache,
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Empty(cache.Writes);
     }
 
     [Fact]
@@ -479,7 +704,15 @@ public class SourceLinkQueryServiceTests
             HttpRequestMessage request,
             CancellationToken cancellationToken)
             => Task.FromException<HttpResponseMessage>(
-                new InvalidOperationException(message));
+                new HttpRequestException(message));
+    }
+
+    private sealed class UnexpectedThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromException<HttpResponseMessage>(exception);
     }
 
     private sealed class RecordingSourceLinkQueryCache : ISourceLinkQueryCache
@@ -524,6 +757,43 @@ public class SourceLinkQueryServiceTests
         string Key,
         string Content,
         string Extension);
+
+    private sealed class CancellationAtEofContent(
+        byte[] content,
+        CancellationTokenSource cancellation)
+        : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context)
+            => stream.WriteAsync(content).AsTask();
+
+        protected override Task<Stream> CreateContentReadStreamAsync()
+            => Task.FromResult<Stream>(
+                new CancellationAtEofStream(content, cancellation));
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = content.Length;
+            return true;
+        }
+    }
+
+    private sealed class CancellationAtEofStream(
+        byte[] content,
+        CancellationTokenSource cancellation)
+        : MemoryStream(content, writable: false)
+    {
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            int read = Read(buffer.Span);
+            if (read == 0)
+                cancellation.Cancel();
+            return ValueTask.FromResult(read);
+        }
+    }
 
     private sealed class TrackingContent(byte[] content) : HttpContent
     {


### PR DESCRIPTION
Build robust, capable SourceLink auditing by giving
`SourceIntegrityService` one focused normative contract and ensuring canceled
or unexpectedly failed acquisitions cannot leave success-shaped integrity
evidence.

Closes #6680.

## Demo

The production package flow audits `System.Text.Json` from nuget.org:

```console
$ dnx dotnet-inspect -y -- package System.Text.Json \
    -S "SourceLink: Integrity"

# System.Text.Json

## SourceLink: Integrity

| Field | Value |
| ----- | ----- |
| Checked Libraries | 1/1 checked |
| CR/LF Mismatch | 338 normalized |
| Mismatched | 0 |
| Status | Partial |
| Unverifiable | 2 |
| Verified | 338 |
```

What to notice:

- All 338 fetched compiler sources passed their portable-PDB checksums after
  line endings were normalized. The audit preserves that distinction instead
  of reporting an exact byte match.
- Two observations lacked enough evidence to verify. They remain
  `Unverifiable`; they are not mislabeled as checksum mismatches.
- For a commit-pinned immutable URL, an exact or normalized positive can be
  reused because the cache subject includes both immutable content identity and
  the expected checksum. A mutable URL is downloaded and verified on every
  audit.
- The deterministic cancellation gate returns the complete body and requests
  cancellation at EOF. The audit now observes that cancellation before
  checksum classification or cache publication.

The focused contract gates run together:

```console
$ dotnet run --project tests/DotnetInspector.Services.Tests -c Release --no-build \
    -- --filter-class DotnetInspector.Services.Tests.SourceLinkQueryServiceTests

Test run summary: Passed!
  total: 21
  failed: 0
  succeeded: 21
```

## Summary

- Add `docs/design/source-integrity-audit.md` as the single owner for the
  checksum-audit denominator, verdict classification, final-origin and body
  admission, immutable positive reuse, failures, cancellation, concurrency,
  pathological cases, and non-claims.
- Preserve the current `source-integrity-v2` subject and permanent reuse only
  for exact or line-ending-normalized evidence over recognized immutable URLs.
- Observe cancellation after body acquisition and checksum computation, before
  result classification or cache publication.
- Stop converting unexpected exceptions into successful summaries containing
  only `Unverifiable` evidence. Expected typed transport, response, timeout, and
  body-limit outcomes remain unverifiable.
- Gate immutable exact and normalized reuse, mutable non-reuse, duplicate
  denominator observations, final-origin rejection, typed failure, unexpected
  failure, and EOF-timed cancellation without publication.
- Leave `SourceFetch`, `PdbSourceHouse`, `HttpRetryHelper`, SourceReady Library
  work in PR #6531, and PackageHouse untouched.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.Services.Tests -c Release`
  (1,431 passed)
- focused `SourceLinkQueryServiceTests` (21 passed)
- `npx markdownlint-cli docs/design/source-integrity-audit.md docs/sourcelink-exposure.md docs/design/version-resolution.md docs/README.md`
- `git diff --check`
