### PR TITLE
Add exact Catalog package receipt evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [Member Body Substrate](design/member-body-substrate.md) | One base for skeleton/full/merged/diff body rendering: `ApiType` shape, `MemberAnchor` address, one scope, and `MemberBody`'s scalar (whole-body) and vector (offset-keyed) shapes. |
 | [NuGet API Selection](design/nuget.md) | Scenario-to-API decisions, endpoint roles, first/last-result performance evidence, and current versus proposed adoption. |
 | [NuGet Catalog Acquisition](design/nuget-catalog-acquisition.md) | Bounded incremental acquisition of advertised Catalog event windows with source identity, horizon, completion, and typed failure. |
+| [NuGet Catalog Package Receipt](design/nuget-catalog-package-receipt.md) | Exact Package Details leaf enrichment for source-issued first-receipt time with event correspondence and typed failure. |
 | [GitHub NuGet Advisory Evidence](design/github-nuget-advisory-evidence.md) | Bounded reviewed-advisory acquisition and exact-coordinate current-affected and explicitly-fixed evidence with honest category availability. |
 | [Package Query Input Selection](design/package-query-input-selection.md) | Exact-ID and explicit-prefix selection shared by Package Query consumers, with blank input remaining idle. |
 | [Package Query Inspection Evidence](design/package-query-inspection-evidence.md) | Inspection-produced item counts and bounded previews, distinct from query-wide context. |

--- a/docs/design/nuget-catalog-package-receipt.md
+++ b/docs/design/nuget-catalog-package-receipt.md
@@ -1,0 +1,120 @@
+# NuGet Catalog package-receipt evidence
+
+## Status and authority
+
+This document is the normative owner for enriching one NuGet Catalog Package
+Details event with the source-issued time when that package version was first
+received. Its claim is deliberately narrow:
+
+> Given one factory-issued Package Details event, acquire its advertised
+> Catalog leaf and return the source-issued package-receipt timestamp while
+> preserving exact event and source-result identity.
+
+The immediate consumer is the
+[ecosystem change report](ecosystem-change-report.md), whose tracked production
+path in [#6124](https://github.com/richlander/dotnet-inspect/issues/6124)
+continues through shared query and rendering, CLI, and browser/Wasm adoption.
+That report remains the owner of joining receipt evidence to advisory evidence
+and classifying a security release.
+
+This owner does not define ecosystem membership, advisory interpretation,
+security-release meaning, report filtering or ordering, Registration metadata,
+presentation, caching, or a maintained package inventory.
+
+| Owner | Boundary consumed here |
+| --- | --- |
+| [NuGet Catalog acquisition](nuget-catalog-acquisition.md) | Factory-issued Details events, retained advertised leaf URLs, exact coordinate and commit identity, and source-result provenance. |
+| [NuGetFetch source and deadline contracts](browser-package-sources.md#nugetfetch-typed-source-result-identity) | Caller-authorized source association, typed failure, guarded transport, credential scope, request and operation deadlines, and cancellation. |
+| [Untrusted-data threat model](untrusted-data-threat-model.md#feed-discovered-package-resources-use-a-guarded-destination-policy) | Guarded advertised destinations, bounded response bodies, duplicate-property rejection, and construction-time validation. |
+| [NuGet Catalog specification][catalog-spec] | Package Details leaf fields and the meanings of `created`, `published`, and Catalog commit identity. |
+
+## Evidence contract
+
+`NuGetCatalogPackageReceipt` retains the exact factory-issued
+`NuGetCatalogEvent`, its `PackageSourceResultIdentity`, one UTC
+`ReceivedAt` timestamp, and the closed basis that supplied that timestamp.
+
+The preferred basis is the Package Details leaf's `created` field. The Catalog
+specification defines it as when the package was first received by the package
+source and names `published` as its fallback property. When `created` is absent,
+the result therefore uses the required `published` field and records
+`PublishedFallback` rather than presenting the two fields as equivalent.
+
+This is source-receipt evidence. It is not publisher intent, semantic-version
+meaning, a Catalog commit time, an advisory time, or proof of why the package
+was released. In particular, `published` is the time when a package was last
+listed and is a year-1900 sentinel for an unlisted package on nuget.org.
+Consumers retain the basis and decide whether fallback evidence is suitable
+for their own claim.
+
+Enrichment does not rename the input event. The event remains **snapshot
+observed**; a later reflow, relist, metadata update, or vulnerability update can
+produce another Details event carrying the same package-receipt time.
+
+## Acquisition and admission
+
+The Catalog capability accepts only a non-null Details event issued by that
+same runtime client. A Delete event or an event issued by another client is a
+caller contract violation rejected before network work.
+
+The client fetches only the event's retained, advertised leaf URL. It does not
+synthesize a leaf URL, rescan the Catalog, or query Registration. Credentials
+follow the existing same-origin rule relative to the configured service index;
+the configured desktop or browser transport applies destination policy to the
+leaf request.
+
+One complete leaf is admitted atomically only when:
+
+- the root is an object whose `@type` includes `PackageDetails`;
+- `id` and normalized `version` equal the event coordinate;
+- `catalog:commitId` and `catalog:commitTimeStamp` equal the event;
+- required `published` and optional `created` values are complete ISO 8601
+  timestamps with an explicit UTC designator or numeric offset; and
+- no object at any depth contains duplicate properties.
+
+Accepted timestamps are normalized to UTC. Unknown optional properties are
+ignored. Malformed text, timestamp, coordinate, kind, or correspondence is a
+typed invalid response; it never produces partial evidence.
+
+## Bounds, failure, and portability
+
+One enrichment is one logical NuGet operation. It inherits the source's
+existing retry policy, per-response metadata-byte limit, request deadline,
+operation deadline, caller cancellation, destination policy, and
+authentication handling. The eventual report owns the finite number of events
+it chooses to enrich; this owner does not add a hidden multi-event batch or
+independent work budget.
+
+A missing retained leaf is an invalid source response rather than proof that
+the package coordinate is absent. Authentication, timeout, response rejection,
+transport failure, and invalid metadata remain distinct typed failures carrying
+the event coordinate and source-result identity. Caller cancellation
+propagates as cancellation.
+
+The implementation uses `HttpClient`, `System.Text.Json`, and existing
+NuGetFetch abstractions only. It introduces no platform-specific API,
+reflection, inspected-assembly loading, or synchronous blocking and therefore
+inherits NuGetFetch's desktop and browser/Wasm compatibility contract.
+
+## Evidence and non-claims
+
+The focused Release suite gates:
+
+- a nuget.org-shaped real Package Details leaf and its `created` receipt time;
+- the specification-defined `published` fallback and explicit basis;
+- exact package, version, kind, commit ID, and commit-time correspondence;
+- duplicate properties, malformed values, and over-bound response bodies;
+- no credential forwarding to an off-origin advertised leaf;
+- typed missing-leaf and deadline failures plus caller cancellation; and
+- pre-network rejection of Delete and foreign-client events.
+
+The real shape is grounded in the documented nuget.org Catalog resource and
+the live `Util.Biz.Payments@0.0.4-preview` Package Details leaf. Tests remain
+hermetic and preserve only the fields required by this contract.
+
+The suite does not claim that every feed publishes Catalog, every Details leaf
+has `created`, source receipt equals publisher release intent, or every
+fallback timestamp is suitable security-release evidence. Those are outside
+this owner's claim.
+
+[catalog-spec]: https://learn.microsoft.com/nuget/api/catalog-resource

--- a/src/NuGetFetch/NuGetCatalogPackageReceipt.cs
+++ b/src/NuGetFetch/NuGetCatalogPackageReceipt.cs
@@ -1,0 +1,328 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace NuGetFetch;
+
+internal sealed partial class NuGetV3PackageSourceClient
+{
+    public async Task<
+        PackageSourceOperationResult<NuGetCatalogPackageReceipt>>
+        GetPackageReceiptAsync(
+            NuGetCatalogEvent detailsEvent,
+            CancellationToken cancellationToken = default,
+            NuGetOperationContext? operationContext = null)
+    {
+        _results.ValidateCatalogDetailsEvent(detailsEvent);
+        using NuGetOperationDeadline operation =
+            CreateOperation(cancellationToken, operationContext);
+        return await PackageSourceOperation.CaptureCatalogPackageReceiptAsync(
+            _results,
+            detailsEvent.Coordinate,
+            async () =>
+            {
+                ParsedCatalogPackageReceipt parsed =
+                    await ReadPackageReceiptAsync(
+                        detailsEvent,
+                        operation).ConfigureAwait(false);
+                return _results.CatalogPackageReceipt(
+                    detailsEvent,
+                    parsed.ReceivedAt,
+                    parsed.Basis,
+                    operation);
+            },
+            operation,
+            cancellationToken,
+            operationContext).ConfigureAwait(false);
+    }
+
+    private async Task<ParsedCatalogPackageReceipt>
+        ReadPackageReceiptAsync(
+            NuGetCatalogEvent detailsEvent,
+            NuGetOperationDeadline operation)
+    {
+        string serviceIndexUrl =
+            NuGetSourceRequest.EndpointUrl(_endpoint);
+        PackageSourceCredential? credential =
+            NuGetSourceRequest.CredentialForEndpoint(
+                serviceIndexUrl,
+                detailsEvent.LeafUrl,
+                _credential);
+        return await NuGetHttpRetry.RunRequestAsync(
+            operation,
+            async requestToken =>
+            {
+                using HttpRequestMessage request =
+                    NuGetHttpRequest.CreateGetPreservingPathAndQuery(
+                        detailsEvent.LeafUrl);
+                NuGetSourceRequest.ApplyCredential(request, credential);
+                using HttpResponseMessage response = await _client.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    requestToken).ConfigureAwait(false);
+                try
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+                catch (HttpRequestException exception)
+                    when (exception.StatusCode
+                        == System.Net.HttpStatusCode.NotFound)
+                {
+                    throw new NuGetSourceResponseException(
+                        "The Catalog Package Details leaf retained by the source was not found.",
+                        exception);
+                }
+
+                return await NuGetMetadataReader.ReadResponseAsync(
+                    response,
+                    (json, cancellationToken) =>
+                        NuGetCatalogPackageReceiptReader.ReadAsync(
+                            json,
+                            detailsEvent,
+                            cancellationToken),
+                    _options,
+                    operation.RequestTimeout,
+                    requestToken).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+    }
+}
+
+internal sealed record ParsedCatalogPackageReceipt(
+    DateTimeOffset ReceivedAt,
+    NuGetCatalogPackageReceiptBasis Basis);
+
+internal static class NuGetCatalogPackageReceiptReader
+{
+    private const string TimestampFormat =
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK";
+
+    private static JsonDocumentOptions DocumentOptions =>
+        new()
+        {
+            AllowDuplicateProperties = false,
+            MaxDepth = 64,
+        };
+
+    internal static async ValueTask<ParsedCatalogPackageReceipt> ReadAsync(
+        Stream json,
+        NuGetCatalogEvent detailsEvent,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument document =
+            await ParseDocumentAsync(
+                json,
+                cancellationToken).ConfigureAwait(false);
+
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+            throw Invalid("The Catalog Package Details leaf must be an object.");
+        RequirePackageDetailsType(root);
+
+        string packageId = RequiredText(root, "id");
+        string version = RequiredText(root, "version");
+        PackageSourceCoordinate coordinate;
+        try
+        {
+            coordinate = PackageSourceCoordinate.Create(packageId, version);
+        }
+        catch (ArgumentException exception)
+        {
+            throw Invalid(
+                "The Catalog Package Details leaf contained an invalid package coordinate.",
+                exception);
+        }
+
+        if (coordinate != detailsEvent.Coordinate)
+        {
+            throw Invalid(
+                "The Catalog Package Details leaf did not match the retained package coordinate.");
+        }
+
+        if (!RequiredText(root, "catalog:commitId").Equals(
+                detailsEvent.CommitId,
+                StringComparison.Ordinal))
+        {
+            throw Invalid(
+                "The Catalog Package Details leaf did not match the retained commit ID.");
+        }
+
+        DateTimeOffset commitTimestamp =
+            RequiredTimestamp(root, "catalog:commitTimeStamp");
+        if (commitTimestamp != detailsEvent.CommitTimestamp)
+        {
+            throw Invalid(
+                "The Catalog Package Details leaf did not match the retained commit timestamp.");
+        }
+
+        DateTimeOffset published = RequiredTimestamp(root, "published");
+        if (root.TryGetProperty("created", out JsonElement created))
+        {
+            return new ParsedCatalogPackageReceipt(
+                ReadTimestamp(created, "created"),
+                NuGetCatalogPackageReceiptBasis.Created);
+        }
+
+        return new ParsedCatalogPackageReceipt(
+            published,
+            NuGetCatalogPackageReceiptBasis.PublishedFallback);
+    }
+
+    private static async ValueTask<JsonDocument> ParseDocumentAsync(
+        Stream json,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await JsonDocument.ParseAsync(
+                json,
+                DocumentOptions,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (JsonException exception)
+        {
+            throw Invalid(
+                "The Catalog Package Details leaf was not valid JSON.",
+                exception);
+        }
+    }
+
+    private static void RequirePackageDetailsType(JsonElement root)
+    {
+        if (!root.TryGetProperty("@type", out JsonElement type))
+        {
+            throw Invalid(
+                "The Catalog Package Details leaf must contain '@type'.");
+        }
+
+        bool found = false;
+        if (type.ValueKind == JsonValueKind.String)
+        {
+            found = ReadText(type, "@type").Equals(
+                "PackageDetails",
+                StringComparison.Ordinal);
+        }
+        else if (type.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in type.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String)
+                {
+                    throw Invalid(
+                        "The Catalog Package Details leaf had an invalid '@type' value.");
+                }
+
+                found |= ReadText(item, "@type").Equals(
+                    "PackageDetails",
+                    StringComparison.Ordinal);
+            }
+        }
+        else
+        {
+            throw Invalid(
+                "The Catalog Package Details leaf had an invalid '@type' value.");
+        }
+
+        if (!found)
+        {
+            throw Invalid(
+                "The Catalog leaf was not a Package Details document.");
+        }
+    }
+
+    private static string RequiredText(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out JsonElement value)
+            || value.ValueKind != JsonValueKind.String)
+        {
+            throw Invalid(
+                $"The Catalog Package Details leaf must contain nonempty '{name}' text.");
+        }
+
+        string text = ReadText(value, name);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw Invalid(
+                $"The Catalog Package Details leaf must contain nonempty '{name}' text.");
+        }
+
+        return text;
+    }
+
+    private static string ReadText(JsonElement value, string name)
+    {
+        try
+        {
+            return value.GetString()
+                ?? throw Invalid(
+                    $"The Catalog Package Details leaf had an invalid '{name}' value.");
+        }
+        catch (InvalidOperationException exception)
+        {
+            throw Invalid(
+                $"The Catalog Package Details leaf contained invalid UTF-16 '{name}' text.",
+                exception);
+        }
+    }
+
+    private static DateTimeOffset RequiredTimestamp(
+        JsonElement root,
+        string name)
+    {
+        if (!root.TryGetProperty(name, out JsonElement value))
+        {
+            throw Invalid(
+                $"The Catalog Package Details leaf must contain '{name}'.");
+        }
+
+        return ReadTimestamp(value, name);
+    }
+
+    private static DateTimeOffset ReadTimestamp(
+        JsonElement value,
+        string name)
+    {
+        if (value.ValueKind != JsonValueKind.String)
+        {
+            throw Invalid(
+                $"The Catalog Package Details leaf had an invalid '{name}' timestamp.");
+        }
+
+        string text = ReadText(value, name);
+        if (!HasExplicitOffset(text)
+            || !DateTimeOffset.TryParseExact(
+                text,
+                TimestampFormat,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out DateTimeOffset parsed))
+        {
+            throw Invalid(
+                $"The Catalog Package Details leaf had an invalid '{name}' timestamp.");
+        }
+
+        return parsed.ToUniversalTime();
+    }
+
+    private static bool HasExplicitOffset(string value)
+    {
+        if (value.EndsWith('Z'))
+            return true;
+        if (value.Length < 6)
+            return false;
+
+        int offset = value.Length - 6;
+        return value[offset] is '+' or '-'
+            && char.IsAsciiDigit(value[offset + 1])
+            && char.IsAsciiDigit(value[offset + 2])
+            && value[offset + 3] == ':'
+            && char.IsAsciiDigit(value[offset + 4])
+            && char.IsAsciiDigit(value[offset + 5]);
+    }
+
+    private static NuGetSourceResponseException Invalid(string message) =>
+        new(message);
+
+    private static NuGetSourceResponseException Invalid(
+        string message,
+        Exception inner) =>
+        new(message, inner);
+}

--- a/src/NuGetFetch/NuGetCatalogResult.cs
+++ b/src/NuGetFetch/NuGetCatalogResult.cs
@@ -96,6 +96,16 @@ public interface INuGetCatalogPackageSourceClient : IPackageSourceClient
             NuGetCatalogRequest request,
             CancellationToken cancellationToken = default,
             NuGetOperationContext? operationContext = null);
+
+    /// <summary>
+    /// Acquires the source-issued first-receipt timestamp for one Package
+    /// Details event.
+    /// </summary>
+    Task<PackageSourceOperationResult<NuGetCatalogPackageReceipt>>
+        GetPackageReceiptAsync(
+            NuGetCatalogEvent detailsEvent,
+            CancellationToken cancellationToken = default,
+            NuGetOperationContext? operationContext = null);
 }
 
 /// <summary>One validated activity observation from a Catalog page.</summary>
@@ -213,6 +223,63 @@ public sealed class NuGetCatalogPage
         ReferenceEquals(_issuer, issuer);
 }
 
+/// <summary>The source field that supplied a package-receipt timestamp.</summary>
+public enum NuGetCatalogPackageReceiptBasis
+{
+    /// <summary>The Package Details leaf supplied <c>created</c>.</summary>
+    Created,
+
+    /// <summary>
+    /// The leaf omitted <c>created</c>, so <c>published</c> supplied the
+    /// specification-defined fallback.
+    /// </summary>
+    PublishedFallback,
+}
+
+/// <summary>
+/// Source-issued first-receipt evidence for one exact Package Details event.
+/// </summary>
+public sealed class NuGetCatalogPackageReceipt
+{
+    private readonly object _issuer;
+
+    internal NuGetCatalogPackageReceipt(
+        object ownerCapability,
+        object issuer,
+        PackageSourceResultIdentity source,
+        NuGetCatalogEvent detailsEvent,
+        DateTimeOffset receivedAt,
+        NuGetCatalogPackageReceiptBasis basis)
+    {
+        PackageSourceClientFactory.RequireOwnerCapability(ownerCapability);
+        ArgumentNullException.ThrowIfNull(issuer);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(detailsEvent);
+        if (receivedAt.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                "A Catalog package-receipt timestamp must be UTC.",
+                nameof(receivedAt));
+        }
+        if (!Enum.IsDefined(basis))
+            throw new ArgumentOutOfRangeException(nameof(basis), basis, null);
+
+        _issuer = issuer;
+        Source = source;
+        DetailsEvent = detailsEvent;
+        ReceivedAt = receivedAt;
+        Basis = basis;
+    }
+
+    public PackageSourceResultIdentity Source { get; }
+    public NuGetCatalogEvent DetailsEvent { get; }
+    public DateTimeOffset ReceivedAt { get; }
+    public NuGetCatalogPackageReceiptBasis Basis { get; }
+
+    internal bool HasIssuer(object issuer) =>
+        ReferenceEquals(_issuer, issuer);
+}
+
 public sealed partial class PackageSourceResultFactory
 {
     internal NuGetCatalogEvent CatalogEvent(
@@ -270,6 +337,40 @@ public sealed partial class PackageSourceResultFactory
         return value;
     }
 
+    internal void ValidateCatalogDetailsEvent(
+        NuGetCatalogEvent detailsEvent)
+    {
+        ArgumentNullException.ThrowIfNull(detailsEvent);
+        if (!detailsEvent.HasIssuer(_issuer))
+            throw ContractViolation();
+        if (detailsEvent.Kind != NuGetCatalogEventKind.Details)
+        {
+            throw new ArgumentException(
+                "Catalog package-receipt evidence requires a Package Details event.",
+                nameof(detailsEvent));
+        }
+    }
+
+    internal NuGetCatalogPackageReceipt CatalogPackageReceipt(
+        NuGetCatalogEvent detailsEvent,
+        DateTimeOffset receivedAt,
+        NuGetCatalogPackageReceiptBasis basis,
+        NuGetOperationDeadline operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        operation.ThrowIfExpired();
+        ValidateCatalogDetailsEvent(detailsEvent);
+        var value = new NuGetCatalogPackageReceipt(
+            _ownerCapability,
+            _issuer,
+            Source,
+            detailsEvent,
+            receivedAt,
+            basis);
+        operation.ThrowIfExpired();
+        return value;
+    }
+
     internal PackageSourceOperationResult<NuGetCatalogPage>
         SucceededCatalog(
             NuGetCatalogPage value,
@@ -287,4 +388,28 @@ public sealed partial class PackageSourceResultFactory
             PackageSourceCapabilities.Catalog,
             coordinate: null,
             ValidateFailureKind(kind, allowNotFound: false));
+
+    internal PackageSourceOperationResult<NuGetCatalogPackageReceipt>
+        SucceededCatalogPackageReceipt(
+            NuGetCatalogPackageReceipt value,
+            NuGetOperationDeadline operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        operation.ThrowIfExpired();
+        RequireSourceAndIssuer(value.Source, value.HasIssuer(_issuer));
+        ValidateCatalogDetailsEvent(value.DetailsEvent);
+        return Succeeded(value);
+    }
+
+    internal PackageSourceOperationResult<NuGetCatalogPackageReceipt>
+        FailedCatalogPackageReceipt(
+            PackageSourceCoordinate coordinate,
+            PackageSourceFailureKind kind)
+    {
+        ArgumentNullException.ThrowIfNull(coordinate);
+        return Failed<NuGetCatalogPackageReceipt>(
+            PackageSourceCapabilities.Catalog,
+            coordinate,
+            ValidateFailureKind(kind, allowNotFound: false));
+    }
 }

--- a/src/NuGetFetch/PackageSourceResults.cs
+++ b/src/NuGetFetch/PackageSourceResults.cs
@@ -670,6 +670,7 @@ public sealed class PackageSourceOperationResult<T>
         PackageSourceClientFactory.RequireOwnerCapability(ownerCapability);
         if (typeof(T) != typeof(PackageSearchResult)
             && typeof(T) != typeof(NuGetCatalogPage)
+            && typeof(T) != typeof(NuGetCatalogPackageReceipt)
             && typeof(T) != typeof(PackageVersionResult)
             && typeof(T) != typeof(PackageSourceManifest)
             && typeof(T) != typeof(PackageSourcePayload))
@@ -1477,6 +1478,25 @@ internal static class PackageSourceOperation
             value => factory.SucceededSymbols(coordinate, value),
             kind => factory.FailedSymbols(coordinate, kind),
             allowNotFound: true,
+            cancellationToken,
+            operationContext);
+
+    public static Task<
+        PackageSourceOperationResult<NuGetCatalogPackageReceipt>>
+        CaptureCatalogPackageReceiptAsync(
+            PackageSourceResultFactory factory,
+            PackageSourceCoordinate coordinate,
+            Func<Task<NuGetCatalogPackageReceipt>> operation,
+            NuGetOperationDeadline operationDeadline,
+            CancellationToken cancellationToken,
+            NuGetOperationContext? operationContext = null) =>
+        CaptureAsync(
+            operation,
+            value => factory.SucceededCatalogPackageReceipt(
+                value,
+                operationDeadline),
+            kind => factory.FailedCatalogPackageReceipt(coordinate, kind),
+            allowNotFound: false,
             cancellationToken,
             operationContext);
 

--- a/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
+++ b/tests/NuGetFetch.Tests/NuGetCatalogAcquisitionTests.cs
@@ -20,6 +20,10 @@ public sealed class NuGetCatalogAcquisitionTests
         "https://feed.example/v3/catalog/page2.json";
     private const string Page3 =
         "https://feed.example/v3/catalog/page3.json";
+    private const string DetailsLeaf =
+        "https://feed.example/v3/catalog/leaf/details.json";
+    private const string ExternalDetailsLeaf =
+        "https://metadata.example/catalog/leaf/details.json";
 
     private static readonly DateTimeOffset Day0 = Utc(2026, 1, 1);
     private static readonly DateTimeOffset Day1 = Utc(2026, 1, 2);
@@ -81,7 +85,9 @@ public sealed class NuGetCatalogAcquisitionTests
         {
             typeof(NuGetCatalogEvent),
             typeof(NuGetCatalogPage),
+            typeof(NuGetCatalogPackageReceipt),
             typeof(PackageSourceOperationResult<NuGetCatalogPage>),
+            typeof(PackageSourceOperationResult<NuGetCatalogPackageReceipt>),
         })
         {
             ConstructorInfo constructor = Assert.Single(
@@ -1772,6 +1778,459 @@ public sealed class NuGetCatalogAcquisitionTests
         Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
     }
 
+    [Fact]
+    public async Task NuGetOrgPackageDetailsLeafReturnsCreatedReceipt()
+    {
+        const string commitId =
+            "616117f5-d9dd-4664-82b9-74d87169bbe9";
+        DateTimeOffset from = DateTimeOffset.Parse(
+            "2017-10-31T00:00:00Z",
+            CultureInfo.InvariantCulture);
+        DateTimeOffset commitTimestamp = DateTimeOffset.Parse(
+            "2017-10-31T23:30:32.4197849Z",
+            CultureInfo.InvariantCulture);
+        DateTimeOffset created = DateTimeOffset.Parse(
+            "2017-10-31T23:29:22.387Z",
+            CultureInfo.InvariantCulture);
+        var handler = StandardHandler(
+            IndexDocument(
+                commitTimestamp,
+                Page(Page1, commitTimestamp)),
+            PageDocument(
+                Catalog,
+                commitTimestamp,
+                Item(
+                    DetailsLeaf,
+                    "Util.Biz.Payments",
+                    "0.0.4-preview",
+                    commitTimestamp,
+                    "nuget:PackageDetails",
+                    commitId: commitId)));
+        handler[DetailsLeaf] = Json(
+            """
+            {
+              "@type": ["PackageDetails", "catalog:Permalink"],
+              "catalog:commitId": "616117f5-d9dd-4664-82b9-74d87169bbe9",
+              "catalog:commitTimeStamp": "2017-10-31T23:30:32.4197849Z",
+              "created": "2017-10-31T23:29:22.387Z",
+              "id": "Util.Biz.Payments",
+              "published": "2017-10-31T23:29:22.387Z",
+              "version": "0.0.4-preview"
+            }
+            """);
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(
+                source,
+                new NuGetCatalogRequest(
+                    from,
+                    commitTimestamp));
+
+        NuGetCatalogPackageReceipt receipt = SucceededReceipt(
+            await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(source.Source, receipt.Source);
+        Assert.Same(detailsEvent, receipt.DetailsEvent);
+        Assert.Equal(created, receipt.ReceivedAt);
+        Assert.Equal(
+            NuGetCatalogPackageReceiptBasis.Created,
+            receipt.Basis);
+        Assert.Equal(
+            [ServiceIndex, Catalog, Page1, DetailsLeaf],
+            handler.Requested);
+    }
+
+    [Fact]
+    public async Task PackageDetailsLeafUsesPublishedFallbackAndNormalizesUtc()
+    {
+        DateTimeOffset published = new(
+            2026,
+            1,
+            1,
+            2,
+            0,
+            0,
+            TimeSpan.FromHours(2));
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler[DetailsLeaf] = Json(
+            DetailsDocument(
+                "Contoso",
+                "1.0.0",
+                Day1,
+                published,
+                created: null));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        NuGetCatalogPackageReceipt receipt = SucceededReceipt(
+            await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(published.ToUniversalTime(), receipt.ReceivedAt);
+        Assert.Equal(TimeSpan.Zero, receipt.ReceivedAt.Offset);
+        Assert.Equal(
+            NuGetCatalogPackageReceiptBasis.PublishedFallback,
+            receipt.Basis);
+    }
+
+    [Theory]
+    [InlineData("kind")]
+    [InlineData("type-shape")]
+    [InlineData("package")]
+    [InlineData("version")]
+    [InlineData("commit")]
+    [InlineData("commit-time")]
+    [InlineData("created")]
+    [InlineData("published")]
+    [InlineData("duplicate")]
+    public async Task MalformedOrMismatchedDetailsLeafIsInvalidResponse(
+        string fault)
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler[DetailsLeaf] = Json(
+            FaultedDetailsDocument(fault));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            (await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken)).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+        Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
+        Assert.Equal(detailsEvent.Coordinate, failure.Coordinate);
+        Assert.Same(source.Source, failure.Source);
+    }
+
+    [Fact]
+    public async Task MissingRetainedLeafIsInvalidRatherThanCoordinateAbsence()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            (await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken)).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.InvalidResponse, failure.Kind);
+        Assert.NotEqual(PackageSourceFailureKind.NotFound, failure.Kind);
+        Assert.Equal(detailsEvent.Coordinate, failure.Coordinate);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task DetailsLeafAuthenticationFailureIsTyped(
+        HttpStatusCode statusCode)
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler[DetailsLeaf] = new RouteResponse(statusCode, "");
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            (await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken)).Failure);
+
+        Assert.Equal(
+            PackageSourceFailureKind.AuthenticationRequired,
+            failure.Kind);
+        Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
+        Assert.Equal(detailsEvent.Coordinate, failure.Coordinate);
+        Assert.Same(source.Source, failure.Source);
+    }
+
+    [Fact]
+    public async Task DetailsLeafTransportFailureIsTyped()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler.Set(
+            DetailsLeaf,
+            (_, _) => Task.FromException<HttpResponseMessage>(
+                new HttpRequestException(
+                    "Rejected by intermediary.",
+                    inner: null,
+                    HttpStatusCode.BadRequest)));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            (await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken)).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.Transport, failure.Kind);
+        Assert.Equal(PackageSourceCapabilities.Catalog, failure.Capability);
+        Assert.Equal(detailsEvent.Coordinate, failure.Coordinate);
+        Assert.Same(source.Source, failure.Source);
+    }
+
+    [Fact]
+    public async Task OffOriginDetailsLeafDoesNotReceiveSourceCredential()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    ExternalDetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler[ExternalDetailsLeaf] = Json(
+            DetailsDocument(
+                "Contoso",
+                "1.0.0",
+                Day1,
+                Day0 + TimeSpan.FromHours(1),
+                Day0));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                credential: new PackageSourceCredential(
+                    "user",
+                    "token"));
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        _ = SucceededReceipt(
+            await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken));
+
+        Assert.Null(handler.AuthFor(ExternalDetailsLeaf));
+        Assert.Equal("user:token", handler.DecodedAuthFor(ServiceIndex));
+    }
+
+    [Fact]
+    public async Task DeleteAndForeignEventsAreRejectedBeforeNetworkWork()
+    {
+        var deleteHandler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDelete")));
+        using INuGetCatalogPackageSourceClient first =
+            CreateSource(deleteHandler);
+        NuGetCatalogEvent deleteEvent =
+            await AcquireSingleEventAsync(first);
+        int requestsBeforeDelete = deleteHandler.Requested.Count;
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => first.GetPackageReceiptAsync(
+                deleteEvent,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(requestsBeforeDelete, deleteHandler.Requested.Count);
+
+        var otherHandler = new RouteHandler();
+        using INuGetCatalogPackageSourceClient other =
+            CreateSource(otherHandler);
+        int requestsBeforeForeign = otherHandler.Requested.Count;
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => other.GetPackageReceiptAsync(
+                deleteEvent,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(requestsBeforeForeign, otherHandler.Requested.Count);
+    }
+
+    [Fact]
+    public async Task DetailsLeafHonorsMetadataResponseBound()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler[DetailsLeaf] = Json(
+            DetailsDocument(
+                "Contoso",
+                "1.0.0",
+                Day1,
+                Day0,
+                Day0,
+                new string('x', 1_024)));
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxMetadataResponseBytes = 512,
+                });
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            (await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken)).Failure);
+
+        Assert.Equal(
+            PackageSourceFailureKind.ResponseRejected,
+            failure.Kind);
+        Assert.Equal(detailsEvent.Coordinate, failure.Coordinate);
+    }
+
+    [Fact]
+    public async Task DetailsLeafOperationDeadlineIsTypedTimeout()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler.Set(
+            DetailsLeaf,
+            async (_, cancellationToken) =>
+            {
+                await Task.Delay(
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+                throw new InvalidOperationException("Unreachable.");
+            });
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(
+                handler,
+                new NuGetFetchOptions
+                {
+                    RequestTimeout = TimeSpan.FromMilliseconds(20),
+                    OperationTimeout = TimeSpan.FromMilliseconds(80),
+                });
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+
+        PackageSourceFailure failure = Assert.IsType<PackageSourceFailure>(
+            (await source.GetPackageReceiptAsync(
+                detailsEvent,
+                TestContext.Current.CancellationToken)).Failure);
+
+        Assert.Equal(PackageSourceFailureKind.Timeout, failure.Kind);
+        Assert.Equal(detailsEvent.Coordinate, failure.Coordinate);
+    }
+
+    [Fact]
+    public async Task CallerCancellationPropagatesFromDetailsLeaf()
+    {
+        var handler = StandardHandler(
+            IndexDocument(Day1, Page(Page1, Day1)),
+            PageDocument(
+                Catalog,
+                Day1,
+                Item(
+                    DetailsLeaf,
+                    "Contoso",
+                    "1.0.0",
+                    Day1,
+                    "nuget:PackageDetails")));
+        handler.Set(
+            DetailsLeaf,
+            async (_, cancellationToken) =>
+            {
+                await Task.Delay(
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+                throw new InvalidOperationException("Unreachable.");
+            });
+        using INuGetCatalogPackageSourceClient source =
+            CreateSource(handler);
+        NuGetCatalogEvent detailsEvent =
+            await AcquireSingleEventAsync(source);
+        using var cancellation = new CancellationTokenSource(
+            TimeSpan.FromMilliseconds(20));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => source.GetPackageReceiptAsync(
+                detailsEvent,
+                cancellation.Token));
+    }
+
     private static INuGetCatalogPackageSourceClient CreateSource(
         RouteHandler handler,
         NuGetFetchOptions? options = null,
@@ -1791,6 +2250,18 @@ public sealed class NuGetCatalogAcquisitionTests
             source.Capabilities.HasFlag(PackageSourceCapabilities.Catalog));
         return Assert.IsAssignableFrom<INuGetCatalogPackageSourceClient>(
             source);
+    }
+
+    private static async Task<NuGetCatalogEvent> AcquireSingleEventAsync(
+        INuGetCatalogPackageSourceClient source,
+        NuGetCatalogRequest? request = null)
+    {
+        IReadOnlyList<PackageSourceOperationResult<NuGetCatalogPage>> outcomes =
+            await ReadAllAsync(
+                source,
+                request ?? new NuGetCatalogRequest(Day0, Day1));
+        NuGetCatalogPage page = Succeeded(Assert.Single(outcomes));
+        return Assert.Single(page.Events);
     }
 
     private static async Task<
@@ -1820,6 +2291,13 @@ public sealed class NuGetCatalogAcquisitionTests
     {
         Assert.Null(outcome.Failure);
         return Assert.IsType<NuGetCatalogPage>(outcome.Value);
+    }
+
+    private static NuGetCatalogPackageReceipt SucceededReceipt(
+        PackageSourceOperationResult<NuGetCatalogPackageReceipt> outcome)
+    {
+        Assert.Null(outcome.Failure);
+        return Assert.IsType<NuGetCatalogPackageReceipt>(outcome.Value);
     }
 
     private static RouteHandler StandardHandler(
@@ -1946,12 +2424,68 @@ public sealed class NuGetCatalogAcquisitionTests
         string version,
         DateTimeOffset timestamp,
         string kind,
-        string suffix = "") =>
+        string suffix = "",
+        string commitId = "commit") =>
         $$"""
-        {"@id":"{{leafUrl}}","@type":"{{kind}}","commitId":"commit",
+        {"@id":"{{leafUrl}}","@type":"{{kind}}","commitId":"{{commitId}}",
         "commitTimeStamp":"{{Stamp(timestamp)}}","nuget:id":"{{packageId}}",
         "nuget:version":"{{version}}"{{suffix}}}
         """;
+
+    private static string DetailsDocument(
+        string packageId,
+        string version,
+        DateTimeOffset commitTimestamp,
+        DateTimeOffset published,
+        DateTimeOffset? created,
+        string? padding = null)
+    {
+        string createdProperty = created is { } value
+            ? ",\"created\":\"" + Stamp(value) + "\""
+            : "";
+        string paddingProperty = padding is null
+            ? ""
+            : ",\"padding\":\"" + padding + "\"";
+        return $$"""
+        {"@type":["PackageDetails","catalog:Permalink"],
+        "catalog:commitId":"commit",
+        "catalog:commitTimeStamp":"{{Stamp(commitTimestamp)}}",
+        "id":"{{packageId}}","version":"{{version}}",
+        "published":"{{published:yyyy-MM-dd'T'HH:mm:ss.FFFFFFFzzz}}"
+        {{createdProperty}}{{paddingProperty}}}
+        """;
+    }
+
+    private static string FaultedDetailsDocument(string fault)
+    {
+        string type = fault switch
+        {
+            "kind" => "\"PackageDelete\"",
+            "type-shape" => "[\"PackageDetails\",42]",
+            _ => "[\"PackageDetails\",\"catalog:Permalink\"]",
+        };
+        string packageId =
+            fault == "package" ? "Other.Package" : "Contoso";
+        string version = fault == "version" ? "2.0.0" : "1.0.0";
+        string commit = fault == "commit" ? "other" : "commit";
+        string commitTimestamp = fault == "commit-time"
+            ? Stamp(Day0)
+            : Stamp(Day1);
+        string created = fault == "created"
+            ? "2026-01-01"
+            : Stamp(Day0);
+        string published = fault == "published"
+            ? "2026-01-01T00:00:00"
+            : Stamp(Day0);
+        string duplicate =
+            fault == "duplicate" ? ",\"id\":\"Contoso\"" : "";
+        return $$"""
+        {"@type":{{type}},"catalog:commitId":"{{commit}}",
+        "catalog:commitTimeStamp":"{{commitTimestamp}}",
+        "id":"{{packageId}}","version":"{{version}}",
+        "created":"{{created}}","published":"{{published}}"{{duplicate}}}
+        """;
+    }
 
     private static string Stamp(DateTimeOffset value) =>
         value.ToString("O", CultureInfo.InvariantCulture);


### PR DESCRIPTION
Build robust, capable features that provide foundational capabilities or
compelling user experiences, recognizable as conventionally sound,
delightfully new or unique, or both.

## Summary

Adds exact Catalog Package Details enrichment so the ecosystem-change report
can date a package version from source-issued evidence rather than from Catalog
commit time or mutable Registration listing time.

- `NuGetCatalogPackageReceipt` preserves the exact factory-issued event,
  source-result identity, UTC receipt time, and whether `created` or its
  specification-defined `published` fallback supplied the timestamp.
- `GetPackageReceiptAsync` fetches only the event's retained advertised leaf
  and validates kind, coordinate, commit identity, timestamps, and duplicate
  properties before constructing evidence.
- Missing, malformed, over-bound, authentication, timeout, and transport
  outcomes remain typed; Delete and foreign-client events are rejected before
  network work.

The focused design is the sole owner of source-receipt evidence. The ecosystem
report remains the owner of combining it with exact first-patched advisory
evidence and deciding whether a row is a security release.

## Demo

For the real nuget.org-shaped
`Util.Biz.Payments@0.0.4-preview` Package Details event:

```text
Catalog observation: 2017-10-31T23:30:32.4197849Z
Package receipt:      2017-10-31T23:29:22.3870000Z
Receipt basis:        Created
```

The neighboring case omits `created`; the result uses `published`, normalizes
its numeric offset to UTC, and reports `PublishedFallback` rather than hiding
the weaker basis.

## Design basis

The NuGet Catalog specification defines Package Details `created` as when the
package was first received by the source and names `published` as its fallback.
This is the narrow evidence needed by #6124. Registration
`catalogEntry.published` is not used because on nuget.org it is the last-listed
time and becomes a year-1900 sentinel when a package is unlisted.

This PR does not classify security releases, alter Catalog event meaning, add a
report or presentation surface, query Registration, cache leaf data, or claim
that source receipt proves publisher intent.

## Validation

- `dotnet run --project tests/NuGetFetch.Tests -c Release`
  - 1,060 passed, 11 environment-gated skips
- `dotnet run --project tests/NuGetFetch.Tests -c Release -- --filter-class NuGetFetch.Tests.NuGetCatalogAcquisitionTests`
  - 72 passed
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx --yes markdownlint-cli docs/design/nuget-catalog-package-receipt.md docs/README.md`

Closes #6678.
Contributes to #6124.
