### PR TITLE
Materialize Boolean stack-slot identity before printing

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -506,23 +506,43 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    its sole consumer, while the remaining post-F2 stores render as standalone
    assignments rather than through a printer-owned consumer fold. Decided
    in-domain webs in that residual therefore materialize normally; their
-   declaration ordering may change, but no expression moves. One narrower
-   residual remains printer-owned: when integer storage testimony feeds a
-   typed boolean sink, the printer recovers boolean identity for the slot;
-   materializing the integer testimony would produce an invalid assignment.
-   `BooleanSinkIdentityRecovery` makes that boundary explicit until semantic
-   sink identity moves into product-owned testimony. The C2 deletion and the
-   invariant extension follow once the residual census reaches the
-   printer-owned floor. When a direct slot-copy component separates the
-   conditional producer from the boolean sink, the sink-end veto keeps the
-   whole component printer-owned through the existing atomic component gate.
+   declaration ordering may change, but no expression moves.
+
+   At materialization, a slot whose stores are all Boolean-valued may recover
+   the Boolean identity of an integer-typed load consumed by a Boolean sink
+   or condition. Every load still testifies: a numeric use conflicts, and an
+   underivable use vetoes recovery. This is identity recovery, not an
+   integer-to-Boolean conversion; mixed Boolean/integer stores retain the
+   existing `BooleanSinkIdentityRecovery` boundary. Earlier raising passes
+   retain their original testimony so materialization does not preempt their
+   constant or control-flow decisions. The printer uses the same Boolean-sink
+   rule for lowered and still-deferred slots instead of maintaining a second
+   sink vocabulary.
+
+   The motivating real witness is Newtonsoft.Json 13.0.4,
+   `DefaultContractResolver.InitializeContract`: the Boolean conditional
+   assigned to `DefaultCreatorNonPublic` retains an integer-typed stack load.
+   `CompilerProducedPropertyConditionalMaterializesBooleanIdentity` preserves
+   that compiler-produced shape, and
+   `CompilerProducedPropertyConditionalRecompilesWithRetainedTemporary`
+   gates binding and the existing retained-temporary compile-back difference;
+   it does not claim exact IL fidelity.
+   `ConflictingBooleanAndNumericUsesRemainPrinterOwned`,
+   `BooleanSinkDoesNotRetypeMixedBooleanAndIntegerStores`, and
+   `IntegerConditionKeepsItsNumericIdentity` gate the nearby decline and
+   non-action boundaries. Direct-copy components remain atomic:
+   `MaterializesBooleanSinkIdentityAcrossDirectCopyComponent` gates the
+   decided case; an undecided member still retains the entire component.
+   The C2 deletion and invariant extension follow once the residual census
+   reaches the printer-owned floor.
+
    `MaterializesSingleStoreConditionalWithSingleRead` and
-   `DefersIntegerTestimonyWhenConditionalFeedsBooleanLocal` gate both sides of
-   the general boundary;
-   `DefersIntegerTestimonyWhenConditionalFeedsBooleanProperty` gates property
-   setter identity recovery specifically; and
-   `DefersBooleanSinkIdentityAcrossDirectCopyComponent` gates composition with
-   copy-component closure.
+   `MaterializesBooleanIdentityWhenConditionalFeedsBooleanLocal` gate
+   conditional materialization;
+   `MaterializesBooleanIdentityWhenConditionalFeedsBooleanProperty` gates the
+   property setter case. Production adoption is through the shared default
+   raising pipeline used by CLI and Browser/Wasm consumers; no host-specific
+   conversion or naming path is introduced.
 
 Each slice reports the standard decompiler-affecting-PR evidence: focused tests,
 the corpus quality-diff card, and improved/still-flat examples. As ReturnToSender

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1232,37 +1232,8 @@ public sealed partial class CSharpPrinter
         if (CanAssignType(source, load.Type))
             return !StrictlyNarrowsReference(source, load.Type);
         return TypeFamilies.IsBoolean(source)
-            && TypeFamilies.IsIntegerLike(load.Type)
-            && StackSlotLoadTargetType(load) is { } target
-            && TypeFamilies.IsBoolean(target);
+            && CoercionSinks.BooleanSlotLoadType(load, CurrentReturnType, _function.TypeShapes) is not null;
     }
-
-    TypeRef? StackSlotLoadTargetType(LoadStackSlot load)
-        => load.Parent switch
-        {
-            StoreLocal store when ReferenceEquals(store.Value, load) => store.Type,
-            StoreArgument store when ReferenceEquals(store.Value, load) => store.Type,
-            StoreField store when ReferenceEquals(store.Value, load) => store.Field.Type,
-            StoreProperty store when ReferenceEquals(store.Value, load) => StorePropertyTargetType(store),
-            StoreElement store when ReferenceEquals(store.Value, load) => store.ElementType,
-            StoreIndirect store when ReferenceEquals(store.Value, load) => store.Type,
-            Return ret when ReferenceEquals(ret.Value, load) => CurrentReturnType,
-            // A bool-in-int-slot load whose value flows into a boolean operator
-            // or condition position (`!S`, `S && x`, `S ? a : b`, `if (S)`,
-            // `while (S)`) has a boolean target — C# requires bool there. Without
-            // this the slot's bool store and this load get different names (S_1
-            // bool vs S_1_1 int) and the consumer reads an unassigned int split
-            // (CS0165, #2377).
-            LogicalNot not when ReferenceEquals(not.Operand, load) => TypeRef.CoreLib("System", "Boolean"),
-            LogicalBinary logical when ReferenceEquals(logical.Left, load) || ReferenceEquals(logical.Right, load) => TypeRef.CoreLib("System", "Boolean"),
-            Conditional conditional when ReferenceEquals(conditional.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
-            ConditionalBranch branch when ReferenceEquals(branch.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
-            IfStatement ifStatement when ReferenceEquals(ifStatement.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
-            WhileLoop whileLoop when ReferenceEquals(whileLoop.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
-            DoWhileLoop doWhile when ReferenceEquals(doWhile.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
-            ForLoop forLoop when ReferenceEquals(forLoop.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
-            _ => null,
-        };
 
     bool CanAssignTo(IrExpression value, TypeRef target)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -108,17 +108,30 @@ public static class CoercionSinks
     /// <summary>
     /// The product-owned testimony decision behind <see cref="TestifiedSlotTypes"/>.
     /// Measurement consumers use the status to distinguish an untyped load with
-    /// no derivable sink from loads that actively disagree.
+    /// no derivable sink from loads that actively disagree. At materialization,
+    /// Boolean-valued stores may recover integer-typed loads at Boolean sinks;
+    /// earlier passes retain the importer's testimony until raising is complete.
     /// </summary>
     public static Dictionary<int, SlotTypeTestimony> AnalyzeSlotTypeTestimony(
         IrNode scope,
         TypeRef? returnType,
-        IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        bool recoverBooleanIdentity = false)
     {
+        var booleanSlots = recoverBooleanIdentity
+            ? ScopeNodes(scope).OfType<StoreStackSlot>()
+                .GroupBy(static store => store.Slot)
+                .Where(static stores => stores.All(store => TypeFamilies.IsBoolean(store.Value.ResultType)))
+                .Select(static stores => stores.Key)
+                .ToHashSet()
+            : null;
         var testimony = new Dictionary<int, SlotTypeTestimony>();
         foreach (var load in ScopeNodes(scope).OfType<LoadStackSlot>())
         {
-            var evidence = BitwiseEnumSinkType(load, shapes) ?? load.Type ?? LoadSinkTargetType(load, returnType, shapes);
+            var booleanType = booleanSlots?.Contains(load.Slot) == true
+                ? BooleanSlotLoadType(load, returnType, shapes)
+                : null;
+            var evidence = booleanType ?? BitwiseEnumSinkType(load, shapes) ?? load.Type ?? LoadSinkTargetType(load, returnType, shapes);
             if (evidence is null)
             {
                 testimony[load.Slot] = new(null, SlotTypeTestimonyStatus.Underivable);
@@ -140,7 +153,7 @@ public static class CoercionSinks
         return testimony;
     }
 
-    /// <summary>The target type of the sink directly consuming an untyped slot load, where one is derivable — the printer's StackSlotLoadTargetType vocabulary.</summary>
+    /// <summary>The target type of the sink directly consuming an untyped slot load, where one is derivable.</summary>
     static TypeRef? LoadSinkTargetType(LoadStackSlot load, TypeRef? returnType, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
         => load.Parent switch
         {
@@ -168,6 +181,30 @@ public static class CoercionSinks
             && store.Accessor.ParameterTypes is { IsDefault: false, Length: > 0 } setter
                 ? setter[^1]
                 : LoadSinkTargetType(load, returnType, shapes);
+
+    internal static TypeRef? BooleanSlotLoadType(
+        LoadStackSlot load,
+        TypeRef? returnType,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+    {
+        if (load.Type is not { } type || !TypeFamilies.IsIntegerLike(type))
+            return null;
+        if (SemanticLoadSinkTargetType(load, returnType, shapes) is { } target
+            && TypeFamilies.IsBoolean(target))
+            return target;
+        return load.Parent switch
+        {
+            LogicalNot not when ReferenceEquals(not.Operand, load) => TypeRef.CoreLib("System", "Boolean"),
+            LogicalBinary logical when ReferenceEquals(logical.Left, load) || ReferenceEquals(logical.Right, load) => TypeRef.CoreLib("System", "Boolean"),
+            Conditional conditional when ReferenceEquals(conditional.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            ConditionalBranch branch when ReferenceEquals(branch.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            IfStatement statement when ReferenceEquals(statement.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            WhileLoop loop when ReferenceEquals(loop.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            DoWhileLoop loop when ReferenceEquals(loop.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            ForLoop loop when ReferenceEquals(loop.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            _ => null,
+        };
+    }
 
     /// <summary>
     /// The enum family a slot load contributes when its contiguous flags-enum

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotMaterializationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotMaterializationPass.cs
@@ -128,7 +128,8 @@ public sealed class SlotMaterializationPass : IIrPass
         var testimony = CoercionSinks.AnalyzeSlotTypeTestimony(
             function.Body,
             function.Signature.ReturnType,
-            function.TypeShapes);
+            function.TypeShapes,
+            recoverBooleanIdentity: true);
         // Materializable slots retain the prior first-testimony order so
         // AddLocal preserves existing local indices and declaration order.
         var candidates = testimony.Keys

--- a/tests/ILInspector.Decompiler.Tests/BooleanSlotIdentitySamples.cs
+++ b/tests/ILInspector.Decompiler.Tests/BooleanSlotIdentitySamples.cs
@@ -1,0 +1,14 @@
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class BooleanSlotIdentitySample
+{
+    public Type CreatedType { get; set; } = typeof(object);
+    public bool DefaultCreatorNonPublic { get; set; }
+
+    public void Initialize()
+    {
+        DefaultCreatorNonPublic = CreatedType.IsValueType
+            ? false
+            : CreatedType.GetConstructor(Type.EmptyTypes) is null;
+    }
+}

--- a/tests/ILInspector.Decompiler.Tests/SlotMaterializationPassTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/SlotMaterializationPassTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using ILInspector.DecompilerHarness;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -19,6 +20,58 @@ public class SlotMaterializationPassTests
         => new("M", Owner, new MethodSignature(TypeRef.CoreLib("System", "Void"), [
             new Parameter("x", Int32),
         ], HasThis: false, GenericParameterCount: 0), locals, body);
+
+    [Fact]
+    public void CompilerProducedPropertyConditionalMaterializesBooleanIdentity()
+    {
+        // Mirrors the retained Boolean property temporary in Newtonsoft.Json
+        // 13.0.4 DefaultContractResolver.InitializeContract.
+        using var source = MetadataSource.Open(typeof(BooleanSlotIdentitySample).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(BooleanSlotIdentitySample).FullName!,
+            nameof(BooleanSlotIdentitySample.Initialize));
+        Assert.NotNull(function);
+        var context = PassContext.ForImport(method => IrImporter.Import(source, method));
+        foreach (var pass in IrPasses.Default)
+        {
+            if (pass is SlotMaterializationPass)
+                break;
+            pass.Run(function, context);
+        }
+        var recovered = SlotMaterializationPass.Analyze(function)
+            .Where(decision => decision.WillMaterialize && Boolean.Equals(decision.Type))
+            .ToList();
+        Assert.NotEmpty(recovered);
+        var slot = Assert.Single(recovered).Slot;
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(),
+            load => load.Slot == slot && Int32.Equals(load.Type));
+
+        new SlotMaterializationPass().Run(function, context);
+        new CoercionInsertionPass().Run(function, context);
+
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == slot);
+        Assert.DoesNotContain(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == slot);
+        Assert.Contains("bool S_", CSharpPrinter.Print(function).Output);
+        Assert.Empty(CoercionInvariant.Check(function));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    [Trait("Area", "Fidelity")]
+    public void CompilerProducedPropertyConditionalRecompilesWithRetainedTemporary()
+    {
+        var result = Assert.Single(FidelityCheck.Evaluate(
+            typeof(BooleanSlotIdentitySample).Assembly.Location,
+            type => type == typeof(BooleanSlotIdentitySample).FullName,
+            method => method.Method == nameof(BooleanSlotIdentitySample.Initialize)));
+
+        // The printer already retained this temporary before materialization.
+        // Pin that compile-back difference rather than claiming exact fidelity.
+        Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.Status);
+        Assert.Equal("ldarg ldarg call callvirt brtrue ldarg call ldsfld callvirt ldnull ceq br ldc.i4 call ret",
+            result.OriginalOpcodes);
+        Assert.Equal("ldarg call callvirt brtrue ldarg call ldsfld callvirt ldnull ceq br ldc.i4 stloc ldarg ldloc call ret",
+            result.RecompiledOpcodes);
+    }
 
     // Adversarial review (5b-2, CRITICAL): a materialized store whose value
     // nests a load of a slot processed later. Cloning that store before the
@@ -76,11 +129,8 @@ public class SlotMaterializationPassTests
         function.CheckInvariant();
     }
 
-    // The conditional producer and boolean sink can occupy different members
-    // of one direct-copy component. The sink-end veto must keep the whole
-    // component on the printer's boolean identity recovery.
     [Fact]
-    public void DefersBooleanSinkIdentityAcrossDirectCopyComponent()
+    public void MaterializesBooleanSinkIdentityAcrossDirectCopyComponent()
     {
         var body = new BlockContainer();
         var first = new Block(0);
@@ -104,18 +154,19 @@ public class SlotMaterializationPassTests
         var function = Function([Boolean], body);
 
         var decisions = SlotMaterializationPass.Analyze(function);
-        Assert.Contains(decisions, decision => decision.Slot == 0
-            && decision.Vetoes == SlotMaterializationVeto.IncompleteCopyComponent);
-        Assert.Contains(decisions, decision => decision.Slot == 1
-            && decision.Vetoes.HasFlag(SlotMaterializationVeto.BooleanSinkIdentityRecovery)
-            && decision.Vetoes.HasFlag(SlotMaterializationVeto.IncompleteCopyComponent));
+        Assert.Equal(2, decisions.Count);
+        Assert.All(decisions, decision =>
+        {
+            Assert.True(decision.WillMaterialize);
+            Assert.Equal(Boolean, decision.Type);
+        });
 
         new SlotMaterializationPass().Run(function, PassContext.None);
         new CoercionInsertionPass().Run(function, PassContext.None);
 
         var output = CSharpPrinter.Print(function).Output;
-        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
-        Assert.Equal(2, function.Descendants.OfType<StoreStackSlot>().Count());
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
         Assert.Contains("bool S_0", output);
         Assert.Contains("bool S_1", output);
         Assert.DoesNotContain("int S_1", output);
@@ -291,7 +342,7 @@ public class SlotMaterializationPassTests
     }
 
     [Fact]
-    public void DefersIntegerTestimonyWhenConditionalFeedsBooleanProperty()
+    public void MaterializesBooleanIdentityWhenConditionalFeedsBooleanProperty()
     {
         var setter = new MethodRef(
             Owner,
@@ -321,20 +372,20 @@ public class SlotMaterializationPassTests
         var function = Function([], body);
 
         var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
-        Assert.Equal(Int32, decision.Type);
-        Assert.Equal(SlotMaterializationVeto.BooleanSinkIdentityRecovery, decision.Vetoes);
+        Assert.Equal(Boolean, decision.Type);
+        Assert.True(decision.WillMaterialize);
 
         new SlotMaterializationPass().Run(function, PassContext.None);
 
-        Assert.Single(function.Descendants.OfType<LoadStackSlot>());
-        Assert.Single(function.Descendants.OfType<StoreStackSlot>());
-        Assert.Empty(function.Locals);
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Equal(Boolean, Assert.Single(function.Locals));
         Assert.Contains("bool S_0", CSharpPrinter.Print(function).Output);
         function.CheckInvariant();
     }
 
     [Fact]
-    public void DefersIntegerTestimonyWhenConditionalFeedsBooleanLocal()
+    public void MaterializesBooleanIdentityWhenConditionalFeedsBooleanLocal()
     {
         var body = new BlockContainer();
         var block = new Block(0);
@@ -351,15 +402,128 @@ public class SlotMaterializationPassTests
         var function = Function([Boolean], body);
 
         var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
-        Assert.Equal(Int32, decision.Type);
-        Assert.Equal(SlotMaterializationVeto.BooleanSinkIdentityRecovery, decision.Vetoes);
+        Assert.Equal(Boolean, decision.Type);
+        Assert.True(decision.WillMaterialize);
 
         new SlotMaterializationPass().Run(function, PassContext.None);
 
-        Assert.Single(function.Descendants.OfType<LoadStackSlot>());
-        Assert.Single(function.Descendants.OfType<StoreStackSlot>());
-        Assert.Single(function.Locals);
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Equal(2, function.Locals.Length);
         Assert.Contains("bool S_0", CSharpPrinter.Print(function).Output);
+        function.CheckInvariant();
+    }
+
+    [Theory]
+    [InlineData("return")]
+    [InlineData("not")]
+    [InlineData("and")]
+    [InlineData("conditional")]
+    [InlineData("branch")]
+    [InlineData("argument")]
+    [InlineData("field")]
+    [InlineData("element")]
+    [InlineData("indirect")]
+    public void BooleanIdentityUsesTheSameSinkRuleAsThePrinter(string consumer)
+    {
+        var load = new LoadStackSlot(0, Int32);
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "flag", Boolean)));
+        block.Add(consumer switch
+        {
+            "return" => new Return(load),
+            "not" => new Return(new LogicalNot(load)),
+            "and" => new Return(new LogicalBinary(LogicalKind.And, load, new Constant(true, Boolean))),
+            "conditional" => new Return(new Conditional(load, new Constant(true, Boolean), new Constant(false, Boolean))),
+            "branch" => new ConditionalBranch(load, 4),
+            "argument" => new StoreArgument(0, "flag", Boolean, load),
+            "field" => new StoreField(new FieldRef(Owner, "Flag", Boolean), null, load),
+            "element" => new StoreElement(Boolean, new LoadArgument(1, "values", TypeRef.SzArray(Boolean)), new Constant(0, Int32), load),
+            "indirect" => new StoreIndirect(Boolean, new LoadArgument(1, "address", TypeRef.ByRef(Boolean)), load),
+            _ => throw new ArgumentOutOfRangeException(nameof(consumer)),
+        });
+        var body = new BlockContainer();
+        body.Add(block);
+        var exit = new Block(4);
+        exit.Add(new Return(new Constant(false, Boolean)));
+        body.Add(exit);
+        var function = new IrFunction("M", Owner,
+            new MethodSignature(Boolean, [new Parameter("flag", Boolean)], HasThis: false, GenericParameterCount: 0),
+            [], body);
+
+        Assert.Equal(Int32, CoercionSinks.TestifiedSlotTypes(body, Boolean, function.TypeShapes)[0]);
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.True(decision.WillMaterialize);
+        Assert.Equal(Boolean, decision.Type);
+
+        new SlotMaterializationPass().Run(function, PassContext.None);
+        new CoercionInsertionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Equal(Boolean, Assert.Single(function.Locals));
+        Assert.Empty(CoercionInvariant.Check(function));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ConflictingBooleanAndNumericUsesRemainPrinterOwned()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Constant(true, Boolean)));
+        block.Add(new StoreLocal(0, Boolean, new LoadStackSlot(0, Int32)));
+        block.Add(new StoreLocal(1, Int32, new LoadStackSlot(0, Int32)));
+        body.Add(block);
+        var function = Function([Boolean, Int32], body);
+
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.Equal(SlotMaterializationVeto.ConflictingTypeTestimony, decision.Vetoes);
+        new SlotMaterializationPass().Run(function, PassContext.None);
+        Assert.Single(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void BooleanSinkDoesNotRetypeMixedBooleanAndIntegerStores()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Constant(true, Boolean)));
+        block.Add(new StoreLocal(0, Boolean, new LoadStackSlot(0, Int32)));
+        block.Add(new StoreStackSlot(0, new Constant(2, Int32)));
+        block.Add(new StoreLocal(0, Boolean, new LoadStackSlot(0, Int32)));
+        body.Add(block);
+        var function = Function([Boolean], body);
+
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.Equal(Int32, decision.Type);
+        Assert.Equal(SlotMaterializationVeto.BooleanSinkIdentityRecovery, decision.Vetoes);
+        new SlotMaterializationPass().Run(function, PassContext.None);
+        Assert.Equal(2, function.Descendants.OfType<StoreStackSlot>().Count());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void IntegerConditionKeepsItsNumericIdentity()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Constant(2, Int32)));
+        block.Add(new ConditionalBranch(new LoadStackSlot(0, Int32), 4));
+        body.Add(block);
+        var exit = new Block(4);
+        exit.Add(new Return(null));
+        body.Add(exit);
+        var function = Function([], body);
+
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.True(decision.WillMaterialize);
+        Assert.Equal(Int32, decision.Type);
+        new SlotMaterializationPass().Run(function, PassContext.None);
+        Assert.Equal(Int32, Assert.Single(function.Locals));
+        Assert.Contains("S_0 != 0", CSharpPrinter.Print(function).Output);
         function.CheckInvariant();
     }
 


### PR DESCRIPTION
Advance the thin-writer plan: make the shared decompiler more robust and capable by moving variable identity into typed IR rather than merely splitting the printer into more files.

Advances #2095 and the monotone printer-ownership reduction required by #2209.

**Claim:** materialization can own slots whose producers are already Boolean and whose integer-typed loads testify only to Boolean sinks. The printer loses its duplicate sink switch (29 net lines) and retains one shared fallback rule. This does not retire the full Boolean residual class or the stack-slot unifier.

Head: `347dfe3cb47d47705d6e5fc78c094f8d9e1f5b0d`.
Effective base: `6457342a92a02db78f6043d6248e2e06befdbec3`.

## Demo

Pinned motivating package: Newtonsoft.Json 13.0.4, `lib/net6.0/Newtonsoft.Json.dll`.

`DefaultContractResolver.InitializeContract` (`0x0600063F`) already prints a Boolean temporary for the conditional assigned to `DefaultCreatorNonPublic`. Before, the printer recovers that identity from an integer-typed stack load. After, `SlotMaterializationPass` creates the typed Boolean local before printing, with identical rendered C#.

A neighboring method, `JsonSchemaModel.Combine` (`0x06000950`), makes the ownership change visible:

### Before

```csharp
int S_258 = model.PositionalItemsValidation || schema.PositionalItemsValidation ? 1 : 0;
```

### After

```csharp
bool S_258 = model.PositionalItemsValidation || schema.PositionalItemsValidation;
```

The same simplification applies to its `S_261`/`UniqueItems` temporary. These are verbatim excerpts from the product Render A/B, not a whole-method correctness claim. The method has unrelated existing residuals.

### Fully raised

The endpoint for this slice is a Boolean local in IR with no corresponding stack-slot store/load nodes. Removing the temporary itself, materializing mixed integer producers, nested bodies, cross-block folds, and deleting the unifier remain separate work.

## Design and raise contract

Normative owner: `docs/design/value-typed-emission.md`, Instance 2 and migration step 5. Shared default-pipeline adoption serves CLI and Browser/Wasm; no host-specific path or new dependency is introduced.

| Obligation | Contract and gate |
| --- | --- |
| Lowering shell | A Boolean-valued conditional is stored through an integer-typed evaluation-stack load. The pinned Newtonsoft method and the Release compiler-produced `BooleanSlotIdentitySample.Initialize` preserve this shape. |
| Consumed ownership | Every store in the slot must already be Boolean-valued. Every load contributes testimony. Existing scope, coercibility, copy-component closure, and other materialization gates remain authoritative. |
| Control flow | No block, edge, expression, or evaluation is moved. Existing stores/loads become local stores/loads through the existing atomic rewrite. |
| Replacement | Focused IR/tree/coercion gates plus compiler-produced compile-back. The fixture binds but retains the exact baseline extra-temporary opcode difference; exact IL fidelity is not claimed. |
| Decline boundary | Conflicting numeric observations, mixed Boolean/integer stores, underivable testimony, nested scopes, and otherwise-undecided copy components retain the conservative path. Earlier typing/raising passes keep their original testimony. |
| Falsifier | An accepted slot with a non-Boolean producer, an unaccounted observer, an orphaned slot load, or changed evaluation/control flow would invalidate this slice. |

## Evidence map and shared judgment

| Lens | Scope and fixed identity | Direction / evidence kind | Result |
| --- | --- | --- | --- |
| Ownership census | Same pinned 14 assemblies, 89,065 methods, uncapped | Better / ownership accounting | Materialized webs 1,536 → 1,547; printer-owned slots 40,224 → 40,213; Boolean identity vetoes 26 → 10. Zero pass bugs on both sides. |
| Compiler fixture | Same Release-built `BooleanSlotIdentitySample.Initialize` binary under exact-base and candidate tool binaries | Same / product quality | Binding succeeds; identical `OpcodeDiff` from the pre-existing retained temporary. Not exact IL fidelity. |
| Render A/B | Same 13-assembly subset, 46,945 methods, immutable bytes, cwd, paths, and no cap; final exact base → locked head | Same / sensor validity | Four structural changes: one valid→valid, three invalid→invalid, zero additions/removals. Independent compile-back limitations are recorded below. |
| Quick-corpus quality | Same 14 assemblies, deterministic cap 100, 1,361 selected methods | Same / product quality | No detected-residue, forward-merge, pass-bug, or pinned-control-flow change. Validity/fidelity are not sampled by this quick card. |
| Structural correspondence | Same changed method bodies and product-issued documents | Not directional / evidence coverage | Partial correspondence. Attempted, unavailable for the claimed Boolean changes; no supported structural changes establish them. |
| Full-corpus A/B | Original 14-assembly manifest | Not directional / unavailable evidence | Exact baseline fails on Roslyn structural projection/body disagreement; tracked separately in #6687. The 13-assembly subset excludes that entire assembly explicitly. |

Final Render A/B, quick-corpus, and both uncapped ownership censuses use a baseline executable built at exact effective base `6457342a92a02db78f6043d6248e2e06befdbec3` and candidate `347dfe3cb47d47705d6e5fc78c094f8d9e1f5b0d`. Earlier diagnostic baseline artifacts are retained separately, not substituted for final exact-base evidence. The final census confirms all reported counts.

All four changes were inspected independently:

| Method / pinned package | Text change | Render sensor | Independent compile-back, base → head |
| --- | --- | --- | --- |
| `CrossAssemblyTypeResolver.Upgrade(MethodRef, bool)` / dotnet-inspect.any 0.14.0 | `S_5` becomes Boolean; removes its `? 1 : 0`; declaration moves | invalid→invalid | `RecompileFail` → same, CS1061 for pre-existing `MethodRef.__Clone__` spelling |
| `IrImporter.PropagateAndSpill` / dotnet-inspect.any 0.14.0 | Only the Boolean declaration's order changes | invalid→invalid | `RecompileFail` → same, CS0246 for pre-existing generated display-class spelling |
| `InspectionCommandDefinitions.<>c__DisplayClass1_0.<<CreateLibraryCommand>b__1>d.MoveNext` / dotnet-inspect.any 0.14.0 | Only the Boolean declaration's order changes | invalid→invalid | Not available: generated-member-unsupported boundary of the compile-back harness |
| `JsonSchemaModel.Combine` / Newtonsoft.Json 13.0.4 | Two Boolean declarations lose integer encodings | valid→valid | `RecompileFail` → same, CS0029 on other existing int→bool assignments |

The stricter compile-back result for `Combine` means the sensor's valid→valid classification is **not** whole-member binding evidence. No method-wide correctness or exact-fidelity improvement is claimed for these already-limited methods. The motivating `InitializeContract` has identical original/recompiled opcode streams across revisions and retains its existing extra-temporary `OpcodeDiff`.

### Structural review and source lens

**Attempted — unavailable for the claimed change.** The exact-base/head product documents were retained separately and replayed with `--structural-review`. `Combine` has Partial correspondence, no supported structural changes, and 88 unsupported/ambiguous nodes: Before 11 unsupported + 34 ambiguous; After 11 unsupported + 32 ambiguous. No hand-authored correspondence or replacement carets are supplied.

The current CLI's independent `Source Diff` acquisition reports:

```text
Status  Source diff unavailable: PDB comparison unavailable: No portable PDB is available for the selected member.
```

## Validation

- Release focused gate: 63 passed, zero failures (`SlotMaterializationPassTests`, `CoercionInvariantTests`, `SlotResidualCensusTests`).
- Changed owning design passes Markdown lint.
- Fresh slot residual and actual-printer unifier censuses over the fixed 89,065-method corpus.
- Exact-base/candidate compiler fixture compile-back: same known extra-local opcode difference.
- Release solution build succeeds (three existing SYSLIB1227 fixture warnings).
- Release decompiler fast gate: 6,867 passed, zero failures/skips.
- Exact-base 46,945-method A/B; exit 1 is the harness's changed-without-semantic-regression outcome.
- Same-population quick-corpus quality card: PASS, no movement.
- Current-head `ci-required`: success.
- Adversarial review disposition is recorded in a separate PR comment.
- No merge authorization.
