### PR TITLE
Keep Integrations mode tabs in the title row

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -872,6 +872,11 @@ labels the results panel. Both full labels remain available at narrow widths.
 
 The shared frame uses a quiet count/state header, an optional platform Library
 selector, one full-area results scroller, and bottom assembly context.
+The title and count/state share the existing 40px header with right-aligned
+mode tabs, following Compare's shared header. There is no separate tab row.
+Count/state text may elide, with its complete text retained, before either tab
+label loses space. The existing narrow-screen Types control still occupies
+the title's place.
 It replaces the generic Library hero, repeated summary heading/noninteractive
 category chips, and inset signal cards.
 
@@ -885,8 +890,7 @@ catalog describes the same consolidated inspector; no scanner, acquisition, CLI
 section, or result contract changes.
 
 ```text
-Integrations                             category/signal count or state
-[Integrations]  Opportunities
+Integrations  count/state                 [Integrations]  Opportunities
 optional platform Library selector
 category headings and full-width signal rows
 Library asset and assembly identity              TFM · package@version
@@ -919,8 +923,9 @@ Scan classification, catalog ownership, other lenses, and subject-strip
 interaction remain separate work. `inspect-web/test/integration-inspector.test.ts`
 and the Integration tab scenarios in
 `inspect-web/browser/library-hierarchy.spec.ts` gate the consolidated frame,
-manual activation, same-Library mode changes, navigation retention, and an
-inactive scan settling without replacing the selected mode or keyboard focus.
+single-row header geometry and full tab labels down to 320px, manual activation,
+same-Library mode changes, navigation retention, and an inactive scan settling
+without replacing the selected mode or keyboard focus.
 
 #### Opportunities tab
 

--- a/inspect-web/browser/library-hierarchy.spec.ts
+++ b/inspect-web/browser/library-hierarchy.spec.ts
@@ -2170,7 +2170,30 @@ async function openOpportunities(page: Page, location = root) {
     .toHaveAttribute("aria-selected", "true");
 }
 
-for (const width of [1440, 390]) {
+async function expectCompactIntegrationHeader(page: Page) {
+  const frame = page.locator(".integration-inspector");
+  const header = frame.locator("header");
+  const tabs = header.getByRole("tablist", { name: "Integration views" });
+  await expect(tabs).toBeVisible();
+  for (const name of ["Integrations", "Opportunities"]) {
+    const tab = tabs.getByRole("tab", { name, exact: true });
+    await expect(tab).toBeInViewport({ ratio: 1 });
+    expect(await tab.evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true);
+  }
+  const headerBox = await header.boundingBox();
+  const tabsBox = await tabs.boundingBox();
+  const resultsBox = await frame.getByRole("tabpanel").boundingBox();
+  expect(headerBox!.height).toBe(40);
+  expect(Math.abs(tabsBox!.y - headerBox!.y)).toBeLessThanOrEqual(1);
+  expect(tabsBox!.y + tabsBox!.height).toBeLessThanOrEqual(headerBox!.y + headerBox!.height);
+  expect(headerBox!.x + headerBox!.width - tabsBox!.x - tabsBox!.width).toBeLessThanOrEqual(16);
+  expect(Math.abs(resultsBox!.y - headerBox!.y - headerBox!.height)).toBeLessThanOrEqual(1);
+  expect(await header.evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true);
+  expect(await page.evaluate(() =>
+    document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+}
+
+for (const width of [1440, 390, 320]) {
   test(`Integration tabs preserve the Library and use manual keyboard activation at ${width}px`, async ({ page }, testInfo) => {
     await page.setViewportSize({ width, height: 900 });
     await installFacades(page);
@@ -2182,6 +2205,7 @@ for (const width of [1440, 390]) {
     await expect(integrations).toHaveAttribute("aria-selected", "true");
     await expect(opportunities).toBeInViewport({ ratio: 1 });
     await expect(frame.locator(".signal-row")).toHaveCount(3);
+    await expectCompactIntegrationHeader(page);
     expect(await page.locator("html").getAttribute("data-opportunity-request")).toBeNull();
     await integrations.focus();
     await integrations.press("ArrowRight");
@@ -2196,6 +2220,7 @@ for (const width of [1440, 390]) {
     await expect(frame.locator("footer")).toContainText(core.asset);
     await expect(page.locator('[data-library-lens="integrations"]'))
       .toHaveAttribute("aria-selected", "true");
+    await expectCompactIntegrationHeader(page);
     await page.screenshot({ path: testInfo.outputPath("integration-tabs-opportunities.png") });
 
     await opportunities.press("Home");

--- a/inspect-web/src/integration-inspector.ts
+++ b/inspect-web/src/integration-inspector.ts
@@ -27,8 +27,8 @@ export function renderIntegrationInspector(
     <header class="api-surface-head">
       <h1 id="library-integrations-title">Integrations</h1>
       <p title="${escapeHtml(status)}">${escapeHtml(status)}</p>
+      <div class="integration-mode-tabs" role="tablist" aria-label="Integration views">${tabs}</div>
     </header>
-    <div class="integration-mode-tabs" role="tablist" aria-label="Integration views">${tabs}</div>
     ${pickerHtml ? `<section class="library-${mode}-controls" aria-label="Integration scan library">${pickerHtml}</section>` : ""}
     <div id="integration-results" role="tabpanel" aria-labelledby="integration-mode-${mode}" tabindex="0" class="library-${mode}-scroll">${content}</div>
     <footer class="metadata-surface-footer">

--- a/inspect-web/src/styles.css
+++ b/inspect-web/src/styles.css
@@ -1736,10 +1736,12 @@ kbd {
 .signal-name { font: 13px var(--mono); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .signal-ns { font-size: 11px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .signal-kind { flex: 0 0 auto; font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--line); color: var(--dim); }
-.integration-inspector { grid-template-rows: 40px auto minmax(0, 1fr) 34px; }
 .integration-inspector.library-integrations-with-controls,
-.integration-inspector.library-opportunities-with-controls { grid-template-rows: 40px auto auto minmax(0, 1fr) 34px; }
-.integration-mode-tabs { display: flex; gap: 16px; padding: 0 16px; border-bottom: 1px solid var(--line); }
+.integration-inspector.library-opportunities-with-controls { grid-template-rows: 40px auto minmax(0, 1fr) 34px; }
+.integration-inspector > .api-surface-head { gap: 12px; }
+.integration-inspector > .api-surface-head h1 { flex-shrink: 0; }
+.integration-inspector > .api-surface-head p { flex: 1; }
+.integration-mode-tabs { display: flex; flex: 0 0 auto; align-self: stretch; gap: 16px; }
 .integration-mode-tabs button { min-height: 36px; padding: 6px 0; border: 0; border-bottom: 2px solid transparent; border-radius: 0; background: transparent; color: var(--muted); font-size: 12px; }
 .integration-mode-tabs button[aria-selected="true"] { border-bottom-color: var(--accent); color: var(--text); }
 .integration-mode-tabs button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }

--- a/inspect-web/test/integration-inspector.test.ts
+++ b/inspect-web/test/integration-inspector.test.ts
@@ -19,6 +19,9 @@ for (const mode of ["integrations", "opportunities"] as const) {
     }, mode, "Loading", "<p>Pending scan</p>");
     assert.equal(html.match(/<h1\b/g)?.length, 1);
     assert.match(html, /<h1 id="library-integrations-title">Integrations<\/h1>/);
+    const header = html.match(/<header\b[^>]*>[\s\S]*?<\/header>/)?.[0] ?? "";
+    assert.equal(header.match(/role="tab"/g)?.length, 2);
+    assert.match(header, /<p title="Loading">Loading<\/p>[\s\S]*role="tablist"/);
     assert.equal(html.match(/role="tab"/g)?.length, 2);
     assert.equal(html.match(/aria-selected="true"/g)?.length, 1);
     assert.match(html, new RegExp(`data-integration-mode="${mode}" aria-selected="true"`));


### PR DESCRIPTION
## Purpose

Give the consolidated Integrations inspector more room for useful results:
place its mode tabs at the right of the title row, matching the Compare plan
and removing the redundant horizontal row.

Fixes #6698. Follows merged #6653 and the operator's layout feedback within
#5083's inspector-consolidation work.

## Demo

Before:

```text
Integrations                             2 categories · 3 signals
[Integrations]  Opportunities
Dependency Injection
  WidgetService
```

After:

```text
Integrations  2 categories · 3 signals    [Integrations]  Opportunities
Dependency Injection
  WidgetService
```

The header stays 40px tall. The existing production-composition browser
fixture shows the same result with Opportunities selected, and at 1440px,
390px, and 320px. On narrow screens, Types retains its place at the left,
both tab labels remain complete, and count/state text can elide with its
complete text retained. Optional platform controls stay below the header.

These examples use the existing Example.Package fixture; the design's
motivating real asset remains `Microsoft.Extensions.AI@10.0.0`.

## Design and scope

Normative owner:
`docs/design/inspect-web-surface-composition.md#library-integrations`.
Claim: title/status and right-aligned mode tabs share one header, with no
separate tab row. Compare's shared surface frame is the placement precedent.

This is one completed Browser placement adjustment, not a new architecture,
query, shared substrate, or host path. Existing typed scan renderers and
Browser-owned HTML lowering remain unchanged. There is no CLI adoption or
further migration needed for this layout fix.

The production diff moves the existing tab markup into the header, removes
the extra grid row, and allocates flexible width to status before reducing
tab-label space. Tab bindings, focus restoration, result actions, retained
Workspace mode, scanner policy, and registry compatibility are unchanged.

Review tier: **trivial presentation-only follow-up**. The complete small diff
was inspected directly; no independent adversarial review round is required.

## Validation

- `npm run build`: production bundle, type checks, and artifact verification.
- `node --test test/integration-inspector.test.ts test/library-integrations.test.ts test/package-opportunities.test.ts`: 36 passed.
- `CI=true npx playwright test browser/library-hierarchy.spec.ts --grep 'Integration tabs|production (Integrations|Opportunities)' --project=firefox --workers=2 --retries=0`: 34 passed.
- Browser assertions enforce a 40px shared header, right-aligned tabs, full
  labels, immediately adjacent results, and no horizontal overflow down to
  320px. Existing partial/empty/failure, scrolling, platform, keyboard,
  navigation, and inactive-scan settlement scenarios also pass.
- Changed TypeScript and Markdown lint; `git diff --check`.

Effective base: `6457342a92a02db78f6043d6248e2e06befdbec3`. The second
integration confirmed the base was unchanged. Required CI is pending;
no merge-readiness or merge-authorization claim is made.
