### PR TITLE
Adopt shared architecture for extensions command

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -216,6 +216,31 @@ Formatters decide presentation, not content:
   tree or diagram, a table row) and have no verbosity dial — they either show a
   thing or they do not (see [rendering-model.md](rendering-model.md)).
 
+### Approved `extensions --json` compatibility boundary
+
+The CLI host's `extensions --json` path is an approved bounded exception to
+the ordinary Markout lowering rule. Its typed input is the final
+`List<ExtensionMethodResult>` produced by the extension query, and its lowering
+boundary is the generated `ExtensionMethodJsonResult` contract in
+`ExtensionsJsonContext` / `ExtensionsCompactJsonContext`. The visible result
+is a bare JSON array with the established `method`, `class`, `extended_type`,
+`library`, `signature`, `signatures`, numeric `overloads`, `kind`, source, and
+reachable-path fields; null values remain omitted and `--compact` remains a
+whitespace-only modifier.
+
+This boundary exists to preserve an established machine contract that the
+current lowered Markout formatter cannot represent without changing the
+top-level array shape and converting typed numeric/list values to string table
+cells. It is limited to this CLI host and this plain `--json` output; Markdown,
+table, TSV, JSONL, count, and semantic row selection remain on the normal typed
+view/Markout path. The Release gates are
+`SearchJsonResultTests.ExtensionResult_PreservesPublicJsonFieldNames`,
+`ExtensionsCommandTests.ExecuteAsync_CompactJsonPreservesTypedArrayContract`,
+and the extension JSON cases in `CommandExecutionTests`. The exception is
+owned by the `extensions` adoption tracked in
+[#6697](https://github.com/richlander/dotnet-inspect/issues/6697) and should be
+retired only when a compatible Markout typed-JSON lowering is available.
+
 The current `CountProjectionFormatter` establishes cardinality by intercepting
 structured Markout rows without writing them. Under the target
 [section-row-shaping contract](section-row-shaping.md#result-binding-and-failure),

--- a/src/DotnetInspect.Cli/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/DotnetInspect.Cli/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -451,7 +451,9 @@ public static class SearchCommandDefinitions
         extCommand.Options.Add(opts.Columns);
         extCommand.Options.Add(opts.Fields);
         opts.AddCountOptionTo(extCommand);
-        opts.AddOutputOptionsTo(extCommand);
+        opts.AddOutputOptionsTo(
+            extCommand,
+            validateLegacyRowWindow: static _ => false);
         opts.AddNuGetOptionsTo(extCommand);
 
         extCommand.SetAction(async (parseResult, ct) =>
@@ -478,6 +480,15 @@ public static class SearchCommandDefinitions
                 prefixOption: packagePrefixOption);
             var (selection, sources) = await SearchSourceAdapter.BindAsync(
                 intent, HttpClientFactory.Shared, parseResult.GetValue(opts.Verbose), sourceOptions);
+            if (!CliRowSelectionCommandRegistry.TryGetPreparedSemanticIntent(
+                    parseResult,
+                    "Extensions",
+                    out RowSelectionIntent<string>? rowSelection,
+                    out string? rowSelectionError))
+            {
+                CommandError.Write(rowSelectionError!);
+                return 1;
+            }
 
             var options = new ExtensionsOptions
             {
@@ -493,7 +504,8 @@ public static class SearchCommandDefinitions
                 Tfm = parseResult.GetValue(tfmOption),
                 IncludeAll = parseResult.GetValue(allOption),
                 Limit = CommandLineHelpers.ParseTypeLimit(parseResult.GetValue(typeFilterOption)),
-                Rows = opts.ParseRows(parseResult),
+                Rows = rowSelection is null ? opts.ParseRows(parseResult) : null,
+                RowSelection = rowSelection,
                 Count = parseResult.GetValue(opts.Count),
                 JsonOutput = opts.ResolveFormat(parseResult) == OutputFormat.Json,
                 CompactJson = parseResult.GetValue(compactOption),
@@ -511,6 +523,23 @@ public static class SearchCommandDefinitions
 
             return await ExtensionsCommand.ExecuteAsync(options, ct);
         });
+
+        var linesOption = new Option<bool>("--lines");
+        var tailLinesOption = new Option<bool>("--tail-lines");
+        CliRowSelectionCommandRegistry.Register(
+            extCommand,
+            new(
+                opts.Limit,
+                opts.Rows,
+                top: null,
+                orderBy: null,
+                opts.Head,
+                opts.Tail,
+                linesOption,
+                tailLinesOption),
+            CliRowSelectionCapabilities.HeadTail
+                | CliRowSelectionCapabilities.Window,
+            isActive: static _ => true);
 
         return extCommand;
     }

--- a/src/DotnetInspect.Cli/Commands/ExtensionsCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/ExtensionsCommand.cs
@@ -7,6 +7,7 @@ using ILInspector.Metadata;
 using DotnetInspect.Cli.Options;
 using DotnetInspect.Cli.Output;
 using DotnetInspector.Queries;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspect.Cli.Services;
 using DotnetInspect.Cli.Views;
@@ -46,7 +47,23 @@ public class ExtensionsCommand
                 targetType,
                 cancellationToken);
 
-            // Apply limit
+            bool hasSemanticRowSelection =
+                options.RowSelection?.Operations.Count > 0;
+            if (hasSemanticRowSelection)
+            {
+                results = results
+                    .OrderBy(r => r.ReachablePath ?? "", StringComparer.Ordinal)
+                    .ThenBy(r => r.ExtensionClass, StringComparer.Ordinal)
+                    .ThenBy(r => r.MethodName, StringComparer.Ordinal)
+                    .ThenBy(r => r.Kind, StringComparer.Ordinal)
+                    .ThenBy(r => r.Assembly, StringComparer.Ordinal)
+                    .ThenBy(r => r.Source, StringComparer.Ordinal)
+                    .ThenBy(r => r.SourceVersion, StringComparer.Ordinal)
+                    .ThenBy(r => r.Signature, StringComparer.Ordinal)
+                    .ToList();
+            }
+
+            // Apply the existing work limit before overload collapse.
             if (options.Limit.HasValue && results.Count > options.Limit.Value)
             {
                 results = results.Take(options.Limit.Value).ToList();
@@ -54,6 +71,35 @@ public class ExtensionsCommand
 
             // Collapse overloads into single entries
             results = CollapseOverloads(results);
+
+            RowWindow? outputRows =
+                hasSemanticRowSelection ? null : options.Rows;
+            if (hasSemanticRowSelection
+                && options.RowSelection is { } rowSelection)
+            {
+                RowsCohortResult<string, ExtensionMethodResult> selected =
+                    RowsCohortExecutor.ApplyUnordered(
+                        [
+                            RowsCohortSequence<string, ExtensionMethodResult>.Create(
+                                "Extensions",
+                                results)
+                        ],
+                        rowSelection);
+                if (!selected.IsSuccess)
+                {
+                    RowsCohortSemanticFailure<string> failure =
+                        selected.Failure!;
+                    CommandError.Write(
+                        $"Extensions row selection stage "
+                        + $"{failure.Failure.StageNumber} requires row "
+                        + $"{failure.Failure.RequiredPosition}, but only "
+                        + $"{failure.Failure.AvailableCount} extension rows "
+                        + "are available.");
+                    return 1;
+                }
+
+                results = selected.RowSets[0].Values.ToList();
+            }
 
             if (results.Count == 0)
                 NamespacePrefixHints.WriteIfLikelyNamespacePrefix(targetType);
@@ -64,7 +110,7 @@ public class ExtensionsCommand
             // with the full unprojected result set.
             if (options.Count)
             {
-                if (!WriteCount(targetType, results, options))
+                if (!WriteCount(targetType, results, options, outputRows))
                     return 1;
             }
             else if (options.JsonOutput)
@@ -76,11 +122,11 @@ public class ExtensionsCommand
             }
             else if (options.Tabular || options.Tsv || options.Jsonl || options.NoHeader)
             {
-                WriteTableOutput(targetType, results, options);
+                WriteTableOutput(targetType, results, options, outputRows);
             }
             else
             {
-                WriteMarkoutOutput(targetType, results, options.Verbosity, options.Rows);
+                WriteMarkoutOutput(targetType, results, options.Verbosity, outputRows);
             }
 
             return 0;
@@ -480,6 +526,10 @@ public class ExtensionsCommand
 
     private static void WriteJsonOutput(List<ExtensionMethodResult> results, bool compact)
     {
+        // The established public JSON contract is a typed array with numeric overload
+        // counts and signatures. The output-shapes design records this compatibility
+        // exception because the lowered Markout formatter intentionally emits section
+        // objects with string cells.
         var jsonResults = results.Select(ExtensionMethodJsonResult.From).ToList();
         JsonOutputHelper.Write(jsonResults, ExtensionsJsonContext.Default.ListExtensionMethodJsonResult,
             ExtensionsCompactJsonContext.Default.ListExtensionMethodJsonResult, compact);
@@ -488,7 +538,8 @@ public class ExtensionsCommand
     private static bool WriteCount(
         string targetType,
         List<ExtensionMethodResult> results,
-        ExtensionsOptions options)
+        ExtensionsOptions options,
+        RowWindow? rows)
     {
         var view = ExtensionsOutputFormatter.BuildView(
             targetType,
@@ -499,7 +550,7 @@ public class ExtensionsCommand
             "Extensions",
             options.Columns,
             options.Fields,
-            options.Rows);
+            rows);
     }
 
     private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, RowWindow? rows)
@@ -509,14 +560,18 @@ public class ExtensionsCommand
             opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
     }
 
-    private static void WriteTableOutput(string targetType, List<ExtensionMethodResult> results, ExtensionsOptions options)
+    private static void WriteTableOutput(
+        string targetType,
+        List<ExtensionMethodResult> results,
+        ExtensionsOptions options,
+        RowWindow? rows)
     {
         var view = ExtensionsOutputFormatter.BuildView(targetType, results, options.Verbosity);
         OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
             options.Columns, options.Fields,
             (writer, formatter, writerOptions) =>
                 MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
-            options.Rows);
+            rows);
     }
 
     /// <summary>

--- a/src/DotnetInspect.Cli/Options/ExtensionsOptions.cs
+++ b/src/DotnetInspect.Cli/Options/ExtensionsOptions.cs
@@ -1,5 +1,6 @@
 using DotnetInspect.Cli.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Sections;
 
 using DotnetInspector.SourceSelection;
 
@@ -69,6 +70,11 @@ public record ExtensionsOptions : IAssemblySourceOptions, IProjectionOptions
     /// Limit data rows per rendered table.
     /// </summary>
     public RowWindow? Rows { get; init; }
+
+    /// <summary>
+    /// Prepared semantic row selection for the CLI invocation.
+    /// </summary>
+    public RowSelectionIntent<string>? RowSelection { get; init; }
 
     /// <summary>
     /// Output the number of rendered result rows.

--- a/tests/DotnetInspect.Cli.Tests/ExtensionsCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/ExtensionsCommandTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection.PortableExecutable;
+using System.Text.Json;
+using DotnetInspect.Cli;
 using DotnetInspect.Cli.Commands;
 using DotnetInspect.Cli.Inspectors;
 using DotnetInspect.Cli.Models;
@@ -235,6 +237,145 @@ public class ExtensionsCommandTests
             nameof(ExtensionWorkspaceMethods.WorkspaceExtension),
             output);
         Assert.Contains("\"reachable_path\": \".Reachable\"", output);
+    }
+
+    [Fact]
+    public async Task CommandLine_SemanticTailSelectionReturnsOneCollapsedRow()
+    {
+        var result = await ExecuteCommandLineAsync(
+            "extensions",
+            "String",
+            "--library",
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            "--all",
+            "--json",
+            "-n",
+            "1",
+            "--tail");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using JsonDocument document = JsonDocument.Parse(result.Output);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+        Assert.Equal(
+            "ToUpperCase",
+            document.RootElement[0].GetProperty("method").GetString());
+    }
+
+    [Fact]
+    public async Task CommandLine_SemanticRangeSelectionAppliesBeforeCount()
+    {
+        var result = await ExecuteCommandLineAsync(
+            "extensions",
+            "String",
+            "--library",
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            "--all",
+            "--count",
+            "--rows",
+            "1..2");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Equal("2", result.Output.Trim());
+    }
+
+    [Fact]
+    public async Task CommandLine_SemanticRangeSelectionReportsStrictFailure()
+    {
+        var result = await ExecuteCommandLineAsync(
+            "extensions",
+            "String",
+            "--library",
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            "--all",
+            "--json",
+            "--rows",
+            "1..10");
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains("Extensions row selection stage", result.Error);
+        Assert.Contains("requires row 10", result.Error);
+    }
+
+    [Fact]
+    public async Task CommandLine_SemanticSelectionRejectsCountFormRows()
+    {
+        var result = await ExecuteCommandLineAsync(
+            "extensions",
+            "String",
+            "--library",
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            "--rows",
+            "3");
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains("--rows requires N..M", result.Error);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LegacyRowsFallbackWindowsRenderedOutputOnce()
+    {
+        var options = new ExtensionsOptions
+        {
+            TargetType = "String",
+            Assemblies = [typeof(ExtensionsCommandTests).Assembly.Location],
+            IncludeAll = true,
+            Rows = RowWindow.Range(1, 1),
+            Tabular = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => ExtensionsCommand.ExecuteAsync(
+                    options,
+                    TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("Repeat", output);
+        Assert.DoesNotContain("ToUpperCase", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CompactJsonPreservesTypedArrayContract()
+    {
+        var options = new ExtensionsOptions
+        {
+            TargetType = "String",
+            Assemblies = [typeof(ExtensionsCommandTests).Assembly.Location],
+            IncludeAll = true,
+            JsonOutput = true,
+            CompactJson = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => ExtensionsCommand.ExecuteAsync(
+                    options,
+                    TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        string compact = output.TrimEnd();
+        Assert.DoesNotContain('\n', compact);
+        using JsonDocument document = JsonDocument.Parse(compact);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.NotEmpty(document.RootElement.EnumerateArray());
+    }
+
+    private static async Task<(int ExitCode, string Output, string Error)> ExecuteCommandLineAsync(
+        params string[] arguments)
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        string[] processed = CommandLineBuilder.PreprocessArgs(arguments, root);
+        return await ConsoleCapture.RunAsync(
+            () => CommandLineBuilder.InvokeAsync(
+                root.Parse(processed),
+                processed));
     }
 
     [Fact]


### PR DESCRIPTION
## Demo

`extensions` now uses the shared semantic row-selection surface while preserving its cross-source extension survey and established JSON contract:

```console
$ dotnet-inspect extensions 'IEnumerable<T>' --platform System.Linq -n 2 --tail
...
```

The neighboring reachable case preserves `via`/reachable-path evidence:

```console
$ dotnet-inspect extensions 'IEnumerable<T>' --platform System.Linq --reachable --head 3
...
```

## Summary

Bring `dotnet-inspect extensions` through the shared architecture required by #6639:

- register semantic `--head`, `--tail`, and `--rows` selection;
- apply deterministic selection after overload collapse and before count/projection;
- preserve `-n` as the existing pre-collapse work limit and preserve legacy direct-caller `Rows` behavior;
- retain visible strict out-of-range diagnostics;
- keep Markdown, table, TSV, JSONL, count, and projection paths on the typed Markout view path; and
- document the narrow plain-`--json` compatibility boundary, retaining its established bare typed array, numeric overload counts, signatures, field names, and compact behavior.

The motivating real asset is the published `System.Linq` platform library. The implementation and remaining seven-lane adoption work are tracked by #6697; this PR closes that focused implementation slice and contributes to #6639.

## Validation

- Focused extensions, implements regression, and JSON result tests: 48/48 passed in Release.
- Full Release solution build: passed with 0 errors; the build reports 3 existing `SYSLIB1227` warnings in union fixture sources.
- `markdownlint-cli docs/design/output-shapes.md`: passed.
- `git diff --check`: passed.

## Scope boundary

Share packets, universal House/resource ownership, and complete Workspace admission/lifetime proof remain tracked by the parent adoption work and their owning issues. The plain `extensions --json` serializer exception is intentionally bounded and documented in `docs/design/output-shapes.md`; it should be retired only when compatible Markout typed-JSON lowering is available.

Part of #6697
Part of #6639