### PR TITLE
Graph libraries: adopt typed Markout serialization

### DIFF
--- a/docs/design/pairwise-library-call-use.md
+++ b/docs/design/pairwise-library-call-use.md
@@ -11,6 +11,8 @@ Tracking:
   pair occurrence evidence;
 - [#6602](https://github.com/richlander/dotnet-inspect/issues/6602) — direct-use
   summary projections;
+- [#6694](https://github.com/richlander/dotnet-inspect/issues/6694) — typed
+  Markout serialization;
 - [#6313](https://github.com/richlander/dotnet-inspect/issues/6313) — broader
   feature-relationship experience.
 
@@ -255,6 +257,14 @@ The command exposes three sections:
 | `Consumer Use Sites` | One row per attributed source method and directed target participant, with distinct provider-type and target-member counts |
 | `Provider API Types` | One row per structured target declaring type and directed source participant, with distinct source- and target-member counts |
 | `Call Sites` | The exact physical occurrence rows |
+
+The CLI represents this document and its three row sets as typed Markout views.
+`MarkoutSerializer` and one generated serializer context own section schemas,
+projection, and format lowering. The command may choose the appropriate
+document or table view for the selected shape, but it does not construct a
+`MarkoutWriter`, manually write headings, paragraphs, or tables, or maintain a
+parallel list of rendered column labels. No host-specific rendering exception
+is approved for this command.
 
 Omitting `-S` preserves the exact call-site view. Bare `-S` selects the two
 summary sections; an exact section name selects one projection, and normal

--- a/src/DotnetInspect.Cli/Commands/LibraryCallUseCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/LibraryCallUseCommand.cs
@@ -788,10 +788,14 @@ public static class LibraryCallUseCommand
         ];
     }
 
-    static string FormatAssembly(AssemblyContextSubject subject) =>
-        subject.Identity.Version is { } version
-            ? $"{subject.Identity.Name}@{version}"
-            : subject.Identity.Name;
+    static string FormatAssembly(AssemblyContextSubject subject)
+    {
+        string name =
+            LibraryCallUseViewText.Contain(subject.Identity.Name);
+        return subject.Identity.Version is { } version
+            ? $"{name}@{version}"
+            : name;
+    }
 
     static string FormatPair(AssemblyPairCallUseResult result) =>
         $"{FormatAssembly(result.Subjects[0])} "

--- a/src/DotnetInspect.Cli/Commands/LibraryCallUseCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/LibraryCallUseCommand.cs
@@ -2,6 +2,7 @@ using DotnetInspect.Cli.Inspectors;
 using DotnetInspect.Cli.Models;
 using DotnetInspect.Cli.Options;
 using DotnetInspect.Cli.Output;
+using DotnetInspect.Cli.Views;
 using DotnetInspector.Queries;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
@@ -16,11 +17,11 @@ public static class LibraryCallUseCommand
     public const string Name = "libraries";
 
     internal const string ConsumerUseSitesSection =
-        "Consumer Use Sites";
+        LibraryCallUseViewSections.ConsumerUseSites;
     internal const string ProviderApiTypesSection =
-        "Provider API Types";
+        LibraryCallUseViewSections.ProviderApiTypes;
     internal const string CallSitesSection =
-        "Call Sites";
+        LibraryCallUseViewSections.CallSites;
 
     static readonly string[] SectionOrder =
     [
@@ -32,98 +33,6 @@ public static class LibraryCallUseCommand
     static readonly IReadOnlyDictionary<string, string[]> NoCategories =
         new Dictionary<string, string[]>(
             StringComparer.OrdinalIgnoreCase);
-
-    static readonly string[] CallSiteLabels =
-    [
-        "Source Library",
-        "Source MVID",
-        "Source Member",
-        "Source Token",
-        "Target Library",
-        "Target MVID",
-        "Target Member",
-        "Target Token",
-        "Call",
-        "Evidence Method",
-        "Evidence MVID",
-        "Evidence Token",
-        "IL Offset",
-        "Operand Token",
-        "Exact Target",
-    ];
-
-    static readonly string[] CallSiteIds =
-    [
-        "source-library",
-        "source-mvid",
-        "source-member",
-        "source-token",
-        "target-library",
-        "target-mvid",
-        "target-member",
-        "target-token",
-        "call",
-        "evidence-method",
-        "evidence-mvid",
-        "evidence-token",
-        "il-offset",
-        "operand-token",
-        "exact-target",
-    ];
-
-    static readonly string[] ConsumerUseSiteLabels =
-    [
-        "Source Library",
-        "Source MVID",
-        "Source Member",
-        "Source Token",
-        "Target Library",
-        "Target MVID",
-        "Provider Types",
-        "Target Members",
-        "Call Sites",
-        "Call Site Rows",
-    ];
-
-    static readonly string[] ConsumerUseSiteIds =
-    [
-        "source-library",
-        "source-mvid",
-        "source-member",
-        "source-token",
-        "target-library",
-        "target-mvid",
-        "provider-types",
-        "target-members",
-        "call-sites",
-        "call-site-rows",
-    ];
-
-    static readonly string[] ProviderApiTypeLabels =
-    [
-        "Source Library",
-        "Source MVID",
-        "Target Library",
-        "Target MVID",
-        "Target Type",
-        "Source Members",
-        "Target Members",
-        "Call Sites",
-        "Call Site Rows",
-    ];
-
-    static readonly string[] ProviderApiTypeIds =
-    [
-        "source-library",
-        "source-mvid",
-        "target-library",
-        "target-mvid",
-        "target-type",
-        "source-members",
-        "target-members",
-        "call-sites",
-        "call-site-rows",
-    ];
 
     static readonly string[] DefaultCallSiteColumns =
     [
@@ -306,23 +215,10 @@ public static class LibraryCallUseCommand
         return 0;
     }
 
-    static DocumentSchema CreateSchema()
-    {
-        var schema = new DocumentSchema();
-        schema.Add(
-            ConsumerUseSitesSection,
-            "column",
-            ConsumerUseSiteLabels);
-        schema.Add(
-            ProviderApiTypesSection,
-            "column",
-            ProviderApiTypeLabels);
-        schema.Add(
-            CallSitesSection,
-            "column",
-            CallSiteLabels);
-        return schema;
-    }
+    static DocumentSchema CreateSchema() =>
+        LibraryCallUseViewContext.Default
+            .GetSchemaInfo<LibraryCallUseSelectedView>()!
+            .ToDocumentSchema();
 
     static bool TryResolveSelection(
         LibraryCallUseOptions options,
@@ -430,15 +326,19 @@ public static class LibraryCallUseCommand
         AssemblyPairCallUseResult result,
         LibraryCallUseOptions options)
     {
-        IReadOnlyList<AssemblyPairCallUseOccurrence> occurrences =
-            RowWindow.Apply(
-                options.Rows,
-                result.Occurrences);
-        if (options.Count)
+        List<LibraryCallUseCallSiteRow> rows =
+            CreateCallSiteRows(result.Occurrences);
+        IReadOnlyList<AssemblyPairCallUseOccurrence> selectedOccurrences =
+            RowWindow.Apply(options.Rows, result.Occurrences);
+        var view = new LibraryCallUseCallSitesView
         {
-            CountOutput.WriteCount(occurrences.Count);
-            return;
-        }
+            Title = "Library Call Use",
+            Description = CreateDefaultDescription(
+                result,
+                selectedOccurrences,
+                options.Rows),
+            Rows = rows,
+        };
 
         string[]? columns = options.Columns;
         string[]? fields = options.Fields;
@@ -451,16 +351,29 @@ public static class LibraryCallUseCommand
             columns = DefaultCallSiteColumns;
         }
 
+        var writerOptions =
+            OutputFormatter.CreateProjectedWriterOptions(
+                columns,
+                fields,
+                options.Rows);
+        if (options.Count)
+        {
+            CountProjection count = CountProjectionFormatter.Capture(
+                view,
+                LibraryCallUseViewContext.Default,
+                writerOptions);
+            CountOutput.WriteCount(count.Total);
+            return;
+        }
+
         Action<TextWriter, IMarkoutFormatter, MarkoutWriterOptions>
-            serialize = (writer, formatter, writerOptions) =>
-            {
-                var markout = new MarkoutWriter(
+            serialize = (writer, formatter, projectedOptions) =>
+                MarkoutSerializer.Serialize(
+                    view,
                     writer,
                     formatter,
-                    writerOptions);
-                WriteCallSiteTable(markout, occurrences);
-                markout.Flush();
-            };
+                    LibraryCallUseViewContext.Default,
+                    projectedOptions);
         switch (options.Format)
         {
             case OutputFormat.Json:
@@ -469,7 +382,7 @@ public static class LibraryCallUseCommand
                     columns,
                     fields,
                     serialize,
-                    maxRows: null);
+                    maxRows: options.Rows);
                 break;
             case OutputFormat.Table:
             case OutputFormat.Tsv:
@@ -482,43 +395,17 @@ public static class LibraryCallUseCommand
                     columns,
                     fields,
                     serialize,
-                    maxRows: null);
+                    maxRows: options.Rows);
                 break;
             default:
-                var writerOptions =
-                    OutputFormatter.CreateProjectedWriterOptions(
-                        columns,
-                        fields,
-                        rows: null);
-                var markout = new MarkoutWriter(
+                MarkoutSerializer.Serialize(
+                    view,
                     Console.Out,
                     options.Format == OutputFormat.PlainText
                         ? new PlainTextFormatter()
                         : new MarkdownFormatter(),
+                    LibraryCallUseViewContext.Default,
                     writerOptions);
-                markout.WriteHeading(1, "Library Call Use");
-                markout.WriteParagraph(
-                    $"{FormatAssembly(result.Subjects[0])} "
-                    + "\u2194 "
-                    + FormatAssembly(
-                        result.Subjects[1]));
-                string[] summaries =
-                    [.. RelationshipSummaries(occurrences)];
-                if (summaries.Length == 0)
-                {
-                    markout.WriteParagraph(
-                        result.Occurrences.Length > 0
-                            && options.Rows is not null
-                            ? "No direct pair call use is selected by the row window."
-                            : result.IsComplete
-                            ? "No direct pair call use was observed."
-                            : "No exact pair call use was observed; the evidence is incomplete.");
-                }
-                else
-                    foreach (string summary in summaries)
-                        markout.WriteParagraph(summary);
-                WriteCallSiteTable(markout, occurrences);
-                markout.Flush();
                 break;
         }
     }
@@ -529,53 +416,43 @@ public static class LibraryCallUseCommand
         LibraryCallUseOptions options,
         IReadOnlyCollection<string> selectedNames)
     {
-        LibraryCallUseSection[] sections =
-            CreateSections(projection);
-        LibraryCallUseSection[] selected =
-        [
-            .. sections.Where(
-                section => selectedNames.Contains(
-                    section.Name,
-                    StringComparer.OrdinalIgnoreCase)),
-        ];
         DocumentSchema schema = CreateSchema();
         string[]? projectedColumns =
             ResolveProjectedColumns(options);
         HashSet<string> renderedNames =
             projectedColumns is { Length: > 0 }
-                ? selected
+                ? selectedNames
                     .Where(section =>
                         schema.ValidateProjection(
-                            section.Name,
+                            section,
                             projectedColumns)
                             .Resolved.Length > 0)
-                    .Select(section => section.Name)
                     .ToHashSet(StringComparer.OrdinalIgnoreCase)
                 : selectedNames.ToHashSet(
                     StringComparer.OrdinalIgnoreCase);
-        LibraryCallUseSection[] rendered =
-        [
-            .. selected.Where(
-                section => renderedNames.Contains(section.Name)),
-        ];
-        LibraryCallUseSection[] windowed =
-            ApplyRowWindow(rendered, options.Rows);
+        LibraryCallUseSelectedView view =
+            CreateSelectedView(projection);
+        var writerOptions =
+            OutputFormatter.CreateProjectedWriterOptions(
+                projectedColumns,
+                fields: null,
+                options.Rows);
+        writerOptions.IncludeSections = renderedNames;
 
         if (options.Count)
         {
-            if (selected.Length == 1)
+            string[] ordered =
+                [.. SectionOrder.Where(selectedNames.Contains)];
+            CountProjection counts = CountProjectionFormatter.Capture(
+                view,
+                LibraryCallUseViewContext.Default,
+                writerOptions);
+            if (ordered.Length == 1)
             {
-                CountOutput.WriteCount(
-                    renderedNames.Contains(selected[0].Name)
-                        ? RowWindow.Apply(
-                            options.Rows,
-                            selected[0].Rows).Count
-                        : 0);
+                CountOutput.WriteCount(counts.Total);
                 return;
             }
 
-            string[] ordered =
-                [.. selected.Select(section => section.Name)];
             if (!CountOutput.ValidateMapFormat(
                     options.Format,
                     ordered))
@@ -583,17 +460,6 @@ public static class LibraryCallUseCommand
                 return;
             }
 
-            var counts = new CountProjection();
-            foreach (LibraryCallUseSection section in selected)
-            {
-                counts.SetRows(
-                    section.Name,
-                    renderedNames.Contains(section.Name)
-                        ? RowWindow.Apply(
-                            options.Rows,
-                            section.Rows).Count
-                        : 0);
-            }
             CountOutput.Write(
                 counts,
                 ordered,
@@ -609,17 +475,16 @@ public static class LibraryCallUseCommand
                 projectedColumns,
                 fields: null,
                 (writer, formatter, writerOptions) =>
-                    WriteSelectedDocument(
-                        new MarkoutWriter(
-                            writer,
-                            formatter,
-                            writerOptions),
-                        result,
-                        windowed,
-                        includeDocumentHeading:
-                            selected.Length > 1,
-                        renderEmptyTables: true),
-                maxRows: null);
+                {
+                    writerOptions.IncludeSections = renderedNames;
+                    MarkoutSerializer.Serialize(
+                        view,
+                        writer,
+                        formatter,
+                        LibraryCallUseViewContext.Default,
+                        writerOptions);
+                },
+                maxRows: options.Rows);
             return;
         }
 
@@ -628,7 +493,6 @@ public static class LibraryCallUseCommand
                 or OutputFormat.Tsv
                 or OutputFormat.Jsonl)
         {
-            LibraryCallUseSection section = windowed[0];
             OutputFormatter.WriteProjectedTable(
                 Console.Out,
                 showHeader: !options.NoHeader,
@@ -638,14 +502,15 @@ public static class LibraryCallUseCommand
                 fields: null,
                 (writer, formatter, writerOptions) =>
                 {
-                    var markout = new MarkoutWriter(
+                    writerOptions.IncludeSections = renderedNames;
+                    MarkoutSerializer.Serialize(
+                        view,
                         writer,
                         formatter,
+                        LibraryCallUseViewContext.Default,
                         writerOptions);
-                    WriteSectionTable(markout, section);
-                    markout.Flush();
                 },
-                maxRows: null);
+                maxRows: options.Rows);
             return;
         }
 
@@ -653,182 +518,249 @@ public static class LibraryCallUseCommand
             options.Columns is null && options.Fields is null
                 ? DefaultSelectedColumns
                 : projectedColumns;
-        var projectedWriterOptions =
-            OutputFormatter.CreateProjectedWriterOptions(
-                humanColumns,
-                fields: null,
-                rows: null);
-        var document = new MarkoutWriter(
-            Console.Out,
+        WriteSelectedHuman(
+            result,
+            projection,
+            options,
+            renderedNames,
+            humanColumns,
+            includeDocumentHeading: selectedNames.Count > 1);
+    }
+
+    static void WriteSelectedHuman(
+        AssemblyPairCallUseResult result,
+        AssemblyPairCallUseProjection projection,
+        LibraryCallUseOptions options,
+        IReadOnlySet<string> renderedNames,
+        string[]? columns,
+        bool includeDocumentHeading)
+    {
+        IMarkoutFormatter formatter =
             options.Format == OutputFormat.PlainText
                 ? new PlainTextFormatter()
-                : new MarkdownFormatter(),
-            projectedWriterOptions);
-        WriteSelectedDocument(
-            document,
-            result,
-            windowed,
-            includeDocumentHeading: selected.Length > 1);
-        document.Flush();
-    }
-
-    static LibraryCallUseSection[] CreateSections(
-        AssemblyPairCallUseProjection projection) =>
-    [
-        new(
-            ConsumerUseSitesSection,
-            "Attributed source methods that directly use the other library. "
-                + "These are use sites, not inferred features or public entry points.",
-            ConsumerUseSiteLabels,
-            ConsumerUseSiteIds,
-            [
-                .. projection.ConsumerUseSites.Select(site => new[]
-                {
-                    AssemblyIdentityFormatter.Format(
-                        site.Source.Identity),
-                    site.SourceModuleVersionId.ToString("D"),
-                    LibraryMetadataService.FormatMethod(
-                        site.SourceMethod),
-                    $"0x{site.SourceMethod.MetadataToken:X8}",
-                    AssemblyIdentityFormatter.Format(
-                        site.Target.Identity),
-                    site.TargetModuleVersionId.ToString("D"),
-                    site.TargetTypes.Length.ToString(),
-                    site.TargetMethods.Length.ToString(),
-                    site.CallSiteCount.ToString(),
-                    FormatOccurrenceRows(site.OccurrenceIndexes),
-                }),
-            ],
-            projection.IsComplete
-                ? "No direct consumer use sites were observed."
-                : "No exact consumer use sites were observed; the evidence is incomplete."),
-        new(
-            ProviderApiTypesSection,
-            "Structured declaring types of exact selected target methods. "
-                + "These are consumed provider types, not inferred capability clusters or public API boundaries.",
-            ProviderApiTypeLabels,
-            ProviderApiTypeIds,
-            [
-                .. projection.ProviderApiTypes.Select(type => new[]
-                {
-                    AssemblyIdentityFormatter.Format(
-                        type.Source.Identity),
-                    type.SourceModuleVersionId.ToString("D"),
-                    AssemblyIdentityFormatter.Format(
-                        type.Target.Identity),
-                    type.TargetModuleVersionId.ToString("D"),
-                    type.TargetType.Resolution?.Type.ToMetadataFullName()
-                        ?? type.TargetType.ToQualifiedDisplayString(),
-                    type.SourceMethods.Length.ToString(),
-                    type.TargetMethods.Length.ToString(),
-                    type.CallSiteCount.ToString(),
-                    FormatOccurrenceRows(type.OccurrenceIndexes),
-                }),
-            ],
-            projection.IsComplete
-                ? "No provider API types were observed."
-                : "No exact provider API types were observed; the evidence is incomplete."),
-        new(
-            CallSitesSection,
-            "Exact physical call and construction occurrences crossing the library pair.",
-            CallSiteLabels,
-            CallSiteIds,
-            CreateCallSiteRows(projection.Pair.Occurrences),
-            projection.IsComplete
-                ? "No direct pair call use was observed."
-                : "No exact pair call use was observed; the evidence is incomplete."),
-    ];
-
-    static LibraryCallUseSection[] ApplyRowWindow(
-        IEnumerable<LibraryCallUseSection> sections,
-        RowWindow? rows) =>
-    [
-        .. sections.Select(section => section with
-        {
-            Rows = [.. RowWindow.Apply(rows, section.Rows)],
-            WasLogicallyEmpty = section.Rows.Length == 0,
-        }),
-    ];
-
-    static void WriteSelectedDocument(
-        MarkoutWriter writer,
-        AssemblyPairCallUseResult result,
-        IReadOnlyList<LibraryCallUseSection> sections,
-        bool includeDocumentHeading,
-        bool renderEmptyTables = false)
-    {
+                : new MarkdownFormatter();
         if (includeDocumentHeading)
         {
-            writer.WriteHeading(1, "Library Call Use");
-            writer.WriteParagraph(
-                $"{FormatAssembly(result.Subjects[0])} "
-                + "\u2194 "
-                + FormatAssembly(result.Subjects[1]));
+            MarkoutSerializer.Serialize(
+                new LibraryCallUseHeaderView
+                {
+                    Description = FormatPair(result),
+                },
+                Console.Out,
+                formatter,
+                LibraryCallUseViewContext.Default);
         }
 
-        bool first = true;
-        foreach (LibraryCallUseSection section in sections)
+        var writerOptions =
+            OutputFormatter.CreateProjectedWriterOptions(
+                columns,
+                fields: null,
+                options.Rows);
+        writerOptions.HeadingLevelOffset = 1;
+        bool wroteDocument = includeDocumentHeading;
+        foreach (string section in SectionOrder)
         {
-            if (!first || includeDocumentHeading)
-                writer.WriteBlankLine();
-            first = false;
-            writer.WriteHeading(2, section.Name);
-            writer.WriteParagraph(section.Summary);
-            if (section.Rows.Length == 0
-                && !renderEmptyTables)
-            {
-                writer.WriteParagraph(
-                    section.WasLogicallyEmpty
-                        ? section.EmptyText
-                        : "No rows are selected by the row window.");
+            if (!renderedNames.Contains(section))
                 continue;
+
+            if (wroteDocument)
+            {
+                Console.WriteLine();
+                Console.WriteLine();
             }
-            WriteSectionTable(writer, section);
+
+            switch (section)
+            {
+                case ConsumerUseSitesSection:
+                    MarkoutSerializer.Serialize(
+                        CreateConsumerUseSitesView(
+                            projection,
+                            options.Rows),
+                        Console.Out,
+                        formatter,
+                        LibraryCallUseViewContext.Default,
+                        writerOptions);
+                    break;
+                case ProviderApiTypesSection:
+                    MarkoutSerializer.Serialize(
+                        CreateProviderApiTypesView(
+                            projection,
+                            options.Rows),
+                        Console.Out,
+                        formatter,
+                        LibraryCallUseViewContext.Default,
+                        writerOptions);
+                    break;
+                case CallSitesSection:
+                    MarkoutSerializer.Serialize(
+                        CreateSelectedCallSitesView(
+                            projection,
+                            options.Rows),
+                        Console.Out,
+                        formatter,
+                        LibraryCallUseViewContext.Default,
+                        writerOptions);
+                    break;
+            }
+            wroteDocument = true;
         }
     }
 
-    static void WriteSectionTable(
-        MarkoutWriter writer,
-        LibraryCallUseSection section) =>
-        writer.WriteTable(
-            section.Labels,
-            section.Ids,
-            section.Rows);
+    static LibraryCallUseSelectedView CreateSelectedView(
+        AssemblyPairCallUseProjection projection) =>
+        new()
+        {
+            ConsumerUseSites =
+                [.. projection.ConsumerUseSites.Select(CreateConsumerUseSiteRow)],
+            ProviderApiTypes =
+                [.. projection.ProviderApiTypes.Select(CreateProviderApiTypeRow)],
+            CallSites = CreateCallSiteRows(projection.Pair.Occurrences),
+        };
 
-    static void WriteCallSiteTable(
-        MarkoutWriter writer,
-        IReadOnlyList<AssemblyPairCallUseOccurrence> occurrences) =>
-        writer.WriteTable(
-            CallSiteLabels,
-            CallSiteIds,
-            CreateCallSiteRows(occurrences));
+    static LibraryCallUseConsumerUseSitesView CreateConsumerUseSitesView(
+        AssemblyPairCallUseProjection projection,
+        RowWindow? rows)
+    {
+        List<LibraryCallUseConsumerUseSiteRow> values =
+            [.. projection.ConsumerUseSites.Select(CreateConsumerUseSiteRow)];
+        return new()
+        {
+            Description = CreateSectionDescription(
+                "Attributed source methods that directly use the other library. "
+                    + "These are use sites, not inferred features or public entry points.",
+                projection.IsComplete
+                    ? "No direct consumer use sites were observed."
+                    : "No exact consumer use sites were observed; the evidence is incomplete.",
+                values,
+                rows),
+            Rows = HasSelectedRows(values, rows) ? values : null,
+        };
+    }
 
-    static string[][] CreateCallSiteRows(
+    static LibraryCallUseProviderApiTypesView CreateProviderApiTypesView(
+        AssemblyPairCallUseProjection projection,
+        RowWindow? rows)
+    {
+        List<LibraryCallUseProviderApiTypeRow> values =
+            [.. projection.ProviderApiTypes.Select(CreateProviderApiTypeRow)];
+        return new()
+        {
+            Description = CreateSectionDescription(
+                "Structured declaring types of exact selected target methods. "
+                    + "These are consumed provider types, not inferred capability clusters or public API boundaries.",
+                projection.IsComplete
+                    ? "No provider API types were observed."
+                    : "No exact provider API types were observed; the evidence is incomplete.",
+                values,
+                rows),
+            Rows = HasSelectedRows(values, rows) ? values : null,
+        };
+    }
+
+    static LibraryCallUseCallSitesView CreateSelectedCallSitesView(
+        AssemblyPairCallUseProjection projection,
+        RowWindow? rows)
+    {
+        List<LibraryCallUseCallSiteRow> values =
+            CreateCallSiteRows(projection.Pair.Occurrences);
+        return new()
+        {
+            Title = CallSitesSection,
+            Description = CreateSectionDescription(
+                "Exact physical call and construction occurrences crossing the library pair.",
+                projection.IsComplete
+                    ? "No direct pair call use was observed."
+                    : "No exact pair call use was observed; the evidence is incomplete.",
+                values,
+                rows),
+            Rows = HasSelectedRows(values, rows) ? values : null,
+        };
+    }
+
+    static string CreateDefaultDescription(
+        AssemblyPairCallUseResult result,
+        IReadOnlyList<AssemblyPairCallUseOccurrence> occurrences,
+        RowWindow? rows)
+    {
+        string[] summaries = [.. RelationshipSummaries(occurrences)];
+        string detail = summaries.Length > 0
+            ? string.Join("\n\n", summaries)
+            : result.Occurrences.Length > 0 && rows is not null
+                ? "No direct pair call use is selected by the row window."
+                : result.IsComplete
+                    ? "No direct pair call use was observed."
+                    : "No exact pair call use was observed; the evidence is incomplete.";
+        return $"{FormatPair(result)}\n\n{detail}";
+    }
+
+    static string CreateSectionDescription<T>(
+        string summary,
+        string emptyText,
+        IReadOnlyList<T> values,
+        RowWindow? rows) =>
+        HasSelectedRows(values, rows)
+            ? summary
+            : $"{summary}\n\n{(values.Count == 0 ? emptyText : "No rows are selected by the row window.")}";
+
+    static bool HasSelectedRows<T>(
+        IReadOnlyList<T> values,
+        RowWindow? rows) =>
+        RowWindow.Apply(rows, values).Count > 0;
+
+    static LibraryCallUseConsumerUseSiteRow CreateConsumerUseSiteRow(
+        AssemblyPairCallUseConsumerUseSite site) =>
+        new()
+        {
+            SourceLibrary = AssemblyIdentityFormatter.Format(site.Source.Identity),
+            SourceMvid = site.SourceModuleVersionId.ToString("D"),
+            SourceMember = LibraryMetadataService.FormatMethod(site.SourceMethod),
+            SourceToken = $"0x{site.SourceMethod.MetadataToken:X8}",
+            TargetLibrary = AssemblyIdentityFormatter.Format(site.Target.Identity),
+            TargetMvid = site.TargetModuleVersionId.ToString("D"),
+            ProviderTypes = site.TargetTypes.Length,
+            TargetMembers = site.TargetMethods.Length,
+            CallSites = site.CallSiteCount,
+            CallSiteRows = FormatOccurrenceRows(site.OccurrenceIndexes),
+        };
+
+    static LibraryCallUseProviderApiTypeRow CreateProviderApiTypeRow(
+        AssemblyPairCallUseProviderApiType type) =>
+        new()
+        {
+            SourceLibrary = AssemblyIdentityFormatter.Format(type.Source.Identity),
+            SourceMvid = type.SourceModuleVersionId.ToString("D"),
+            TargetLibrary = AssemblyIdentityFormatter.Format(type.Target.Identity),
+            TargetMvid = type.TargetModuleVersionId.ToString("D"),
+            TargetType = type.TargetType.Resolution?.Type.ToMetadataFullName()
+                ?? type.TargetType.ToQualifiedDisplayString(),
+            SourceMembers = type.SourceMethods.Length,
+            TargetMembers = type.TargetMethods.Length,
+            CallSites = type.CallSiteCount,
+            CallSiteRows = FormatOccurrenceRows(type.OccurrenceIndexes),
+        };
+
+    static List<LibraryCallUseCallSiteRow> CreateCallSiteRows(
         IEnumerable<AssemblyPairCallUseOccurrence> occurrences) =>
     [
-        .. occurrences.Select(occurrence => new[]
+        .. occurrences.Select(occurrence => new LibraryCallUseCallSiteRow
         {
-            AssemblyIdentityFormatter.Format(
-                occurrence.Source.Identity),
-            occurrence.SourceModuleVersionId.ToString("D"),
-            LibraryMetadataService.FormatMethod(
-                occurrence.SourceMethod),
-            $"0x{occurrence.SourceMethod.MetadataToken:X8}",
-            AssemblyIdentityFormatter.Format(
-                occurrence.Target.Identity),
-            occurrence.TargetModuleVersionId.ToString("D"),
-            LibraryMetadataService.FormatMethod(
-                occurrence.TargetMethod),
-            $"0x{occurrence.TargetMethod.MetadataToken:X8}",
-            FormatCallKind(occurrence.Call.Kind),
-            LibraryMetadataService.FormatMethod(
+            SourceLibrary = AssemblyIdentityFormatter.Format(occurrence.Source.Identity),
+            SourceMvid = occurrence.SourceModuleVersionId.ToString("D"),
+            SourceMember = LibraryMetadataService.FormatMethod(occurrence.SourceMethod),
+            SourceToken = $"0x{occurrence.SourceMethod.MetadataToken:X8}",
+            TargetLibrary = AssemblyIdentityFormatter.Format(occurrence.Target.Identity),
+            TargetMvid = occurrence.TargetModuleVersionId.ToString("D"),
+            TargetMember = LibraryMetadataService.FormatMethod(occurrence.TargetMethod),
+            TargetToken = $"0x{occurrence.TargetMethod.MetadataToken:X8}",
+            Call = FormatCallKind(occurrence.Call.Kind),
+            EvidenceMethod = LibraryMetadataService.FormatMethod(
                 occurrence.Call.EvidenceMethod),
-            occurrence.Call.EvidenceMethod.ModuleVersionId
-                .ToString("D"),
-            $"0x{occurrence.Call.EvidenceMethod.MetadataToken:X8}",
-            $"0x{occurrence.Call.ILOffset:X4}",
-            $"0x{occurrence.Call.OperandToken:X8}",
-            occurrence.Call.ExactTarget ? "yes" : "no",
+            EvidenceMvid = occurrence.Call.EvidenceMethod.ModuleVersionId.ToString("D"),
+            EvidenceToken =
+                $"0x{occurrence.Call.EvidenceMethod.MetadataToken:X8}",
+            IlOffset = $"0x{occurrence.Call.ILOffset:X4}",
+            OperandToken = $"0x{occurrence.Call.OperandToken:X8}",
+            ExactTarget = occurrence.Call.ExactTarget ? "yes" : "no",
         }),
     ];
 
@@ -860,6 +792,11 @@ public static class LibraryCallUseCommand
         subject.Identity.Version is { } version
             ? $"{subject.Identity.Name}@{version}"
             : subject.Identity.Name;
+
+    static string FormatPair(AssemblyPairCallUseResult result) =>
+        $"{FormatAssembly(result.Subjects[0])} "
+        + "\u2194 "
+        + FormatAssembly(result.Subjects[1]);
 
     static string FormatCallKind(CallKind kind) => kind switch
     {
@@ -941,17 +878,6 @@ public static class LibraryCallUseCommand
                 + $"{result.Diagnostics.UnresolvedCandidateCallCount} "
                 + "call sites name the other library but could not be matched.";
         }
-    }
-
-    sealed record LibraryCallUseSection(
-        string Name,
-        string Summary,
-        string[] Labels,
-        string[] Ids,
-        string[][] Rows,
-        string EmptyText)
-    {
-        internal bool WasLogicallyEmpty { get; init; }
     }
 
     sealed class AssemblySubjectPairComparer

--- a/src/DotnetInspect.Cli/Views/LibraryCallUseViews.cs
+++ b/src/DotnetInspect.Cli/Views/LibraryCallUseViews.cs
@@ -1,0 +1,181 @@
+using Markout;
+
+namespace DotnetInspect.Cli.Views;
+
+internal static class LibraryCallUseViewSections
+{
+    internal const string ConsumerUseSites = "Consumer Use Sites";
+    internal const string ProviderApiTypes = "Provider API Types";
+    internal const string CallSites = "Call Sites";
+}
+
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    DescriptionProperty = nameof(Description),
+    AutoFields = false)]
+public sealed class LibraryCallUseHeaderView
+{
+    [MarkoutIgnore]
+    public string Title { get; init; } = "Library Call Use";
+
+    [MarkoutIgnore]
+    public required string Description { get; init; }
+
+    [MarkoutSection(Name = "Header", Headless = true)]
+    public List<MarkoutField>? Content => null;
+}
+
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    DescriptionProperty = nameof(Description),
+    AutoFields = false)]
+public sealed class LibraryCallUseConsumerUseSitesView
+{
+    [MarkoutIgnore]
+    public string Title { get; init; } =
+        LibraryCallUseViewSections.ConsumerUseSites;
+
+    [MarkoutIgnore]
+    public required string Description { get; init; }
+
+    [MarkoutSection(
+        Name = LibraryCallUseViewSections.ConsumerUseSites,
+        Headless = true)]
+    public List<LibraryCallUseConsumerUseSiteRow>? Rows { get; init; }
+}
+
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    DescriptionProperty = nameof(Description),
+    AutoFields = false)]
+public sealed class LibraryCallUseProviderApiTypesView
+{
+    [MarkoutIgnore]
+    public string Title { get; init; } =
+        LibraryCallUseViewSections.ProviderApiTypes;
+
+    [MarkoutIgnore]
+    public required string Description { get; init; }
+
+    [MarkoutSection(
+        Name = LibraryCallUseViewSections.ProviderApiTypes,
+        Headless = true)]
+    public List<LibraryCallUseProviderApiTypeRow>? Rows { get; init; }
+}
+
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    DescriptionProperty = nameof(Description),
+    AutoFields = false)]
+public sealed class LibraryCallUseCallSitesView
+{
+    [MarkoutIgnore]
+    public required string Title { get; init; }
+
+    [MarkoutIgnore]
+    public required string Description { get; init; }
+
+    [MarkoutSection(
+        Name = LibraryCallUseViewSections.CallSites,
+        Headless = true)]
+    public List<LibraryCallUseCallSiteRow>? Rows { get; init; }
+}
+
+[MarkoutSerializable(AutoFields = false)]
+public sealed class LibraryCallUseSelectedView
+{
+    [MarkoutSection(Name = LibraryCallUseViewSections.ConsumerUseSites)]
+    public List<LibraryCallUseConsumerUseSiteRow> ConsumerUseSites { get; init; } = [];
+
+    [MarkoutSection(Name = LibraryCallUseViewSections.ProviderApiTypes)]
+    public List<LibraryCallUseProviderApiTypeRow> ProviderApiTypes { get; init; } = [];
+
+    [MarkoutSection(Name = LibraryCallUseViewSections.CallSites)]
+    public List<LibraryCallUseCallSiteRow> CallSites { get; init; } = [];
+}
+
+[MarkoutSerializable]
+public sealed class LibraryCallUseConsumerUseSiteRow
+{
+    public required string SourceLibrary { get; init; }
+
+    [MarkoutPropertyName("Source MVID")]
+    public required string SourceMvid { get; init; }
+
+    public required string SourceMember { get; init; }
+    public required string SourceToken { get; init; }
+    public required string TargetLibrary { get; init; }
+
+    [MarkoutPropertyName("Target MVID")]
+    public required string TargetMvid { get; init; }
+
+    public int ProviderTypes { get; init; }
+    public int TargetMembers { get; init; }
+    public int CallSites { get; init; }
+    public required string CallSiteRows { get; init; }
+}
+
+[MarkoutSerializable]
+public sealed class LibraryCallUseProviderApiTypeRow
+{
+    public required string SourceLibrary { get; init; }
+
+    [MarkoutPropertyName("Source MVID")]
+    public required string SourceMvid { get; init; }
+
+    public required string TargetLibrary { get; init; }
+
+    [MarkoutPropertyName("Target MVID")]
+    public required string TargetMvid { get; init; }
+
+    public required string TargetType { get; init; }
+    public int SourceMembers { get; init; }
+    public int TargetMembers { get; init; }
+    public int CallSites { get; init; }
+    public required string CallSiteRows { get; init; }
+}
+
+[MarkoutSerializable]
+public sealed class LibraryCallUseCallSiteRow
+{
+    public required string SourceLibrary { get; init; }
+
+    [MarkoutPropertyName("Source MVID")]
+    public required string SourceMvid { get; init; }
+
+    public required string SourceMember { get; init; }
+    public required string SourceToken { get; init; }
+    public required string TargetLibrary { get; init; }
+
+    [MarkoutPropertyName("Target MVID")]
+    public required string TargetMvid { get; init; }
+
+    public required string TargetMember { get; init; }
+    public required string TargetToken { get; init; }
+    public required string Call { get; init; }
+    public required string EvidenceMethod { get; init; }
+
+    [MarkoutPropertyName("Evidence MVID")]
+    public required string EvidenceMvid { get; init; }
+
+    public required string EvidenceToken { get; init; }
+
+    [MarkoutPropertyName("IL Offset")]
+    public required string IlOffset { get; init; }
+
+    public required string OperandToken { get; init; }
+    public required string ExactTarget { get; init; }
+}
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(LibraryCallUseHeaderView))]
+[MarkoutContext(typeof(LibraryCallUseConsumerUseSitesView))]
+[MarkoutContext(typeof(LibraryCallUseProviderApiTypesView))]
+[MarkoutContext(typeof(LibraryCallUseCallSitesView))]
+[MarkoutContext(typeof(LibraryCallUseSelectedView))]
+[MarkoutContext(typeof(LibraryCallUseConsumerUseSiteRow))]
+[MarkoutContext(typeof(LibraryCallUseProviderApiTypeRow))]
+[MarkoutContext(typeof(LibraryCallUseCallSiteRow))]
+public partial class LibraryCallUseViewContext : MarkoutSerializerContext
+{
+}

--- a/src/DotnetInspect.Cli/Views/LibraryCallUseViews.cs
+++ b/src/DotnetInspect.Cli/Views/LibraryCallUseViews.cs
@@ -9,6 +9,19 @@ internal static class LibraryCallUseViewSections
     internal const string CallSites = "Call Sites";
 }
 
+internal static class LibraryCallUseViewText
+{
+    internal static string Contain(string value) =>
+        LibraryViewText.Contain(value) ?? "";
+
+    internal static string ContainDescription(string value) =>
+        string.Join(
+            "\n",
+            value.ReplaceLineEndings("\n")
+                .Split('\n')
+                .Select(Contain));
+}
+
 [MarkoutSerializable(
     TitleProperty = nameof(Title),
     DescriptionProperty = nameof(Description),
@@ -16,10 +29,18 @@ internal static class LibraryCallUseViewSections
 public sealed class LibraryCallUseHeaderView
 {
     [MarkoutIgnore]
-    public string Title { get; init; } = "Library Call Use";
+    public string Title
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    } = LibraryCallUseViewText.Contain("Library Call Use");
 
     [MarkoutIgnore]
-    public required string Description { get; init; }
+    public required string Description
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.ContainDescription(value);
+    }
 
     [MarkoutSection(Name = "Header", Headless = true)]
     public List<MarkoutField>? Content => null;
@@ -32,11 +53,19 @@ public sealed class LibraryCallUseHeaderView
 public sealed class LibraryCallUseConsumerUseSitesView
 {
     [MarkoutIgnore]
-    public string Title { get; init; } =
-        LibraryCallUseViewSections.ConsumerUseSites;
+    public string Title
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    } = LibraryCallUseViewText.Contain(
+        LibraryCallUseViewSections.ConsumerUseSites);
 
     [MarkoutIgnore]
-    public required string Description { get; init; }
+    public required string Description
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.ContainDescription(value);
+    }
 
     [MarkoutSection(
         Name = LibraryCallUseViewSections.ConsumerUseSites,
@@ -51,11 +80,19 @@ public sealed class LibraryCallUseConsumerUseSitesView
 public sealed class LibraryCallUseProviderApiTypesView
 {
     [MarkoutIgnore]
-    public string Title { get; init; } =
-        LibraryCallUseViewSections.ProviderApiTypes;
+    public string Title
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    } = LibraryCallUseViewText.Contain(
+        LibraryCallUseViewSections.ProviderApiTypes);
 
     [MarkoutIgnore]
-    public required string Description { get; init; }
+    public required string Description
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.ContainDescription(value);
+    }
 
     [MarkoutSection(
         Name = LibraryCallUseViewSections.ProviderApiTypes,
@@ -70,10 +107,18 @@ public sealed class LibraryCallUseProviderApiTypesView
 public sealed class LibraryCallUseCallSitesView
 {
     [MarkoutIgnore]
-    public required string Title { get; init; }
+    public required string Title
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutIgnore]
-    public required string Description { get; init; }
+    public required string Description
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.ContainDescription(value);
+    }
 
     [MarkoutSection(
         Name = LibraryCallUseViewSections.CallSites,
@@ -97,74 +142,195 @@ public sealed class LibraryCallUseSelectedView
 [MarkoutSerializable]
 public sealed class LibraryCallUseConsumerUseSiteRow
 {
-    public required string SourceLibrary { get; init; }
+    public required string SourceLibrary
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("Source MVID")]
-    public required string SourceMvid { get; init; }
+    public required string SourceMvid
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
-    public required string SourceMember { get; init; }
-    public required string SourceToken { get; init; }
-    public required string TargetLibrary { get; init; }
+    public required string SourceMember
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string SourceToken
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string TargetLibrary
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("Target MVID")]
-    public required string TargetMvid { get; init; }
+    public required string TargetMvid
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     public int ProviderTypes { get; init; }
     public int TargetMembers { get; init; }
     public int CallSites { get; init; }
-    public required string CallSiteRows { get; init; }
+    public required string CallSiteRows
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 }
 
 [MarkoutSerializable]
 public sealed class LibraryCallUseProviderApiTypeRow
 {
-    public required string SourceLibrary { get; init; }
+    public required string SourceLibrary
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("Source MVID")]
-    public required string SourceMvid { get; init; }
+    public required string SourceMvid
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
-    public required string TargetLibrary { get; init; }
+    public required string TargetLibrary
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("Target MVID")]
-    public required string TargetMvid { get; init; }
+    public required string TargetMvid
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
-    public required string TargetType { get; init; }
+    public required string TargetType
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
     public int SourceMembers { get; init; }
     public int TargetMembers { get; init; }
     public int CallSites { get; init; }
-    public required string CallSiteRows { get; init; }
+    public required string CallSiteRows
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 }
 
 [MarkoutSerializable]
 public sealed class LibraryCallUseCallSiteRow
 {
-    public required string SourceLibrary { get; init; }
+    public required string SourceLibrary
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("Source MVID")]
-    public required string SourceMvid { get; init; }
+    public required string SourceMvid
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
-    public required string SourceMember { get; init; }
-    public required string SourceToken { get; init; }
-    public required string TargetLibrary { get; init; }
+    public required string SourceMember
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string SourceToken
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string TargetLibrary
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("Target MVID")]
-    public required string TargetMvid { get; init; }
+    public required string TargetMvid
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
-    public required string TargetMember { get; init; }
-    public required string TargetToken { get; init; }
-    public required string Call { get; init; }
-    public required string EvidenceMethod { get; init; }
+    public required string TargetMember
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string TargetToken
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string Call
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string EvidenceMethod
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("Evidence MVID")]
-    public required string EvidenceMvid { get; init; }
+    public required string EvidenceMvid
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
-    public required string EvidenceToken { get; init; }
+    public required string EvidenceToken
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
     [MarkoutPropertyName("IL Offset")]
-    public required string IlOffset { get; init; }
+    public required string IlOffset
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 
-    public required string OperandToken { get; init; }
-    public required string ExactTarget { get; init; }
+    public required string OperandToken
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
+
+    public required string ExactTarget
+    {
+        get => field;
+        init => field = LibraryCallUseViewText.Contain(value);
+    }
 }
 
 [MarkoutContextOptions(SuppressTableWarnings = true)]

--- a/tests/DotnetInspect.Cli.Tests/InspectionGraphCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/InspectionGraphCommandTests.cs
@@ -669,6 +669,69 @@ public sealed class InspectionGraphCommandTests
     }
 
     [Fact]
+    public async Task LibrariesCommand_ContainsAssemblyNamesBeforeComposingDescriptions()
+    {
+        const string injectedHeading = "# INJECTED HEADING";
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-graph-libraries-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string hostilePath = Path.Combine(directory, "Hostile.dll");
+            string safePath = Path.Combine(directory, "Safe.dll");
+            WriteNamedAssembly(
+                hostilePath,
+                $"Hostile\n{injectedHeading}");
+            WriteNamedAssembly(safePath, "Safe");
+
+            async Task<(int ExitCode, string Output, string Error)> Execute(
+                params string[] selection) =>
+                await ConsoleCapture.RunAsync(
+                    () => CommandLineBuilder.CreateRootCommand()
+                        .Parse(
+                            [
+                                "graph",
+                                "libraries",
+                                "--library",
+                                hostilePath,
+                                "--library",
+                                safePath,
+                                .. selection,
+                            ])
+                        .InvokeAsync());
+
+            var defaultView = await Execute();
+            var selectedView = await Execute("-S");
+
+            Assert.Equal(0, defaultView.ExitCode);
+            Assert.Equal(0, selectedView.ExitCode);
+            Assert.DoesNotContain(
+                $"\n{injectedHeading}",
+                defaultView.Output.ReplaceLineEndings("\n"),
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                $"\n{injectedHeading}",
+                selectedView.Output.ReplaceLineEndings("\n"),
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Hostile # INJECTED HEADING@",
+                defaultView.Output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Hostile # INJECTED HEADING@",
+                selectedView.Output,
+                StringComparison.Ordinal);
+            Assert.Empty(defaultView.Error);
+            Assert.Empty(selectedView.Error);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task LibrariesCommand_ReportsPairRelevantVersionSkew()
     {
         var captured = await ConsoleCapture.RunAsync(
@@ -1756,6 +1819,26 @@ public sealed class InspectionGraphCommandTests
                 producer,
                 Framework,
                 runtimeIdentifier: null));
+
+    static void WriteNamedAssembly(
+        string path,
+        string name)
+    {
+        var assemblyName = new System.Reflection.AssemblyName(name)
+        {
+            Version = new Version(1, 0, 0, 0),
+        };
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            assemblyName,
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("GraphLibraries");
+        module.DefineType(
+                "GraphLibraries.Sample",
+                System.Reflection.TypeAttributes.Public
+                    | System.Reflection.TypeAttributes.Class)
+            .CreateType();
+        assembly.Save(path);
+    }
 
     sealed class FailingHandler : HttpMessageHandler
     {

--- a/tests/DotnetInspect.Cli.Tests/InspectionGraphCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/InspectionGraphCommandTests.cs
@@ -4,11 +4,13 @@ using System.Text.Json;
 using DotnetInspect.Cli.Commands;
 using DotnetInspect.Cli.Options;
 using DotnetInspect.Cli.Output;
+using DotnetInspect.Cli.Views;
 using DotnetInspector.Fixtures;
 using DotnetInspector.Packages;
 using DotnetInspector.Queries;
 using ILInspector.Analysis;
 using ILInspector.Metadata;
+using Markout;
 using NuGetFetch;
 
 namespace DotnetInspect.Cli.Tests;
@@ -168,6 +170,45 @@ public sealed class InspectionGraphCommandTests
         Assert.Contains("Provider API Types", captured.Output);
         Assert.Contains("Call Sites", captured.Output);
         Assert.Empty(captured.Error);
+    }
+
+    [Fact]
+    public void LibrariesCommand_ProjectionSchemaComesFromGeneratedViewContext()
+    {
+        DocumentSchema schema = LibraryCallUseViewContext.Default
+            .GetSchemaInfo<LibraryCallUseSelectedView>()!
+            .ToDocumentSchema();
+
+        Assert.Equal(
+            [
+                LibraryCallUseCommand.ConsumerUseSitesSection,
+                LibraryCallUseCommand.ProviderApiTypesSection,
+                LibraryCallUseCommand.CallSitesSection,
+            ],
+            schema.SectionNames);
+        Assert.Equal(
+            [
+                "source_library",
+                "source_mvid",
+                "source_member",
+                "source_token",
+                "target_library",
+                "target_mvid",
+                "provider_types",
+                "target_members",
+                "call_sites",
+                "call_site_rows",
+            ],
+            schema.GetSection(
+                    LibraryCallUseCommand.ConsumerUseSitesSection)!
+                .Items
+                .Select(item => item.Key));
+        Assert.Equal(
+            "IL Offset",
+            schema.GetSection(LibraryCallUseCommand.CallSitesSection)!
+                .Items
+                .Single(item => item.Key == "il_offset")
+                .Name);
     }
 
     [Fact]


### PR DESCRIPTION
`graph libraries` now uses typed Markout views and one generated serializer
context for schema discovery, row projection, counts, and every supported output
format. The migration preserves the command's existing output contract while
removing its parallel label/ID inventories and direct `MarkoutWriter`
construction.

## Demo

The real Markout dogfood scenario still reports the same directed pair evidence:

```console
$ dotnet-inspect graph libraries \
    --library artifacts/bin/DotnetInspect.Cli.Tests/release/DotnetInspector.Presentation.dll \
    --library artifacts/bin/DotnetInspect.Cli.Tests/release/Markout.dll \
    --count
6
```

The selected summaries remain the same document:

```console
$ dotnet-inspect graph libraries \
    --library artifacts/bin/DotnetInspect.Cli.Tests/release/DotnetInspector.Presentation.dll \
    --library artifacts/bin/DotnetInspect.Cli.Tests/release/Markout.dll \
    -S --count --json
[
  {
    "section": "Consumer Use Sites",
    "count": 2
  },
  {
    "section": "Provider API Types",
    "count": 4
  }
]
```

Representative default, selected, window-empty, Markdown, plain-text, table,
JSON, and JSONL outputs were captured before the migration and remain
byte-identical afterward.

## Implementation

- Adds typed call-site, consumer-use-site, and provider-API-type row views plus
  document/table shapes registered in `LibraryCallUseViewContext`.
- Derives discovery schema and machine keys from the generated context.
- Routes Markdown, plain text, table, TSV, JSONL, lowered JSON, and count through
  `MarkoutSerializer`.
- Preserves post-group summary windows, physical call-site windows, structured
  receipts, empty/windowed-empty distinctions, and existing section-selection
  behavior.
- Updates the owning design to require typed Markout serialization and records
  the generated-schema contract in the focused command tests.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --no-build -- --filter-class '*InspectionGraphCommandTests'`
  - 37 passed
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release -- --filter-class '*MarkoutRowContainmentTests' '*InspectionGraphCommandTests'`
  - 39 passed
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release -- --filter-not-trait 'Speed=Slow'`
  - 5,589 passed; 18 skipped; 0 failed
- `npx markdownlint-cli docs/design/pairwise-library-call-use.md`
- Captured-output comparison across nine representative format/selection cases

Closes #6694.
