### PR TITLE
Reduce Browser prefix stream crossings

### DIFF
--- a/docs/design/package-prefix-candidate-stream.md
+++ b/docs/design/package-prefix-candidate-stream.md
@@ -149,6 +149,11 @@ from 272 to 82 on fernie and 85 on merritt. Median stream-read time fell from
 513 to 85 ms and from 897 to 68 ms; row-20 latency fell from 2.347 to 1.839
 seconds and from 1.701 to 0.820 seconds. A 256 KB probe produced no further
 row-20 improvement on fernie, so 128 KB is the smallest measured plateau.
+Five alternating clean-production pairs then compared `origin/main` with
+candidate `e080cdb21`. `AWSSDK.*` median row-20 latency fell from 2.900 to
+2.668 seconds on a heavily loaded fernie and from 1.672 to 0.816 seconds on
+merritt. The candidate was faster in every fernie pair; one merritt candidate
+request was a network outlier, while the other four improved by 51-53%.
 
 This slice does not claim a fixed first-row latency, reduce NuGet round-trip
 time, yield individual candidates before one raw page completes, isolate

--- a/docs/design/package-prefix-candidate-stream.md
+++ b/docs/design/package-prefix-candidate-stream.md
@@ -140,15 +140,15 @@ and from about 78 to 40 MB respectively. The sparse `Grpc.*` witness grew to
 100-row requests and completed source exhaustion within 0.4 seconds of the
 fixed-100 baseline on both hosts.
 
-The phase-timing prototype at `cb016eeb9` then compared the serializer-default
-and 128 KB prefix buffers with five samples for `System.*`, `Azure.*`,
-`AWSSDK.*`, and `Grpc.*` on each host. Both artifacts used the same supported
-Search Query Service response and the same prefix projection. For the 3.55 MB
-decoded `AWSSDK.*` first page, the larger buffer reduced managed stream reads
-from 272 to 82 on fernie and 85 on merritt. Median stream-read time fell from
-513 to 85 ms and from 897 to 68 ms; row-20 latency fell from 2.347 to 1.839
-seconds and from 1.701 to 0.820 seconds. A 256 KB probe produced no further
-row-20 improvement on fernie, so 128 KB is the smallest measured plateau.
+The #5816 phase-timing prototype then compared the serializer-default and
+128 KB prefix buffers with five samples for `System.*`, `Azure.*`, `AWSSDK.*`,
+and `Grpc.*` on each host. Both artifacts used the same supported Search Query
+Service response and the same prefix projection. For the 3.55 MB decoded
+`AWSSDK.*` first page, the larger buffer reduced managed stream reads from 272
+to 82 on fernie and 85 on merritt. Median stream-read time fell from 513 to
+85 ms and from 897 to 68 ms; row-20 latency fell from 2.347 to 1.839 seconds
+and from 1.701 to 0.820 seconds. A 256 KB probe produced no further row-20
+improvement on fernie, so 128 KB is the smallest measured plateau.
 Five alternating clean-production pairs then compared `origin/main` with
 candidate `e080cdb21`. `AWSSDK.*` median row-20 latency fell from 2.900 to
 2.668 seconds on a heavily loaded fernie and from 1.672 to 0.816 seconds on

--- a/docs/design/package-prefix-candidate-stream.md
+++ b/docs/design/package-prefix-candidate-stream.md
@@ -72,6 +72,12 @@ sparse prefixes recover the established scan throughput. Materialized prefix
 search retains 100-row requests because its caller has already requested one
 aggregate rather than demand-driven pages.
 
+The Gallery candidate projection uses a 128 KB `System.Text.Json` read buffer.
+This setting belongs only to the prefix projection context; materialized search
+retains the serializer default. The larger prefix buffer reduces Browser/Wasm
+stream crossings without changing the response, decoded fields, validation, or
+candidate ordering.
+
 Pagination advances by the raw response count and retains the existing 3,000
 maximum skip and 100-page client ceiling. Metadata byte limits, repeat-page
 rejection, candidate limits, and exact manifest validation remain in force.
@@ -134,9 +140,19 @@ and from about 78 to 40 MB respectively. The sparse `Grpc.*` witness grew to
 100-row requests and completed source exhaustion within 0.4 seconds of the
 fixed-100 baseline on both hosts.
 
+The phase-timing prototype at `cb016eeb9` then compared the serializer-default
+and 128 KB prefix buffers with five samples for `System.*`, `Azure.*`,
+`AWSSDK.*`, and `Grpc.*` on each host. Both artifacts used the same supported
+Search Query Service response and the same prefix projection. For the 3.55 MB
+decoded `AWSSDK.*` first page, the larger buffer reduced managed stream reads
+from 272 to 82 on fernie and 85 on merritt. Median stream-read time fell from
+513 to 85 ms and from 897 to 68 ms; row-20 latency fell from 2.347 to 1.839
+seconds and from 1.701 to 0.820 seconds. A 256 KB probe produced no further
+row-20 improvement on fernie, so 128 KB is the smallest measured plateau.
+
 This slice does not claim a fixed first-row latency, reduce NuGet round-trip
 time, yield individual candidates before one raw page completes, isolate
-decompression from JSON processing, parallelize manifests, virtualize the DOM,
-or change the Worker credit protocol. The production measurements in #5816
-explain the motivation and observed result, not a deterministic latency
-guarantee.
+decompression within stream-read time, parallelize manifests, virtualize the
+DOM, or change the Worker credit protocol. The production measurements in
+issue #5816 explain the motivation and observed result, not a deterministic
+latency guarantee.

--- a/src/NuGetFetch/NuGetApi.cs
+++ b/src/NuGetFetch/NuGetApi.cs
@@ -282,7 +282,8 @@ public partial class NuGetJsonContext : JsonSerializerContext
 
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    NumberHandling = JsonNumberHandling.AllowReadingFromString)]
+    NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    DefaultBufferSize = 128 * 1024)]
 [JsonSerializable(typeof(PrefixSearchWireResponse))]
 internal partial class PrefixSearchJsonContext : JsonSerializerContext
 {

--- a/tests/NuGetFetch.Tests/PackagePrefixSearchTests.cs
+++ b/tests/NuGetFetch.Tests/PackagePrefixSearchTests.cs
@@ -86,6 +86,14 @@ public sealed class PackagePrefixSearchTests
             takes: [20, 20, 40, 80]);
     }
 
+    [Fact]
+    public void Gallery_CandidateProjectionUsesMeasuredReadBuffer()
+    {
+        Assert.Equal(
+            128 * 1024,
+            PrefixSearchJsonContext.Default.Options.DefaultBufferSize);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
Build robust Package Query responsiveness by reducing Browser/Wasm stream
crossings while preserving the supported NuGet API, literal-prefix fidelity,
provider order, and existing bounds.

## Demo

`AWSSDK.*` returns 371 KB gzip but 3.55 MB of decoded JSON for its first 20
Search rows. The prefix projection consumes the top-level package fields, but
the default 16 KB JSON buffer required 272 managed stream reads.

Five alternating clean-production pairs compared `origin/main` with the
candidate:

| Host | Before | Candidate | Change |
| --- | ---: | ---: | ---: |
| fernie | 2,900 ms | 2,668 ms | -8.0% |
| merritt | 1,672 ms | 816 ms | -51.2% |

Fernie was heavily loaded during the clean A/B, but the candidate was faster
in all five pairs. One merritt candidate request was a network outlier; the
other four improved by 51-53%.

The instrumented phase run explains the host difference:

| Host | Stream reads | Stream-read time | Row 20 |
| --- | ---: | ---: | ---: |
| fernie default | 272 | 513 ms | 2,347 ms |
| fernie 128 KB | 82 | 85 ms | 1,839 ms |
| merritt default | 272 | 897 ms | 1,701 ms |
| merritt 128 KB | 85 | 68 ms | 820 ms |

The same candidate retained one Worker, a 20-row first request, exact 20-row
publication before viewport pressure, and the existing `20 -> 40 -> 80 -> 100`
sparse-page policy. `System.*`, `Azure.*`, and `Grpc.*` were the neighboring
witnesses. A 256 KB probe produced no further fernie row-20 improvement.

## Change

- Give only `PrefixSearchJsonContext` a 128 KB `System.Text.Json` read buffer.
- Keep materialized search on the serializer default.
- Gate the measured setting and record the dual-host pathological evidence in
  the candidate-stream owner design.

The larger buffer changes neither the response nor its decoded fields,
validation, ordering, retry behavior, byte limits, or deadlines. It adds at
most 112 KB over the serializer default for one active prefix deserializer.
Stream-read timing still combines the network tail, browser decompression, and
Browser/Wasm copying; it is not an isolated decompression measurement.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/NuGetFetch.Tests -c Release` — 1,042 passed,
  11 environment/platform skips
- `npx markdownlint-cli docs/design/package-prefix-candidate-stream.md`
- Five phase samples per prefix and host for `System.*`, `Azure.*`,
  `AWSSDK.*`, and `Grpc.*`
- Five alternating clean-production `AWSSDK.*` pairs per host

Refs #5816
