### PR TITLE
Gate authentic Npgsql type-dependency evidence

### DIFF
--- a/docs/design/inspection-operation-composition.md
+++ b/docs/design/inspection-operation-composition.md
@@ -219,6 +219,48 @@ The gates are:
 - `TypeProjection_RetainsTypedRelationshipRowSelection` plus the existing
   cross-package Browser tests for retained Web capability and Workspace use.
 
+### Authentic package evidence
+
+The CLI test project restores the exact Npgsql and EF Relational `8.0.4`
+packages named in the motivation using `PackageDownload`. These are inspected
+inputs, not test-host assembly references. The original `.nupkg` archives are
+copied into test output without rewriting them or checking third-party content
+into the repository.
+
+`ConfiguredPayloadAcquisitionTests.AuthenticTypeDependencies.cs` owns the
+package coordinates, archive SHA-256 values, and expected relationships.
+The hashes were verified against the exact
+`https://api.nuget.org/v3-flatcontainer/` publications. Tests verify the archive
+bytes before supplying them through the existing offline HTTP test boundary;
+package acquisition, asset selection, metadata decoding, Workspace admission,
+query execution, row selection, and CLI rendering remain product-owned.
+
+The normal Release CLI suite runs five authentic cases:
+
+- `Depends_AuthenticPackages_ExpandOnlySelectedPopulation` checks both the
+  two-package relationship chain and the single-package neighbor. The neighbor
+  retains the direct `declared` base-type edge without claiming the unavailable
+  ancestor's interface edge.
+- `Depends_AuthenticPackages_SelectSecondLogicalRelationship` checks that
+  `--rows 2..2` selects the cross-package interface edge.
+- `TypeDependency_AuthenticPackages_RequireTheOwningParticipant` checks the
+  same populations through Workspace loading and the participant-qualified L2
+  executor. It preserves the exact Npgsql package/version provenance and refuses
+  to borrow the Npgsql root when the EF Relational participant is selected.
+
+Run these cases without live test-time network access:
+
+```bash
+dotnet run --project tests/DotnetInspect.Cli.Tests -c Release -- \
+  --filter-method '*AuthenticPackages*'
+```
+
+The malformed-input, same-name, fuzzy-root, strict-row-failure, and Browser
+transport fixtures remain complementary gates. This evidence slice does not
+retire the remaining direct CLI scanner adapter or adopt Discover and Share;
+those are separate follow-ups in
+[#6704](https://github.com/richlander/dotnet-inspect/issues/6704).
+
 ## Adoption sequence
 
 1. Lock this composition map and the Type Relationships execution pilot.

--- a/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.AuthenticTypeDependencies.cs
+++ b/tests/DotnetInspect.Cli.Tests/ConfiguredPayloadAcquisitionTests.AuthenticTypeDependencies.cs
@@ -1,0 +1,219 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+using DotnetInspector.Packages;
+using DotnetInspector.Queries;
+using DotnetInspector.Sections;
+using ILInspector.Metadata;
+using NuGetFetch;
+
+using CoreHttpClientFactory = DotnetInspector.Networking.HttpClientFactory;
+
+namespace DotnetInspect.Cli.Tests;
+
+public sealed partial class ConfiguredPayloadAcquisitionTests
+{
+    private const string AuthenticDependencyVersion = "8.0.4";
+    private const string NpgsqlPackage = "Npgsql.EntityFrameworkCore.PostgreSQL";
+    private const string RelationalPackage = "Microsoft.EntityFrameworkCore.Relational";
+    private const string NpgsqlOptions =
+        "Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.NpgsqlOptionsExtension";
+    private const string RelationalOptions =
+        "Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension";
+    private const string OptionsInterface =
+        "Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension";
+
+    private static readonly AuthenticDependencyPackage[] AuthenticDependencyPackages =
+    [
+        new(NpgsqlPackage,
+            "4f9cae32541cfde509b538c7ca046ab443b8c0a73d610495603294ed94bc5885"),
+        new(RelationalPackage,
+            "4d13ff228afbd3c1108c3d37186c4aa26d9e2cec5c51837532816ace4de5629f"),
+    ];
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Depends_AuthenticPackages_ExpandOnlySelectedPopulation(
+        bool includeRelational)
+    {
+        ConfigureAuthenticDependencyFeed();
+        var result = await RunCommandAsync(
+            AuthenticDependencyArguments(includeRelational));
+
+        Assert.True(result.Exit == 0, result.Error);
+        using JsonDocument document = JsonDocument.Parse(result.Output);
+        JsonElement[] edges = [.. document.RootElement.GetProperty("edges").EnumerateArray()];
+        Assert.Equal(
+            AuthenticRelationships(includeRelational),
+            edges.Select(edge => (
+                Assert.IsType<string>(edge.GetProperty("source_identity").GetProperty("type").GetString()),
+                Assert.IsType<string>(edge.GetProperty("target_identity").GetProperty("type").GetString()),
+                Assert.IsType<string>(edge.GetProperty("relationship").GetString()))));
+        Assert.All(edges, edge =>
+            Assert.Equal("declared", edge.GetProperty("resolution").GetString()));
+        JsonElement root = Assert.Single(
+            document.RootElement.GetProperty("nodes").EnumerateArray(),
+            node => node.GetProperty("root_occurrences").GetArrayLength() > 0);
+        Assert.Equal(NpgsqlOptions, root.GetProperty("identity").GetProperty("type").GetString());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task Depends_AuthenticPackages_SelectSecondLogicalRelationship()
+    {
+        ConfigureAuthenticDependencyFeed();
+        var result = await RunCommandAsync(
+            [.. AuthenticDependencyArguments(includeRelational: true), "--rows", "2..2"]);
+
+        Assert.True(result.Exit == 0, result.Error);
+        using JsonDocument document = JsonDocument.Parse(result.Output);
+        JsonElement edge = Assert.Single(
+            document.RootElement.GetProperty("edges").EnumerateArray());
+        Assert.Equal(RelationalOptions,
+            edge.GetProperty("source_identity").GetProperty("type").GetString());
+        Assert.Equal(OptionsInterface,
+            edge.GetProperty("target_identity").GetProperty("type").GetString());
+        Assert.Equal("interface", edge.GetProperty("relationship").GetString());
+        Assert.Empty(result.Error);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TypeDependency_AuthenticPackages_RequireTheOwningParticipant(
+        bool includeRelational)
+    {
+        using var client = new HttpClient(new AuthenticDependencyFeedHandler());
+        using var workspace = new InspectionWorkspace();
+        WorkspaceMemberCoordinate[] members = includeRelational
+            ?
+            [
+                WorkspaceMemberCoordinate.Package(RelationalPackage, AuthenticDependencyVersion),
+                WorkspaceMemberCoordinate.Package(NpgsqlPackage, AuthenticDependencyVersion),
+            ]
+            : [WorkspaceMemberCoordinate.Package(NpgsqlPackage, AuthenticDependencyVersion)];
+        WorkspaceContextLoadOutcome outcome = await WorkspaceContextLoader.LoadAsync(
+            workspace,
+            new WorkspaceContextInput { Framework = "net8.0", Members = members },
+            new WorkspaceContextLoadOptions
+            {
+                HttpClient = client,
+                SourceAuthorization = new UniformPackageSourceAuthorization(
+                    [new PackageSource("authentic-type-dependencies", FirstFeed)]),
+                PackageStore = new InMemoryPackageStore(),
+                UseVersionCache = false,
+            },
+            TestContext.Current.CancellationToken);
+        var loaded = Assert.IsType<WorkspaceContextLoadOutcome.Loaded>(outcome);
+        AssemblyContextParticipant root = Assert.Single(
+            loaded.Group.Participants,
+            participant => participant.Assembly.Identity.Name == NpgsqlPackage);
+        var provenance = Assert.IsType<AssemblyResolutionProvenance.PackageAsset>(
+            root.Assembly.Provenance);
+        Assert.Equal(NpgsqlPackage, provenance.PackageId, ignoreCase: true);
+        Assert.Equal(AuthenticDependencyVersion, provenance.PackageVersion);
+        Assert.Equal("net8.0", loaded.Framework);
+
+        TypeDependencySectionPlan plan = TypeDependencySectionPlan.All(NpgsqlOptions);
+        TypeDependencySectionResult result =
+            TypeDependencySectionExecutor.ExecuteParticipant(loaded.Group, root, plan);
+        Assert.Equal(NpgsqlOptions, result.QueryResult.Dependency.MatchedType);
+        Assert.True(result.RowSelection.IsSuccess);
+        Assert.Equal(
+            AuthenticRelationships(includeRelational),
+            result.RowSelection.Relationships.Select(relationship => (
+                relationship.SourceTypeName,
+                relationship.TargetTypeName,
+                relationship.Kind == TypeDependencyRelationshipKind.BaseType
+                    ? "base-type"
+                    : "interface")));
+        Assert.All(result.QueryResult.Participants, participant =>
+            Assert.IsType<AssemblyContextTypeDependencyEntry.Completed>(participant));
+
+        if (includeRelational)
+        {
+            AssemblyContextParticipant other = Assert.Single(
+                loaded.Group.Participants,
+                participant => participant.Assembly.Identity.Name == RelationalPackage);
+            TypeDependencySectionResult wrongRoot =
+                TypeDependencySectionExecutor.ExecuteParticipant(loaded.Group, other, plan);
+            Assert.False(wrongRoot.QueryResult.Dependency.Found);
+            Assert.Empty(wrongRoot.RowSelection.Relationships);
+        }
+    }
+
+    private static (string Source, string Target, string Kind)[] AuthenticRelationships(
+        bool includeRelational) =>
+        includeRelational
+            ?
+            [
+                (NpgsqlOptions, RelationalOptions, "base-type"),
+                (RelationalOptions, OptionsInterface, "interface"),
+            ]
+            : [(NpgsqlOptions, RelationalOptions, "base-type")];
+
+    private static string[] AuthenticDependencyArguments(bool includeRelational) =>
+    [
+        "depends", NpgsqlOptions,
+        "--package", $"{NpgsqlPackage}@{AuthenticDependencyVersion}",
+        .. includeRelational
+            ? new[] { "--package", $"{RelationalPackage}@{AuthenticDependencyVersion}" }
+            : [],
+        "--tfm", "net8.0",
+        "--source", FirstFeed,
+        "--json",
+        "--tips", "q",
+    ];
+
+    private static void ConfigureAuthenticDependencyFeed()
+    {
+        CoreHttpClientFactory.SetAuthenticationDecorator(_ => new AuthenticDependencyFeedHandler());
+        CoreHttpClientFactory.ResetSharedForTesting();
+    }
+
+    private sealed record AuthenticDependencyPackage(string Id, string Sha256)
+    {
+        internal byte[] ReadArchive()
+        {
+            string path = Path.Combine(AppContext.BaseDirectory, "RealAssets", "TypeDependencies",
+                $"{Id.ToLowerInvariant()}.{AuthenticDependencyVersion}.nupkg");
+            byte[] archive = File.ReadAllBytes(path);
+            Assert.Equal(Sha256, Convert.ToHexStringLower(SHA256.HashData(archive)));
+            return archive;
+        }
+    }
+
+    private sealed class AuthenticDependencyFeedHandler : HttpMessageHandler
+    {
+        private static readonly string Flat = new Uri(new Uri(FirstFeed), "flat2/").AbsoluteUri;
+        private readonly Dictionary<string, byte[]> _archives = AuthenticDependencyPackages
+            .ToDictionary(
+                package => $"{Flat}{package.Id.ToLowerInvariant()}/{AuthenticDependencyVersion}/"
+                    + $"{package.Id.ToLowerInvariant()}.{AuthenticDependencyVersion}.nupkg",
+                package => package.ReadArchive(),
+                StringComparer.Ordinal);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string url = request.RequestUri!.AbsoluteUri;
+            HttpContent content = url == FirstFeed
+                ? new StringContent($$"""
+                    {"version":"3.0.0","resources":[
+                      {"@id":"{{Flat}}","@type":"PackageBaseAddress/3.0.0"}
+                    ]}
+                    """)
+                : _archives.TryGetValue(url, out byte[]? archive)
+                    ? new ByteArrayContent(archive)
+                    : throw new InvalidOperationException($"Unexpected authentic package request: {url}");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = content,
+                RequestMessage = request,
+            });
+        }
+    }
+}

--- a/tests/DotnetInspect.Cli.Tests/DotnetInspect.Cli.Tests.csproj
+++ b/tests/DotnetInspect.Cli.Tests/DotnetInspect.Cli.Tests.csproj
@@ -18,6 +18,19 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="xunit.v3" />
+    <PackageDownload Include="Npgsql.EntityFrameworkCore.PostgreSQL"
+                     Version="[8.0.4]" />
+    <PackageDownload Include="Microsoft.EntityFrameworkCore.Relational"
+                     Version="[8.0.4]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(NuGetPackageRoot)npgsql.entityframeworkcore.postgresql/8.0.4/npgsql.entityframeworkcore.postgresql.8.0.4.nupkg"
+          Link="RealAssets/TypeDependencies/npgsql.entityframeworkcore.postgresql.8.0.4.nupkg"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(NuGetPackageRoot)microsoft.entityframeworkcore.relational/8.0.4/microsoft.entityframeworkcore.relational.8.0.4.nupkg"
+          Link="RealAssets/TypeDependencies/microsoft.entityframeworkcore.relational.8.0.4.nupkg"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Preserve authentic evidence for robust shared type-dependency inspection:
the motivating Npgsql relationship now runs through normal product entry
points in the fast Release test suite, using unmodified published packages.

Advances #6704, slice 1 of 4. Parent #6664 is merged. This does not close the
remaining CLI-path retirement, Discover, or Share work.

## Demo

The production scenario was run against nuget.org with the merged CLI:

```bash
dotnet-inspect depends \
  Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.NpgsqlOptionsExtension \
  --package Npgsql.EntityFrameworkCore.PostgreSQL@8.0.4 \
  --package Microsoft.EntityFrameworkCore.Relational@8.0.4 \
  --tfm net8.0 --json
```

The typed graph contains:

```text
NpgsqlOptionsExtension --base-type--> RelationalOptionsExtension
RelationalOptionsExtension --interface--> IDbContextOptionsExtension
```

`--rows 2..2` selects only the interface relationship.

The neighboring invocation omits the EF Relational package. Its graph contains
only `NpgsqlOptionsExtension --base-type--> RelationalOptionsExtension`, with
resolution `declared`; it does not invent the unavailable ancestor's interface.

Previously this real scenario was motivation/demo evidence alongside synthetic
regressions. It is now five offline cases that exercise CLI dispatch, package
acquisition, shared Workspace/L2 execution, graph JSON, and exact participant
selection.

## Changes

- Restore the two exact `8.0.4` inputs through `PackageDownload`, without adding
  them as test-host assembly references or vendoring third-party binaries.
- Copy the original archives to test output and verify their pinned SHA-256
  hashes before serving their bytes through the existing HTTP test boundary.
  Both restored archives were compared byte-for-byte with direct downloads
  from the exact nuget.org flat-container coordinates.
- Check the authentic composed and single-package CLI graphs, the second
  logical relationship window, and both populations through the shared
  participant-qualified executor. The latter preserves package/version
  provenance and rejects a root attributed to the wrong participant.
- Document the evidence in the existing composition owner.

## Design and scope

Normative owner:
`docs/design/inspection-operation-composition.md#type-dependency-pilot`.
This is evidence for the existing contract, not a runtime or architecture
change. The harness replaces transport responses only; product code still
acquires and decodes original package bytes and constructs all inspected
results. The existing malformed-input, same-name, fuzzy-root, strict-window,
and Browser transport fixtures are unchanged.

The current CLI's remaining direct scanner adapter is deliberately retained
for #6704 slice 2. Discover and Share are slices 3 and 4. The shared executor's
Browser consumer remains covered by the existing Browser gates; this slice
adds authentic CLI/shared-executor evidence rather than new host behavior.

## Validation

- `dotnet build tests/DotnetInspect.Cli.Tests -c Release --verbosity quiet`
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release -- --filter-method '*AuthenticPackages*' --report-xunit --report-xunit-filename issue6704-tests.xml --results-directory /tmp/issue6704-results`
  — 5 passed; slowest case 0.231 seconds, all five totaled 0.548 seconds.
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --no-build -- --filter-class '*ConfiguredPayloadAcquisitionTests'`
  — 108 passed.
- `npx markdownlint-cli docs/design/inspection-operation-composition.md`
- `git diff --check`
- Real published-package CLI demo: two composed edges, one root-only declared
  edge; restore output hashes matched direct nuget.org archive downloads.
