### PR TITLE
Design shared inspection envelopes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Package: System.Text.Json | Version: 10.0.0 | TFM: net10.0 | Library: lib/net10.
 | [CLI Workspace Sharing](design/cli-workspace-sharing.md) | Common `--share` projection of an inspection command's effective resolved state to a canonical Workspace packet or Inspect Web URL, without a second Workspace-construction grammar. |
 | [Inspection Plan Projections](design/inspection-plan-projections.md) | Shared resolved inspection basis with distinct typed plans for section execution, effective-section discovery, and portable sharing. |
 | [Inspection Operation Composition](design/inspection-operation-composition.md) | Cross-host sequencing of semantic intent, House and Workspace resolution, terminal purpose, query/section/row/work plans, typed results, and host-specific projection. |
+| [Inspection Envelope](design/inspection-envelope.md) | Shared terminal wrapper that preserves owner-issued primary content while carrying typed cross-host diagnostics and supporting broader host composition. |
 | [Decompiler Architecture](decompiler-architecture.md) | Decompiler project boundaries, import/IR/pass/printer flow, host consumers, and testing/evidence infrastructure. |
 | [CLI Change Classification and Obsolete Inputs](design/cli-change-classification.md) | Published CLI surfaces, observable change classification, disclosure, invalid-input guards, and routing reservations. |
 | [CLI Option-Value Validation](design/cli-option-value-validation.md) | Shared zero-arity diagnostics that preserve positional ownership and command-owned capacity. |

--- a/docs/design/inspection-envelope.md
+++ b/docs/design/inspection-envelope.md
@@ -3,25 +3,28 @@
 Status: **proposed**.
 
 This design owns one cross-cutting result pattern:
-`InspectionEnvelope<TContent>` is the host-neutral terminal boundary around one
-owner-issued inspection result. The CLI consumes that baseline envelope.
-Broader hosts consume the same baseline and may compose additional
-owner-issued content or host-owned experience state around it without changing
-the baseline content.
+`InspectionEnvelope<TContent>` is the host-neutral boundary around one explicit
+content presence, one required Share outcome, and cross-host diagnostics. The
+CLI consumes that baseline envelope. Broader hosts consume the same baseline
+and may compose additional owner-issued content or host-owned experience state
+around it without changing the baseline.
 
 The implementation tracker is
 [#6710](https://github.com/richlander/dotnet-inspect/issues/6710).
-The first adoption follows the authentic type-dependency evidence in
-[#6709](https://github.com/richlander/dotnet-inspect/pull/6709).
+The prerequisite content/share plan is
+[#6717](https://github.com/richlander/dotnet-inspect/pull/6717), and the first
+implementation adoption is
+[#6712](https://github.com/richlander/dotnet-inspect/issues/6712).
 
 ## Claim
 
-For one resolved content generation and semantic plan, every host receives the
-same primary content and diagnostics:
+For one resolved semantic plan, every host receives the same content presence,
+Share outcome, and diagnostics:
 
 ```text
 InspectionEnvelope<TContent>
-  Content
+  Content: Present(TContent) | NotRequested
+  Share: Available(FullUrl) | NonProjectable(Path, Reason)
   Diagnostics
 ```
 
@@ -29,9 +32,10 @@ InspectionEnvelope<TContent>
 does not replace that type, reinterpret its facts, or become a universal
 inspection-content model.
 
-The envelope initially owns only:
+The envelope owns:
 
-- the non-null primary content value; and
+- explicit presence of the owner-issued content value;
+- one required Share outcome for the same semantic plan; and
 - an immutable ordered sequence of cross-host diagnostics.
 
 Other information may join the envelope only when a separately demonstrated
@@ -40,8 +44,8 @@ action dictionary is not an extension mechanism.
 
 ## Motivation
 
-The CLI and Inspect Web already need the same semantic results but currently
-adapt supplemental evidence independently.
+The CLI and Inspect Web already need the same semantic results and Share
+scenario but currently adapt supplemental evidence independently.
 
 The type-dependency path demonstrates the split:
 
@@ -51,8 +55,8 @@ The type-dependency path demonstrates the split:
   diagnostics, availability, and row-selection failure;
 - `BrowserTypeMetadata` combines projected type facts and graph content with
   stringified `InspectionFailures`; and
-- Inspect Web adds Research-owned derived relationships, sharing, navigation,
-  and interactive rendering that the CLI does not request.
+- Inspect Web adds Research-owned derived relationships, navigation, and
+  interactive rendering that the CLI does not request.
 
 The duplicated wrappers make it easy for one host to drop a diagnostic,
 translate a failure into empty content, or attach supplemental evidence to a
@@ -64,27 +68,17 @@ This is not a claim that both hosts request the same amount of information.
 Equal semantic plans produce equal baseline envelopes. A broader host requests
 additional owner-issued results and composes them explicitly.
 
-## Authentic basis
+## Adoption evidence
 
-The first adoption uses:
+This generic pattern does not prescribe a package, subject, or fixture.
+Authentic assets and expected facts belong to each adopting inspection owner.
+The first adoption uses the already-merged real-package evidence in #6709 and
+the focused host integration in #6712.
 
-- `Npgsql.EntityFrameworkCore.PostgreSQL@8.0.4`;
-- `Microsoft.EntityFrameworkCore.Relational@8.0.4`;
-- target
-  `Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.NpgsqlOptionsExtension`;
-- target framework `net8.0`; and
-- the relationship chain
-  `NpgsqlOptionsExtension -> RelationalOptionsExtension ->
-  IDbContextOptionsExtension`.
-
-PR #6709 preserves the exact published packages and gates the composed and
-neighboring single-package results through normal Workspace, query, section,
-row, and CLI paths.
-
-Existing participant-rejection, unavailable-root, fuzzy-root, strict-row, and
-Browser transport cases supply the pathological evidence for diagnostics.
-Synthetic boundary fixtures complement the authentic content evidence; they do
-not replace it.
+The envelope-specific evidence is cross-host equality and boundary behavior:
+the adopting tests must prove the same content presence, Share outcome, and
+diagnostics for equivalent plans, plus the `NotRequested` and
+`NonProjectable` cases defined here.
 
 ## Boundary
 
@@ -93,8 +87,9 @@ result to a host:
 
 ```text
 resolved basis
-  -> one terminal plan
-  -> owner-issued result
+  -> one content disposition plus required Share projection
+  -> Present(owner-issued result) or NotRequested
+  -> Share outcome
   -> InspectionEnvelope<TContent>
   -> CLI or Browser composition and presentation
 ```
@@ -104,13 +99,23 @@ internal intermediate. An operation with no L2 owner may envelope its final L1
 result. An operation with an L2 section or inspection owner envelopes the L2
 result rather than nesting envelopes around each prerequisite.
 
-Execute, Discover, and Share may each return an envelope around their own
-primary result type. One envelope does not grant or combine multiple terminal
-purposes.
+Execute and Discover return envelopes around their own content result types.
+A share-only gesture returns the same generic envelope type for its command but
+with content `NotRequested`. One envelope never authorizes both Execute and
+Discover.
 
-## Primary content
+## Content presence
 
-`Content` is required and non-null. Its owner continues to define:
+`Content` is a closed presence type:
+
+```text
+InspectionContent<TContent>
+  = Present(TContent)
+  | NotRequested
+```
+
+`Present` contains one non-null owner-issued value. Its owner continues to
+define:
 
 - semantic facts and identities;
 - success, partial, unavailable, and failure variants;
@@ -120,20 +125,57 @@ purposes.
 - domain-specific structured diagnostics that are themselves semantic
   evidence.
 
-The envelope does not impose one universal success/failure union. If an owner
-cannot produce valid content, its existing typed non-success remains the
-operation outcome; an empty `TContent` plus a diagnostic is not an equivalent
-substitute.
+`NotRequested` means the content producer was deliberately suppressed before
+execution. `--share` uses this arm. It is not null, failed, unavailable,
+partial, cancelled, or a successful empty result, and a producer cannot return
+it after attempted execution.
 
-Wrapping content does not change its equality, row count, ordering,
+`TContent` still names the command's owner-issued ordinary content result type.
+For example, a share-only type-dependency operation has
+`InspectionEnvelope<TypeDependencySectionResult>` with `Content.NotRequested`;
+it does not substitute a unit, object, or Share-specific content type.
+
+The envelope does not impose one universal success/failure union. If an owner
+cannot produce valid content, its existing typed non-success is a
+`Present(TContent)` operation outcome; an empty value, `NotRequested`, or a
+diagnostic is not an equivalent substitute.
+
+Wrapping present content does not change its equality, row count, ordering,
 serialization meaning, or resource ownership. A host may lower or render
-`Content`, but it may not add facts to it after the envelope crosses the shared
-boundary.
+the present value, but it may not add facts to it after the envelope crosses
+the shared boundary.
+
+## Share outcome
+
+Every envelope has one `Share` value derived from the same resolved basis:
+
+```text
+InspectionShare
+  = Available(FullUrl)
+  | NonProjectable(Path, Reason)
+```
+
+`Available` contains the complete canonical production URL, including the
+canonical Workspace packet. Hosts do not rebuild it from argv, rendered
+content, display names, Browser navigation, or the current origin.
+
+`NonProjectable` identifies the semantic path and owner-issued reason that
+cannot be represented faithfully. It contains no partial URL and never drops,
+defaults, or approximates semantic state to manufacture one.
+
+Share projection performs no ordinary content execution or effectiveness
+probe. A non-projectable Share outcome does not invalidate independently valid
+present content. It is the visible operation failure when content is
+`NotRequested`, because a share-only request then has no successful output.
+
+Packet schema, canonical encoding, capacity, and restoration remain owned by
+Workspace Definitions. Public CLI packet-versus-URL selection and exit
+behavior remain owned by CLI Workspace Sharing.
 
 ## Diagnostics
 
-Diagnostics are the first common supplemental currency because both hosts need
-to disclose useful evidence that is not itself a content row:
+Diagnostics are common supplemental currency because both hosts need to
+disclose useful evidence that is not itself content or the Share outcome:
 
 - one Workspace participant was rejected while neighboring participants
   produced useful content;
@@ -155,19 +197,22 @@ The code is semantic identity; the summary is presentation input. Hosts do not
 parse the summary to recover kind, severity, subject, participant, or failure
 meaning. Artifact-authored text is contained before entering the diagnostic.
 
-Diagnostics are immutable and deterministic under deterministic inputs. The
-terminal operation preserves owner order when it already exists and otherwise
+Diagnostics are immutable and deterministic under deterministic inputs.
+Envelope assembly preserves owner order when it already exists and otherwise
 uses a documented stable composition order. A code may occur more than once
 when distinct owner-issued identities distinguish the occurrences.
 
 Severity alone does not determine operation success, CLI exit status, retry,
-or Browser navigation. Those decisions remain with the content owner and
-host policy. In particular:
+or Browser navigation. Those decisions remain with the content and Share
+owners plus host policy. In particular:
 
 - an `Error` diagnostic may accompany a valid partial result;
 - a `Warning` cannot hide owner-issued incomplete evidence;
 - an empty diagnostic sequence does not certify completeness; and
 - adding a diagnostic cannot change content rows or selection.
+
+A diagnostic cannot replace `Content.NotRequested`, a typed content
+non-success, `Share.NonProjectable`, or a missing required Share value.
 
 Verbose logs, traces, tips, performance telemetry, exception stack traces, and
 host-authored convenience messages are not inspection diagnostics.
@@ -177,7 +222,9 @@ host-authored convenience messages are not inspection diagnostics.
 The CLI consumes `InspectionEnvelope<TContent>` as its complete shared input.
 It may:
 
-- lower `Content` through Markout or another approved typed presentation;
+- lower present content through Markout or another approved typed
+  presentation;
+- render `Share` for `--share` while leaving content `NotRequested`;
 - render diagnostics to stderr or a structured diagnostic projection;
 - map the owner-issued outcome to exit status; and
 - omit envelope structure from a published output format whose existing
@@ -190,7 +237,6 @@ Browser-owned experience around it:
 Browser inspection experience
   InspectionEnvelope<TContent>
   additional owner-issued inspection envelopes
-  Share projection
   navigation and interaction state
   Browser presentation
 ```
@@ -202,8 +248,8 @@ one identifiable value; inheritance is valid only when serialization,
 NativeAOT, and facade ownership preserve the same contract.
 
 A Browser-specific DTO may project an envelope for transport, but it must
-preserve the primary content and diagnostic identity without converting the
-DTO into an alternate domain model.
+preserve content presence, Share, and diagnostic identity without converting
+the DTO into an alternate domain model.
 
 ## Content extent and equality
 
@@ -217,7 +263,8 @@ For the same:
 - semantic query, section, traversal, and row plan; and
 - owner-issued capabilities that affect result semantics,
 
-the primary content and diagnostic sequence are semantically equal. Host
+the content presence, Share outcome, and diagnostic sequence are semantically
+equal. `Available` Share outcomes use the same complete canonical URL. Host
 request IDs, operation epochs, cache keys, rendering formats, verbosity,
 navigation, and interaction do not participate.
 
@@ -234,7 +281,7 @@ CLI depends experience
 Browser Type Relationships experience
   InspectionEnvelope<TypeDependencySectionResult>
   Research-owned derived-relationship result
-  Share and navigation state
+  navigation and interaction state
 ```
 
 The first component agrees exactly when the plans agree. The Browser experience
@@ -255,11 +302,11 @@ A new envelope field requires:
 5. a resource-free, contained transport shape; and
 6. adoption gates in both hosts.
 
-Completion, coverage, provenance, semantic-plan receipts, and portable
-projection are plausible future candidates. They remain in their current
-owner-issued content until a focused proposal demonstrates one cross-domain
-meaning. Browser Share URLs, navigation, interaction, loading, and presentation
-are host companions rather than envelope candidates.
+Completion, coverage, provenance, and semantic-plan receipts are plausible
+future candidates. They remain in their current owner-issued content until a
+focused proposal demonstrates one cross-domain meaning. Browser navigation,
+interaction, loading, and presentation are host companions rather than
+envelope candidates.
 
 Envelope evolution is additive and typed. A versioned serializer may omit a
 new optional field for an older transport contract, but a host cannot silently
@@ -267,8 +314,9 @@ discard required evidence and still claim the same envelope.
 
 ## Safety and lifetime
 
-The envelope crosses the existing resource-free result boundary. `Content`,
-diagnostics, and any future supplement must therefore be detached from:
+The envelope crosses the existing resource-free result boundary. Present
+content, Share, diagnostics, and any future supplement must therefore be
+detached from:
 
 - Workspace participants and leases;
 - metadata readers, streams, pooled buffers, or callbacks;
@@ -287,27 +335,43 @@ dependencies:
 
 1. define the baseline envelope and diagnostic contracts in the lowest
    host-neutral product layer that both Queries/Sections and hosts can consume;
-2. return the selected `TypeDependencySectionResult` as primary content;
-3. move participant rejection and other cross-host notices into typed
+2. represent content as `Present(TypeDependencySectionResult)` or
+   `NotRequested`;
+3. include the required full Share URL or typed non-projectable outcome;
+4. move participant rejection and other cross-host notices into typed
    diagnostics without removing richer owner-issued evidence from the content;
-4. make CLI `depends <type>` consume the envelope while preserving current
+5. make CLI `depends <type>` consume the envelope while preserving current
    output and exit behavior;
-5. make Inspect Web Type Relationships consume the same baseline and compose
+6. make Inspect Web Type Relationships consume the same baseline and compose
    its Research-owned derived relationships and Browser experience separately;
    and
-6. compare baseline content and diagnostics across hosts for equivalent plans.
+7. compare content presence, Share, and diagnostics across hosts for equivalent
+   plans.
 
-The adoption does not retire the remaining direct CLI scanner path or add
-Discover and Share behavior. Those remain in
+The adoption does not add Discover behavior or retire the remaining direct CLI
+scanner path. Those remain in
 [#6704](https://github.com/richlander/dotnet-inspect/issues/6704).
 
 Planned Release gates:
 
 - generic construction and deterministic diagnostic-order tests;
 - the #6709 authentic composed and neighboring package cases;
+- present-content, share-only `NotRequested`, and non-projectable Share cases;
 - CLI participant-rejection and strict-row-failure behavior; and
 - Browser managed-boundary tests that compare the same baseline content and
-  diagnostics before Browser-only composition.
+  Share outcome and diagnostics before Browser-only composition.
+
+## CLI envelope passthrough
+
+A direct serialized-envelope projection would be useful for debugging and
+typed automation. Its output spelling and compatibility classification belong
+to the CLI output owners, not this generic envelope. It is tracked by
+[#6719](https://github.com/richlander/dotnet-inspect/issues/6719).
+
+It cannot reuse `--raw` without an explicit compatibility change:
+`--raw` already selects raw/fetchable GitHub URL shape. Any future passthrough
+must preserve the envelope exactly, bypass ordinary content presentation
+deliberately, and use separately approved non-colliding syntax.
 
 ## Non-claims
 
@@ -323,6 +387,7 @@ This design does not:
   envelope;
 - move domain-specific evidence out of `TContent`;
 - make diagnostic severity determine success or exit status;
-- permit diagnostics to replace typed failure or completion;
+- permit diagnostics to replace content presence, Share, typed failure, or
+  completion;
 - add an untyped metadata, extension, or action bag; or
 - authorize adopting every command or website inspector in one PR.

--- a/docs/design/inspection-envelope.md
+++ b/docs/design/inspection-envelope.md
@@ -1,0 +1,328 @@
+# Inspection envelope
+
+Status: **proposed**.
+
+This design owns one cross-cutting result pattern:
+`InspectionEnvelope<TContent>` is the host-neutral terminal boundary around one
+owner-issued inspection result. The CLI consumes that baseline envelope.
+Broader hosts consume the same baseline and may compose additional
+owner-issued content or host-owned experience state around it without changing
+the baseline content.
+
+The implementation tracker is
+[#6710](https://github.com/richlander/dotnet-inspect/issues/6710).
+The first adoption follows the authentic type-dependency evidence in
+[#6709](https://github.com/richlander/dotnet-inspect/pull/6709).
+
+## Claim
+
+For one resolved content generation and semantic plan, every host receives the
+same primary content and diagnostics:
+
+```text
+InspectionEnvelope<TContent>
+  Content
+  Diagnostics
+```
+
+`TContent` remains the result type issued by the inspection owner. The envelope
+does not replace that type, reinterpret its facts, or become a universal
+inspection-content model.
+
+The envelope initially owns only:
+
+- the non-null primary content value; and
+- an immutable ordered sequence of cross-host diagnostics.
+
+Other information may join the envelope only when a separately demonstrated
+cross-host need establishes one common meaning. Adding an untyped metadata or
+action dictionary is not an extension mechanism.
+
+## Motivation
+
+The CLI and Inspect Web already need the same semantic results but currently
+adapt supplemental evidence independently.
+
+The type-dependency path demonstrates the split:
+
+- shared Queries and Sections produce dependency facts, participant outcomes,
+  traversal evidence, and selected relationship rows;
+- CLI `TypeDependencyExecutionResult` combines those facts with scan
+  diagnostics, availability, and row-selection failure;
+- `BrowserTypeMetadata` combines projected type facts and graph content with
+  stringified `InspectionFailures`; and
+- Inspect Web adds Research-owned derived relationships, sharing, navigation,
+  and interactive rendering that the CLI does not request.
+
+The duplicated wrappers make it easy for one host to drop a diagnostic,
+translate a failure into empty content, or attach supplemental evidence to a
+different semantic result. Moving the common minimum into a host-neutral
+envelope lets the CLI use the baseline directly and lets the Browser build a
+richer experience without privately extending the shared content.
+
+This is not a claim that both hosts request the same amount of information.
+Equal semantic plans produce equal baseline envelopes. A broader host requests
+additional owner-issued results and composes them explicitly.
+
+## Authentic basis
+
+The first adoption uses:
+
+- `Npgsql.EntityFrameworkCore.PostgreSQL@8.0.4`;
+- `Microsoft.EntityFrameworkCore.Relational@8.0.4`;
+- target
+  `Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.NpgsqlOptionsExtension`;
+- target framework `net8.0`; and
+- the relationship chain
+  `NpgsqlOptionsExtension -> RelationalOptionsExtension ->
+  IDbContextOptionsExtension`.
+
+PR #6709 preserves the exact published packages and gates the composed and
+neighboring single-package results through normal Workspace, query, section,
+row, and CLI paths.
+
+Existing participant-rejection, unavailable-root, fuzzy-root, strict-row, and
+Browser transport cases supply the pathological evidence for diagnostics.
+Synthetic boundary fixtures complement the authentic content evidence; they do
+not replace it.
+
+## Boundary
+
+The envelope sits where a completed host-neutral operation hands one detached
+result to a host:
+
+```text
+resolved basis
+  -> one terminal plan
+  -> owner-issued result
+  -> InspectionEnvelope<TContent>
+  -> CLI or Browser composition and presentation
+```
+
+It does not wrap every producer, prerequisite query, Workspace operation, or
+internal intermediate. An operation with no L2 owner may envelope its final L1
+result. An operation with an L2 section or inspection owner envelopes the L2
+result rather than nesting envelopes around each prerequisite.
+
+Execute, Discover, and Share may each return an envelope around their own
+primary result type. One envelope does not grant or combine multiple terminal
+purposes.
+
+## Primary content
+
+`Content` is required and non-null. Its owner continues to define:
+
+- semantic facts and identities;
+- success, partial, unavailable, and failure variants;
+- completion and traversal evidence;
+- provenance and participant correspondence;
+- section and row identities, ordering, selection, and Count; and
+- domain-specific structured diagnostics that are themselves semantic
+  evidence.
+
+The envelope does not impose one universal success/failure union. If an owner
+cannot produce valid content, its existing typed non-success remains the
+operation outcome; an empty `TContent` plus a diagnostic is not an equivalent
+substitute.
+
+Wrapping content does not change its equality, row count, ordering,
+serialization meaning, or resource ownership. A host may lower or render
+`Content`, but it may not add facts to it after the envelope crosses the shared
+boundary.
+
+## Diagnostics
+
+Diagnostics are the first common supplemental currency because both hosts need
+to disclose useful evidence that is not itself a content row:
+
+- one Workspace participant was rejected while neighboring participants
+  produced useful content;
+- a requested root could not be certified;
+- a strict semantic selection failed;
+- a source or producer was unavailable without invalidating an independent
+  result; or
+- a result is valid but carries an owner-issued limitation that users need to
+  see.
+
+One `InspectionDiagnostic` has:
+
+- a stable owner-scoped code;
+- `Information`, `Warning`, or `Error` severity;
+- a contained summary suitable for cross-host display; and
+- optional correspondence only through an existing owner-issued identity.
+
+The code is semantic identity; the summary is presentation input. Hosts do not
+parse the summary to recover kind, severity, subject, participant, or failure
+meaning. Artifact-authored text is contained before entering the diagnostic.
+
+Diagnostics are immutable and deterministic under deterministic inputs. The
+terminal operation preserves owner order when it already exists and otherwise
+uses a documented stable composition order. A code may occur more than once
+when distinct owner-issued identities distinguish the occurrences.
+
+Severity alone does not determine operation success, CLI exit status, retry,
+or Browser navigation. Those decisions remain with the content owner and
+host policy. In particular:
+
+- an `Error` diagnostic may accompany a valid partial result;
+- a `Warning` cannot hide owner-issued incomplete evidence;
+- an empty diagnostic sequence does not certify completeness; and
+- adding a diagnostic cannot change content rows or selection.
+
+Verbose logs, traces, tips, performance telemetry, exception stack traces, and
+host-authored convenience messages are not inspection diagnostics.
+
+## Same baseline, broader clients
+
+The CLI consumes `InspectionEnvelope<TContent>` as its complete shared input.
+It may:
+
+- lower `Content` through Markout or another approved typed presentation;
+- render diagnostics to stderr or a structured diagnostic projection;
+- map the owner-issued outcome to exit status; and
+- omit envelope structure from a published output format whose existing
+  contract exposes only the primary content.
+
+Inspect Web consumes the same envelope. It may use it directly or compose a
+Browser-owned experience around it:
+
+```text
+Browser inspection experience
+  InspectionEnvelope<TContent>
+  additional owner-issued inspection envelopes
+  Share projection
+  navigation and interaction state
+  Browser presentation
+```
+
+This is a semantic subtype relationship: the Browser experience contains the
+unchanged shared baseline and may be broader. The design does not require CLR
+inheritance. Composition is valid when it preserves the baseline envelope as
+one identifiable value; inheritance is valid only when serialization,
+NativeAOT, and facade ownership preserve the same contract.
+
+A Browser-specific DTO may project an envelope for transport, but it must
+preserve the primary content and diagnostic identity without converting the
+DTO into an alternate domain model.
+
+## Content extent and equality
+
+Host agreement applies per envelope, not to the complete visible experience.
+
+For the same:
+
+- content contract;
+- admitted content generation and participant population;
+- exact subject;
+- semantic query, section, traversal, and row plan; and
+- owner-issued capabilities that affect result semantics,
+
+the primary content and diagnostic sequence are semantically equal. Host
+request IDs, operation epochs, cache keys, rendering formats, verbosity,
+navigation, and interaction do not participate.
+
+When Inspect Web requests more information than the CLI, it receives additional
+owner-issued envelopes or a focused aggregate whose components retain their
+identities. It does not add rows or facts to the common envelope.
+
+For type relationships:
+
+```text
+CLI depends experience
+  InspectionEnvelope<TypeDependencySectionResult>
+
+Browser Type Relationships experience
+  InspectionEnvelope<TypeDependencySectionResult>
+  Research-owned derived-relationship result
+  Share and navigation state
+```
+
+The first component agrees exactly when the plans agree. The Browser experience
+as a whole is intentionally broader.
+
+## Evolution
+
+The generic envelope is the stable seam; it is not an excuse to predict every
+future field.
+
+A new envelope field requires:
+
+1. the same meaning for at least the CLI and Browser;
+2. evidence that changing each primary content type would duplicate or
+   misplace the concern;
+3. one typed owner and construction rule;
+4. defined interaction with content equality and diagnostics;
+5. a resource-free, contained transport shape; and
+6. adoption gates in both hosts.
+
+Completion, coverage, provenance, semantic-plan receipts, and portable
+projection are plausible future candidates. They remain in their current
+owner-issued content until a focused proposal demonstrates one cross-domain
+meaning. Browser Share URLs, navigation, interaction, loading, and presentation
+are host companions rather than envelope candidates.
+
+Envelope evolution is additive and typed. A versioned serializer may omit a
+new optional field for an older transport contract, but a host cannot silently
+discard required evidence and still claim the same envelope.
+
+## Safety and lifetime
+
+The envelope crosses the existing resource-free result boundary. `Content`,
+diagnostics, and any future supplement must therefore be detached from:
+
+- Workspace participants and leases;
+- metadata readers, streams, pooled buffers, or callbacks;
+- executable closures and service instances;
+- credentials or authorization grants; and
+- host UI objects.
+
+The envelope does not extend the lifetime of inspected content. Hosts may
+retain it, cache it under their existing policies, or serialize an approved
+projection without retaining a live Workspace borrow.
+
+## First adoption
+
+The first implementation slice follows #6709 and adopts the pattern for type
+dependencies:
+
+1. define the baseline envelope and diagnostic contracts in the lowest
+   host-neutral product layer that both Queries/Sections and hosts can consume;
+2. return the selected `TypeDependencySectionResult` as primary content;
+3. move participant rejection and other cross-host notices into typed
+   diagnostics without removing richer owner-issued evidence from the content;
+4. make CLI `depends <type>` consume the envelope while preserving current
+   output and exit behavior;
+5. make Inspect Web Type Relationships consume the same baseline and compose
+   its Research-owned derived relationships and Browser experience separately;
+   and
+6. compare baseline content and diagnostics across hosts for equivalent plans.
+
+The adoption does not retire the remaining direct CLI scanner path or add
+Discover and Share behavior. Those remain in
+[#6704](https://github.com/richlander/dotnet-inspect/issues/6704).
+
+Planned Release gates:
+
+- generic construction and deterministic diagnostic-order tests;
+- the #6709 authentic composed and neighboring package cases;
+- CLI participant-rejection and strict-row-failure behavior; and
+- Browser managed-boundary tests that compare the same baseline content and
+  diagnostics before Browser-only composition.
+
+## Non-claims
+
+This design does not:
+
+- define one universal content, subject, provenance, completion, or failure
+  type;
+- require every internal query or producer result to be enveloped;
+- require all hosts to request the same content extent;
+- make Browser experience state part of the CLI baseline;
+- require CLR inheritance for Browser extensions;
+- change existing CLI output schemas merely because the host consumes an
+  envelope;
+- move domain-specific evidence out of `TContent`;
+- make diagnostic severity determine success or exit status;
+- permit diagnostics to replace typed failure or completion;
+- add an untyped metadata, extension, or action bag; or
+- authorize adopting every command or website inspector in one PR.

--- a/docs/design/inspection-envelope.md
+++ b/docs/design/inspection-envelope.md
@@ -3,11 +3,11 @@
 Status: **proposed**.
 
 This design owns one cross-cutting result pattern:
-`InspectionEnvelope<TContent>` is the host-neutral boundary around one explicit
-content presence, one required Share outcome, and cross-host diagnostics. The
-CLI consumes that baseline envelope. Broader hosts consume the same baseline
-and may compose additional owner-issued content or host-owned experience state
-around it without changing the baseline.
+`InspectionEnvelope<TContent>` is the host-neutral boundary around one
+owner-issued content value, one required Share outcome, and cross-host
+diagnostics. The CLI consumes that baseline envelope. Broader hosts consume the
+same baseline and may compose additional owner-issued content or host-owned
+experience state around it without changing the baseline.
 
 The implementation tracker is
 [#6710](https://github.com/richlander/dotnet-inspect/issues/6710).
@@ -18,12 +18,12 @@ implementation adoption is
 
 ## Claim
 
-For one resolved semantic plan, every host receives the same content presence,
-Share outcome, and diagnostics:
+For one resolved semantic plan, every host receives the same content, Share
+outcome, and diagnostics:
 
 ```text
 InspectionEnvelope<TContent>
-  Content: Present(TContent) | NotRequested
+  Content: TContent
   Share: Available(FullUrl) | NonProjectable(Path, Reason)
   Diagnostics
 ```
@@ -34,7 +34,7 @@ inspection-content model.
 
 The envelope owns:
 
-- explicit presence of the owner-issued content value;
+- the non-null owner-issued content value;
 - one required Share outcome for the same semantic plan; and
 - an immutable ordered sequence of cross-host diagnostics.
 
@@ -76,9 +76,8 @@ The first adoption uses the already-merged real-package evidence in #6709 and
 the focused host integration in #6712.
 
 The envelope-specific evidence is cross-host equality and boundary behavior:
-the adopting tests must prove the same content presence, Share outcome, and
-diagnostics for equivalent plans, plus the `NotRequested` and
-`NonProjectable` cases defined here.
+the adopting tests must prove the same content, Share outcome, and diagnostics
+for equivalent plans, plus the non-projectable Share case defined here.
 
 ## Boundary
 
@@ -87,8 +86,8 @@ result to a host:
 
 ```text
 resolved basis
-  -> one content disposition plus required Share projection
-  -> Present(owner-issued result) or NotRequested
+  -> one content plan plus required Share projection
+  -> owner-issued result
   -> Share outcome
   -> InspectionEnvelope<TContent>
   -> CLI or Browser composition and presentation
@@ -100,21 +99,13 @@ result. An operation with an L2 section or inspection owner envelopes the L2
 result rather than nesting envelopes around each prerequisite.
 
 Execute and Discover return envelopes around their own content result types.
-A share-only gesture returns the same generic envelope type for its command but
-with content `NotRequested`. One envelope never authorizes both Execute and
-Discover.
+One envelope never authorizes both Execute and Discover. CLI `--share` does not
+select another content state; it asks the host to present the same envelope's
+Share outcome alongside ordinary content.
 
-## Content presence
+## Primary content
 
-`Content` is a closed presence type:
-
-```text
-InspectionContent<TContent>
-  = Present(TContent)
-  | NotRequested
-```
-
-`Present` contains one non-null owner-issued value. Its owner continues to
+`Content` contains one non-null owner-issued value. Its owner continues to
 define:
 
 - semantic facts and identities;
@@ -125,25 +116,15 @@ define:
 - domain-specific structured diagnostics that are themselves semantic
   evidence.
 
-`NotRequested` means the content producer was deliberately suppressed before
-execution. `--share` uses this arm. It is not null, failed, unavailable,
-partial, cancelled, or a successful empty result, and a producer cannot return
-it after attempted execution.
-
-`TContent` still names the command's owner-issued ordinary content result type.
-For example, a share-only type-dependency operation has
-`InspectionEnvelope<TypeDependencySectionResult>` with `Content.NotRequested`;
-it does not substitute a unit, object, or Share-specific content type.
-
 The envelope does not impose one universal success/failure union. If an owner
-cannot produce valid content, its existing typed non-success is a
-`Present(TContent)` operation outcome; an empty value, `NotRequested`, or a
-diagnostic is not an equivalent substitute.
+cannot produce valid content, its existing typed non-success remains the
+operation outcome; an empty value or diagnostic is not an equivalent
+substitute.
 
-Wrapping present content does not change its equality, row count, ordering,
-serialization meaning, or resource ownership. A host may lower or render
-the present value, but it may not add facts to it after the envelope crosses
-the shared boundary.
+Wrapping content does not change its equality, row count, ordering,
+serialization meaning, or resource ownership. A host may lower or render the
+value, but it may not add facts to it after the envelope crosses the shared
+boundary.
 
 ## Share outcome
 
@@ -165,8 +146,9 @@ defaults, or approximates semantic state to manufacture one.
 
 Share projection performs no ordinary content execution or effectiveness
 probe. A non-projectable Share outcome does not invalidate independently valid
-present content. It is the visible operation failure when content is
-`NotRequested`, because a share-only request then has no successful output.
+content. A host that explicitly requests Share presentation may classify the
+missing requested side output as unsuccessful without discarding or changing
+the content.
 
 Packet schema, canonical encoding, capacity, and restoration remain owned by
 Workspace Definitions. Public CLI packet-versus-URL selection and exit
@@ -211,8 +193,8 @@ owners plus host policy. In particular:
 - an empty diagnostic sequence does not certify completeness; and
 - adding a diagnostic cannot change content rows or selection.
 
-A diagnostic cannot replace `Content.NotRequested`, a typed content
-non-success, `Share.NonProjectable`, or a missing required Share value.
+A diagnostic cannot replace a typed content non-success,
+`Share.NonProjectable`, or a missing required Share value.
 
 Verbose logs, traces, tips, performance telemetry, exception stack traces, and
 host-authored convenience messages are not inspection diagnostics.
@@ -222,9 +204,8 @@ host-authored convenience messages are not inspection diagnostics.
 The CLI consumes `InspectionEnvelope<TContent>` as its complete shared input.
 It may:
 
-- lower present content through Markout or another approved typed
-  presentation;
-- render `Share` for `--share` while leaving content `NotRequested`;
+- lower content through Markout or another approved typed presentation;
+- write `Share` to stderr for `--share` without changing ordinary stdout;
 - render diagnostics to stderr or a structured diagnostic projection;
 - map the owner-issued outcome to exit status; and
 - omit envelope structure from a published output format whose existing
@@ -248,8 +229,8 @@ one identifiable value; inheritance is valid only when serialization,
 NativeAOT, and facade ownership preserve the same contract.
 
 A Browser-specific DTO may project an envelope for transport, but it must
-preserve content presence, Share, and diagnostic identity without converting
-the DTO into an alternate domain model.
+preserve content, Share, and diagnostic identity without converting the DTO
+into an alternate domain model.
 
 ## Content extent and equality
 
@@ -263,8 +244,8 @@ For the same:
 - semantic query, section, traversal, and row plan; and
 - owner-issued capabilities that affect result semantics,
 
-the content presence, Share outcome, and diagnostic sequence are semantically
-equal. `Available` Share outcomes use the same complete canonical URL. Host
+the content, Share outcome, and diagnostic sequence are semantically equal.
+`Available` Share outcomes use the same complete canonical URL. Host
 request IDs, operation epochs, cache keys, rendering formats, verbosity,
 navigation, and interaction do not participate.
 
@@ -314,8 +295,8 @@ discard required evidence and still claim the same envelope.
 
 ## Safety and lifetime
 
-The envelope crosses the existing resource-free result boundary. Present
-content, Share, diagnostics, and any future supplement must therefore be
+The envelope crosses the existing resource-free result boundary. Content,
+Share, diagnostics, and any future supplement must therefore be
 detached from:
 
 - Workspace participants and leases;
@@ -335,18 +316,17 @@ dependencies:
 
 1. define the baseline envelope and diagnostic contracts in the lowest
    host-neutral product layer that both Queries/Sections and hosts can consume;
-2. represent content as `Present(TypeDependencySectionResult)` or
-   `NotRequested`;
-3. include the required full Share URL or typed non-projectable outcome;
+2. return the selected non-null `TypeDependencySectionResult` as content;
+3. include the required full Share URL or typed non-projectable outcome without
+   executing the dependency query a second time;
 4. move participant rejection and other cross-host notices into typed
    diagnostics without removing richer owner-issued evidence from the content;
-5. make CLI `depends <type>` consume the envelope while preserving current
-   output and exit behavior;
+5. make CLI `depends <type>` consume the envelope, preserve ordinary content
+   output, and migrate `--share` to the additive stderr contract;
 6. make Inspect Web Type Relationships consume the same baseline and compose
    its Research-owned derived relationships and Browser experience separately;
    and
-7. compare content presence, Share, and diagnostics across hosts for equivalent
-   plans.
+7. compare content, Share, and diagnostics across hosts for equivalent plans.
 
 The adoption does not add Discover behavior or retire the remaining direct CLI
 scanner path. Those remain in
@@ -356,10 +336,10 @@ Planned Release gates:
 
 - generic construction and deterministic diagnostic-order tests;
 - the #6709 authentic composed and neighboring package cases;
-- present-content, share-only `NotRequested`, and non-projectable Share cases;
+- content equality with and without CLI `--share`, plus non-projectable Share;
 - CLI participant-rejection and strict-row-failure behavior; and
 - Browser managed-boundary tests that compare the same baseline content and
-  Share outcome and diagnostics before Browser-only composition.
+  the same Share outcome and diagnostics before Browser-only composition.
 
 ## CLI envelope passthrough
 
@@ -370,8 +350,8 @@ to the CLI output owners, not this generic envelope. It is tracked by
 
 It cannot reuse `--raw` without an explicit compatibility change:
 `--raw` already selects raw/fetchable GitHub URL shape. Any future passthrough
-must preserve the envelope exactly, bypass ordinary content presentation
-deliberately, and use separately approved non-colliding syntax.
+must preserve the envelope exactly, deliberately select its own output
+contract, and use separately approved non-colliding syntax.
 
 ## Non-claims
 
@@ -387,7 +367,6 @@ This design does not:
   envelope;
 - move domain-specific evidence out of `TContent`;
 - make diagnostic severity determine success or exit status;
-- permit diagnostics to replace content presence, Share, typed failure, or
-  completion;
+- permit diagnostics to replace Share, typed failure, or completion;
 - add an untyped metadata, extension, or action bag; or
 - authorize adopting every command or website inspector in one PR.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -519,6 +519,10 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
   candidate collection, classification precedence, source ordering, limits,
   failure visibility, and typed result boundary for `find`.
 - [Inspection layers](design/inspection-layers.md): layer split for multiple consumers, vocabulary, and seam rules.
+- [Inspection envelope](design/inspection-envelope.md): host-neutral terminal
+  wrapper preserving owner-issued primary content and typed cross-host
+  diagnostics while broader clients compose additional results and experience
+  state separately.
 - [Library family boundaries](design/library-family-boundaries.md): subject
   families for shared inspection substrate, compiled-program inspection,
   ecosystem composition, independent domains, and product hosts.


### PR DESCRIPTION
Build robust, capable inspection experiences from one stable host-neutral result
contract while allowing richer clients to add typed capabilities without
forking or mutating the baseline.

## Demo

Every completed inspection has one consistent host-neutral handoff:

```text
InspectionEnvelope<TContent>
  Content: TContent
  Share: Available(FullUrl, Packet) | NonProjectable(Path, Reason)
  Diagnostics
```

An ordinary type-dependency operation returns a non-null
`TypeDependencySectionResult` and retains its Share URL. The same invocation
with `--share` produces identical stdout content and writes that URL as the
final non-empty stderr line.
The available Share value carries both the complete canonical URL and the
encoded Workspace packet. Producers supply both values; consumers do not split
the URL to recover the packet.

The neighboring non-projectable case preserves independently valid content. An
explicit `--share` request still fails visibly because the requested side output
could not be produced, but it never converts the content to empty or suppresses
it.

## Summary

- Add `docs/design/inspection-envelope.md` as the focused owner for
  `InspectionEnvelope<TContent>`.
- Require one non-null owner-issued `TContent`, one Share outcome, and ordered
  typed diagnostics.
- Keep diagnostics supplemental and unable to replace Share, typed failure,
  completion, or row semantics.
- Make the CLI consume the baseline directly and write Share to stderr for
  `--share` without changing ordinary stdout.
- Define the Browser's broader experience as explicit composition rather than
  private enrichment or host-local Share reconstruction.
- Keep authentic package coordinates with the adopting type-dependency owner
  (#6709 and #6712), not in the generic envelope schema.
- Record the optional non-colliding CLI envelope passthrough separately in
  #6719 because existing `--raw` owns GitHub URL shape.

## Scope

This is the envelope-pattern slice, step 2 of 4 in #6710, stacked on the
content/share prerequisite #6717. It does not implement the type, change packet
schema, or adopt a command. #6703 consumes the accepted owner as contributor
guidance; #6712 implements the first CLI and Browser/Wasm type-dependency
adoption, including the intentional additive `--share` output change.

## Validation

- `npx markdownlint-cli docs/design/inspection-envelope.md docs/README.md docs/overview.md`
- `git diff --check origin/docs/share-envelope-projection...HEAD`

Advances #6710.

