### PR TITLE
Add Artifact content ownership leases

### DIFF
--- a/docs/design/artifact-ownership-and-borrowing.md
+++ b/docs/design/artifact-ownership-and-borrowing.md
@@ -11,6 +11,15 @@ It expands step 9 of
 tracked end to end by
 [#6647](https://github.com/richlander/dotnet-inspect/issues/6647).
 
+The current implementation floor classifies the existing Artifact obligations
+and issues `ArtifactContentLease` children from a published session. A child
+retains the exact Artifact identity and immutable snapshot without retaining
+the current authority-bearing compatibility reference. Session disposal
+rejects new issuance, keeps existing children usable, waits for their release
+and active-borrow completion, and only then releases acquisition leases.
+Making `ArtifactContentReference` resource-free and adding that exact reference
+to the child view remains the next slice.
+
 ## Authority and exact claim
 
 Artifact acquisition and Workspace composition owns this claim:

--- a/src/Inspector.Artifacts.Workspaces/ArtifactContentLease.cs
+++ b/src/Inspector.Artifacts.Workspaces/ArtifactContentLease.cs
@@ -1,0 +1,86 @@
+using System.Collections.Immutable;
+using Inspector.Resources;
+
+namespace Inspector.Artifacts.Workspaces;
+
+/// <summary>
+/// Artifact-issued ownership of continued access to one exact retained content
+/// item.
+/// </summary>
+[ResourceOwnership]
+public sealed class ArtifactContentLease : IDisposable
+{
+    private ArtifactSetSession? _owner;
+    private ImmutableArray<byte> _snapshot;
+
+    internal ArtifactContentLease(
+        ArtifactSetSession owner,
+        ArtifactIdentity artifact,
+        ImmutableArray<byte> snapshot)
+    {
+        _owner = owner;
+        Artifact = artifact;
+        _snapshot = snapshot;
+    }
+
+    public ArtifactIdentity Artifact { get; }
+    public ArtifactGenerationIdentity Generation => Artifact.Generation;
+
+    /// <summary>
+    /// Borrows the exact retained bytes synchronously.
+    /// </summary>
+    public ArtifactContentAccessOutcome<TResult> WithContent<TResult>(
+        ArtifactContentCallback<TResult> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        ArtifactSetSession owner =
+            Volatile.Read(ref _owner)
+            ?? throw new ObjectDisposedException(
+                nameof(ArtifactContentLease));
+        return owner.WithContent(
+            this,
+            callback,
+            cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        ArtifactSetSession? owner = Volatile.Read(ref _owner);
+        owner?.ReleaseContentLease(this);
+    }
+
+    internal bool IsOwnedBy(ArtifactSetSession owner) =>
+        ReferenceEquals(Volatile.Read(ref _owner), owner);
+
+    internal ImmutableArray<byte> Snapshot => _snapshot;
+    internal int ActiveBorrows { get; set; }
+
+    internal void MarkReleased()
+    {
+        _snapshot = default;
+        Volatile.Write(ref _owner, null);
+    }
+}
+
+/// <summary>
+/// Owner-attested retained bytes borrowed through one exact content lease.
+/// </summary>
+public readonly ref struct ArtifactContentView
+{
+    internal ArtifactContentView(
+        ArtifactIdentity artifact,
+        ReadOnlySpan<byte> content)
+    {
+        Artifact = artifact;
+        Content = content;
+    }
+
+    public ArtifactGenerationIdentity Generation => Artifact.Generation;
+    public ArtifactIdentity Artifact { get; }
+    public ReadOnlySpan<byte> Content { get; }
+}
+
+public delegate TResult ArtifactContentCallback<TResult>(
+    scoped ArtifactContentView view,
+    CancellationToken cancellationToken);

--- a/src/Inspector.Artifacts.Workspaces/ArtifactContentReference.cs
+++ b/src/Inspector.Artifacts.Workspaces/ArtifactContentReference.cs
@@ -29,6 +29,8 @@ public sealed class ArtifactContentReference
 
     public ArtifactDescriptor Descriptor { get; }
 
+    internal ArtifactSetSession Owner => _owner;
+
     public ArtifactAcquisitionRegistration Registration =>
         _owner.GetRegistration(Descriptor.Identity, _lease);
 

--- a/src/Inspector.Artifacts.Workspaces/ArtifactSetSession.cs
+++ b/src/Inspector.Artifacts.Workspaces/ArtifactSetSession.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -139,10 +140,13 @@ public sealed class ArtifactSetSession : IAsyncDisposable
     private readonly List<ArtifactSetAdmissionFailure> _failures = [];
     private readonly HashSet<IArtifactAcquisitionLease> _leases =
         new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<ArtifactContentLease> _contentLeases =
+        new(ReferenceEqualityComparer.Instance);
     private IReadOnlyList<ArtifactDescriptor>? _catalog;
     private Dictionary<ArtifactIdentity, PublishedArtifact>? _artifacts;
     private IReadOnlyList<Exception> _cleanupFailures = [];
     private Task<IReadOnlyList<Exception>>? _terminationTask;
+    private TaskCompletionSource? _contentLeaseQuiescence;
     private SupplementalOperationOrder? _supplementalOperation;
     private SessionState _state;
     private RequiredCheckpointState _requiredCheckpoint;
@@ -1059,6 +1063,128 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Issues ownership of continued access to one exact selected content item.
+    /// </summary>
+    public ArtifactContentLease IssueContentLease(
+        ArtifactContentReference reference,
+        ArtifactQueryLease lease)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        ArgumentNullException.ThrowIfNull(lease);
+        lock (_gate)
+        {
+            EnsurePublished();
+            _authority.ValidateQueryLease(lease);
+            if (!ReferenceEquals(reference.Owner, this))
+            {
+                throw new ArgumentException(
+                    "The artifact content reference belongs to another session.",
+                    nameof(reference));
+            }
+
+            PublishedArtifact artifact =
+                FindArtifact(reference.Descriptor.Identity);
+            if (!ReferenceEquals(
+                    artifact.Descriptor,
+                    reference.Descriptor))
+            {
+                throw new ArgumentException(
+                    "The artifact content reference does not match the published content.",
+                    nameof(reference));
+            }
+
+            if (_contentLeases.Count == 0)
+            {
+                _contentLeaseQuiescence =
+                    new(
+                        TaskCreationOptions
+                            .RunContinuationsAsynchronously);
+            }
+
+            var contentLease = new ArtifactContentLease(
+                this,
+                artifact.Descriptor.Identity,
+                artifact.Content.Snapshot);
+            _contentLeases.Add(contentLease);
+            return contentLease;
+        }
+    }
+
+    internal ArtifactContentAccessOutcome<TResult> WithContent<TResult>(
+        ArtifactContentLease lease,
+        ArtifactContentCallback<TResult> callback,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ImmutableArray<byte> snapshot;
+        lock (_gate)
+        {
+            if (!lease.IsOwnedBy(this)
+                || !_contentLeases.Contains(lease))
+            {
+                throw new ObjectDisposedException(
+                    nameof(ArtifactContentLease));
+            }
+
+            lease.ActiveBorrows =
+                checked(lease.ActiveBorrows + 1);
+            snapshot = lease.Snapshot;
+        }
+
+        try
+        {
+            TResult result = callback(
+                new ArtifactContentView(
+                    lease.Artifact,
+                    snapshot.AsSpan()),
+                cancellationToken);
+            return new ArtifactContentAccessOutcome<TResult>.Accessed(
+                result);
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                if (lease.ActiveBorrows <= 0)
+                {
+                    throw new InvalidOperationException(
+                        "Artifact content borrow completion was unbalanced.");
+                }
+
+                lease.ActiveBorrows--;
+            }
+        }
+    }
+
+    internal void ReleaseContentLease(
+        ArtifactContentLease lease)
+    {
+        TaskCompletionSource? completion = null;
+        lock (_gate)
+        {
+            if (!lease.IsOwnedBy(this))
+                return;
+            if (!_contentLeases.Contains(lease))
+            {
+                throw new InvalidOperationException(
+                    "The artifact content lease is not registered with its owner.");
+            }
+            if (lease.ActiveBorrows != 0)
+            {
+                throw new InvalidOperationException(
+                    "An artifact content lease cannot be released while a borrow is active.");
+            }
+
+            _contentLeases.Remove(lease);
+            lease.MarkReleased();
+            if (_contentLeases.Count == 0)
+                completion = _contentLeaseQuiescence;
+        }
+
+        completion?.TrySetResult();
+    }
+
     internal ArtifactAcquisitionRegistration GetRegistration(
         ArtifactIdentity identity,
         ArtifactQueryLease lease)
@@ -1673,6 +1799,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
     {
         TaskCompletionSource<IReadOnlyList<Exception>>? starter = null;
         Task<IReadOnlyList<Exception>> termination;
+        Task contentLeaseQuiescence = Task.CompletedTask;
         lock (_gate)
         {
             if (_terminationTask is null)
@@ -1702,6 +1829,10 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                 _preparedArtifactCount = 0;
                 _preparedRetainedBytes = 0;
                 _failures.Clear();
+                contentLeaseQuiescence =
+                    _contentLeases.Count == 0
+                        ? Task.CompletedTask
+                        : _contentLeaseQuiescence!.Task;
             }
 
             termination = _terminationTask;
@@ -1721,6 +1852,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                 {
                     failures.Add(ex);
                 }
+                await contentLeaseQuiescence.ConfigureAwait(false);
                 _admissionLease.Dispose();
                 IReadOnlyList<Exception> leaseFailures =
                     await DisposeLeasesAsync().ConfigureAwait(false);

--- a/src/Inspector.Artifacts/ArtifactAccess.cs
+++ b/src/Inspector.Artifacts/ArtifactAccess.cs
@@ -229,7 +229,6 @@ public sealed class RetainedArtifactContent
                 Registration.Artifact,
                 _snapshot.AsSpan()),
             cancellationToken);
-        cancellationToken.ThrowIfCancellationRequested();
         return new ArtifactContentAccessOutcome<TResult>.Accessed(result);
     }
 
@@ -251,8 +250,16 @@ public sealed class RetainedArtifactContent
                 Registration.Artifact,
                 _snapshot.AsSpan()),
             cancellationToken);
-        cancellationToken.ThrowIfCancellationRequested();
         return new ArtifactContentAccessOutcome<TResult>.Accessed(result);
+    }
+
+    internal ImmutableArray<byte> Snapshot
+    {
+        get
+        {
+            EnsureSnapshot();
+            return _snapshot;
+        }
     }
 
     private void EnsureSnapshot()

--- a/src/Inspector.Artifacts/Inspector.Artifacts.csproj
+++ b/src/Inspector.Artifacts/Inspector.Artifacts.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="../Inspector.Resources/Inspector.Resources.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Inspector.Artifacts.Workspaces" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Inspector.Artifacts.Tests/ArtifactContentLeaseTests.cs
+++ b/tests/Inspector.Artifacts.Tests/ArtifactContentLeaseTests.cs
@@ -1,0 +1,262 @@
+using Inspector.Artifacts.Workspaces;
+
+namespace Inspector.Artifacts.Tests;
+
+public sealed partial class ArtifactSetSessionTests
+{
+    [Fact]
+    public async Task ArtifactContentLease_SurvivesQueryReplacementAndPinsRetirement()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        var acquisition = new TrackingLease();
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) => Acquired(
+                scope,
+                new Provenance("content"),
+                [1, 2, 3],
+                acquisition),
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(cancellationToken));
+
+        ArtifactQueryAuthorization authorization =
+            session.CreateQueryAuthorization();
+        using ArtifactQueryLease query =
+            session.IssueLease(authorization);
+        ArtifactContentReference reference =
+            session.GetContentReference(
+                Assert.Single(session.GetCatalog(query)).Identity,
+                query);
+        using ArtifactContentLease content =
+            session.IssueContentLease(reference, query);
+
+        ArtifactQueryAuthorization replacement =
+            session.ReplaceQueryAuthorization(authorization);
+        query.Dispose();
+        using ArtifactQueryLease current =
+            session.IssueLease(replacement);
+        Task disposal = session.DisposeAsync().AsTask();
+
+        Assert.False(disposal.IsCompleted);
+        Assert.Equal(0, acquisition.DisposeCount);
+        Assert.Throws<ObjectDisposedException>(
+            () => session.IssueContentLease(reference, current));
+        var accessed =
+            Assert.IsType<
+                ArtifactContentAccessOutcome<int>.Accessed>(
+                    content.WithContent(
+                        (view, _) =>
+                        {
+                            Assert.Same(
+                                reference.Descriptor.Identity,
+                                view.Artifact);
+                            Assert.Same(
+                                session.Generation,
+                                view.Generation);
+                            Assert.True(
+                                view.Content.SequenceEqual<byte>(
+                                    [1, 2, 3]));
+                            return view.Content.Length;
+                        },
+                        cancellationToken));
+        Assert.Equal(3, accessed.Value);
+
+        content.Dispose();
+        await disposal.WaitAsync(cancellationToken);
+        Assert.Equal(1, acquisition.DisposeCount);
+        Assert.Throws<ObjectDisposedException>(
+            () => content.WithContent(
+                static (_, _) => 0,
+                cancellationToken));
+    }
+
+    [Fact]
+    public async Task ArtifactContentLease_IssuanceRequiresCurrentQueryAndExactReference()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) => Acquired(
+                scope,
+                new Provenance("local"),
+                [1],
+                ArtifactAcquisitionLeases.None),
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(cancellationToken));
+        ArtifactQueryAuthorization authorization =
+            session.CreateQueryAuthorization();
+        using ArtifactQueryLease query =
+            session.IssueLease(authorization);
+        ArtifactContentReference reference =
+            session.GetContentReference(
+                Assert.Single(session.GetCatalog(query)).Identity,
+                query);
+
+        await using var foreignSession = new ArtifactSetSession();
+        await foreignSession.AddRequiredAcquisitionAsync(
+            (scope, _) => Acquired(
+                scope,
+                new Provenance("foreign"),
+                [2],
+                ArtifactAcquisitionLeases.None),
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await foreignSession.SealAsync(cancellationToken));
+        ArtifactQueryAuthorization foreignAuthorization =
+            foreignSession.CreateQueryAuthorization();
+        using ArtifactQueryLease foreignQuery =
+            foreignSession.IssueLease(foreignAuthorization);
+        ArtifactContentReference foreignReference =
+            foreignSession.GetContentReference(
+                Assert.Single(
+                    foreignSession.GetCatalog(foreignQuery)).Identity,
+                foreignQuery);
+
+        Assert.Throws<ArgumentException>(
+            () => session.IssueContentLease(
+                foreignReference,
+                query));
+        Assert.Throws<UnauthorizedAccessException>(
+            () => session.IssueContentLease(
+                reference,
+                foreignQuery));
+
+        ArtifactQueryAuthorization replacement =
+            session.ReplaceQueryAuthorization(authorization);
+        Assert.Throws<UnauthorizedAccessException>(
+            () => session.IssueContentLease(reference, query));
+        using ArtifactQueryLease current =
+            session.IssueLease(replacement);
+        using ArtifactContentLease content =
+            session.IssueContentLease(reference, current);
+        Assert.Same(reference.Descriptor.Identity, content.Artifact);
+        current.Dispose();
+        Assert.Throws<ObjectDisposedException>(
+            () => session.IssueContentLease(reference, current));
+    }
+
+    [Fact]
+    public async Task ArtifactContentLease_ActiveBorrowPreventsReleaseAndPinsRetirement()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        var acquisition = new TrackingLease();
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) => Acquired(
+                scope,
+                new Provenance("content"),
+                [4, 5],
+                acquisition),
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(cancellationToken));
+        using ArtifactQueryLease query =
+            session.IssueLease(
+                session.CreateQueryAuthorization());
+        ArtifactContentReference reference =
+            session.GetContentReference(
+                Assert.Single(session.GetCatalog(query)).Identity,
+                query);
+        ArtifactContentLease content =
+            session.IssueContentLease(reference, query);
+
+        Task? disposal = null;
+        var accessed =
+            Assert.IsType<
+                ArtifactContentAccessOutcome<int>.Accessed>(
+                    content.WithContent(
+                        (view, _) =>
+                        {
+                            disposal =
+                                session.DisposeAsync().AsTask();
+                            Assert.False(disposal.IsCompleted);
+                            Assert.Equal(
+                                0,
+                                acquisition.DisposeCount);
+                            Assert.Throws<InvalidOperationException>(
+                                content.Dispose);
+                            Assert.True(
+                                view.Content.SequenceEqual<byte>(
+                                    [4, 5]));
+                            return view.Content.Length;
+                        },
+                        cancellationToken));
+        Assert.Equal(2, accessed.Value);
+        Assert.NotNull(disposal);
+        Assert.False(disposal.IsCompleted);
+
+        content.Dispose();
+        await disposal.WaitAsync(cancellationToken);
+        Assert.Equal(1, acquisition.DisposeCount);
+    }
+
+    [Fact]
+    public async Task ArtifactContentLease_NormalReturnWinsLaterCancellation()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) => Acquired(
+                scope,
+                new Provenance("content"),
+                [7],
+                ArtifactAcquisitionLeases.None),
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(cancellationToken));
+        using ArtifactQueryLease query =
+            session.IssueLease(
+                session.CreateQueryAuthorization());
+        ArtifactContentReference reference =
+            session.GetContentReference(
+                Assert.Single(session.GetCatalog(query)).Identity,
+                query);
+        using ArtifactContentLease content =
+            session.IssueContentLease(reference, query);
+        using var cancellation = new CancellationTokenSource();
+        var marker = new object();
+        var failure =
+            new InvalidOperationException("Callback failed.");
+        int calls = 0;
+
+        Assert.Same(
+            failure,
+            Assert.Throws<InvalidOperationException>(
+                () => content.WithContent<object>(
+                    (_, _) => throw failure,
+                    cancellationToken)));
+        var accessed =
+            Assert.IsType<
+                ArtifactContentAccessOutcome<object>.Accessed>(
+                    content.WithContent(
+                        (view, token) =>
+                        {
+                            Assert.Equal(
+                                cancellation.Token,
+                                token);
+                            Assert.Equal(7, view.Content[0]);
+                            calls++;
+                            cancellation.Cancel();
+                            return marker;
+                        },
+                        cancellation.Token));
+
+        Assert.Same(marker, accessed.Value);
+        Assert.Equal(1, calls);
+        Assert.Throws<OperationCanceledException>(
+            () => content.WithContent(
+                (_, _) =>
+                {
+                    calls++;
+                    return marker;
+                },
+                cancellation.Token));
+        Assert.Equal(1, calls);
+    }
+}

--- a/tests/Inspector.Artifacts.Tests/ArtifactResourceClassificationTests.cs
+++ b/tests/Inspector.Artifacts.Tests/ArtifactResourceClassificationTests.cs
@@ -17,6 +17,7 @@ public sealed class ArtifactResourceClassificationTests
             typeof(IArtifactAccessLease),
             typeof(IArtifactAcquisitionLease),
             typeof(ArtifactContributionScope),
+            typeof(ArtifactContentLease),
             typeof(ArtifactQueryLease),
             typeof(ArtifactSetSession),
             typeof(ArtifactGenerationAuthority).GetNestedType(

--- a/tests/Inspector.Artifacts.Tests/ArtifactScopedContentTests.cs
+++ b/tests/Inspector.Artifacts.Tests/ArtifactScopedContentTests.cs
@@ -148,7 +148,7 @@ public sealed class ArtifactScopedContentTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void ScopedContent_CancellationRemainsCancellation(bool query)
+    public void ScopedContent_NormalReturnCommitsBeforeLaterCancellation(bool query)
     {
         var owner = new ArtifactGenerationAuthority();
         ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
@@ -164,24 +164,32 @@ public sealed class ArtifactScopedContentTests
             return 1;
         }
 
-        OperationCanceledException failure;
+        ArtifactContentAccessOutcome<int> outcome;
         if (query)
         {
             owner.CompleteAdmission(admission);
             using ArtifactQueryLease lease = owner.IssueLease(owner.CreateQueryAuthorization());
-            failure = Assert.Throws<OperationCanceledException>(() =>
-                content.WithQueryContent(lease, (_, token) => Cancel(token), cancellation.Token));
+            outcome = content.WithQueryContent(
+                lease,
+                (_, token) => Cancel(token),
+                cancellation.Token);
             Assert.Throws<OperationCanceledException>(() =>
                 content.WithQueryContent(lease, (_, _) => ++calls, cancellation.Token));
         }
         else
         {
-            failure = Assert.Throws<OperationCanceledException>(() =>
-                content.WithAdmissionContent(admissionLease, (_, token) => Cancel(token), cancellation.Token));
+            outcome = content.WithAdmissionContent(
+                admissionLease,
+                (_, token) => Cancel(token),
+                cancellation.Token);
             Assert.Throws<OperationCanceledException>(() =>
                 content.WithAdmissionContent(admissionLease, (_, _) => ++calls, cancellation.Token));
         }
-        Assert.Equal(cancellation.Token, failure.CancellationToken);
+
+        Assert.Equal(
+            1,
+            Assert.IsType<ArtifactContentAccessOutcome<int>.Accessed>(
+                outcome).Value);
         Assert.Equal(1, calls);
         Assert.True(owner.EndGenerationAsync().IsCompletedSuccessfully);
     }

--- a/tests/Inspector.Artifacts.Tests/ArtifactSetSessionDigestTests.cs
+++ b/tests/Inspector.Artifacts.Tests/ArtifactSetSessionDigestTests.cs
@@ -185,7 +185,7 @@ public sealed partial class ArtifactSetSessionTests
     }
 
     [Fact]
-    public async Task Digest_CancellationRemainsCancellationAndCompletedWorkIsMemoized()
+    public async Task Digest_CompletedWorkWinsLaterCancellationAndIsMemoized()
     {
         await using var session = new ArtifactSetSession();
         ArtifactIdentity identity = await PublishDigestFixture(session, [1, 2]);
@@ -197,7 +197,7 @@ public sealed partial class ArtifactSetSessionTests
             identity, lease, _ => Assert.Fail("Cancelled charge."), cancellation.Token));
         using var duringPass = new CancellationTokenSource();
         int charges = 0;
-        Assert.Throws<OperationCanceledException>(() => session.GetContentDigest(
+        AccessedDigest(session.GetContentDigest(
             identity, lease, _ =>
             {
                 charges++;


### PR DESCRIPTION
dotnet-inspect's ownership work serves robust, capable features that provide
foundational capabilities and compelling user experiences through
conventionally sound resource lifetimes.

## Demo

Before this slice, selected Artifact content remained usable only through
query-bound access:

```csharp
ArtifactContentReference reference =
    session.GetContentReference(identity, queryLease);
reference.WithContent(callback);
```

After this slice, the Artifact owner can issue an independently transferable
child for the exact immutable content:

```csharp
using ArtifactContentLease content =
    session.IssueContentLease(reference, queryLease);

Task retirement = session.DisposeAsync().AsTask();

ArtifactContentAccessOutcome<int> accessed =
    content.WithContent((view, _) => view.Content.Length);

content.Dispose();
await retirement;
```

Replacing or disposing the query authorization does not revoke an already
issued child. Starting session retirement rejects new issuance but preserves
existing child borrows, and acquisition cleanup waits until those children
settle.

## Summary

- Add Artifact-owned `ArtifactContentLease` and a synchronous scoped
  `ArtifactContentView`.
- Validate current query authority and exact same-session content evidence at
  issuance without retaining the authority-bearing compatibility reference.
- Drain content children before releasing acquisition leases; reject child
  release while its borrow is active.
- Make normal callback return the commit point, so cancellation requested only
  after callback return does not discard the result.
- Extend the exact Artifact ownership inventory and focused lifetime gates.

## Compatibility boundary

This is slice 3 of #6647. `ArtifactContentReference` remains the current
migration shape and still captures query authority; slice 4 will make it
resource-free and add that exact reference to the child view. This slice does
not change CLI or Browser/Wasm presentation.

## Validation

- `dotnet run --project tests/Inspector.Artifacts.Tests -c Release`
  - 123 total, 117 passed, 6 platform skips
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx markdownlint-cli docs/design/artifact-ownership-and-borrowing.md`
