### PR TITLE
Remove project legacy-option diagnostics

### DIFF
--- a/docs/design/cli-change-classification.md
+++ b/docs/design/cli-change-classification.md
@@ -194,12 +194,6 @@ one manifest:
 - removed `package --readme` receives replacement guidance at the package parse
   boundary. No independent current-input ambiguity is recorded, so the special
   diagnostic's current-policy justification is **unverified**;
-- removed `project --agents-index` and `project --readme <package-id>` receive
-  replacement guidance both at the optional project-path boundary, where a
-  removed option could otherwise bind as the path, and at the project parse
-  error boundary when a preceding path makes it an unmatched option.
-  `Project_RemovedDocumentModes_ReportMigrationGuidance` gates separated and
-  `=` spellings in both positions; and
 - removed top-level command names `api`, `audit`, and `source` remain reserved
   because releasing them would send the same bare tokens through implicit
   target resolution. The `api` and `source` outcomes are gated; the `audit`

--- a/src/DotnetInspect.Cli/CommandLine/Commands/ProjectCommandDefinitions.cs
+++ b/src/DotnetInspect.Cli/CommandLine/Commands/ProjectCommandDefinitions.cs
@@ -22,14 +22,6 @@ public static class ProjectCommandDefinitions
             Description = "Project file, project directory, or project.assets.json path (defaults to current directory)",
             Arity = ArgumentArity.ZeroOrOne
         };
-        pathArg.Validators.Add(result =>
-        {
-            if (result.Tokens.Count == 0)
-                return;
-
-            if (GetRemovedOptionError(result.Tokens[^1].Value) is { } error)
-                result.AddError(error);
-        });
         var tfmOption = new Option<string?>("--tfm")
         {
             Description = "Select target framework from project.assets.json (e.g., net10.0)"
@@ -109,41 +101,5 @@ public static class ProjectCommandDefinitions
         });
 
         return projectCommand;
-    }
-
-    internal static string? GetRemovedOptionError(string option)
-    {
-        if (option.Equals("--agents-index", StringComparison.Ordinal)
-            || option.StartsWith("--agents-index=", StringComparison.Ordinal))
-        {
-            return "'--agents-index' is no longer supported. Inspect package "
-                + "skills with '-S Skills'; package AGENTS.md files are not a "
-                + "supported project document surface.";
-        }
-
-        if (option.Equals("--readme", StringComparison.Ordinal)
-            || option.StartsWith("--readme=", StringComparison.Ordinal))
-        {
-            return "'--readme' is no longer valid. Select package README rows "
-                + "with '-S \"Package README file\"' and add '--print --row N' "
-                + "to print one document.";
-        }
-
-        return null;
-    }
-
-    internal static string? GetRemovedOptionErrorFromParseMessage(
-        string message)
-    {
-        foreach (string option in new[] { "--agents-index", "--readme" })
-        {
-            if (message.Contains($"'{option}'", StringComparison.Ordinal)
-                || message.Contains($"'{option}=", StringComparison.Ordinal))
-            {
-                return GetRemovedOptionError(option);
-            }
-        }
-
-        return null;
     }
 }

--- a/src/DotnetInspect.Cli/CommandLineBuilder.cs
+++ b/src/DotnetInspect.Cli/CommandLineBuilder.cs
@@ -398,21 +398,8 @@ public static class CommandLineBuilder
         if (parseResult.Errors.Count == 0)
             return false;
 
-        IEnumerable<string> messages =
-            parseResult.Errors.Select(error => error.Message);
-        if (parseResult.CommandResult.Command.Name == ProjectCommand.Name)
-        {
-            string? removedOptionError = parseResult.Errors
-                .Select(error =>
-                    ProjectCommandDefinitions
-                        .GetRemovedOptionErrorFromParseMessage(error.Message))
-                .FirstOrDefault(error => error is not null);
-            if (removedOptionError is not null)
-                messages = [removedOptionError];
-        }
-
-        foreach (string message in messages)
-            CommandError.Write(FormatParseError(message));
+        foreach (var error in parseResult.Errors)
+            CommandError.Write(FormatParseError(error.Message));
         return true;
     }
 

--- a/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
@@ -34976,58 +34976,6 @@ public partial class CommandExecutionTests
         }
     }
 
-    [Theory]
-    [InlineData("--agents-index", null, "-S Skills")]
-    [InlineData("--agents-index=true", null, "-S Skills")]
-    [InlineData(
-        "--readme",
-        "Test.Package",
-        "-S \"Package README file\"")]
-    [InlineData(
-        "--readme=Test.Package",
-        null,
-        "-S \"Package README file\"")]
-    public async Task Project_RemovedDocumentModes_ReportMigrationGuidance(
-        string option,
-        string? value,
-        string replacement)
-    {
-        string[] removedArguments =
-            value is null ? [option] : [option, value];
-        var withoutPath = await RunAppAsync(
-            ["project", .. removedArguments]);
-        var afterPath = await RunAppAsync(
-            ["project", ".", .. removedArguments]);
-
-        foreach (var result in new[] { withoutPath, afterPath })
-        {
-            Assert.NotEqual(0, result.Exit);
-            Assert.Empty(result.Output);
-            Assert.Contains(option.Split('=', 2)[0], result.Error);
-            Assert.Contains(replacement, result.Error);
-            Assert.DoesNotContain(
-                "Unrecognized command or argument",
-                result.Error);
-        }
-    }
-
-    [Fact]
-    public async Task Project_RemovedReadmeMode_DoesNotRebindPackageIdAsPath()
-    {
-        var (exit, output, error) = await RunAppAsync(
-            "project",
-            "--readme",
-            "Test.Package");
-
-        Assert.NotEqual(0, exit);
-        Assert.Empty(output);
-        Assert.Contains("--readme", error);
-        Assert.Contains("-S \"Package README file\"", error);
-        Assert.DoesNotContain(
-            "Select at least one project section",
-            error);
-    }
-
     [Fact]
     public async Task Project_Help_ListsOnlySectionDrivenDocumentControls()
     {


### PR DESCRIPTION
dotnet-inspect builds robust, capable features that serve as foundational or
compelling user experiences and are conventionally sound, delightfully
new, or both. This focused cleanup applies that standard to the `project`
command's breaking-change boundary: removed syntax is gone rather than retained
as a compatibility affordance.

## Summary

- remove the optional project-path validator that recognized
  `--agents-index` and `--readme`
- remove project-specific parse-error translation and replacement guidance
- remove the tests and design classification that treated those spellings as
  supported invalid-input guards
- preserve the section-driven `Skills` and `Package README file` contract from
  #6702

## Demo

The removed spellings are absent from help and no longer receive
project-authored migration guidance:

```console
$ dotnet run --project src/DotnetInspect.Cli -c Release --no-build -- project --help | grep -E -- '--agents-index|--readme'
$ dotnet run --project src/DotnetInspect.Cli -c Release --no-build -- project --agents-index
Error: Select at least one project section: -S Skills or -S "Package README file".
$ dotnet run --project src/DotnetInspect.Cli -c Release --no-build -- project . --agents-index
Error: Unrecognized command or argument '--agents-index'.
```

The current section-driven surface is unchanged:

```console
$ dotnet run --project src/DotnetInspect.Cli -c Release --no-build -- project src/DotnetInspect.Cli -S Skills --count
5
$ dotnet run --project src/DotnetInspect.Cli -c Release --no-build -- project src/DotnetInspect.Cli -S "Package README file" --count
3
```

The differing ordinary errors are intentional. Per the user-directed
zero-compatibility scope, this change does not add a general parser rule for
option-looking positional paths.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- 72 focused `Project_*` tests
- 278 `CommandLineTests`
- `CommandErrorOwnershipTests.CompiledIl_SpellsASeverityPrefixOnlyWhereAccountedFor`
- `npx --yes markdownlint-cli docs/design/cli-change-classification.md`
- `git diff origin/main...HEAD --check`

Closes #6718.
Follow-up to #6702 under #6639.
