### PR TITLE
Make Artifact content references resource-free

### DIFF
--- a/docs/design/artifact-ownership-and-borrowing.md
+++ b/docs/design/artifact-ownership-and-borrowing.md
@@ -11,14 +11,15 @@ It expands step 9 of
 tracked end to end by
 [#6647](https://github.com/richlander/dotnet-inspect/issues/6647).
 
-The current implementation floor classifies the existing Artifact obligations
-and issues `ArtifactContentLease` children from a published session. A child
-retains the exact Artifact identity and immutable snapshot without retaining
-the current authority-bearing compatibility reference. Session disposal
-rejects new issuance, keeps existing children usable, waits for their release
-and active-borrow completion, and only then releases acquisition leases.
-Making `ArtifactContentReference` resource-free and adding that exact reference
-to the child view remains the next slice.
+The current implementation floor classifies the existing Artifact obligations,
+issues `ArtifactContentLease` children from a published session, and gives each
+published Artifact one resource-free `ArtifactContentReference`. The lease and
+its scoped view carry that exact reference; retained-content digest work uses
+the content lease as explicit authority after query-policy replacement and
+during session retirement. Session disposal rejects new issuance, keeps
+existing children usable, waits for their release and active-borrow completion,
+and only then releases acquisition leases. Owner-scoped compatibility adopter
+migrations remain the next slices.
 
 ## Authority and exact claim
 
@@ -77,11 +78,13 @@ independent of Metadata, package, storage, Workspace composition, and host
 implementations. `Inspector.Artifacts.Workspaces` consumes both contract
 floors.
 
-The current `ArtifactContentReference` is migration evidence, not the target.
-It captures both `ArtifactSetSession` and `ArtifactQueryLease`, so registration,
-roles, digests, and content opening appear to be reference operations while
-actually using hidden revocable authority. A downstream aggregate cannot own
-that shape without retaining another caller's query-policy lease.
+The previous `ArtifactContentReference` captured both `ArtifactSetSession` and
+`ArtifactQueryLease`, so registration, roles, digests, and content opening
+appeared to be reference operations while actually using hidden revocable
+authority. The current reference records only immutable descriptor,
+registration, provenance, and role evidence. Compatibility consumers still
+retain explicit query authority until their owner-scoped migrations transfer
+`ArtifactContentLease` children instead.
 
 ## Motivating product scenario
 

--- a/src/DotnetInspector.Queries/PackageArtifactAssemblyContextRealization.cs
+++ b/src/DotnetInspector.Queries/PackageArtifactAssemblyContextRealization.cs
@@ -136,6 +136,8 @@ public sealed partial class InspectionWorkspace
                 CreateArtifactRole(
                     preparation.SurfaceAssets,
                     contentByAsset,
+                    session,
+                    queryLease,
                     cancellationToken);
             ImmutableArray<RoleAssembly> implementationRole =
                 preparation.Shared
@@ -143,6 +145,8 @@ public sealed partial class InspectionWorkspace
                     : CreateArtifactRole(
                         preparation.ImplementationAssets,
                         contentByAsset,
+                        session,
+                        queryLease,
                         cancellationToken);
             realization = CreatePackageAssemblyContextRealization(
                 preparation,
@@ -310,6 +314,8 @@ public sealed partial class InspectionWorkspace
         ImmutableArray<RoleAsset> assets,
         IReadOnlyDictionary<RoleAsset, ProjectedPackageArtifact>
             contentByAsset,
+        ArtifactSetSession session,
+        ArtifactQueryLease queryLease,
         CancellationToken cancellationToken)
     {
         var result =
@@ -320,6 +326,8 @@ public sealed partial class InspectionWorkspace
             RoleAsset asset = assets[index];
             ResolvedAssemblyReference assembly = CreatePackageArtifactAssembly(
                 contentByAsset[asset],
+                session,
+                queryLease,
                 PackageProvenance(asset),
                 index,
                 out bool identityDecoded);
@@ -336,6 +344,8 @@ public sealed partial class InspectionWorkspace
 
     static ResolvedAssemblyReference CreatePackageArtifactAssembly(
         ProjectedPackageArtifact artifact,
+        ArtifactSetSession session,
+        ArtifactQueryLease queryLease,
         AssemblyResolutionProvenance provenance,
         int index,
         out bool identityDecoded)
@@ -346,14 +356,24 @@ public sealed partial class InspectionWorkspace
         {
             identityDecoded = true;
             return ResolvedAssemblyReference.CreateFromArtifactProjection(
-                content.Registration, projected.Value, content.OpenRead, provenance);
+                content.Registration,
+                projected.Value,
+                () => session.OpenRead(
+                    content.Descriptor.Identity,
+                    queryLease),
+                provenance);
         }
 
         // Preserve partially decoded identity as well as Metadata's rejection carrier.
         ResolvedAssemblyReference assembly =
             ResolvedAssemblyReference.CreateFromArtifactWithFallbackIdentity(
-                content.Registration, content.OpenRead, RejectionCarrierIdentity(index),
-                provenance, out bool usedFallbackIdentity);
+                content.Registration,
+                () => session.OpenRead(
+                    content.Descriptor.Identity,
+                    queryLease),
+                RejectionCarrierIdentity(index),
+                provenance,
+                out bool usedFallbackIdentity);
         identityDecoded = !usedFallbackIdentity;
         return assembly;
     }
@@ -494,8 +514,10 @@ public sealed partial class InspectionWorkspace
             {
                 foreach (ArtifactDescriptor artifact in Session.GetCatalog(QueryLease!))
                 {
-                    using Stream content = Session.GetContentReference(
-                        artifact.Identity, QueryLease!).OpenRead();
+                    using Stream content =
+                        Session.OpenRead(
+                            artifact.Identity,
+                            QueryLease!);
                     bytes = checked(bytes + content.Length);
                 }
             }

--- a/src/DotnetInspector.Queries/PackageInspectionAssemblyContext.cs
+++ b/src/DotnetInspector.Queries/PackageInspectionAssemblyContext.cs
@@ -184,7 +184,10 @@ public sealed partial class InspectionWorkspace
                         selection.Input.Provenance(entry.TargetFramework);
                     if (artifact.Projection is not ArtifactAssemblyProjectionOutcome.Projected
                         && ResolvedAssemblyReference.CreateFromStreamIfManaged(
-                            artifact.Content.OpenRead, provenance) is null)
+                            () => session.OpenRead(
+                                artifact.Content.Descriptor.Identity,
+                                lease),
+                            provenance) is null)
                     {
                         lease.Dispose();
                         await session.DisposeAsync().ConfigureAwait(false);
@@ -195,10 +198,17 @@ public sealed partial class InspectionWorkspace
                         continue;
                     }
                     long retainedBytes;
-                    using (Stream retained = artifact.Content.OpenRead())
+                    using (Stream retained = session.OpenRead(
+                        artifact.Content.Descriptor.Identity,
+                        lease))
                         retainedBytes = retained.Length;
                     ResolvedAssemblyReference assembly = CreatePackageArtifactAssembly(
-                        artifact, provenance, acquired.Count, out _);
+                        artifact,
+                        session,
+                        lease,
+                        provenance,
+                        acquired.Count,
+                        out _);
                     remainingBytes -= retainedBytes;
                     acquired.Add(new InspectionArtifact(
                         new PackageInspectionAssemblyReference(entry, assembly),

--- a/src/DotnetInspector.Queries/SparsePackageAssemblyProjection.cs
+++ b/src/DotnetInspector.Queries/SparsePackageAssemblyProjection.cs
@@ -508,6 +508,8 @@ public sealed partial class InspectionWorkspace
                     queryLease);
             ResolvedAssemblyReference assembly = SparseAssembly(
                 reference,
+                session,
+                queryLease,
                 package,
                 selectedAsset,
                 admission!,
@@ -630,6 +632,8 @@ public sealed partial class InspectionWorkspace
 
     ResolvedAssemblyReference SparseAssembly(
         ArtifactContentReference reference,
+        ArtifactSetSession session,
+        ArtifactQueryLease queryLease,
         PackageRootBinding package,
         PackageCompileAsset selectedAsset,
         ArtifactAssemblyProjectionOutcome admission,
@@ -648,7 +652,9 @@ public sealed partial class InspectionWorkspace
             return ResolvedAssemblyReference.CreateFromArtifactProjection(
                 reference.Registration,
                 projected.Value,
-                reference.OpenRead,
+                () => session.OpenRead(
+                    reference.Descriptor.Identity,
+                    queryLease),
                 provenance);
         }
 
@@ -658,7 +664,9 @@ public sealed partial class InspectionWorkspace
         ResolvedAssemblyReference carrier = ResolvedAssemblyReference
             .CreateFromArtifactWithFallbackIdentity(
                 reference.Registration,
-                reference.OpenRead,
+                () => session.OpenRead(
+                    reference.Descriptor.Identity,
+                    queryLease),
                 new AssemblyReferenceIdentity(
                     SparseRejectionCarrierName,
                     Version: null,

--- a/src/Inspector.Artifacts.Workspaces/ArtifactContentLease.cs
+++ b/src/Inspector.Artifacts.Workspaces/ArtifactContentLease.cs
@@ -15,15 +15,16 @@ public sealed class ArtifactContentLease : IDisposable
 
     internal ArtifactContentLease(
         ArtifactSetSession owner,
-        ArtifactIdentity artifact,
+        ArtifactContentReference reference,
         ImmutableArray<byte> snapshot)
     {
         _owner = owner;
-        Artifact = artifact;
+        Reference = reference;
         _snapshot = snapshot;
     }
 
-    public ArtifactIdentity Artifact { get; }
+    public ArtifactContentReference Reference { get; }
+    public ArtifactIdentity Artifact => Reference.Descriptor.Identity;
     public ArtifactGenerationIdentity Generation => Artifact.Generation;
 
     /// <summary>
@@ -41,6 +42,24 @@ public sealed class ArtifactContentLease : IDisposable
         return owner.WithContent(
             this,
             callback,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Computes or reuses the digest for this lease's exact retained content.
+    /// </summary>
+    public ArtifactContentAccessOutcome<ArtifactContentDigest> GetContentDigest(
+        Action<long> chargeWork,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(chargeWork);
+        ArtifactSetSession owner =
+            Volatile.Read(ref _owner)
+            ?? throw new ObjectDisposedException(
+                nameof(ArtifactContentLease));
+        return owner.GetContentDigest(
+            this,
+            chargeWork,
             cancellationToken);
     }
 
@@ -69,15 +88,16 @@ public sealed class ArtifactContentLease : IDisposable
 public readonly ref struct ArtifactContentView
 {
     internal ArtifactContentView(
-        ArtifactIdentity artifact,
+        ArtifactContentReference reference,
         ReadOnlySpan<byte> content)
     {
-        Artifact = artifact;
+        Reference = reference;
         Content = content;
     }
 
+    public ArtifactContentReference Reference { get; }
     public ArtifactGenerationIdentity Generation => Artifact.Generation;
-    public ArtifactIdentity Artifact { get; }
+    public ArtifactIdentity Artifact => Reference.Descriptor.Identity;
     public ReadOnlySpan<byte> Content { get; }
 }
 

--- a/src/Inspector.Artifacts.Workspaces/ArtifactContentReference.cs
+++ b/src/Inspector.Artifacts.Workspaces/ArtifactContentReference.cs
@@ -1,51 +1,43 @@
+using System.Collections.Immutable;
 using Inspector.Artifacts;
 
 namespace Inspector.Artifacts.Workspaces;
 
 /// <summary>
-/// An owner-issued reference to one published artifact's identity,
-/// registration, roles, and retained content.
+/// Resource-free evidence for one exact published Artifact content item.
 /// </summary>
 /// <remarks>
-/// The query lease remains caller-owned. Registration and role observations
-/// and content opens revalidate it against the issuing session. Binding
-/// integrity is gated by
-/// <c>ArtifactContentReference_BindsIdentityRegistrationRoleAndContent</c>.
+/// Creating the reference is query-authorized. Once returned, its descriptor,
+/// registration, provenance, and roles remain immutable evidence without
+/// retaining the issuing session or query authority.
 /// </remarks>
 public sealed class ArtifactContentReference
 {
-    private readonly ArtifactSetSession _owner;
-    private readonly ArtifactQueryLease _lease;
+    private readonly ImmutableArray<ArtifactWorkspaceRole> _roles;
 
     internal ArtifactContentReference(
-        ArtifactSetSession owner,
         ArtifactDescriptor descriptor,
-        ArtifactQueryLease lease)
+        ArtifactAcquisitionRegistration registration,
+        ImmutableArray<ArtifactWorkspaceRole> roles)
     {
-        _owner = owner;
         Descriptor = descriptor;
-        _lease = lease;
+        Registration = registration;
+        _roles = roles;
     }
 
     public ArtifactDescriptor Descriptor { get; }
 
-    internal ArtifactSetSession Owner => _owner;
+    public ArtifactAcquisitionRegistration Registration { get; }
 
-    public ArtifactAcquisitionRegistration Registration =>
-        _owner.GetRegistration(Descriptor.Identity, _lease);
+    public bool HasRole(ArtifactWorkspaceRole role)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        foreach (ArtifactWorkspaceRole candidate in _roles)
+        {
+            if (ReferenceEquals(candidate, role))
+                return true;
+        }
 
-    public bool HasRole(ArtifactWorkspaceRole role) =>
-        _owner.HasRole(Descriptor.Identity, role, _lease);
-
-    public Stream OpenRead() =>
-        _owner.OpenRead(Descriptor.Identity, _lease);
-
-    public ArtifactContentAccessOutcome<ArtifactContentDigest> GetContentDigest(
-        Action<long> chargeWork,
-        CancellationToken cancellationToken = default) =>
-        _owner.GetContentDigest(
-            Descriptor.Identity,
-            _lease,
-            chargeWork,
-            cancellationToken);
+        return false;
+    }
 }

--- a/src/Inspector.Artifacts.Workspaces/ArtifactSetSession.cs
+++ b/src/Inspector.Artifacts.Workspaces/ArtifactSetSession.cs
@@ -140,7 +140,8 @@ public sealed class ArtifactSetSession : IAsyncDisposable
     private readonly List<ArtifactSetAdmissionFailure> _failures = [];
     private readonly HashSet<IArtifactAcquisitionLease> _leases =
         new(ReferenceEqualityComparer.Instance);
-    private readonly HashSet<ArtifactContentLease> _contentLeases =
+    private readonly Dictionary<ArtifactContentLease, PublishedArtifact>
+        _contentLeases =
         new(ReferenceEqualityComparer.Instance);
     private IReadOnlyList<ArtifactDescriptor>? _catalog;
     private Dictionary<ArtifactIdentity, PublishedArtifact>? _artifacts;
@@ -1043,7 +1044,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
     }
 
     /// <summary>
-    /// Projects one published artifact into an owner-bound content reference.
+    /// Projects one published artifact into a resource-free content reference.
     /// </summary>
     public ArtifactContentReference GetContentReference(
         ArtifactIdentity identity,
@@ -1055,11 +1056,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         {
             EnsurePublished();
             _authority.ValidateQueryLease(lease);
-            PublishedArtifact artifact = FindArtifact(identity);
-            return new ArtifactContentReference(
-                this,
-                artifact.Descriptor,
-                lease);
+            return FindArtifact(identity).Reference;
         }
     }
 
@@ -1076,18 +1073,10 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         {
             EnsurePublished();
             _authority.ValidateQueryLease(lease);
-            if (!ReferenceEquals(reference.Owner, this))
-            {
-                throw new ArgumentException(
-                    "The artifact content reference belongs to another session.",
-                    nameof(reference));
-            }
-
-            PublishedArtifact artifact =
-                FindArtifact(reference.Descriptor.Identity);
-            if (!ReferenceEquals(
-                    artifact.Descriptor,
-                    reference.Descriptor))
+            if (!_artifacts!.TryGetValue(
+                    reference.Descriptor.Identity,
+                    out PublishedArtifact? artifact)
+                || !ReferenceEquals(artifact.Reference, reference))
             {
                 throw new ArgumentException(
                     "The artifact content reference does not match the published content.",
@@ -1104,9 +1093,9 @@ public sealed class ArtifactSetSession : IAsyncDisposable
 
             var contentLease = new ArtifactContentLease(
                 this,
-                artifact.Descriptor.Identity,
+                artifact.Reference,
                 artifact.Content.Snapshot);
-            _contentLeases.Add(contentLease);
+            _contentLeases.Add(contentLease, artifact);
             return contentLease;
         }
     }
@@ -1121,7 +1110,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         lock (_gate)
         {
             if (!lease.IsOwnedBy(this)
-                || !_contentLeases.Contains(lease))
+                || !_contentLeases.ContainsKey(lease))
             {
                 throw new ObjectDisposedException(
                     nameof(ArtifactContentLease));
@@ -1136,7 +1125,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         {
             TResult result = callback(
                 new ArtifactContentView(
-                    lease.Artifact,
+                    lease.Reference,
                     snapshot.AsSpan()),
                 cancellationToken);
             return new ArtifactContentAccessOutcome<TResult>.Accessed(
@@ -1165,7 +1154,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         {
             if (!lease.IsOwnedBy(this))
                 return;
-            if (!_contentLeases.Contains(lease))
+            if (!_contentLeases.ContainsKey(lease))
             {
                 throw new InvalidOperationException(
                     "The artifact content lease is not registered with its owner.");
@@ -1217,7 +1206,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         {
             EnsurePublished();
             _authority.ValidateQueryLease(lease);
-            return FindArtifact(identity).Roles.Contains(role);
+            return FindArtifact(identity).Reference.HasRole(role);
         }
     }
 
@@ -1276,7 +1265,42 @@ public sealed class ArtifactSetSession : IAsyncDisposable
 
         return artifact.Content.WithQueryContent(
             lease,
-            (view, token) => artifact.GetDigest(view, chargeWork, token),
+            (view, token) => artifact.GetDigest(
+                view.Artifact,
+                view.Content,
+                chargeWork,
+                token),
+            cancellationToken);
+    }
+
+    internal ArtifactContentAccessOutcome<ArtifactContentDigest>
+        GetContentDigest(
+        ArtifactContentLease lease,
+        Action<long> chargeWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(lease);
+        ArgumentNullException.ThrowIfNull(chargeWork);
+        cancellationToken.ThrowIfCancellationRequested();
+        PublishedArtifact artifact;
+        lock (_gate)
+        {
+            if (!lease.IsOwnedBy(this)
+                || !_contentLeases.TryGetValue(
+                    lease,
+                    out artifact!))
+            {
+                throw new ObjectDisposedException(
+                    nameof(ArtifactContentLease));
+            }
+        }
+
+        return lease.WithContent(
+            (view, token) => artifact.GetDigest(
+                view.Artifact,
+                view.Content,
+                chargeWork,
+                token),
             cancellationToken);
     }
 
@@ -1538,13 +1562,13 @@ public sealed class ArtifactSetSession : IAsyncDisposable
             _authority.CreateRetainedContent(
                 contribution.Registration,
                 ImmutableCollectionsMarshal.AsImmutableArray(snapshot));
-        return new PublishedArtifact(
+        var reference = new ArtifactContentReference(
             contribution.Descriptor,
             contribution.Registration,
+            [.. roles]);
+        return new PublishedArtifact(
+            reference,
             retained,
-            new HashSet<ArtifactWorkspaceRole>(
-                roles,
-                ReferenceEqualityComparer.Instance),
             snapshot.LongLength);
     }
 
@@ -2058,17 +2082,20 @@ public sealed class ArtifactSetSession : IAsyncDisposable
     }
 
     private sealed record PublishedArtifact(
-        ArtifactDescriptor Descriptor,
-        ArtifactAcquisitionRegistration Registration,
+        ArtifactContentReference Reference,
         RetainedArtifactContent Content,
-        HashSet<ArtifactWorkspaceRole> Roles,
         long RetainedBytes)
     {
         private readonly object _digestGate = new();
         private ArtifactContentDigest? _digest;
 
+        public ArtifactDescriptor Descriptor => Reference.Descriptor;
+        public ArtifactAcquisitionRegistration Registration =>
+            Reference.Registration;
+
         public ArtifactContentDigest GetDigest(
-            scoped ArtifactQueryContentView view,
+            ArtifactIdentity artifact,
+            ReadOnlySpan<byte> content,
             Action<long> chargeWork,
             CancellationToken cancellationToken)
         {
@@ -2078,10 +2105,10 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                 if (_digest is not null)
                     return _digest;
 
-                chargeWork(view.Content.Length);
+                chargeWork(content.Length);
                 string hexValue = Convert.ToHexStringLower(
-                    SHA256.HashData(view.Content));
-                _digest = new ArtifactContentDigest(view.Artifact, hexValue);
+                    SHA256.HashData(content));
+                _digest = new ArtifactContentDigest(artifact, hexValue);
                 return _digest;
             }
         }

--- a/tests/DotnetInspector.AssemblyOnlyHost.Fixture/AssemblyOnlyInspector.cs
+++ b/tests/DotnetInspector.AssemblyOnlyHost.Fixture/AssemblyOnlyInspector.cs
@@ -62,7 +62,9 @@ public static class AssemblyOnlyInspector
         ResolvedAssemblyReference assembly =
             ResolvedAssemblyReference.CreateFromArtifactIfManaged(
                 artifactRegistration,
-                content.OpenRead,
+                () => artifacts.OpenRead(
+                    content.Descriptor.Identity,
+                    lease),
                 AssemblyResolutionProvenance.Local(
                     "artifact-session"))
             ?? throw new BadImageFormatException(

--- a/tests/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -1804,7 +1804,9 @@ public sealed class InspectionWorkspaceTests
         ResolvedAssemblyReference assembly =
             ResolvedAssemblyReference.CreateFromArtifactIfManaged(
                 content.Registration,
-                content.OpenRead,
+                () => session.OpenRead(
+                    content.Descriptor.Identity,
+                    queryLease),
                 AssemblyResolutionProvenance.Local(
                     "artifact workspace test"))
             ?? throw new InvalidOperationException(

--- a/tests/ILInspector.Decompiler.Tests/CompileReferenceSetTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/CompileReferenceSetTests.cs
@@ -293,7 +293,10 @@ public sealed class CompileReferenceSetTests
             Assert.Same(digest.Value, image.ContentDigest);
             Assert.Same(image.InventoryId, image.ContentDigest.Artifact);
             Assert.Same(fixture.Session.Generation, image.ContentDigest.Generation);
-            using Stream retained = fixture.Session.GetContentReference(image.InventoryId, fixture.Lease).OpenRead();
+            using Stream retained =
+                fixture.Session.OpenRead(
+                    image.InventoryId,
+                    fixture.Lease);
             using var copy = new MemoryStream();
             retained.CopyTo(copy);
             Assert.Equal(copy.ToArray(), image.Snapshot.Content);

--- a/tests/Inspector.Artifacts.Tests/ArtifactContentLeaseTests.cs
+++ b/tests/Inspector.Artifacts.Tests/ArtifactContentLeaseTests.cs
@@ -31,6 +31,7 @@ public sealed partial class ArtifactSetSessionTests
                 query);
         using ArtifactContentLease content =
             session.IssueContentLease(reference, query);
+        Assert.Same(reference, content.Reference);
 
         ArtifactQueryAuthorization replacement =
             session.ReplaceQueryAuthorization(authorization);
@@ -49,6 +50,9 @@ public sealed partial class ArtifactSetSessionTests
                     content.WithContent(
                         (view, _) =>
                         {
+                            Assert.Same(
+                                reference,
+                                view.Reference);
                             Assert.Same(
                                 reference.Descriptor.Identity,
                                 view.Artifact);

--- a/tests/Inspector.Artifacts.Tests/ArtifactSetSessionDigestTests.cs
+++ b/tests/Inspector.Artifacts.Tests/ArtifactSetSessionDigestTests.cs
@@ -25,8 +25,11 @@ public sealed partial class ArtifactSetSessionTests
         using ArtifactQueryLease anotherLease =
             session.IssueLease(session.CreateQueryAuthorization());
         ArtifactContentDigest second = AccessedDigest(
-            session.GetContentReference(identity, anotherLease)
-                .GetContentDigest(charges.Add, TestContext.Current.CancellationToken));
+            session.GetContentDigest(
+                identity,
+                anotherLease,
+                charges.Add,
+                TestContext.Current.CancellationToken));
 
         Assert.Equal("SHA-256", first.Algorithm);
         Assert.Equal(expectedHash, first.HexValue);
@@ -145,14 +148,17 @@ public sealed partial class ArtifactSetSessionTests
     }
 
     [Fact]
-    public async Task Digest_ReferenceRevalidatesAndAuthorizesBeforeLookup()
+    public async Task Digest_QueryAuthorityRevalidatesBeforeLookup()
     {
         await using var session = new ArtifactSetSession();
         ArtifactIdentity identity = await PublishDigestFixture(session, [1]);
         ArtifactQueryAuthorization authorization = session.CreateQueryAuthorization();
         using ArtifactQueryLease lease = session.IssueLease(authorization);
-        ArtifactContentReference reference = session.GetContentReference(identity, lease);
-        AccessedDigest(reference.GetContentDigest(_ => { }, TestContext.Current.CancellationToken));
+        AccessedDigest(session.GetContentDigest(
+            identity,
+            lease,
+            _ => { },
+            TestContext.Current.CancellationToken));
         await using var other = new ArtifactSetSession();
         ArtifactIdentity unknown = await PublishDigestFixture(other, [2]);
 
@@ -160,9 +166,67 @@ public sealed partial class ArtifactSetSessionTests
             () => session.GetContentDigest(unknown, lease, _ => { }, TestContext.Current.CancellationToken));
         session.Revoke(authorization);
         Assert.IsType<ArtifactContentAccessOutcome<ArtifactContentDigest>.Unauthorized>(
-            reference.GetContentDigest(_ => Assert.Fail("Unauthorized charge."), TestContext.Current.CancellationToken));
-        Assert.IsType<ArtifactContentAccessOutcome<ArtifactContentDigest>.Unauthorized>(
             session.GetContentDigest(unknown, lease, _ => Assert.Fail("Unauthorized charge."), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Digest_ContentLeaseRemainsAuthorityAfterQueryReplacementAndRetirement()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        var acquisitionLease = new TrackingLease();
+        await using var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) => Acquired(
+                scope,
+                new Provenance("digest"),
+                [1, 2],
+                acquisitionLease),
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(cancellationToken));
+        ArtifactQueryAuthorization authorization =
+            session.CreateQueryAuthorization();
+        using ArtifactQueryLease query =
+            session.IssueLease(authorization);
+        ArtifactIdentity identity =
+            Assert.Single(session.GetCatalog(query)).Identity;
+        ArtifactContentReference reference =
+            session.GetContentReference(identity, query);
+        using ArtifactContentLease content =
+            session.IssueContentLease(reference, query);
+        session.ReplaceQueryAuthorization(authorization);
+        var charges = new List<long>();
+
+        Assert.IsType<
+            ArtifactContentAccessOutcome<ArtifactContentDigest>.Unauthorized>(
+                session.GetContentDigest(
+                    identity,
+                    query,
+                    _ => Assert.Fail("Stale query authority was charged."),
+                    cancellationToken));
+        ArtifactContentDigest digest =
+            AccessedDigest(content.GetContentDigest(
+                charges.Add,
+                cancellationToken));
+
+        Task disposal = session.DisposeAsync().AsTask();
+        Assert.False(disposal.IsCompleted);
+        Assert.Same(
+            digest,
+            AccessedDigest(content.GetContentDigest(
+                _ => Assert.Fail("Cached content authority was charged."),
+                cancellationToken)));
+        Assert.Equal([2L], charges);
+        Assert.Equal(0, acquisitionLease.DisposeCount);
+
+        content.Dispose();
+        await disposal.WaitAsync(cancellationToken);
+        Assert.Equal(1, acquisitionLease.DisposeCount);
+        Assert.Throws<ObjectDisposedException>(
+            () => content.GetContentDigest(
+                _ => Assert.Fail("Released content authority was charged."),
+                cancellationToken));
     }
 
     [Fact]

--- a/tests/Inspector.Artifacts.Tests/ArtifactSetSessionTests.cs
+++ b/tests/Inspector.Artifacts.Tests/ArtifactSetSessionTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 using Inspector.Artifacts.Workspaces;
@@ -1724,7 +1726,7 @@ public sealed partial class ArtifactSetSessionTests
     }
 
     [Fact]
-    public async Task ArtifactContentReference_BindsIdentityRegistrationRoleAndContent()
+    public async Task ArtifactContentReference_PreservesExactRegistrationRolesAndGeneration()
     {
         CancellationToken cancellationToken =
             TestContext.Current.CancellationToken;
@@ -1767,10 +1769,15 @@ public sealed partial class ArtifactSetSessionTests
         Assert.Same(
             first.Descriptor.Identity,
             first.Registration.Artifact);
+        Assert.Same(
+            firstSession.Generation,
+            first.Descriptor.Identity.Generation);
         Assert.Same(firstProvenance, first.Registration.Provenance);
         Assert.True(first.HasRole(
             ArtifactWorkspaceRole.CallerDesignated));
-        using Stream firstContent = first.OpenRead();
+        using Stream firstContent = firstSession.OpenRead(
+            first.Descriptor.Identity,
+            lease);
         Assert.Equal([1], ReadAll(firstContent));
 
         Assert.Same(catalog[1], second.Descriptor);
@@ -1780,8 +1787,18 @@ public sealed partial class ArtifactSetSessionTests
         Assert.Same(secondProvenance, second.Registration.Provenance);
         Assert.False(second.HasRole(
             ArtifactWorkspaceRole.CallerDesignated));
-        using Stream secondContent = second.OpenRead();
+        using Stream secondContent = firstSession.OpenRead(
+            second.Descriptor.Identity,
+            lease);
         Assert.Equal([2], ReadAll(secondContent));
+        using ArtifactQueryLease anotherLease =
+            firstSession.IssueLease(
+                firstSession.CreateQueryAuthorization());
+        Assert.Same(
+            first,
+            firstSession.GetContentReference(
+                first.Descriptor.Identity,
+                anotherLease));
 
         await using var secondSession = new ArtifactSetSession();
         await secondSession.AddRequiredAcquisitionAsync(
@@ -1805,24 +1822,61 @@ public sealed partial class ArtifactSetSessionTests
                 lease));
 
         firstSession.Revoke(authorization);
+        Assert.Same(catalog[0], first.Descriptor);
+        Assert.Same(firstProvenance, first.Registration.Provenance);
+        Assert.True(first.HasRole(
+            ArtifactWorkspaceRole.CallerDesignated));
         Assert.Throws<UnauthorizedAccessException>(
-            () => _ = first.Registration);
-        Assert.Throws<UnauthorizedAccessException>(
-            () => first.HasRole(
-                ArtifactWorkspaceRole.CallerDesignated));
-        Assert.Throws<UnauthorizedAccessException>(
-            () => first.OpenRead());
+            () => firstSession.OpenRead(
+                first.Descriptor.Identity,
+                lease));
 
         lease.Dispose();
-        Assert.Throws<ObjectDisposedException>(
-            () => _ = first.Registration);
-        Assert.Throws<ObjectDisposedException>(
-            () => first.HasRole(
-                ArtifactWorkspaceRole.CallerDesignated));
-        Assert.Throws<ObjectDisposedException>(
-            () => first.OpenRead());
+        Assert.Same(firstProvenance, first.Registration.Provenance);
+        Assert.True(first.HasRole(
+            ArtifactWorkspaceRole.CallerDesignated));
+        Assert.Throws<ObjectDisposedException>(() =>
+            firstSession.OpenRead(
+                first.Descriptor.Identity,
+                lease));
+        anotherLease.Dispose();
+        firstContent.Dispose();
+        secondContent.Dispose();
+        await firstSession.DisposeAsync();
+        Assert.Same(catalog[0], first.Descriptor);
+        Assert.Same(
+            firstSession.Generation,
+            first.Descriptor.Identity.Generation);
+        Assert.Same(firstProvenance, first.Registration.Provenance);
+        Assert.True(first.HasRole(
+            ArtifactWorkspaceRole.CallerDesignated));
         Assert.Empty(
             typeof(ArtifactContentReference).GetConstructors());
+    }
+
+    [Fact]
+    public void ArtifactContentReference_IsResourceFreeEvidence()
+    {
+        Type type = typeof(ArtifactContentReference);
+        Type[] fieldTypes = type
+            .GetFields(
+                BindingFlags.Instance
+                | BindingFlags.Public
+                | BindingFlags.NonPublic)
+            .Select(field => field.FieldType)
+            .OrderBy(fieldType => fieldType.FullName)
+            .ToArray();
+
+        Assert.Equal(
+            [
+                typeof(ArtifactAcquisitionRegistration),
+                typeof(ArtifactDescriptor),
+                typeof(ImmutableArray<ArtifactWorkspaceRole>)
+            ],
+            fieldTypes);
+        Assert.DoesNotContain(
+            type.GetMethods(BindingFlags.Instance | BindingFlags.Public),
+            method => method.Name is "OpenRead" or "GetContentDigest");
     }
 
     [Fact]

--- a/tools/DecompilerHarness/CompileReferenceInventory.cs
+++ b/tools/DecompilerHarness/CompileReferenceInventory.cs
@@ -176,7 +176,11 @@ public sealed class CompileReferenceInventory
                 ArtifactContentReference content = owner.GetContentReference(input.Artifact, lease);
                 ResolvedAssemblyReference? assembly =
                     ResolvedAssemblyReference.CreateFromArtifactIfManaged(
-                        content.Registration, content.OpenRead, input.Provenance);
+                        content.Registration,
+                        () => owner.OpenRead(
+                            content.Descriptor.Identity,
+                            lease),
+                        input.Provenance);
                 if (assembly is null)
                     return Reject(CompileReferenceFailureKind.ReferenceImageInvalid, input.Artifact);
 


### PR DESCRIPTION
Build robust, capable shared infrastructure that is conventionally sound and
unlocks compelling XML-documentation experiences through the House
architecture.

## Demo

The real `System.Text.Json.dll` platform assembly now demonstrates the intended
authority split:

```text
artifact=System.Text.Json.dll
reference-role=True
query-after-replacement=Unauthorized
lease-after-replacement=Accessed
digest=SHA-256:61bfbbb5104e2531474d5bc3e6cf5b596608174ee374b98e62957620dea7f870
```

The resource-free reference preserves exact registration and role evidence
after query-policy replacement. The stale query lease can no longer read the
image, while the already-issued content lease still borrows and digests its
exact retained bytes.

## Summary

- Create one canonical resource-free `ArtifactContentReference` per published
  Artifact, containing only descriptor, registration, provenance, and immutable
  role evidence.
- Carry that exact reference through `ArtifactContentLease` and
  `ArtifactContentView`.
- Move ownership-backed digest work onto the live content lease while sharing
  the Artifact-owned cache with query-authorized digest requests.
- Remove parameterless content and digest operations from the reference and
  make compatibility callers pass their existing session and query authority
  explicitly.

## Compatibility

Queries, the assembly-only host, and the decompiler harness retain their
existing query-lease lifetime in this slice, but no longer hide it inside the
resource-free reference. The remaining owner-scoped adopter slices will
transfer `ArtifactContentLease` children and retire those compatibility
lifetimes without changing Metadata's image contract here.

## Validation

- `dotnet run --project tests/Inspector.Artifacts.Tests -c Release`
  (119 passed, 6 platform skips)
- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release`
  (2,126 passed)
- `DotnetInspect.Cli.Tests.LayeringTests.LocalOnlyHost_PreservesArtifactRegistrationThroughAssemblyInspection`
- `ILInspector.Decompiler.Tests.CompileReferenceSetTests` and
  `CompileReferencePlatformPolicyTests` (41 passed)
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx markdownlint-cli docs/design/artifact-ownership-and-borrowing.md`

Progresses #6647.
