### PR TITLE
Materialize char and enum element-store slot identity

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -488,8 +488,7 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    coercion insertion, which discharges the minted loads' sink obligations
    like any local's. What stays on the print-time unifier is the counted
    residual: ambiguous testimony, cross-family (true disjoint ranges),
-   element-store identity recovery (the #1751 char class — the printer
-   re-types those slots, which a materialized local would foreclose), incomplete
+   unproven element-store identity recovery, incomplete
    slot-copy components, and nested `Lambda`/`LocalFunctionStatement` scopes.
    The nested-name prerequisite #2275 landed in #2356; recursively materializing
    each nested body's own locals table remains. Direct slot-copy components now
@@ -535,6 +534,32 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    decided case; an undecided member still retains the entire component.
    The C2 deletion and invariant extension follow once the residual census
    reaches the printer-owned floor.
+
+   Element-store identity also recovers late: integer-typed loads used as the
+   value of a char or metadata-resolved enum array store may testify to that
+   element type when every producer is a conditional with two representable
+   constant arms. Char recovery shares
+   `CoercionRendering.TryCharConstantValue` with the printer; enum recovery
+   requires resolved backing data and constants within its signed/unsigned
+   range. Stack-family compatibility alone is not a value-preservation proof.
+   The existing slot-coercion gate still rejects unsupported widths. Every
+   observer contributes testimony, and all existing scope, control-flow, and
+   atomic copy-component gates remain. No expression or condition moves.
+   Nonconditional producers, nonconstant arms, out-of-range values, and missing
+   enum backing remain printer-owned. Earlier testimony is unchanged; the
+   general element-target printer fallback remains necessary for lowered and
+   deferred trees.
+
+   Real witnesses are Newtonsoft.Json 13.0.4
+   `DateTimeUtils.WriteDateTimeOffset` (`'+'`/`'-'`),
+   Microsoft.CodeAnalysis 5.0.0 `BitVector.GetDebuggerDisplay` (`'1'`/`'0'`),
+   and the two `ReadParameterRefKinds` implementations in
+   dotnet-inspect.any 0.14.0 (`ArgumentRefKind.Ref`/`Value`).
+   `ElementSlotIdentityTests` gates compiler-produced activation, constant
+   boundaries, competing and underivable observations, all-store agreement,
+   and incomplete copies. Its compile-back gate preserves the existing
+   retained-temporary `OpcodeDiff`, not an exact-IL claim. The existing
+   `CharElementStorePrinterTests` binding gate remains in force.
 
    `MaterializesSingleStoreConditionalWithSingleRead` and
    `MaterializesBooleanIdentityWhenConditionalFeedsBooleanLocal` gate

--- a/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
@@ -7,6 +7,25 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public static class CoercionRendering
 {
+    public static bool TryCharConstantValue(IrExpression expression, out char value)
+    {
+        switch (expression)
+        {
+            case Constant { Value: char c }:
+                value = c;
+                return true;
+            case Constant { Value: int i } when i is >= char.MinValue and <= char.MaxValue:
+                value = (char)i;
+                return true;
+            case Constant { Value: long l } when l is >= char.MinValue and <= char.MaxValue:
+                value = (char)l;
+                return true;
+            default:
+                value = default;
+                return false;
+        }
+    }
+
     /// <summary>
     /// The slot-store wrappability contract: every accepted pair is both a
     /// coercion spelling that <c>CoerceText</c> renders and a stack-family

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -2870,21 +2870,9 @@ public sealed partial class CSharpPrinter
 
     static bool TryCharConstantText(IrExpression expression, out string text)
     {
-        switch (expression)
-        {
-            case Constant { Value: char c }:
-                text = CharText(c);
-                return true;
-            case Constant { Value: int i } when i is >= char.MinValue and <= char.MaxValue:
-                text = CharText((char)i);
-                return true;
-            case Constant { Value: long l } when l is >= char.MinValue and <= char.MaxValue:
-                text = CharText((char)l);
-                return true;
-            default:
-                text = "";
-                return false;
-        }
+        bool isChar = CoercionRendering.TryCharConstantValue(expression, out char value);
+        text = isChar ? CharText(value) : "";
+        return isChar;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -110,28 +110,34 @@ public static class CoercionSinks
     /// Measurement consumers use the status to distinguish an untyped load with
     /// no derivable sink from loads that actively disagree. At materialization,
     /// Boolean-valued stores may recover integer-typed loads at Boolean sinks;
-    /// earlier passes retain the importer's testimony until raising is complete.
+    /// constant conditionals may recover char/enum element-store identity.
+    /// Earlier passes retain the importer's testimony until raising is complete.
     /// </summary>
     public static Dictionary<int, SlotTypeTestimony> AnalyzeSlotTypeTestimony(
         IrNode scope,
         TypeRef? returnType,
         IReadOnlyDictionary<TypeRef, TypeShape> shapes,
-        bool recoverBooleanIdentity = false)
+        bool recoverBooleanIdentity = false,
+        bool recoverElementIdentity = false,
+        IReadOnlyDictionary<TypeRef, TypeRef>? enumUnderlyingTypes = null)
     {
-        var booleanSlots = recoverBooleanIdentity
+        var storesBySlot = recoverBooleanIdentity || recoverElementIdentity
             ? ScopeNodes(scope).OfType<StoreStackSlot>()
-                .GroupBy(static store => store.Slot)
-                .Where(static stores => stores.All(store => TypeFamilies.IsBoolean(store.Value.ResultType)))
-                .Select(static stores => stores.Key)
-                .ToHashSet()
+                .ToLookup(static store => store.Slot, static store => store.Value)
             : null;
         var testimony = new Dictionary<int, SlotTypeTestimony>();
         foreach (var load in ScopeNodes(scope).OfType<LoadStackSlot>())
         {
-            var booleanType = booleanSlots?.Contains(load.Slot) == true
+            var stores = storesBySlot?[load.Slot];
+            var booleanType = recoverBooleanIdentity && stores?.Any() == true
+                && stores.All(static value => TypeFamilies.IsBoolean(value.ResultType))
                 ? BooleanSlotLoadType(load, returnType, shapes)
                 : null;
-            var evidence = booleanType ?? BitwiseEnumSinkType(load, shapes) ?? load.Type ?? LoadSinkTargetType(load, returnType, shapes);
+            var elementType = recoverElementIdentity && stores?.Any() == true
+                ? ElementSlotLoadType(load, stores, shapes, enumUnderlyingTypes)
+                : null;
+            var evidence = booleanType ?? elementType ?? BitwiseEnumSinkType(load, shapes)
+                ?? load.Type ?? LoadSinkTargetType(load, returnType, shapes);
             if (evidence is null)
             {
                 testimony[load.Slot] = new(null, SlotTypeTestimonyStatus.Underivable);
@@ -151,6 +157,36 @@ public static class CoercionSinks
             }
         }
         return testimony;
+    }
+
+    static TypeRef? ElementSlotLoadType(
+        LoadStackSlot load,
+        IEnumerable<IrExpression> stores,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef>? enumUnderlyingTypes)
+    {
+        if (load.Type is not { } type || !TypeFamilies.IsIntegerLike(type)
+            || load.Parent is not StoreElement element || !ReferenceEquals(element.Value, load)
+            || StoreElementTarget(element, shapes) is not { } target)
+            return null;
+
+        bool isChar = target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" };
+        var underlying = enumUnderlyingTypes?.GetValueOrDefault(CoercionRendering.NamedDefinition(target));
+        if (!isChar && (!CoercionRendering.IsEnum(target, shapes) || underlying is null))
+            return null;
+
+        return stores.All(value => value is Conditional conditional
+            && PreservesConstant(conditional.WhenTrue) && PreservesConstant(conditional.WhenFalse))
+                ? target
+                : null;
+
+        bool PreservesConstant(IrExpression value)
+            => value.ResultType is { } valueType && TypeFamilies.IsIntegerLike(valueType)
+                && (isChar
+                    ? CoercionRendering.TryCharConstantValue(value, out _)
+                    : value is Constant { Value: int or long } constant
+                        && CSharpConversionRules.ConstantFits(
+                            constant.Value is int i ? i : (long)constant.Value, underlying!));
     }
 
     /// <summary>The target type of the sink directly consuming an untyped slot load, where one is derivable.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotMaterializationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotMaterializationPass.cs
@@ -129,7 +129,9 @@ public sealed class SlotMaterializationPass : IIrPass
             function.Body,
             function.Signature.ReturnType,
             function.TypeShapes,
-            recoverBooleanIdentity: true);
+            recoverBooleanIdentity: true,
+            recoverElementIdentity: true,
+            enumUnderlyingTypes: function.EnumUnderlyingTypes);
         // Materializable slots retain the prior first-testimony order so
         // AddLocal preserves existing local indices and declaration order.
         var candidates = testimony.Keys

--- a/tests/ILInspector.Decompiler.Tests/ElementSlotIdentitySamples.cs
+++ b/tests/ILInspector.Decompiler.Tests/ElementSlotIdentitySamples.cs
@@ -1,0 +1,12 @@
+namespace ILInspector.Decompiler.Tests;
+
+public enum ElementSlotKind { Value, Ref, Out }
+
+public static class ElementSlotIdentitySamples
+{
+    // The constant enum conditional retained by ReadParameterRefKinds in
+    // dotnet-inspect.any 0.14.0. A non-Boolean pair keeps current csc from
+    // replacing the conditional with a comparison's 0/1 result.
+    public static void StoreKind(ElementSlotKind[] kinds, int index, int[] input)
+        => kinds[index] = input[index] == 1 ? ElementSlotKind.Ref : ElementSlotKind.Out;
+}

--- a/tests/ILInspector.Decompiler.Tests/ElementSlotIdentityTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/ElementSlotIdentityTests.cs
@@ -1,0 +1,260 @@
+using ILInspector.DecompilerHarness;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Pass")]
+public class ElementSlotIdentityTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Char = TypeRef.CoreLib("System", "Char");
+    static readonly TypeRef Kind = TypeRef.Definition("Synthetic", "Samples", "Kind");
+    static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CompilerProducedElementConditionalMaterializesIdentity(bool enumElement)
+    {
+        var sample = enumElement ? typeof(ElementSlotIdentitySamples) : typeof(CfgSampleClass);
+        string method = enumElement
+            ? nameof(ElementSlotIdentitySamples.StoreKind)
+            : nameof(CfgSampleClass.CharConditionalElementStore);
+        using var source = MetadataSource.Open(sample.Assembly.Location);
+        var function = IrImporter.Import(source, sample.FullName!, method);
+        Assert.NotNull(function);
+        var context = PassContext.ForImport(reference => IrImporter.Import(source, reference));
+        foreach (var pass in IrPasses.Default)
+        {
+            if (pass is SlotMaterializationPass)
+                break;
+            pass.Run(function, context);
+        }
+
+        var element = Assert.Single(function.Descendants.OfType<StoreElement>());
+        var target = CoercionSinks.StoreElementTarget(element, function.TypeShapes);
+        var load = Assert.IsType<LoadStackSlot>(element.Value);
+        Assert.Equal(Int32, load.Type);
+        Assert.Equal(Int32, CoercionSinks.TestifiedSlotTypes(
+            function.Body, function.Signature.ReturnType, function.TypeShapes)[load.Slot]);
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function),
+            candidate => candidate.Slot == load.Slot);
+        Assert.True(decision.WillMaterialize);
+        Assert.Equal(target, decision.Type);
+
+        new SlotMaterializationPass().Run(function, context);
+        new CoercionInsertionPass().Run(function, context);
+
+        Assert.IsType<LoadLocal>(element.Value);
+        Assert.Equal(target, element.Value.ResultType);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), node => node.Slot == load.Slot);
+        Assert.DoesNotContain(function.Descendants.OfType<StoreStackSlot>(), node => node.Slot == load.Slot);
+        Assert.Empty(CoercionInvariant.Check(function));
+        function.CheckInvariant();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    [Trait("Area", "Fidelity")]
+    public void CompilerProducedElementConditionalBindsWithRetainedTemporaries(bool enumElement)
+    {
+        var sample = enumElement ? typeof(ElementSlotIdentitySamples) : typeof(CfgSampleClass);
+        string method = enumElement
+            ? nameof(ElementSlotIdentitySamples.StoreKind)
+            : nameof(CfgSampleClass.CharConditionalElementStore);
+        var result = Assert.Single(FidelityCheck.Evaluate(
+            sample.Assembly.Location, type => type == sample.FullName,
+            candidate => candidate.Method == method));
+
+        // Both renders retain index/value temporaries; this gates binding,
+        // not opcode-exact lowering of the original stack-only assignment.
+        Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.Status);
+        Assert.NotNull(result.RecompiledOpcodes);
+        Assert.Contains("stloc", result.RecompiledOpcodes);
+    }
+
+    [Theory]
+    [InlineData(0, 65535)]
+    [InlineData(43, 45)]
+    public void MaterializesRepresentableCharConditional(int left, int right)
+    {
+        var function = Function(Char, Conditional(left, right));
+        AssertMaterializes(function, Char);
+    }
+
+    [Theory]
+    [InlineData("SByte", -128, 127)]
+    [InlineData("Byte", 0, 255)]
+    [InlineData("Int16", -32768, 32767)]
+    [InlineData("UInt16", 0, 65535)]
+    [InlineData("Int32", int.MinValue, int.MaxValue)]
+    [InlineData("UInt32", 0, int.MaxValue)]
+    public void MaterializesEnumConditionalUsingResolvedBackingRange(string backing, int left, int right)
+    {
+        var function = EnumFunction(Conditional(left, right), backing);
+        AssertMaterializes(function, Kind);
+    }
+
+    [Theory]
+    [InlineData(-1, 45)]
+    [InlineData(43, 65536)]
+    public void OutOfRangeCharArmRetainsElementVeto(int left, int right)
+        => AssertElementVeto(Function(Char, Conditional(left, right)));
+
+    [Theory]
+    [InlineData("Byte", -1)]
+    [InlineData("Byte", 256)]
+    [InlineData("SByte", 128)]
+    [InlineData("UInt16", 65536)]
+    [InlineData("UInt32", -1)]
+    [InlineData(null, 1)]
+    public void EnumRangeOrMissingBackingRetainsElementVeto(string? backing, int value)
+        => AssertElementVeto(EnumFunction(Conditional(value, 0), backing));
+
+    [Fact]
+    public void WideEnumTargetStillRequiresSlotCoercionEvidence()
+    {
+        var function = EnumFunction(Conditional(1, 0), "Int64");
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.Equal(Kind, decision.Type);
+        Assert.Equal(SlotMaterializationVeto.UnrenderableStoreType, decision.Vetoes);
+        AssertRetained(function);
+    }
+
+    [Fact]
+    public void WideCharProducerStillRequiresSlotCoercionEvidence()
+    {
+        var wide = TypeRef.CoreLib("System", "Int64");
+        var function = Function(Char, new Conditional(new LoadArgument(0, "flag", Boolean),
+            new Constant(43L, wide), new Constant(45L, wide)));
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.Equal(Char, decision.Type);
+        Assert.Equal(SlotMaterializationVeto.UnrenderableStoreType, decision.Vetoes);
+        AssertRetained(function);
+    }
+
+    [Fact]
+    public void UnknownEnumShapeDoesNotRecoverIdentity()
+    {
+        var function = EnumFunction(Conditional(1, 0), "Int32");
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape>();
+        AssertElementVeto(function);
+    }
+
+    [Fact]
+    public void NonconstantArmRetainsElementVeto()
+        => AssertElementVeto(Function(Char, new Conditional(
+            new LoadArgument(0, "flag", Boolean),
+            new Constant(43, Int32), new LoadArgument(2, "value", Int32))));
+
+    [Theory]
+    [InlineData("numeric")]
+    [InlineData("other-element")]
+    [InlineData("underivable")]
+    public void EveryObserverStillTestifies(string observer)
+    {
+        var additional = new LoadStackSlot(0, observer == "underivable" ? null : Int32);
+        var function = Function(Char, Conditional(43, 45), observer switch
+        {
+            "numeric" => new StoreArgument(2, "value", Int32, additional),
+            "other-element" => new StoreElement(Int32,
+                new LoadArgument(3, "numbers", TypeRef.SzArray(Int32)), new Constant(0, Int32), additional),
+            "underivable" => new ExpressionStatement(additional),
+            _ => throw new ArgumentOutOfRangeException(nameof(observer)),
+        });
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.Equal(observer == "underivable"
+            ? SlotMaterializationVeto.UnderivableTypeTestimony
+            : SlotMaterializationVeto.ConflictingTypeTestimony, decision.Vetoes);
+        AssertRetained(function);
+    }
+
+    [Fact]
+    public void EveryStoreMustPreserveTheElementValue()
+    {
+        var function = Function(Char, Conditional(43, 45),
+            new StoreStackSlot(0, Conditional(43, 65536)),
+            Element(Char, new LoadStackSlot(0, Int32)));
+        AssertElementVeto(function);
+    }
+
+    [Fact]
+    public void UndecidedDirectCopyRetainsTheWholeComponent()
+    {
+        var function = Function(Char, Conditional(43, 45),
+            new StoreStackSlot(1, new LoadStackSlot(0, Int32)),
+            Element(Char, new LoadStackSlot(1, Int32)));
+        var decisions = SlotMaterializationPass.Analyze(function);
+        Assert.Equal(2, decisions.Count);
+        Assert.All(decisions, decision =>
+            Assert.True(decision.Vetoes.HasFlag(SlotMaterializationVeto.IncompleteCopyComponent)));
+        AssertRetained(function);
+    }
+
+    static Conditional Conditional(int left, int right)
+        => new(new LoadArgument(0, "flag", Boolean),
+            new Constant(left, Int32), new Constant(right, Int32));
+
+    static StoreElement Element(TypeRef type, IrExpression value)
+        => new(type.Equals(Kind) ? Int32 : type,
+            new LoadArgument(1, "values", TypeRef.SzArray(type)), new Constant(0, Int32), value);
+
+    static IrFunction Function(TypeRef target, IrExpression value, params IrNode[] observers)
+    {
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, value));
+        block.Add(Element(target, new LoadStackSlot(0, Int32)));
+        foreach (var observer in observers)
+            block.Add(observer);
+        var body = new BlockContainer();
+        body.Add(block);
+        return new("M", Owner, new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [new Parameter("flag", Boolean), new Parameter("values", TypeRef.SzArray(target)),
+                new Parameter("value", Int32), new Parameter("numbers", TypeRef.SzArray(Int32))],
+            HasThis: false, GenericParameterCount: 0), [], body);
+    }
+
+    static IrFunction EnumFunction(IrExpression value, string? backing)
+    {
+        var function = Function(Kind, value);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [Kind] = TypeShape.Enum };
+        if (backing is not null)
+            function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef>
+                { [Kind] = TypeRef.CoreLib("System", backing) };
+        return function;
+    }
+
+    static void AssertMaterializes(IrFunction function, TypeRef target)
+    {
+        var decision = Assert.Single(SlotMaterializationPass.Analyze(function));
+        Assert.True(decision.WillMaterialize);
+        Assert.Equal(target, decision.Type);
+        new SlotMaterializationPass().Run(function, PassContext.None);
+        new CoercionInsertionPass().Run(function, PassContext.None);
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        Assert.Equal(target, Assert.Single(function.Locals));
+        Assert.Empty(CoercionInvariant.Check(function));
+        function.CheckInvariant();
+    }
+
+    static void AssertElementVeto(IrFunction function)
+    {
+        Assert.Equal(SlotMaterializationVeto.ElementStoreIdentityRecovery,
+            Assert.Single(SlotMaterializationPass.Analyze(function)).Vetoes);
+        AssertRetained(function);
+    }
+
+    static void AssertRetained(IrFunction function)
+    {
+        int stores = function.Descendants.OfType<StoreStackSlot>().Count();
+        int loads = function.Descendants.OfType<LoadStackSlot>().Count();
+        new SlotMaterializationPass().Run(function, PassContext.None);
+        Assert.Equal(stores, function.Descendants.OfType<StoreStackSlot>().Count());
+        Assert.Equal(loads, function.Descendants.OfType<LoadStackSlot>().Count());
+        Assert.Empty(function.Locals);
+        function.CheckInvariant();
+    }
+}

--- a/tests/ILInspector.Decompiler.Tests/SlotMaterializationPassTests.cs
+++ b/tests/ILInspector.Decompiler.Tests/SlotMaterializationPassTests.cs
@@ -527,14 +527,10 @@ public class SlotMaterializationPassTests
         function.CheckInvariant();
     }
 
-    // Adversarial review (5b-2 round 2, blocking): a typed-int slot feeding a
-    // char[] element store is the printer's #1751 identity recovery — the
-    // slot RE-TYPES to char ('+' / '-'), which a materialized int local
-    // forecloses. Slots whose element-store target disagrees with the
-    // testified type stay on the unifier.
     [Fact]
     public void DefersSlotWhoseElementStoreTargetDisagreesWithTestimony()
     {
+        // Scalar producers remain outside conditional element identity recovery.
         var body = new BlockContainer();
         var block = new Block(0);
         block.Add(new StoreStackSlot(0, new Constant(43, Int32)));


### PR DESCRIPTION
Advances #2095 and #2209: make robust decompilation rest on typed IR rather than printer guesses. This slice removes **12 printer lines** and moves **four real char/enum slot webs** into late materialization.

## Demo

In dotnet-inspect.any 0.14.0, both `ReadParameterRefKinds` implementations now declare the retained conditional temporary as `ArgumentRefKind`, rather than carrying an `int` temporary and recovering its enum meaning at the array store. The generated Before/After below shows the real output.

The neighboring char cases are render-neutral: Newtonsoft.Json 13.0.4 `DateTimeUtils.WriteDateTimeOffset` still spells `'+'` / `'-'`; Microsoft.CodeAnalysis 5.0.0 `BitVector.GetDebuggerDisplay` still spells `'1'` / `'0'`. Their identity is now decided before printing.

## Change

**Conclusion: PASS** — the scoped ownership reduction is measured, the fixed-population quality card passes, and the exact head has a clean independent review. This is not deletion of the general unifier, nor a claim of improved opcode fidelity.

- Exact head: `133584b1807027cfcc3541540575014b004aea90`
- Effective base: `8fe09457e9020868f529a7133475093e7f1c0285`
- Normative owner: `docs/design/value-typed-emission.md`, Instance 2 / migration step 5: decided slot identity belongs in typed local IR.
- Complexity basis: reuse the existing testimony, slot-materialization, coercion, and atomic copy-component machinery. The only new admission is representable constant conditionals at char/resolved-enum element sinks.
- Production adoption: one step, already wired through the shared default raising pipeline used by both CLI and Browser/Wasm. No host code, dependency, broad rendering domain, or separate architecture is introduced.
- Retirement: #2095/#2209 continue toward removing `TryChooseUnifiedStackSlotType`. The broader printer fallback remains for lowered/deferred trees; this slice removes shared char-constant classification from the printer and retires the four measured webs.

### Evidence map and shared judgment

| Lens | Scope and fixed identity | Evidence kind | Direction | Result |
| --- | --- | --- | --- | --- |
| Ownership | Same 14 pinned assemblies / 89,065 methods, exact base to head | Product maintenance | Better | Four fewer webs reach the printer |
| Render A/B | Same explicit 13-assembly / 46,945-method subset, bytes, paths, cwd and uncapped selection | Product quality | Same | Two structural changes, both sensor-valid to sensor-valid; no added/removed methods |
| Full Render A/B | All 14 pinned assemblies | Evidence coverage | Not directional | Base acquisition unavailable at the existing #6687 Roslyn projection mismatch |
| Structural review | Same physical `IrImporter.ReadParameterRefKinds`, token `0x060002D7` | Evidence coverage | Not directional | Partial; supported ForStatement/AssignmentStatement rows include the changed consumer; gaps remain |
| PDB Source to After | Same pinned method, PDB-selected source at `8681f6eac3ff44b231925913c3e2b17c8be0ddd4` | Product quality | Not directional | Checksum-matching source; text similarity is not fidelity |
| Same-population quality | Same 14-assembly corpus and sampling identity, validity/fidelity caps 3 | Product quality | Same | Generated card below |
| Compiler-produced witnesses | Existing char fixture and new enum fixture, Release .NET 11 RC1 | Evidence coverage | Better | Activation, binding, retained-temporary OpcodeDiff; not exact IL |
| Whole-member binding | Same two changed pinned enum methods, exact base to head | Product quality | Same | RecompileFail → RecompileFail, unchanged CS0029 `Parameter` name collision |
| Method IL fidelity | Same two changed pinned enum methods | Evidence coverage | Not directional | Unavailable because whole-member binding fails at both revisions |

### Raise contract

| Obligation | Contract |
| --- | --- |
| Lowering shell | `StoreStackSlot(Conditional(condition, constant, constant))`, with integer-typed loads consumed directly as a char/known-enum array value. Real witnesses come from the pinned corpus; compiler-produced char/enum fixtures gate activation. The new enum fixture uses 1/2 rather than 1/0 to avoid current csc's Boolean-result optimization. |
| Consumed ownership | All body-scoped stores and loads of a decided slot become typed locals. Every observer contributes testimony; no outside or underivable observer is silently dropped. All direct-copy members must independently be decided. |
| Control flow | No blocks, edges, conditions, expressions, or evaluation order move. Existing multi-store/cross-block and nested-scope vetoes remain. |
| Replacement | Char values must fit 0..65535. Enum values require known shape and backing and must fit its signed/unsigned range. The pre-existing slot-coercion gate separately rejects unsupported stack widths. |
| Decline boundary | Nonconditional producers, nonconstant/out-of-range arms, missing enum shape/backing, unsupported widths, competing numeric/element observers, underivable observers, and incomplete copy components. |
| Falsifier | Any newly accepted slot changes a stored value, bypasses an observer or copy-component veto, changes effect order, or produces newly invalid output. |

### Before → After: generated structural review

The two real changed methods are `IrImporter.ReadParameterRefKinds` and `MethodDefinitionFacts.ReadParameterRefKinds`. Both have the same enum-local/cast-placement change and sensor-valid → sensor-valid classification. The first method's product-issued documents were also extracted as separate roots and replayed through `--structural-review`.

**Before/After verdicts:** validity sensor True → True, but whole-member binding False → False: both methods retain the existing CS0029 collision between `System.Reflection.Metadata.Parameter` and `ILInspector.Decompiler.Pipeline.Parameter`. Complete-body correctness and IL fidelity are therefore unverified; this slice's value/evaluation-order preservation is supported by its constant-range and all-observer contract and gates. Printer exact is not enrolled. Base/head commits are the exact digests above. Structural gaps do not establish the unsupported declaration correspondence.

**Applied Taste:** neither revision emits section content for this method (`--bare` reports no content); the structured responses are retained. The base acquisition uses the unchanged CLI host with the retained exact-base product dependencies.

# Structural review

Target: ` ILInspector.Decompiler.Pipeline.IrImporter.ReadParameterRefKinds (0x060002D7) `

Structural review status: **Partial** - 22 unsupported or ambiguous nodes were excluded. Supported rows do not establish changes represented only by the gaps below.

## Before

```csharp
int S_1;
int S_2;

bool anyByRef = false;
ImmutableArray<TypeRef>.Enumerator V_2 = parameterTypes.GetEnumerator();

while (V_2.MoveNext())
{
    if (V_2.Current.Kind == TypeRefKind.ByRef)
    {
        anyByRef = true;
        break;
    }
}

if (!anyByRef)
{
    return ImmutableArray<ArgumentRefKind>.Empty;
}

ArgumentRefKind[] kinds = new ArgumentRefKind[parameterTypes.Length];
for (int i = 0; i < kinds.Length; i++)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
raise: ForStatement construct; text changed
{
^
raise: ForStatement construct; text changed
    S_1 = i;
//  ^^^^^^^^
//  raise: ForStatement construct; text changed
    S_2 = parameterTypes[i].Kind == TypeRefKind.ByRef ? 1 : 0;
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//  raise: ForStatement construct; text changed
    kinds[S_1] = (ArgumentRefKind)S_2;
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//  raise: ForStatement construct; text changed
//  raise: AssignmentStatement body; text changed
}
^
raise: ForStatement construct; text changed

foreach (ParameterHandle handle in method.GetParameters())
{
    Parameter parameter = reader.GetParameter(handle);
    int index = parameter.SequenceNumber - 1;
    if (index >= 0 && index < kinds.Length && parameterTypes[index].Kind == TypeRefKind.ByRef)
    {
        kinds[index] = ClassifyByRefParameter(reader, parameter);
    }
}
return ImmutableArray.Create<ArgumentRefKind>(kinds);

```

## After

```csharp
int S_1;
ArgumentRefKind S_2;

bool anyByRef = false;
ImmutableArray<TypeRef>.Enumerator V_2 = parameterTypes.GetEnumerator();

while (V_2.MoveNext())
{
    if (V_2.Current.Kind == TypeRefKind.ByRef)
    {
        anyByRef = true;
        break;
    }
}

if (!anyByRef)
{
    return ImmutableArray<ArgumentRefKind>.Empty;
}

ArgumentRefKind[] kinds = new ArgumentRefKind[parameterTypes.Length];
for (int i = 0; i < kinds.Length; i++)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
raise: ForStatement construct; text changed
{
^
raise: ForStatement construct; text changed
    S_1 = i;
//  ^^^^^^^^
//  raise: ForStatement construct; text changed
    S_2 = (ArgumentRefKind)(parameterTypes[i].Kind == TypeRefKind.ByRef ? 1 : 0);
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//  raise: ForStatement construct; text changed
    kinds[S_1] = S_2;
//  ^^^^^^^^^^^^^^^^^
//  raise: ForStatement construct; text changed
//  raise: AssignmentStatement body; text changed
}
^
raise: ForStatement construct; text changed

foreach (ParameterHandle handle in method.GetParameters())
{
    Parameter parameter = reader.GetParameter(handle);
    int index = parameter.SequenceNumber - 1;
    if (index >= 0 && index < kinds.Length && parameterTypes[index].Kind == TypeRefKind.ByRef)
    {
        kinds[index] = ClassifyByRefParameter(reader, parameter);
    }
}
return ImmutableArray.Create<ArgumentRefKind>(kinds);

```

## Structural diff

| Change | Structure | Region |
| --- | --- | --- |
| Changed | ForStatement | Construct |
| Changed | AssignmentStatement | Body |

## Correspondence gaps

| Side | Reason | Count | Example nodes |
| --- | --- | ---: | --- |
| Before | Unsupported | 2 | 39, 40 |
| Before | Ambiguous | 9 | 15, 16, 19, 20, 26 (+4 more) |
| After | Unsupported | 3 | 29, 40, 41 |
| After | Ambiguous | 8 | 15, 16, 19, 20, 26 (+3 more) |

### PDB Source → After

```text
PDB source     https://raw.githubusercontent.com/richlander/dotnet-inspect/8681f6eac3ff44b231925913c3e2b17c8be0ddd4/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
Integrity      PDB source document bytes match portable-PDB SHA256 checksum 3CF7726F11C1A1C68E274157BDE136D33F4ADA57BD258ADF144FFE313323CB90.
Added lines    0
Removed lines  0
Changed lines  16 PDB comparison -> 47 Decompiled comparison
Moved lines    0 PDB comparison -> 0 Decompiled comparison
```

### Fully raised

The intended endpoint remains a directly expressed enum conditional using member names, with no synthetic stack-slot temporary. This slice deliberately retains temporaries and does not move the array/index/value evaluations.

### Ownership census

| Metric | Base | Head |
| --- | ---: | ---: |
| Materialized webs | 1,547 | 1,551 |
| Deferred webs after materialization | 40,220 | 40,216 |
| Element-store identity vetoes | 4 | 0 |
| Actual printer-unifier slots | 40,213 | 40,209 |
| Actual printer StoreStackSlot nodes | 46,135 | 46,131 |
| Actual printer LoadStackSlot nodes | 70,801 | 70,797 |
| Multi-candidate slots unified by printer | 299 | 297 |
| Un-unified split slots | 188 | 188 |

All census rows use the same 14 assemblies / 89,065 methods; both revisions have zero pass bugs. The zero element veto count describes this corpus, not universal support.

### Same-population quality

### Decompiler quality diff

| Metric | Change |
| ------ | ------ |
| Detected lowering residue ↓ | 10,428 (11.71%) → 10,428 (11.71%) (0 methods) |
| Conditional-branch residue ↓ | 2,359 (2.65%) → 2,359 (2.65%) (0 methods) |
| Forward-merge stops ↓ | 2,253 (2.53%) → 2,253 (2.53%) (0 methods) |
| Full malformed ↓ | 0 → 0 (0) |
| Semantic defects ↓ | 1 (2.38%) → 1 (2.38%) (0 methods) |
| Fidelity opcode diffs ↓ | 5 (13.89%) → 5 (13.89%) (0 methods) |
| Fidelity operand diffs ↓ | 0 (0.00%) → 0 (0.00%) (0 methods) |
| Fidelity unavailable comparisons ↓ | 0 (0.00%) → 0 (0.00%) (0 methods) |
| Fidelity not Full ↓ | 0 (0.00%) → 0 (0.00%) (0 methods) |
| Fidelity recompile failures ↓ | 0 (0.00%) → 0 (0.00%) (0 methods) |
| Fidelity context failures ↓ | 0 (0.00%) → 0 (0.00%) (0 methods) |
| Pass bugs ↓ | 0 → 0 (0) |
| Fidelity check coverage ↑ | 36 (0.04%) → 36 (0.04%) (0 methods) |
| Fidelity exact (contract v3; EH-blind) ↑ | 31 (86.11%) → 31 (86.11%) (0 methods) |
| Fully raised ↑ | 39 (33.05%) → 39 (33.05%) (0 methods) |

**Input**

- Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
- Corpus profile: real-world
- Method cap: uncapped
- Per-assembly fidelity cap: 3

**Analysis**

- Correctness coverage: validity compiled 42 methods (compile-cap 3; per-sample, not corpus-wide); fidelity (compile-back) sampled 36 / 89,065 (0.04%)
- Pinned control-flow raises: 0 lost, 0 gained across 161,978 stable sites.
- Current measured debt: 10,428 methods with detected lowering residue; 1 semantic defect among 42 checked; 5 fidelity opcode diffs among 36 checked.
- Regression verdict: PASS — corpus sensor matched baseline tolerances.

Pinned-subset gate (PR quick rate/count regressions evaluated here): detected lowering residue 11.71% -> 11.71% (0 pp); conditional-branch residue 2.65% -> 2.65% (0 pp); Full malformed 0 -> 0 (0); semantic defects 1 -> 1 (0); opcode diffs 5 -> 5 (0).

## Validation

- Focused Release gates: 216 passed, including `ElementSlotIdentityTests`, slot materialization, char-element binding, coercion invariants, coercion rendering, and enum rendering.
- Release solution build passed after restoring the missing worktree assets; three existing SYSLIB1227 fixture warnings.
- Changed Markdown and `git diff --check` pass.
- Fast decompiler gate: 6,899 passed. The initial run's four missing-fixture failures were resolved by building the normal solution graph before the complete rerun.
- Independent exact-base/head whole-member fidelity: both changed pinned methods remain `RecompileFail` with the same CS0029 `Parameter` collision. Both compiler-produced fixtures remain `OpcodeDiff`, with identical base/head recompiled opcode streams. Sensor-valid does not mean whole-member binding or exact fidelity.
- Full Render A/B was attempted and remains unavailable on the unchanged base at `Microsoft.CodeAnalysis.CSharp.LocalRewriter.MergeArgumentsAndSideEffects` (#6687). The explicit 13-assembly subset excludes that assembly, not individual inconvenient methods.
- Exact-base/head census, Render A/B, strict structural documents, source comparison, and quality-card artifacts are retained under `artifacts/element-slot-evidence/`.

Current-head `ci-required` passed, and the independent fixed-head review is clean. Public reconciliation is recorded separately. Merge remains separately authorized.
