### PR TITLE
ts-jsexport: project generic JSON records and closed uses

### DIFF
--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -259,7 +259,12 @@ arguments are JSON wire types. Closed uses retain their structured argument
 identities. A parameter embedded inside a case signature remains unsupported:
 substituting a wire type into a CLR container is not generally faithful
 (`T[]` writes an array for `T = int`, but a Base64 string for `T = byte`).
-This boundary does not add general generic DTO support.
+Generic JSON records with direct, recursively parametric members use generic
+TypeScript interfaces. Closed constructions are discovered only from
+authenticated source-generated JSON roots, and their arguments are substituted
+through supported records, arrays, dictionaries, nullable values, and unions.
+Open, embedded non-parametric, or unauthenticated constructions fail visibly
+before publication; the boundary does not infer arbitrary CLR generic shapes.
 
 Deserialize-reached unions, unavailable case/null evidence, unsupported
 converters, unmapped alternatives, and recursive union-case alias components

--- a/eng/test-ts-jsexport-typescript.sh
+++ b/eng/test-ts-jsexport-typescript.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-scratch=$(mktemp -d)
+scratch="$repo_root/artifacts/ts-jsexport-typescript-test"
+rm -rf "$scratch"
+mkdir -p "$scratch"
 trap 'rm -rf "$scratch"' EXIT
 
 dotnet_root=${DOTNET_ROOT:-$(dirname "$(command -v dotnet)")}
@@ -65,6 +67,8 @@ import {
   getCollectionSelection,
   getDefaultSelection,
   getFlagSelection,
+  getGenericRecordIntAsync,
+  getGenericRecordWidgetAsync,
   getKindSelection,
   getOutcomeSelection,
   getSelectionEnvelopeAsync,
@@ -75,6 +79,7 @@ import type {
   Boxed,
   CollectionSelection,
   FlagSelection,
+  GenericRecord,
   KindSelection,
   OutcomeSelection,
   SelectionEnvelope,
@@ -239,6 +244,26 @@ export async function summarizeEnvelope(): Promise<string> {
     describeBoxed(envelope.count, envelope.widget),
     describeBlob(envelope.blob),
     describeGroup(envelope.group),
+  ].join("|");
+}
+
+export async function summarizeGenericRecords(): Promise<string> {
+  const numbers: GenericRecord<number> = await getGenericRecordIntAsync();
+  const widgets: GenericRecord<WidgetDto> =
+    await getGenericRecordWidgetAsync("sample");
+  return [
+    numbers.content,
+    numbers.nested.value,
+    numbers.items.join(","),
+    numbers.lookup["missing"],
+    numbers.choice,
+    widgets.content.name,
+    widgets.nested.value.count,
+    widgets.items[0]?.count,
+    widgets.lookup["missing"]?.name ?? "null",
+    typeof widgets.choice === "object" && widgets.choice !== null
+      ? widgets.choice.count
+      : "unexpected",
   ].join("|");
 }
 TS
@@ -430,6 +455,11 @@ expect_union_facade_compile_failure \
   'Boxed<string>' \
   '^export function getBoxedCount'
 expect_union_facade_compile_failure \
+  generic-record-closed-argument \
+  'GenericRecord<number>' \
+  'GenericRecord<string>' \
+  '^export async function getGenericRecordIntAsync'
+expect_union_facade_compile_failure \
   union-closed-byte-array-argument \
   'Wrapped<string>' \
   'Wrapped<number>' \
@@ -471,5 +501,10 @@ expect_union_usage_compile_failure \
   union-closed-generic-mismatch \
   'describeBoxed\(getBoxedCount\(11\), getBoxedWidget\("boxed"\)\)' \
   'describeBoxed(getBoxedWidget("boxed"), getBoxedCount(11))'
+
+expect_union_usage_compile_failure \
+  generic-record-closed-mismatch \
+  'numbers: GenericRecord<number>' \
+  'numbers: GenericRecord<WidgetDto>'
 
 echo "ts-jsexport TypeScript compiler gates passed."

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/README.md
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/README.md
@@ -30,6 +30,11 @@ lowering contract in
   in a case signature, such as `T[]`, stays unsupported and lives in
   `ILInspector.JsExportSurface.UnionFixtures`.
 - `SelectionEnvelope` — union-valued members, arrays, and dictionaries.
+- `GenericRecord<TValue>` — a source-generated generic record whose direct,
+  nested-record, array, dictionary, and generic-union members are projected
+  through `TValue`. The fixture exports closed `int` and `WidgetDto`
+  constructions so declaration emission and facade signatures are checked
+  against both scalar and record arguments.
 
 Every union export writes with the source-generated
 `UnionFixtureJsonContext`, so the fixture reaches serialization only. Reading a

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
@@ -9,6 +9,15 @@ public sealed record WidgetDto(string Name, int Count);
 
 public sealed record RuntimeAPI(string Value);
 
+public sealed record GenericNested<TValue>(TValue Value);
+
+public sealed record GenericRecord<TValue>(
+    TValue Content,
+    GenericNested<TValue> Nested,
+    TValue[] Items,
+    IReadOnlyDictionary<string, TValue> Lookup,
+    Boxed<TValue> Choice);
+
 public sealed record BlobDto(
     byte[] Blob,
     byte[]? MaybeBlob,
@@ -49,6 +58,11 @@ internal sealed partial class FixtureJsonContext : JsonSerializerContext;
 [JsonSerializable(typeof(BlobDto))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class BlobFixtureJsonContext : JsonSerializerContext;
+
+[JsonSerializable(typeof(GenericRecord<int>))]
+[JsonSerializable(typeof(GenericRecord<WidgetDto>))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class GenericRecordJsonContext : JsonSerializerContext;
 
 [SupportedOSPlatform("browser")]
 public static partial class TypeScriptFixtureExports
@@ -162,6 +176,38 @@ public static partial class TypeScriptFixtureExports
                     ["none"] = null,
                 }),
             BlobFixtureJsonContext.Default.BlobDto);
+    }
+
+    [JSExport]
+    public static async Task<string> GetGenericRecordIntAsync()
+    {
+        await Task.Yield();
+        return JsonSerializer.Serialize(
+            new GenericRecord<int>(
+                7,
+                new GenericNested<int>(8),
+                [1, 2],
+                new Dictionary<string, int> { ["missing"] = 0 },
+                new Boxed<int>(9)),
+            GenericRecordJsonContext.Default.GenericRecordInt32);
+    }
+
+    [JSExport]
+    public static async Task<string> GetGenericRecordWidgetAsync(
+        string name)
+    {
+        await Task.Yield();
+        return JsonSerializer.Serialize(
+            new GenericRecord<WidgetDto>(
+                new WidgetDto(name, 10),
+                new GenericNested<WidgetDto>(new WidgetDto(name, 11)),
+                [new WidgetDto(name, 12)],
+                new Dictionary<string, WidgetDto>
+                {
+                    ["missing"] = null!,
+                },
+                new Boxed<WidgetDto>(new WidgetDto(name, 13))),
+            GenericRecordJsonContext.Default.GenericRecordWidgetDto);
     }
 
     [JSExport]

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -532,14 +532,102 @@ static class DtsEmitter
                 surface.AssemblyIdentity,
                 identityNames,
                 surface.AssemblyIdentity is { } unionAssembly
-                    ? surface.Unions
-                        .Where(union => union.Definition.TypeParameters.Count > 0)
+                    ? declarationTypes
+                        .Where(type => type.TypeParameters.Count > 0)
                         .ToDictionary(
-                            union => new ApiTypeReferenceIdentity(
-                                unionAssembly, union.Definition.FullName, union.Definition.DefinitionName),
-                            union => union.Definition.TypeParameters.Count)
+                            type => new ApiTypeReferenceIdentity(
+                                unionAssembly, type.FullName, type.DefinitionName),
+                            type => type.TypeParameters.Count)
                     : new Dictionary<ApiTypeReferenceIdentity, int>(),
+                GenericTypeNames(declarationTypes, allocatedTypeNames),
+                GenericTypeNameArities(declarationTypes, allocatedTypeNames),
                 delegateMappingContext));
+    }
+
+    static string[] GenericParameterNames(
+        ApiType type,
+        TypeMappingEnvironment environment)
+    {
+        if (type.TypeParameters.Count == 0)
+            return [];
+
+        var usedNames = new HashSet<string>(
+            environment.IdentityNames.Values,
+            StringComparer.Ordinal);
+        var names = new string[type.TypeParameters.Count];
+        for (int index = 0; index < names.Length; index++)
+        {
+            string name = $"T{index}";
+            while (!usedNames.Add(name))
+                name += "_";
+            names[index] = name;
+        }
+        return names;
+    }
+
+    static Dictionary<string, string> GenericTypeNames(
+        IEnumerable<ApiType> types,
+        IReadOnlyDictionary<ApiType, string>? allocatedTypeNames)
+    {
+        var names = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (ApiType type in types.Where(type => type.TypeParameters.Count > 0))
+        {
+            string allocatedName = AllocatedTypeName(type, allocatedTypeNames);
+            foreach (string? alias in new string?[]
+            {
+                type.Name,
+                type.FullName,
+                type.MetadataName,
+                allocatedName,
+            })
+            {
+                if (!string.IsNullOrEmpty(alias))
+                {
+                    names.TryAdd(alias, allocatedName);
+                    names.TryAdd(RemoveMetadataArity(alias), allocatedName);
+                }
+            }
+        }
+        return names;
+    }
+
+    static Dictionary<string, int> GenericTypeNameArities(
+        IEnumerable<ApiType> types,
+        IReadOnlyDictionary<ApiType, string>? allocatedTypeNames)
+    {
+        var arities = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (ApiType type in types.Where(type => type.TypeParameters.Count > 0))
+        {
+            foreach (string? alias in new string?[]
+            {
+                type.Name,
+                type.FullName,
+                type.MetadataName,
+                AllocatedTypeName(type, allocatedTypeNames),
+            })
+            {
+                if (!string.IsNullOrEmpty(alias))
+                {
+                    arities.TryAdd(alias, type.TypeParameters.Count);
+                    arities.TryAdd(RemoveMetadataArity(alias), type.TypeParameters.Count);
+                }
+            }
+        }
+        return arities;
+    }
+
+    static string RemoveMetadataArity(string name)
+    {
+        string segment = name;
+        int lastDot = name.LastIndexOf('.');
+        if (lastDot >= 0)
+            segment = name[(lastDot + 1)..];
+
+        int arity = segment.LastIndexOf('`');
+        if (arity < 0)
+            return name;
+
+        return name[..(lastDot + 1)] + segment[..arity];
     }
 
     static IReadOnlyDictionary<string, string> MappedTypeNames(
@@ -578,8 +666,7 @@ static class DtsEmitter
 
     internal static string PreferredTypeName(ApiType type)
     {
-        if (type.HasUnionAttribute == true
-            && type.TypeParameters.Count > 0
+        if (type.TypeParameters.Count > 0
             && type.DefinitionName is { } definition)
         {
             string segment = definition.Segments[^1];
@@ -720,6 +807,23 @@ static class DtsEmitter
             return;
         }
 
+        string[] genericParameters =
+            GenericParameterNames(record, typeEnvironment);
+        IReadOnlyDictionary<string, string> recordTypeNames =
+            MappedTypeNames(typeEnvironment, []);
+        if (record.TypeParameters.Count > 0)
+        {
+            var names = new Dictionary<string, string>(
+                recordTypeNames,
+                StringComparer.Ordinal);
+            for (int index = 0; index < record.TypeParameters.Count; index++)
+            {
+                names[record.TypeParameters[index].Name] =
+                    genericParameters[index];
+            }
+            recordTypeNames = names;
+        }
+
         var members = record.Members
             .Where(member => JsonWireMemberRules.IsSerialized(
                 member,
@@ -731,7 +835,10 @@ static class DtsEmitter
                 ResolvedName: member.JsonPropertyName ?? ApplyNamingPolicy(member.Name, namingPolicy)))
             .ToArray();
 
-        sb.Append("export interface ").Append(declarationName).Append(" {\n");
+        sb.Append("export interface ").Append(declarationName);
+        if (genericParameters.Length > 0)
+            sb.Append('<').AppendJoin(", ", genericParameters).Append('>');
+        sb.Append(" {\n");
 
         foreach ((ApiMember member, string resolvedName) in members)
         {
@@ -758,7 +865,13 @@ static class DtsEmitter
                     MappedTypeNames(
                         typeEnvironment,
                         member.SignatureModel?.ReturnTypeReferences
-                            ?? []),
+                            ?? [])
+                        .Concat(recordTypeNames)
+                        .GroupBy(item => item.Key, StringComparer.Ordinal)
+                        .ToDictionary(
+                            group => group.Key,
+                            group => group.Last().Value,
+                            StringComparer.Ordinal),
                     member.SignatureModel?.ReturnTypeShape,
                     typeEnvironment.IdentityNames,
                     typeEnvironment.UnionContext);

--- a/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
@@ -7,6 +7,8 @@ sealed record TsJsonUnionMappingContext(
     ApiAssemblyIdentity? Assembly,
     IReadOnlyDictionary<ApiTypeReferenceIdentity, string> Names,
     IReadOnlyDictionary<ApiTypeReferenceIdentity, int> GenericArities,
+    IReadOnlyDictionary<string, string> GenericNames,
+    IReadOnlyDictionary<string, int> GenericNameArities,
     TsDelegateMappingContext LocalTypes);
 
 static class TsJsonUnionMapper

--- a/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
@@ -409,11 +409,56 @@ static class TsTypeMapper
         }
 
         if (mappingContext == TsTypeMappingContext.JsonWire
-            && typeShape is { Kind: ApiTypeShapeKind.GenericInstance, Definition: { } unionIdentity }
-            && unionContext?.GenericArities.ContainsKey(unionIdentity) == true)
+            && typeShape is
+            {
+                Kind: ApiTypeShapeKind.GenericInstance,
+                Definition: { } closedGenericIdentity,
+            }
+            && unionContext?.GenericArities.ContainsKey(closedGenericIdentity) == true)
         {
             return TsJsonUnionMapper.MapClosedShape(
-                typeShape, unionContext, location ?? trimmed);
+                typeShape,
+                unionContext,
+                location ?? trimmed);
+        }
+
+        if (mappingContext == TsTypeMappingContext.JsonWire
+            && unionContext is not null
+            && TryParseGenericType(
+                trimmed,
+                out string? genericDefinition,
+                out IReadOnlyList<string> genericArguments)
+            && TryGetGenericName(
+                genericDefinition!,
+                unionContext,
+                mappedTypeNames,
+                out string? genericName,
+                out int genericArity))
+        {
+            if (genericArguments.Count != genericArity)
+            {
+                throw new UnsupportedWireContractException(
+                    location ?? trimmed,
+                    "generic JSON construction has the wrong arity");
+            }
+
+            string[] mappedArguments = new string[genericArguments.Count];
+            for (int index = 0; index < mappedArguments.Length; index++)
+            {
+                mappedArguments[index] = Map(
+                    genericArguments[index],
+                    recordNames,
+                    diagnostics,
+                    location,
+                    blockedAliases,
+                    mappedTypeNames,
+                    mappingContext,
+                    GenericArgumentShape(typeShape, index),
+                    identityNames,
+                    unionContext);
+            }
+
+            return $"{genericName}<{string.Join(", ", mappedArguments)}>";
         }
 
         if (typeShape is
@@ -1507,6 +1552,30 @@ static class TsTypeMapper
         return TrySplitGenericArguments(
             typeName[(genericStart + 1)..^1],
             out arguments);
+    }
+
+    static bool TryGetGenericName(
+        string definition,
+        TsJsonUnionMappingContext context,
+        IReadOnlyDictionary<string, string>? mappedTypeNames,
+        out string? name,
+        out int arity)
+    {
+        string simpleName = LastSegment(definition);
+        if (!context.GenericNameArities.TryGetValue(definition, out arity)
+            && !context.GenericNameArities.TryGetValue(simpleName, out arity))
+        {
+            name = null;
+            arity = 0;
+            return false;
+        }
+
+        if (mappedTypeNames?.TryGetValue(definition, out name) == true
+            || mappedTypeNames?.TryGetValue(simpleName, out name) == true)
+            return true;
+
+        return context.GenericNames.TryGetValue(definition, out name)
+            || context.GenericNames.TryGetValue(simpleName, out name);
     }
     static bool IsPrimitiveByteArray(
         string csharpType,

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
@@ -33,6 +33,8 @@ for (
     "boxedCount",
     "boxedWidget",
     "wrappedBlob",
+    "genericRecordInt",
+    "genericRecordWidget",
     "selectionEnvelope",
   ]
 ) {
@@ -81,6 +83,10 @@ const getBoxedWidgetKey =
   facadeSource.match(/"(GetBoxedWidget\.-?\d+)"/)?.[1];
 const getWrappedBlobKey =
   facadeSource.match(/"(GetWrappedBlob\.-?\d+)"/)?.[1];
+const getGenericRecordIntAsyncKey =
+  facadeSource.match(/"(GetGenericRecordIntAsync\.-?\d+)"/)?.[1];
+const getGenericRecordWidgetAsyncKey =
+  facadeSource.match(/"(GetGenericRecordWidgetAsync\.-?\d+)"/)?.[1];
 const getSelectionEnvelopeAsyncKey =
   facadeSource.match(/"(GetSelectionEnvelopeAsync\.-?\d+)"/)?.[1];
 const observeValueKey =
@@ -174,6 +180,14 @@ assert.ok(
 assert.ok(
   getWrappedBlobKey,
   "The generated GetWrappedBlob runtime dispatch key was not found.",
+);
+assert.ok(
+  getGenericRecordIntAsyncKey,
+  "The generated GetGenericRecordIntAsync runtime dispatch key was not found.",
+);
+assert.ok(
+  getGenericRecordWidgetAsyncKey,
+  "The generated GetGenericRecordWidgetAsync runtime dispatch key was not found.",
 );
 assert.ok(
   getSelectionEnvelopeAsyncKey,
@@ -293,6 +307,12 @@ function managedExports(methods = {}) {
               methods.getBoxedWidget ?? (() => unionPayloads.boxedWidget),
             [getWrappedBlobKey]:
               methods.getWrappedBlob ?? (() => unionPayloads.wrappedBlob),
+            [getGenericRecordIntAsyncKey]:
+              methods.getGenericRecordIntAsync
+              ?? (async () => unionPayloads.genericRecordInt),
+            [getGenericRecordWidgetAsyncKey]:
+              methods.getGenericRecordWidgetAsync
+              ?? (async () => unionPayloads.genericRecordWidget),
             [getSelectionEnvelopeAsyncKey]:
               methods.getSelectionEnvelopeAsync
               ?? (async () => unionPayloads.selectionEnvelope),
@@ -468,6 +488,26 @@ async function freshFacade() {
   // A closed byte[] union argument keeps its Base64 JSON string wire form.
   assert.equal(facade.getWrappedBlob(), "AQID");
   assert.deepEqual(
+    await facade.getGenericRecordIntAsync(),
+    {
+      content: 7,
+      nested: { value: 8 },
+      items: [1, 2],
+      lookup: { missing: 0 },
+      choice: 9,
+    },
+  );
+  assert.deepEqual(
+    await facade.getGenericRecordWidgetAsync("sample"),
+    {
+      content: { name: "sample", count: 10 },
+      nested: { value: { name: "sample", count: 11 } },
+      items: [{ name: "sample", count: 12 }],
+      lookup: { missing: null },
+      choice: { name: "sample", count: 13 },
+    },
+  );
+  assert.deepEqual(
     await facade.getSelectionEnvelopeAsync("envelope"),
     {
       result: { name: "envelope", count: 5 },
@@ -500,6 +540,10 @@ async function freshFacade() {
     await unionUsage.summarizeEnvelope(),
     "envelope:5|first|envelope:6|outcome|kind-0|7/envelope|blob:BAU="
       + "|group:envelope,null",
+  );
+  assert.equal(
+    await unionUsage.summarizeGenericRecords(),
+    "7|8|1,2|0|9|sample|11|12|null|13",
   );
   assert.equal(unionUsage.missingSelectionEntry, null);
   assert.equal(unionUsage.missingMapEntry, null);

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
@@ -32,6 +32,12 @@ if (args is not [string outputPath])
     ("boxedWidget", TypeScriptFixtureExports.GetBoxedWidget("boxed")),
     ("wrappedBlob", TypeScriptFixtureExports.GetWrappedBlob()),
     (
+        "genericRecordInt",
+        await TypeScriptFixtureExports.GetGenericRecordIntAsync()),
+    (
+        "genericRecordWidget",
+        await TypeScriptFixtureExports.GetGenericRecordWidgetAsync("sample")),
+    (
         "selectionEnvelope",
         await TypeScriptFixtureExports.GetSelectionEnvelopeAsync("envelope")),
 ];

--- a/tests/ILInspector.JsExportSurface.Tests/TypeScriptFacadeEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/TypeScriptFacadeEmitterTests.cs
@@ -581,6 +581,118 @@ public sealed class TypeScriptFacadeEmitterTests
     }
 
     [Fact]
+    public void Emit_ProjectsGenericRecordDeclarationsAndClosedJsonRoots()
+    {
+        string path = typeof(global::ILInspector.JsExportSurface.TypeScriptFixtures
+            .TypeScriptFixtureExports).Assembly.Location;
+        global::ILInspector.JsExportSurface.JsExportSurface surface =
+            BuildSurface(path);
+
+        string source = TypeScriptFacadeEmitter.Emit(surface, RuntimeModule);
+
+        Assert.Contains(
+            """
+            export interface GenericNested<T0> {
+              readonly value: T0;
+            }
+            """,
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            """
+            export interface GenericRecord<T0> {
+              readonly content: T0;
+              readonly nested: GenericNested<T0>;
+              readonly items: ReadonlyArray<T0>;
+              readonly lookup: Readonly<Record<string, T0>>;
+              readonly choice: Boxed<T0>;
+            }
+            """,
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export async function getGenericRecordIntAsync(): "
+                + "Promise<GenericRecord<number>>",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export async function getGenericRecordWidgetAsync(name: string): "
+                + "Promise<GenericRecord<WidgetDto>>",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Emit_ReportsUnregisteredGenericRecordConstruction()
+    {
+        var record = new ApiType
+        {
+            Namespace = "Fixture",
+            Name = "GenericRecord",
+            Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "TValue" }],
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Value",
+                    Kind = "property",
+                    HasGetter = true,
+                    IndexParameterCount = 0,
+                    ReturnType = "Missing<TValue>",
+                },
+            ],
+        };
+        var diagnostics = new TypeScriptGenerationDiagnostics();
+        string source = DtsEmitter.Emit(
+            new global::ILInspector.JsExportSurface.JsExportSurface
+            {
+                Records = [record],
+            },
+            diagnostics);
+
+        Assert.Contains("readonly Value: unknown;", source, StringComparison.Ordinal);
+        Assert.Contains(
+            diagnostics.UnmappedTypes,
+            diagnostic => diagnostic.CSharpType == "Missing<TValue>");
+    }
+
+    [Fact]
+    public void Emit_ReportsOpenGenericRecordUseWithoutWireShape()
+    {
+        var record = new ApiType
+        {
+            Namespace = "Fixture",
+            Name = "GenericRecord",
+            Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "TValue" }],
+        };
+        var diagnostics = new TypeScriptGenerationDiagnostics();
+        _ = DtsEmitter.Emit(
+            new global::ILInspector.JsExportSurface.JsExportSurface
+            {
+                AssemblyIdentity = AssemblyIdentity(),
+                Records = [record],
+                Functions =
+                [
+                    new JsExportFunction
+                    {
+                        DeclaringType = "Fixture.Exports",
+                        Name = "Get",
+                        RuntimeDispatchKey = "Get.1",
+                        ReturnType = "string",
+                        ReturnWireType = "Fixture.GenericRecord<TValue>",
+                    },
+                ],
+            },
+            diagnostics);
+
+        Assert.Contains(
+            diagnostics.UnmappedTypes,
+            diagnostic => diagnostic.CSharpType == "TValue");
+    }
+
+    [Fact]
     public void Emit_ReservesModuleInteropNamesAndParsesNullableJsonEnvelope()
     {
         global::ILInspector.JsExportSurface.JsExportSurface surface =


### PR DESCRIPTION
## Summary

Adds generic JSON-record projection to `ts-jsexport`, including reusable generic TypeScript interfaces and exact closed uses discovered from authenticated source-generated System.Text.Json roots. It also resolves referenced JSON wire definitions from explicit assembly search paths without granting those assemblies unrelated JavaScript export ownership.

## Demo

Before:

```text
InspectionEnvelope<TypeDependencySectionResult>
  -> manual Browser-only transport mirror
```

After this predecessor:

```text
InspectionEnvelope<TypeDependencySectionResult>
  -> generic JSON record declaration
  -> InspectionEnvelope<TypeDependencySectionResult>
```

The follow-up stacked slice is PR #6736, which consumes the exact closed envelope and removes its Browser envelope/content/Share/diagnostic mirror.

## Stack

This is the bottom slice of the #6712 stack. PR #6736 targets this branch and supplies the CLI/Inspect Web adoption.

## Validation

- `dotnet run --project tests/ILInspector.JsExportSurface.Tests -c Release` — 544/544 passed
- `./eng/test-ts-jsexport-typescript.sh` — compiler gates and runtime probe passed
- `./eng/generate-inspect-web-engine-facade.sh --check` — generated declarations and runtime canary passed through the stacked consumer
- `npx --yes markdownlint-cli docs/design/ts-jsexport.md docs/design/inspection-envelope.md` and `git diff --check` — passed

Closes #6739.