### PR TITLE
ts-jsexport: project generic JSON records

### DIFF
--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -311,6 +311,13 @@ instantiation, so `GenericEnvelope<byte[]>` is exposed as
 JavaScript ABI, and generic `[JSExport]` methods and generic `JsExportRoot`
 types remain unsupported.
 
+Structured shape owns each argument's identity and CLR construction; the
+corresponding reachable member signature supplies nullable-reference
+annotations that the structural metadata view does not retain. The mapper
+combines those two views by argument position, so `GenericEnvelope<string?>`
+becomes `GenericEnvelope<string | null>` without accepting a display-text
+lookalike as identity evidence.
+
 The initial contract intentionally admits only direct type-parameter members,
 including their direct nullable form. A parameter embedded in a CLR shape is
 not generally parametric in the corresponding TypeScript wire type. For
@@ -335,7 +342,7 @@ reachable wire graph is authenticated.
 `eng/test-ts-jsexport-typescript.sh` compiles consumers of two distinct closed
 constructions, rejects a mismatched argument, and executes the facade against
 real source-generated System.Text.Json payloads, including the wire-sensitive
-`byte[]` argument.
+`byte[]` argument and a null value carried by a nullable-reference argument.
 
 ### Public facade view
 

--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -327,6 +327,11 @@ conservatively nullable. A direct `GenericEnvelope<byte[]>` root is therefore
 This is disclosure of unavailable evidence, not a claim that every producer
 writes null.
 
+Union case signatures have the same nested-annotation erasure. When an
+authenticated union alternative is a generic record, its reference-shaped
+arguments are therefore conservative by the same rule; an outer union `null`
+alternative cannot substitute for a nullable member inside a non-null record.
+
 The initial contract intentionally admits only direct type-parameter members,
 including their direct nullable form. A parameter embedded in a CLR shape is
 not generally parametric in the corresponding TypeScript wire type. For
@@ -339,6 +344,10 @@ arguments because each argument is mapped from its own closed wire shape.
 
 The projection retains the existing naming, direction, converter,
 constructor-binding, scoped-identity, and declaration-name allocation rules.
+Retained concrete field references preserve matching concrete components,
+including array elements, when field metadata lacks a structured return shape.
+A genuine parameter component has no such concrete identity and still reaches
+the non-parametric rejection boundary.
 It does not invent serializer support for the record's reachable graph:
 envelope Share, diagnostic, content, and collection types must independently
 carry supported System.Text.Json evidence. The production adoption path is
@@ -352,8 +361,9 @@ reachable wire graph is authenticated.
 constructions, rejects a mismatched argument, and executes the facade against
 real source-generated System.Text.Json payloads, including the wire-sensitive
 `byte[]` argument, a direct root whose erased reference argument carries null,
-a nullable-reference member argument, and a concrete included-field identity
-that collides with a generic parameter name.
+a nullable-reference member argument, a union alternative carrying a generic
+record with null content, and direct and array-valued included-field identities
+that collide with a generic parameter name.
 
 ### Public facade view
 

--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -259,7 +259,6 @@ arguments are JSON wire types. Closed uses retain their structured argument
 identities. A parameter embedded inside a case signature remains unsupported:
 substituting a wire type into a CLR container is not generally faithful
 (`T[]` writes an array for `T = int`, but a Base64 string for `T = byte`).
-This boundary does not add general generic DTO support.
 
 Deserialize-reached unions, unavailable case/null evidence, unsupported
 converters, unmapped alternatives, and recursive union-case alias components
@@ -275,6 +274,68 @@ The four-step adoption path remains Metadata evidence, JsExportSurface
 evidence, this CLI generation/harness slice, and inspect-web browser/Wasm
 adoption. The existing TypeScript emitter owns this format lowering; no new
 human-readable rendering path or architecture retirement is needed.
+
+### Generic JSON record projection
+
+Issue [#6739](https://github.com/richlander/dotnet-inspect/issues/6739)
+extends the same authenticated wire view to generic records. Its motivating
+consumer is the host-neutral
+`InspectionEnvelope<TContent>` from
+[`inspection-envelope.md`](inspection-envelope.md): the Browser can consume a
+closed construction such as
+`InspectionEnvelope<TypeDependencySectionResult>` without introducing a
+parallel Browser envelope solely to erase the type parameter.
+
+A generic record reached through an authenticated closed System.Text.Json
+shape becomes a reusable TypeScript interface. Declaration parameters are
+allocated by metadata position, and a direct parameter-valued member retains
+that position:
+
+```csharp
+public sealed record InspectionEnvelope<TContent>(
+    TContent Content,
+    InspectionShare Share);
+```
+
+```ts
+export interface InspectionEnvelope<T0> {
+  readonly content: T0;
+  readonly share: InspectionShare;
+}
+```
+
+Every facade use remains closed. Its arguments come from the structured,
+authenticated wire shape and pass through the existing JSON mapping before
+instantiation, so `GenericEnvelope<byte[]>` is exposed as
+`GenericEnvelope<string>`, not as a CLR array. No CLR type argument crosses the
+JavaScript ABI, and generic `[JSExport]` methods and generic `JsExportRoot`
+types remain unsupported.
+
+The initial contract intentionally admits only direct type-parameter members,
+including their direct nullable form. A parameter embedded in a CLR shape is
+not generally parametric in the corresponding TypeScript wire type. For
+example, projecting `T[]` as `ReadonlyArray<T0>` would be correct for
+`T = int` but wrong for `T = byte`, whose closed CLR array is a Base64 JSON
+string. Such declarations fail visibly before publication rather than
+producing a plausible but unsound interface. Closed records, arrays,
+dictionaries, nullable values, and supported unions remain valid as type
+arguments because each argument is mapped from its own closed wire shape.
+
+The projection retains the existing naming, direction, converter,
+constructor-binding, scoped-identity, and declaration-name allocation rules.
+It does not invent serializer support for the record's reachable graph:
+envelope Share, diagnostic, content, and collection types must independently
+carry supported System.Text.Json evidence. The production adoption path is
+therefore two steps: this generator capability, then direct
+`InspectionEnvelope<TypeDependencySectionResult>` adoption by
+[#6736](https://github.com/richlander/dotnet-inspect/pull/6736) once that exact
+reachable wire graph is authenticated.
+
+`DtsEmitterTests` gate generic declaration and closed-use identity.
+`eng/test-ts-jsexport-typescript.sh` compiles consumers of two distinct closed
+constructions, rejects a mismatched argument, and executes the facade against
+real source-generated System.Text.Json payloads, including the wire-sensitive
+`byte[]` argument.
 
 ### Public facade view
 
@@ -830,6 +891,7 @@ evidence.
 - infer wire contracts from names, return-type display text, or nearby
   serializer metadata;
 - become a general JavaScript, C#, OpenAPI, or multi-language generator;
+- project open or non-parametric generic record contracts;
 - bundle, download, or select a TypeScript compiler;
 - generate network clients or define a network protocol;
 - bundle the generated runtime module with inspect-web's application assets; or

--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -306,10 +306,9 @@ export interface InspectionEnvelope<T0> {
 
 Every facade use remains closed. Its arguments come from the structured,
 authenticated wire shape and pass through the existing JSON mapping before
-instantiation, so `GenericEnvelope<byte[]>` is exposed as
-`GenericEnvelope<string>`, not as a CLR array. No CLR type argument crosses the
-JavaScript ABI, and generic `[JSExport]` methods and generic `JsExportRoot`
-types remain unsupported.
+instantiation, so a `byte[]` argument becomes its Base64 string wire type, not
+a CLR array. No CLR type argument crosses the JavaScript ABI, and generic
+`[JSExport]` methods and generic `JsExportRoot` types remain unsupported.
 
 Structured shape owns each argument's identity and CLR construction; the
 corresponding reachable member signature supplies nullable-reference
@@ -317,6 +316,16 @@ annotations that the structural metadata view does not retain. The mapper
 combines those two views by argument position, so `GenericEnvelope<string?>`
 becomes `GenericEnvelope<string | null>` without accepting a display-text
 lookalike as identity evidence.
+
+A directly registered serializer root has no member signature carrying nullable
+reference annotations: CLR generic construction and `typeof` metadata erase
+that distinction. Reference-shaped arguments at that boundary remain
+conservatively nullable. A direct `GenericEnvelope<byte[]>` root is therefore
+`GenericEnvelope<string | null>`, and a direct
+`GenericEnvelope<WidgetDto>` root is
+`GenericEnvelope<WidgetDto | null>`. Value-shaped arguments remain exact.
+This is disclosure of unavailable evidence, not a claim that every producer
+writes null.
 
 The initial contract intentionally admits only direct type-parameter members,
 including their direct nullable form. A parameter embedded in a CLR shape is
@@ -342,7 +351,9 @@ reachable wire graph is authenticated.
 `eng/test-ts-jsexport-typescript.sh` compiles consumers of two distinct closed
 constructions, rejects a mismatched argument, and executes the facade against
 real source-generated System.Text.Json payloads, including the wire-sensitive
-`byte[]` argument and a null value carried by a nullable-reference argument.
+`byte[]` argument, a direct root whose erased reference argument carries null,
+a nullable-reference member argument, and a concrete included-field identity
+that collides with a generic parameter name.
 
 ### Public facade view
 

--- a/eng/test-ts-jsexport-typescript.sh
+++ b/eng/test-ts-jsexport-typescript.sh
@@ -60,14 +60,18 @@ TS
 
 cat > "$scratch/union-usage.ts" <<'TS'
 import {
+  getBlobEnvelope,
   getBoxedCount,
   getBoxedWidget,
+  getCollisionEnvelope,
   getCollectionSelection,
   getDefaultSelection,
   getFlagSelection,
   getKindSelection,
+  getNullableIntEnvelope,
   getOutcomeSelection,
   getSelectionEnvelopeAsync,
+  getWidgetEnvelope,
   getWidgetSelection,
   getWrappedBlob,
 } from "./facade.js";
@@ -75,9 +79,13 @@ import type {
   Boxed,
   CollectionSelection,
   FlagSelection,
+  GenericCollision,
+  GenericEnvelope,
   KindSelection,
+  NullableEnvelope,
   OutcomeSelection,
   SelectionEnvelope,
+  T,
   WidgetDto,
   WidgetKind,
   WidgetSelection,
@@ -187,6 +195,22 @@ export function describeBoxed(
     ? "none"
     : typeof widget === "string" ? widget : widget.name;
   return `${left}/${right}`;
+}
+
+export function describeGenericEnvelopes(): string {
+  const widget: GenericEnvelope<WidgetDto> =
+    getWidgetEnvelope("generic");
+  const blob: GenericEnvelope<string> = getBlobEnvelope();
+  const collision: GenericCollision<number> = getCollisionEnvelope();
+  const concrete: T = collision.other;
+  const nullable: NullableEnvelope<number> =
+    getNullableIntEnvelope(true);
+  const missing: NullableEnvelope<number> =
+    getNullableIntEnvelope(false);
+  return `${widget.content.name}:${widget.label}`
+    + `/${blob.content}:${blob.label}`
+    + `/${collision.content}:${concrete.value}`
+    + `/${nullable.content}:${missing.content}`;
 }
 
 export function selectWidget(widget: WidgetDto): WidgetSelection {
@@ -434,6 +458,11 @@ expect_union_facade_compile_failure \
   'Wrapped<string>' \
   'Wrapped<number>' \
   '^export function getWrappedBlob'
+expect_union_facade_compile_failure \
+  generic-record-closed-argument \
+  'GenericEnvelope<string>' \
+  'GenericEnvelope<number>' \
+  '^export function getBlobEnvelope'
 
 expect_union_facade_compile_failure \
   union-collection-entry-null \
@@ -471,5 +500,9 @@ expect_union_usage_compile_failure \
   union-closed-generic-mismatch \
   'describeBoxed\(getBoxedCount\(11\), getBoxedWidget\("boxed"\)\)' \
   'describeBoxed(getBoxedWidget("boxed"), getBoxedCount(11))'
+expect_union_usage_compile_failure \
+  generic-record-closed-mismatch \
+  'getWidgetEnvelope\("generic"\)' \
+  'getBlobEnvelope()'
 
 echo "ts-jsexport TypeScript compiler gates passed."

--- a/eng/test-ts-jsexport-typescript.sh
+++ b/eng/test-ts-jsexport-typescript.sh
@@ -69,6 +69,7 @@ import {
   getFlagSelection,
   getKindSelection,
   getNullableIntEnvelope,
+  getNullableTextRoot,
   getOutcomeSelection,
   getSelectionEnvelopeAsync,
   getWidgetEnvelope,
@@ -83,6 +84,7 @@ import type {
   GenericEnvelope,
   KindSelection,
   NullableEnvelope,
+  NullableTextRoot,
   OutcomeSelection,
   SelectionEnvelope,
   T,
@@ -104,6 +106,8 @@ type GroupEntries = Extract<SelectionEnvelope["group"], ReadonlyArray<unknown>>;
 export const missingSelectionEntry: SelectionEntries[number] = null;
 export const missingMapEntry: SelectionMap[string] = null;
 export const missingGroupEntry: GroupEntries[number] = null;
+export const missingGenericArgument:
+  NullableTextRoot["result"]["content"] = null;
 
 function isEntryArray(
   selection: CollectionSelection,
@@ -207,10 +211,12 @@ export function describeGenericEnvelopes(): string {
     getNullableIntEnvelope(true);
   const missing: NullableEnvelope<number> =
     getNullableIntEnvelope(false);
+  const nullableText: NullableTextRoot = getNullableTextRoot();
   return `${widget.content.name}:${widget.label}`
     + `/${blob.content}:${blob.label}`
     + `/${collision.content}:${concrete.value}`
-    + `/${nullable.content}:${missing.content}`;
+    + `/${nullable.content}:${missing.content}`
+    + `/${nullableText.result.content}:${nullableText.result.label}`;
 }
 
 export function selectWidget(widget: WidgetDto): WidgetSelection {
@@ -463,6 +469,11 @@ expect_union_facade_compile_failure \
   'GenericEnvelope<string>' \
   'GenericEnvelope<number>' \
   '^export function getBlobEnvelope'
+expect_union_facade_compile_failure \
+  generic-record-nullable-argument \
+  'GenericEnvelope<string \| null>' \
+  'GenericEnvelope<string>' \
+  '^  readonly result:'
 
 expect_union_facade_compile_failure \
   union-collection-entry-null \

--- a/eng/test-ts-jsexport-typescript.sh
+++ b/eng/test-ts-jsexport-typescript.sh
@@ -64,6 +64,7 @@ import {
   getBoxedCount,
   getBoxedWidget,
   getCollisionEnvelope,
+  getDirectNullableTextEnvelope,
   getCollectionSelection,
   getDefaultSelection,
   getFlagSelection,
@@ -202,9 +203,11 @@ export function describeBoxed(
 }
 
 export function describeGenericEnvelopes(): string {
-  const widget: GenericEnvelope<WidgetDto> =
+  const widget: GenericEnvelope<WidgetDto | null> =
     getWidgetEnvelope("generic");
-  const blob: GenericEnvelope<string> = getBlobEnvelope();
+  const blob: GenericEnvelope<string | null> = getBlobEnvelope();
+  const directNullable: GenericEnvelope<string | null> =
+    getDirectNullableTextEnvelope();
   const collision: GenericCollision<number> = getCollisionEnvelope();
   const concrete: T = collision.other;
   const nullable: NullableEnvelope<number> =
@@ -212,9 +215,10 @@ export function describeGenericEnvelopes(): string {
   const missing: NullableEnvelope<number> =
     getNullableIntEnvelope(false);
   const nullableText: NullableTextRoot = getNullableTextRoot();
-  return `${widget.content.name}:${widget.label}`
+  return `${widget.content?.name ?? "none"}:${widget.label}`
     + `/${blob.content}:${blob.label}`
-    + `/${collision.content}:${concrete.value}`
+    + `/${directNullable.content}:${directNullable.label}`
+    + `/${collision.content}:${concrete.value}:${collision.included.value}`
     + `/${nullable.content}:${missing.content}`
     + `/${nullableText.result.content}:${nullableText.result.label}`;
 }
@@ -466,7 +470,7 @@ expect_union_facade_compile_failure \
   '^export function getWrappedBlob'
 expect_union_facade_compile_failure \
   generic-record-closed-argument \
-  'GenericEnvelope<string>' \
+  'GenericEnvelope<string \| null>' \
   'GenericEnvelope<number>' \
   '^export function getBlobEnvelope'
 expect_union_facade_compile_failure \

--- a/eng/test-ts-jsexport-typescript.sh
+++ b/eng/test-ts-jsexport-typescript.sh
@@ -65,6 +65,7 @@ import {
   getBoxedWidget,
   getCollisionEnvelope,
   getDirectNullableTextEnvelope,
+  getGenericRecordChoice,
   getCollectionSelection,
   getDefaultSelection,
   getFlagSelection,
@@ -83,6 +84,7 @@ import type {
   FlagSelection,
   GenericCollision,
   GenericEnvelope,
+  GenericRecordChoice,
   KindSelection,
   NullableEnvelope,
   NullableTextRoot,
@@ -109,6 +111,9 @@ export const missingMapEntry: SelectionMap[string] = null;
 export const missingGroupEntry: GroupEntries[number] = null;
 export const missingGenericArgument:
   NullableTextRoot["result"]["content"] = null;
+export const missingUnionRecordContent:
+  Extract<GenericRecordChoice, { readonly content: unknown }>["content"] =
+    null;
 
 function isEntryArray(
   selection: CollectionSelection,
@@ -208,6 +213,7 @@ export function describeGenericEnvelopes(): string {
   const blob: GenericEnvelope<string | null> = getBlobEnvelope();
   const directNullable: GenericEnvelope<string | null> =
     getDirectNullableTextEnvelope();
+  const choice: GenericRecordChoice = getGenericRecordChoice();
   const collision: GenericCollision<number> = getCollisionEnvelope();
   const concrete: T = collision.other;
   const nullable: NullableEnvelope<number> =
@@ -218,7 +224,13 @@ export function describeGenericEnvelopes(): string {
   return `${widget.content?.name ?? "none"}:${widget.label}`
     + `/${blob.content}:${blob.label}`
     + `/${directNullable.content}:${directNullable.label}`
+    + `/${choice === null || typeof choice === "number"
+      ? choice
+      : choice.content}:${choice === null || typeof choice === "number"
+      ? "union"
+      : choice.label}`
     + `/${collision.content}:${concrete.value}:${collision.included.value}`
+    + `:${collision.includedItems[0]?.value ?? "missing"}`
     + `/${nullable.content}:${missing.content}`
     + `/${nullableText.result.content}:${nullableText.result.label}`;
 }
@@ -478,6 +490,11 @@ expect_union_facade_compile_failure \
   'GenericEnvelope<string \| null>' \
   'GenericEnvelope<string>' \
   '^  readonly result:'
+expect_union_facade_compile_failure \
+  generic-record-union-nullable-argument \
+  'GenericEnvelope<string \| null>' \
+  'GenericEnvelope<string>' \
+  '^export type GenericRecordChoice'
 
 expect_union_facade_compile_failure \
   union-collection-entry-null \

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace ILInspector.JsExportSurface.TypeScriptFixtures;
+
+public sealed record GenericEnvelope<TContent>(
+    TContent Content,
+    string Label);
+
+public sealed record T(string Value);
+
+public sealed record GenericCollision<T>(
+    T Content,
+    global::ILInspector.JsExportSurface.TypeScriptFixtures.T Other);
+
+public sealed record NullableEnvelope<T>(T? Content)
+    where T : struct;
+
+[JsonSerializable(
+    typeof(GenericEnvelope<WidgetDto>),
+    TypeInfoPropertyName = "WidgetEnvelope")]
+[JsonSerializable(
+    typeof(GenericEnvelope<byte[]>),
+    TypeInfoPropertyName = "BlobEnvelope")]
+[JsonSerializable(
+    typeof(GenericCollision<int>),
+    TypeInfoPropertyName = "CollisionEnvelope")]
+[JsonSerializable(
+    typeof(NullableEnvelope<int>),
+    TypeInfoPropertyName = "NullableIntEnvelope")]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class GenericRecordFixtureJsonContext :
+    JsonSerializerContext;

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
@@ -6,6 +6,8 @@ public sealed record GenericEnvelope<TContent>(
     TContent Content,
     string Label);
 
+public union GenericRecordChoice(GenericEnvelope<string?>, int);
+
 public sealed record T(string Value);
 
 public sealed record GenericCollision<T>(
@@ -15,6 +17,10 @@ public sealed record GenericCollision<T>(
     [JsonInclude]
     public global::ILInspector.JsExportSurface.TypeScriptFixtures.T Included =
         new("included");
+
+    [JsonInclude]
+    public global::ILInspector.JsExportSurface.TypeScriptFixtures.T[]
+        IncludedItems = [new("included-array")];
 }
 
 public sealed record NullableEnvelope<T>(T? Content)
@@ -32,6 +38,7 @@ public sealed record NullableTextRoot(
 [JsonSerializable(
     typeof(GenericEnvelope<string>),
     TypeInfoPropertyName = "DirectNullableTextEnvelope")]
+[JsonSerializable(typeof(GenericRecordChoice))]
 [JsonSerializable(
     typeof(GenericCollision<int>),
     TypeInfoPropertyName = "CollisionEnvelope")]

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
@@ -10,7 +10,12 @@ public sealed record T(string Value);
 
 public sealed record GenericCollision<T>(
     T Content,
-    global::ILInspector.JsExportSurface.TypeScriptFixtures.T Other);
+    global::ILInspector.JsExportSurface.TypeScriptFixtures.T Other)
+{
+    [JsonInclude]
+    public global::ILInspector.JsExportSurface.TypeScriptFixtures.T Included =
+        new("included");
+}
 
 public sealed record NullableEnvelope<T>(T? Content)
     where T : struct;
@@ -24,6 +29,9 @@ public sealed record NullableTextRoot(
 [JsonSerializable(
     typeof(GenericEnvelope<byte[]>),
     TypeInfoPropertyName = "BlobEnvelope")]
+[JsonSerializable(
+    typeof(GenericEnvelope<string>),
+    TypeInfoPropertyName = "DirectNullableTextEnvelope")]
 [JsonSerializable(
     typeof(GenericCollision<int>),
     TypeInfoPropertyName = "CollisionEnvelope")]

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/GenericRecords.cs
@@ -15,6 +15,9 @@ public sealed record GenericCollision<T>(
 public sealed record NullableEnvelope<T>(T? Content)
     where T : struct;
 
+public sealed record NullableTextRoot(
+    GenericEnvelope<string?> Result);
+
 [JsonSerializable(
     typeof(GenericEnvelope<WidgetDto>),
     TypeInfoPropertyName = "WidgetEnvelope")]
@@ -27,6 +30,7 @@ public sealed record NullableEnvelope<T>(T? Content)
 [JsonSerializable(
     typeof(NullableEnvelope<int>),
     TypeInfoPropertyName = "NullableIntEnvelope")]
+[JsonSerializable(typeof(NullableTextRoot))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class GenericRecordFixtureJsonContext :
     JsonSerializerContext;

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
@@ -273,6 +273,12 @@ public static partial class TypeScriptFixtureExports
             GenericRecordFixtureJsonContext.Default.BlobEnvelope);
 
     [JSExport]
+    public static string GetDirectNullableTextEnvelope() =>
+        JsonSerializer.Serialize(
+            new GenericEnvelope<string?>(null, "direct-nullable"),
+            GenericRecordFixtureJsonContext.Default.DirectNullableTextEnvelope);
+
+    [JSExport]
     public static string GetCollisionEnvelope() =>
         JsonSerializer.Serialize(
             new GenericCollision<int>(

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
@@ -288,6 +288,13 @@ public static partial class TypeScriptFixtureExports
             GenericRecordFixtureJsonContext.Default.NullableIntEnvelope);
 
     [JSExport]
+    public static string GetNullableTextRoot() =>
+        JsonSerializer.Serialize(
+            new NullableTextRoot(
+                new GenericEnvelope<string?>(null, "nullable")),
+            GenericRecordFixtureJsonContext.Default.NullableTextRoot);
+
+    [JSExport]
     public static async Task<string> GetSelectionEnvelopeAsync(string name)
     {
         await Task.Yield();

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
@@ -259,6 +259,35 @@ public static partial class TypeScriptFixtureExports
             UnionFixtureJsonContext.Default.WrappedByteArray);
 
     [JSExport]
+    public static string GetWidgetEnvelope(string name) =>
+        JsonSerializer.Serialize(
+            new GenericEnvelope<WidgetDto>(
+                new WidgetDto(name, 12),
+                "widget"),
+            GenericRecordFixtureJsonContext.Default.WidgetEnvelope);
+
+    [JSExport]
+    public static string GetBlobEnvelope() =>
+        JsonSerializer.Serialize(
+            new GenericEnvelope<byte[]>([1, 2, 3], "blob"),
+            GenericRecordFixtureJsonContext.Default.BlobEnvelope);
+
+    [JSExport]
+    public static string GetCollisionEnvelope() =>
+        JsonSerializer.Serialize(
+            new GenericCollision<int>(
+                7,
+                new global::ILInspector.JsExportSurface.TypeScriptFixtures.T(
+                    "concrete")),
+            GenericRecordFixtureJsonContext.Default.CollisionEnvelope);
+
+    [JSExport]
+    public static string GetNullableIntEnvelope(bool hasValue) =>
+        JsonSerializer.Serialize(
+            new NullableEnvelope<int>(hasValue ? 42 : null),
+            GenericRecordFixtureJsonContext.Default.NullableIntEnvelope);
+
+    [JSExport]
     public static async Task<string> GetSelectionEnvelopeAsync(string name)
     {
         await Task.Yield();

--- a/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
+++ b/fixtures/js-export/ILInspector.JsExportSurface.TypeScriptFixtures/TypeScriptFixtureExports.cs
@@ -279,6 +279,15 @@ public static partial class TypeScriptFixtureExports
             GenericRecordFixtureJsonContext.Default.DirectNullableTextEnvelope);
 
     [JSExport]
+    public static string GetGenericRecordChoice() =>
+        JsonSerializer.Serialize(
+            new GenericRecordChoice(
+                new GenericEnvelope<string?>(
+                    null,
+                    "union-nullable")),
+            GenericRecordFixtureJsonContext.Default.GenericRecordChoice);
+
+    [JSExport]
     public static string GetCollisionEnvelope() =>
         JsonSerializer.Serialize(
             new GenericCollision<int>(

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -536,7 +536,16 @@ static class DtsEmitter
                                 type.DefinitionName),
                             type => type.TypeParameters.Count)
                     : new Dictionary<ApiTypeReferenceIdentity, int>(),
-                delegateMappingContext));
+                delegateMappingContext,
+                surface.AssemblyIdentity is { } recordAssembly
+                    ? surface.Records
+                        .Where(type => type.TypeParameters.Count > 0)
+                        .Select(type => new ApiTypeReferenceIdentity(
+                            recordAssembly,
+                            type.FullName,
+                            type.DefinitionName))
+                        .ToHashSet()
+                    : new HashSet<ApiTypeReferenceIdentity>()));
     }
 
     static IReadOnlyDictionary<string, string> MappedTypeNames(
@@ -545,6 +554,8 @@ static class DtsEmitter
         IReadOnlyList<TypeParameter>? genericParameters = null,
         IReadOnlyList<string>? allocatedParameters = null)
     {
+        ApiTypeReferenceIdentity[] retainedReferences =
+            [.. references];
         var aliases = new Dictionary<string, string>(
             StringComparer.Ordinal);
         foreach ((string alias, string allocatedName) in environment.Aliases)
@@ -552,7 +563,7 @@ static class DtsEmitter
             if (!TsTypeMapper.IsIntrinsicTypeSpelling(alias))
                 aliases.Add(alias, allocatedName);
         }
-        foreach (ApiTypeReferenceIdentity reference in references)
+        foreach (ApiTypeReferenceIdentity reference in retainedReferences)
         {
             if (!environment.IdentityNames.TryGetValue(
                     reference,
@@ -571,8 +582,15 @@ static class DtsEmitter
                 throw new ArgumentException(
                     "Generic parameter definitions and allocated names must have equal counts.");
             for (int index = 0; index < genericParameters.Count; index++)
-                aliases[genericParameters[index].Name] =
-                    allocatedParameters[index];
+            {
+                if (!HasConcreteTypeReference(
+                        genericParameters[index].Name,
+                        retainedReferences))
+                {
+                    aliases[genericParameters[index].Name] =
+                        allocatedParameters[index];
+                }
+            }
         }
         return aliases;
     }
@@ -751,6 +769,7 @@ static class DtsEmitter
                     propertyType,
                     record.TypeParameters,
                     member.SignatureModel?.ReturnTypeShape,
+                    member.SignatureModel?.ReturnTypeReferences,
                     out string? parameter))
             {
                 throw new UnsupportedWireContractException(
@@ -796,7 +815,8 @@ static class DtsEmitter
                     IsDirectGenericRecordParameter(
                         propertyType,
                         record.TypeParameters,
-                        member.SignatureModel?.ReturnTypeShape)
+                        member.SignatureModel?.ReturnTypeShape,
+                        member.SignatureModel?.ReturnTypeReferences)
                             ? null
                             : member.SignatureModel?.ReturnTypeShape,
                     typeEnvironment.IdentityNames,
@@ -1234,54 +1254,58 @@ static class DtsEmitter
     static bool IsDirectGenericRecordParameter(
         string propertyType,
         IReadOnlyList<TypeParameter> parameters,
-        ApiTypeShape? typeShape)
+        ApiTypeShape? typeShape,
+        IReadOnlyList<ApiTypeReferenceIdentity>? references)
     {
-        if (typeShape is not null)
-            return false;
-
-        string candidate = propertyType.Trim();
-        if (candidate.EndsWith("?", StringComparison.Ordinal))
-            candidate = candidate[..^1].TrimEnd();
-        else if (candidate.EndsWith('>'))
+        if (typeShape is not null
+            || !TryGetDirectGenericRecordParameterCandidate(
+                propertyType,
+                out string candidate))
         {
-            const string qualifiedNullable = "System.Nullable<";
-            const string nullable = "Nullable<";
-            if (candidate.StartsWith(
-                    qualifiedNullable,
-                    StringComparison.Ordinal))
-            {
-                candidate = candidate[
-                    qualifiedNullable.Length..^1].Trim();
-            }
-            else if (candidate.StartsWith(
-                    nullable,
-                    StringComparison.Ordinal))
-            {
-                candidate = candidate[nullable.Length..^1].Trim();
-            }
+            return false;
         }
+
         return parameters.Any(
-            parameter => string.Equals(
-                candidate,
-                parameter.Name,
-                StringComparison.Ordinal)
-                || string.Equals(
-                    candidate,
-                    $"@{parameter.Name}",
-                    StringComparison.Ordinal));
+            parameter =>
+                !HasConcreteTypeReference(
+                    parameter.Name,
+                    references)
+                && (string.Equals(
+                        candidate,
+                        parameter.Name,
+                        StringComparison.Ordinal)
+                    || string.Equals(
+                        candidate,
+                        $"@{parameter.Name}",
+                        StringComparison.Ordinal)));
     }
 
     static bool HasEmbeddedGenericRecordParameter(
         string propertyType,
         IReadOnlyList<TypeParameter> parameters,
         ApiTypeShape? typeShape,
+        IReadOnlyList<ApiTypeReferenceIdentity>? references,
         out string? parameterName)
     {
         if (typeShape is not null
             || IsDirectGenericRecordParameter(
                 propertyType,
                 parameters,
-                typeShape))
+                typeShape,
+                references))
+        {
+            parameterName = null;
+            return false;
+        }
+
+        if (TryGetDirectGenericRecordParameterCandidate(
+                propertyType,
+                out string directCandidate)
+            && parameters.Any(parameter =>
+                IsDirectConcreteTypeReference(
+                    directCandidate,
+                    parameter.Name,
+                    references)))
         {
             parameterName = null;
             return false;
@@ -1312,6 +1336,74 @@ static class DtsEmitter
         parameterName = null;
         return false;
     }
+
+    static bool IsDirectConcreteTypeReference(
+        string candidate,
+        string parameterName,
+        IReadOnlyList<ApiTypeReferenceIdentity>? references)
+    {
+        if (!HasConcreteTypeReference(parameterName, references))
+            return false;
+
+        const string globalPrefix = "global::";
+        if (candidate.StartsWith(
+                globalPrefix,
+                StringComparison.Ordinal))
+        {
+            candidate = candidate[globalPrefix.Length..];
+        }
+
+        return string.Equals(
+            LastSegment(candidate),
+            parameterName,
+            StringComparison.Ordinal);
+    }
+
+    static bool TryGetDirectGenericRecordParameterCandidate(
+        string propertyType,
+        out string candidate)
+    {
+        candidate = propertyType.Trim();
+        if (candidate.EndsWith("?", StringComparison.Ordinal))
+        {
+            candidate = candidate[..^1].TrimEnd();
+            return true;
+        }
+        if (!candidate.EndsWith('>'))
+            return true;
+
+        const string qualifiedNullable = "System.Nullable<";
+        const string nullable = "Nullable<";
+        if (candidate.StartsWith(
+                qualifiedNullable,
+                StringComparison.Ordinal))
+        {
+            candidate = candidate[
+                qualifiedNullable.Length..^1].Trim();
+            return true;
+        }
+        if (candidate.StartsWith(
+                nullable,
+                StringComparison.Ordinal))
+        {
+            candidate = candidate[nullable.Length..^1].Trim();
+            return true;
+        }
+        return false;
+    }
+
+    static bool HasConcreteTypeReference(
+        string parameterName,
+        IReadOnlyList<ApiTypeReferenceIdentity>? references) =>
+        references?.Any(reference =>
+            string.Equals(
+                LastSegment(reference.FullName),
+                parameterName,
+                StringComparison.Ordinal)
+            || string.Equals(
+                reference.DefinitionName?.Segments[^1],
+                parameterName,
+                StringComparison.Ordinal)) == true;
 
     static bool IsIdentifierCharacter(char value) =>
         value == '_' || char.IsLetterOrDigit(value);

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -1353,6 +1353,21 @@ static class DtsEmitter
             candidate = candidate[globalPrefix.Length..];
         }
 
+        while (true)
+        {
+            if (candidate.EndsWith("[]", StringComparison.Ordinal))
+            {
+                candidate = candidate[..^2].TrimEnd();
+                continue;
+            }
+            if (candidate.EndsWith("?", StringComparison.Ordinal))
+            {
+                candidate = candidate[..^1].TrimEnd();
+                continue;
+            }
+            break;
+        }
+
         return string.Equals(
             LastSegment(candidate),
             parameterName,

--- a/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
+++ b/src/ILInspector.TypeScriptGeneration/DtsEmitter.cs
@@ -283,15 +283,8 @@ static class DtsEmitter
         TypeMappingEnvironment environment,
         string name)
     {
-        var usedNames = new HashSet<string>(environment.IdentityNames.Values, StringComparer.Ordinal);
-        string[] parameters = new string[union.Definition.TypeParameters.Count];
-        for (int index = 0; index < parameters.Length; index++)
-        {
-            string parameter = $"T{index}";
-            while (!usedNames.Add(parameter))
-                parameter += "_";
-            parameters[index] = parameter;
-        }
+        string[] parameters =
+            AllocateTypeParameters(union.Definition, environment);
 
         string[] mapped = [.. union.CaseTypes.SelectMany(type =>
             TsJsonUnionMapper.MapCase(type, parameters, environment.UnionContext, union.Definition.FullName))];
@@ -531,20 +524,26 @@ static class DtsEmitter
             new TsJsonUnionMappingContext(
                 surface.AssemblyIdentity,
                 identityNames,
-                surface.AssemblyIdentity is { } unionAssembly
-                    ? surface.Unions
-                        .Where(union => union.Definition.TypeParameters.Count > 0)
+                surface.AssemblyIdentity is { } genericAssembly
+                    ? declarationTypes
+                        .Where(type =>
+                            type.Kind != "enum"
+                            && type.TypeParameters.Count > 0)
                         .ToDictionary(
-                            union => new ApiTypeReferenceIdentity(
-                                unionAssembly, union.Definition.FullName, union.Definition.DefinitionName),
-                            union => union.Definition.TypeParameters.Count)
+                            type => new ApiTypeReferenceIdentity(
+                                genericAssembly,
+                                type.FullName,
+                                type.DefinitionName),
+                            type => type.TypeParameters.Count)
                     : new Dictionary<ApiTypeReferenceIdentity, int>(),
                 delegateMappingContext));
     }
 
     static IReadOnlyDictionary<string, string> MappedTypeNames(
         TypeMappingEnvironment environment,
-        IEnumerable<ApiTypeReferenceIdentity> references)
+        IEnumerable<ApiTypeReferenceIdentity> references,
+        IReadOnlyList<TypeParameter>? genericParameters = null,
+        IReadOnlyList<string>? allocatedParameters = null)
     {
         var aliases = new Dictionary<string, string>(
             StringComparer.Ordinal);
@@ -565,6 +564,16 @@ static class DtsEmitter
             aliases[reference.FullName] = allocatedName;
             aliases[LastSegment(reference.FullName)] = allocatedName;
         }
+        if (genericParameters is not null
+            && allocatedParameters is not null)
+        {
+            if (genericParameters.Count != allocatedParameters.Count)
+                throw new ArgumentException(
+                    "Generic parameter definitions and allocated names must have equal counts.");
+            for (int index = 0; index < genericParameters.Count; index++)
+                aliases[genericParameters[index].Name] =
+                    allocatedParameters[index];
+        }
         return aliases;
     }
 
@@ -578,8 +587,7 @@ static class DtsEmitter
 
     internal static string PreferredTypeName(ApiType type)
     {
-        if (type.HasUnionAttribute == true
-            && type.TypeParameters.Count > 0
+        if (type.TypeParameters.Count > 0
             && type.DefinitionName is { } definition)
         {
             string segment = definition.Segments[^1];
@@ -669,17 +677,19 @@ static class DtsEmitter
         TypeMappingEnvironment typeEnvironment,
         TypeScriptGenerationDiagnostics? diagnostics)
     {
+        string[] parameters =
+            AllocateTypeParameters(record, typeEnvironment);
         JsonWireNamingPolicy namingPolicy = record.JsonPropertyNamingPolicy ?? JsonWireNamingPolicy.None;
         if (namingPolicy == JsonWireNamingPolicy.Unsupported)
         {
             ReportUnsupportedContextOptions(record, diagnostics);
-            EmitBlockedType(sb, declarationName);
+            EmitBlockedType(sb, declarationName, parameters);
             return;
         }
         if (HasUnsupportedJsonConverter(record))
         {
             ReportUnsupportedJsonConverter(record.Name, diagnostics);
-            EmitBlockedType(sb, declarationName);
+            EmitBlockedType(sb, declarationName, parameters);
             return;
         }
         if (HasUnsupportedRecordWireShape(
@@ -688,7 +698,7 @@ static class DtsEmitter
                 declaredTypesByScopedIdentity))
         {
             ReportUnsupportedJsonWireShape(record.Name, diagnostics);
-            EmitBlockedType(sb, declarationName);
+            EmitBlockedType(sb, declarationName, parameters);
             return;
         }
         if ((directions & JsonWireDirection.Deserialize)
@@ -704,7 +714,7 @@ static class DtsEmitter
             ReportUnsupportedConstructorBinding(
                 record.Name,
                 diagnostics);
-            EmitBlockedType(sb, declarationName);
+            EmitBlockedType(sb, declarationName, parameters);
             return;
         }
 
@@ -716,7 +726,7 @@ static class DtsEmitter
                     declaredTypesByScopedIdentity)))
         {
             ReportDirectionSplitWireShape(record.Name, diagnostics);
-            EmitBlockedType(sb, declarationName);
+            EmitBlockedType(sb, declarationName, parameters);
             return;
         }
 
@@ -731,7 +741,29 @@ static class DtsEmitter
                 ResolvedName: member.JsonPropertyName ?? ApplyNamingPolicy(member.Name, namingPolicy)))
             .ToArray();
 
-        sb.Append("export interface ").Append(declarationName).Append(" {\n");
+        foreach ((ApiMember member, _) in members)
+        {
+            string propertyType =
+                member.SignatureModel?.ReturnType
+                ?? member.ReturnType
+                ?? "unknown";
+            if (HasEmbeddedGenericRecordParameter(
+                    propertyType,
+                    record.TypeParameters,
+                    member.SignatureModel?.ReturnTypeShape,
+                    out string? parameter))
+            {
+                throw new UnsupportedWireContractException(
+                    $"{record.FullName}.{member.Name}",
+                    $"generic record parameter '{parameter}' is embedded "
+                        + "in a member type whose JSON mapping is not parametric");
+            }
+        }
+
+        sb.Append("export interface ").Append(declarationName);
+        if (parameters.Length > 0)
+            sb.Append('<').AppendJoin(", ", parameters).Append('>');
+        sb.Append(" {\n");
 
         foreach ((ApiMember member, string resolvedName) in members)
         {
@@ -758,8 +790,15 @@ static class DtsEmitter
                     MappedTypeNames(
                         typeEnvironment,
                         member.SignatureModel?.ReturnTypeReferences
-                            ?? []),
-                    member.SignatureModel?.ReturnTypeShape,
+                            ?? [],
+                        record.TypeParameters,
+                        parameters),
+                    IsDirectGenericRecordParameter(
+                        propertyType,
+                        record.TypeParameters,
+                        member.SignatureModel?.ReturnTypeShape)
+                            ? null
+                            : member.SignatureModel?.ReturnTypeShape,
                     typeEnvironment.IdentityNames,
                     typeEnvironment.UnionContext);
             }
@@ -1163,8 +1202,119 @@ static class DtsEmitter
     static string ResolvedEnumMemberName(ApiMember member) =>
         member.JsonStringEnumMemberName ?? member.Name;
 
-    static void EmitBlockedType(StringBuilder sb, string declarationName) =>
-        sb.Append("export type ").Append(declarationName).Append(" = unknown;\n\n");
+    static void EmitBlockedType(
+        StringBuilder sb,
+        string declarationName,
+        IReadOnlyList<string>? parameters = null)
+    {
+        sb.Append("export type ").Append(declarationName);
+        if (parameters is { Count: > 0 })
+            sb.Append('<').AppendJoin(", ", parameters).Append('>');
+        sb.Append(" = unknown;\n\n");
+    }
+
+    static string[] AllocateTypeParameters(
+        ApiType type,
+        TypeMappingEnvironment environment)
+    {
+        var usedNames = new HashSet<string>(
+            environment.IdentityNames.Values,
+            StringComparer.Ordinal);
+        string[] parameters = new string[type.TypeParameters.Count];
+        for (int index = 0; index < parameters.Length; index++)
+        {
+            string parameter = $"T{index}";
+            while (!usedNames.Add(parameter))
+                parameter += "_";
+            parameters[index] = parameter;
+        }
+        return parameters;
+    }
+
+    static bool IsDirectGenericRecordParameter(
+        string propertyType,
+        IReadOnlyList<TypeParameter> parameters,
+        ApiTypeShape? typeShape)
+    {
+        if (typeShape is not null)
+            return false;
+
+        string candidate = propertyType.Trim();
+        if (candidate.EndsWith("?", StringComparison.Ordinal))
+            candidate = candidate[..^1].TrimEnd();
+        else if (candidate.EndsWith('>'))
+        {
+            const string qualifiedNullable = "System.Nullable<";
+            const string nullable = "Nullable<";
+            if (candidate.StartsWith(
+                    qualifiedNullable,
+                    StringComparison.Ordinal))
+            {
+                candidate = candidate[
+                    qualifiedNullable.Length..^1].Trim();
+            }
+            else if (candidate.StartsWith(
+                    nullable,
+                    StringComparison.Ordinal))
+            {
+                candidate = candidate[nullable.Length..^1].Trim();
+            }
+        }
+        return parameters.Any(
+            parameter => string.Equals(
+                candidate,
+                parameter.Name,
+                StringComparison.Ordinal)
+                || string.Equals(
+                    candidate,
+                    $"@{parameter.Name}",
+                    StringComparison.Ordinal));
+    }
+
+    static bool HasEmbeddedGenericRecordParameter(
+        string propertyType,
+        IReadOnlyList<TypeParameter> parameters,
+        ApiTypeShape? typeShape,
+        out string? parameterName)
+    {
+        if (typeShape is not null
+            || IsDirectGenericRecordParameter(
+                propertyType,
+                parameters,
+                typeShape))
+        {
+            parameterName = null;
+            return false;
+        }
+
+        foreach (TypeParameter parameter in parameters)
+        {
+            int start = 0;
+            while ((start = propertyType.IndexOf(
+                parameter.Name,
+                start,
+                StringComparison.Ordinal)) >= 0)
+            {
+                int end = start + parameter.Name.Length;
+                bool leftBoundary = start == 0
+                    || !IsIdentifierCharacter(propertyType[start - 1]);
+                bool rightBoundary = end == propertyType.Length
+                    || !IsIdentifierCharacter(propertyType[end]);
+                if (leftBoundary && rightBoundary)
+                {
+                    parameterName = parameter.Name;
+                    return true;
+                }
+                start = end;
+            }
+        }
+
+        parameterName = null;
+        return false;
+    }
+
+    static bool IsIdentifierCharacter(char value) =>
+        value == '_' || char.IsLetterOrDigit(value);
 
     private sealed record TypeMappingEnvironment(
         HashSet<string> KnownTypeNames,

--- a/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
@@ -7,7 +7,9 @@ sealed record TsJsonUnionMappingContext(
     ApiAssemblyIdentity? Assembly,
     IReadOnlyDictionary<ApiTypeReferenceIdentity, string> Names,
     IReadOnlyDictionary<ApiTypeReferenceIdentity, int> LocalGenericArities,
-    TsDelegateMappingContext LocalTypes);
+    TsDelegateMappingContext LocalTypes,
+    IReadOnlySet<ApiTypeReferenceIdentity>? GenericRecords = null,
+    bool ConservativeReferenceArguments = false);
 
 static class TsJsonUnionMapper
 {
@@ -167,12 +169,22 @@ static class TsJsonUnionMapper
                                 display,
                                 shape.TypeArguments.Length,
                                 location);
+                        bool conservativeArguments =
+                            context.ConservativeReferenceArguments
+                            && context.GenericRecords?.Contains(identity)
+                                == true;
                         return $"{name}<{string.Join(", ", shape.TypeArguments.Select(
-                            (argument, index) => MapClosedShape(
-                                argument,
-                                context,
-                                location,
-                                displayArguments?[index])))}>";
+                            (argument, index) => conservativeArguments
+                                ? MapCollectionShape(
+                                    argument,
+                                    context,
+                                    location,
+                                    displayArguments?[index])
+                                : MapClosedShape(
+                                    argument,
+                                    context,
+                                    location,
+                                    displayArguments?[index])))}>";
                     }
                 }
             }

--- a/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
@@ -6,7 +6,7 @@ namespace ILInspector.TypeScriptGeneration;
 sealed record TsJsonUnionMappingContext(
     ApiAssemblyIdentity? Assembly,
     IReadOnlyDictionary<ApiTypeReferenceIdentity, string> Names,
-    IReadOnlyDictionary<ApiTypeReferenceIdentity, int> GenericArities,
+    IReadOnlyDictionary<ApiTypeReferenceIdentity, int> LocalGenericArities,
     TsDelegateMappingContext LocalTypes);
 
 static class TsJsonUnionMapper
@@ -74,12 +74,19 @@ static class TsJsonUnionMapper
             }
 
             if (LocalIdentity(definition, context) is { } identity
-                && context.GenericArities.TryGetValue(identity, out int arity)
-                && arity == type.TypeArguments.Length
                 && context.Names.TryGetValue(identity, out string? name))
             {
-                return $"{name}<{string.Join(", ", type.TypeArguments.Select(
-                    argument => MapClosedCase(argument, context, location)))}>";
+                if (!context.LocalGenericArities.TryGetValue(
+                        identity,
+                        out int arity))
+                {
+                    return name;
+                }
+                if (arity == type.TypeArguments.Length)
+                {
+                    return $"{name}<{string.Join(", ", type.TypeArguments.Select(
+                        argument => MapClosedCase(argument, context, location)))}>";
+                }
             }
             throw Unsupported(location, "unsupported generic union case type");
         }
@@ -97,7 +104,7 @@ static class TsJsonUnionMapper
             return "unknown";
 
         if (LocalIdentity(definition, context) is { } local
-            && !context.GenericArities.ContainsKey(local)
+            && !context.LocalGenericArities.ContainsKey(local)
             && context.Names.TryGetValue(local, out string? localName))
             return localName;
 
@@ -125,14 +132,21 @@ static class TsJsonUnionMapper
             if (context.Names.TryGetValue(identity, out string? name))
             {
                 if (shape.Kind == ApiTypeShapeKind.Named
-                    && !context.GenericArities.ContainsKey(identity))
+                    && !context.LocalGenericArities.ContainsKey(identity))
                     return name;
-                if (shape.Kind == ApiTypeShapeKind.GenericInstance
-                    && context.GenericArities.TryGetValue(identity, out int arity)
-                    && arity == shape.TypeArguments.Length)
+                if (shape.Kind == ApiTypeShapeKind.GenericInstance)
                 {
-                    return $"{name}<{string.Join(", ", shape.TypeArguments.Select(
-                        argument => MapClosedShape(argument, context, location)))}>";
+                    if (!context.LocalGenericArities.TryGetValue(
+                            identity,
+                            out int arity))
+                    {
+                        return name;
+                    }
+                    if (arity == shape.TypeArguments.Length)
+                    {
+                        return $"{name}<{string.Join(", ", shape.TypeArguments.Select(
+                            argument => MapClosedShape(argument, context, location)))}>";
+                    }
                 }
             }
 

--- a/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
@@ -86,8 +86,18 @@ static class TsJsonUnionMapper
                 }
                 if (arity == type.TypeArguments.Length)
                 {
+                    bool conservativeArguments =
+                        context.GenericRecords?.Contains(identity) == true;
                     return $"{name}<{string.Join(", ", type.TypeArguments.Select(
-                        argument => MapClosedCase(argument, context, location)))}>";
+                        argument => conservativeArguments
+                            ? MapCollectionCase(
+                                argument,
+                                context,
+                                location)
+                            : MapClosedCase(
+                                argument,
+                                context,
+                                location)))}>";
                 }
             }
             throw Unsupported(location, "unsupported generic union case type");

--- a/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsJsonUnionMapper.cs
@@ -114,8 +114,20 @@ static class TsJsonUnionMapper
     internal static string MapClosedShape(
         ApiTypeShape shape,
         TsJsonUnionMappingContext context,
-        string location)
+        string location,
+        string? displayType = null)
     {
+        string? display = displayType?.Trim();
+        if (display?.EndsWith("?", StringComparison.Ordinal) == true
+            && !IsNullableShape(shape))
+        {
+            return WithNull(MapClosedShape(
+                shape,
+                context,
+                location,
+                display[..^1]));
+        }
+
         if (shape.Kind == ApiTypeShapeKind.Primitive
             && shape.Primitive is { } primitive
             && primitive != ApiPrimitiveType.Void
@@ -125,7 +137,13 @@ static class TsJsonUnionMapper
         if (shape.Kind == ApiTypeShapeKind.SzArray && shape.ElementType is { } element)
             return element is { Kind: ApiTypeShapeKind.Primitive, Primitive: ApiPrimitiveType.Byte }
                 ? "string"
-                : $"ReadonlyArray<{MapCollectionShape(element, context, location)}>";
+                : $"ReadonlyArray<{MapCollectionShape(
+                    element,
+                    context,
+                    location,
+                    display?.EndsWith("[]", StringComparison.Ordinal) == true
+                        ? display[..^2]
+                        : null)}>";
 
         if (shape.Definition is { } identity)
         {
@@ -144,8 +162,17 @@ static class TsJsonUnionMapper
                     }
                     if (arity == shape.TypeArguments.Length)
                     {
+                        IReadOnlyList<string>? displayArguments =
+                            GenericDisplayArguments(
+                                display,
+                                shape.TypeArguments.Length,
+                                location);
                         return $"{name}<{string.Join(", ", shape.TypeArguments.Select(
-                            argument => MapClosedShape(argument, context, location)))}>";
+                            (argument, index) => MapClosedShape(
+                                argument,
+                                context,
+                                location,
+                                displayArguments?[index])))}>";
                     }
                 }
             }
@@ -161,22 +188,47 @@ static class TsJsonUnionMapper
                 if (shape.Kind == ApiTypeShapeKind.GenericInstance
                     && identity.FullName == "System.Nullable`1"
                     && shape.TypeArguments is [var nullable])
-                    return WithNull(MapClosedShape(nullable, context, location));
+                {
+                    string? nullableDisplay =
+                        display?.EndsWith("?", StringComparison.Ordinal) == true
+                            ? display[..^1]
+                            : GenericDisplayArguments(
+                                display,
+                                1,
+                                location)?[0];
+                    return WithNull(MapClosedShape(
+                        nullable,
+                        context,
+                        location,
+                        nullableDisplay));
+                }
                 if (shape.Kind == ApiTypeShapeKind.GenericInstance
                     && identity.FullName is "System.Collections.Generic.Dictionary`2"
                         or "System.Collections.Generic.IReadOnlyDictionary`2"
                     && shape.TypeArguments is [var key, var value]
                     && key is { Kind: ApiTypeShapeKind.Primitive, Primitive: ApiPrimitiveType.String })
                 {
-                    return $"Readonly<Record<string, {MapCollectionShape(value, context, location)}>>";
+                    IReadOnlyList<string>? displayArguments =
+                        GenericDisplayArguments(
+                            display,
+                            2,
+                            location);
+                    return $"Readonly<Record<string, {MapCollectionShape(
+                        value,
+                        context,
+                        location,
+                        displayArguments?[1])}>>";
                 }
             }
         }
-        throw Unsupported(location, "unsupported closed generic union argument");
+        throw Unsupported(location, "unsupported closed generic JSON argument");
     }
 
     internal static string WithNull(string type) =>
-        $"{type} | null";
+        type == "null"
+            || type.EndsWith(" | null", StringComparison.Ordinal)
+                ? type
+                : $"{type} | null";
 
     // Signature-only case trees do not retain nested nullable-reference annotations.
     static string MapCollectionCase(TypeRef type, TsJsonUnionMappingContext context, string location)
@@ -187,9 +239,17 @@ static class TsJsonUnionMapper
             : mapped;
     }
 
-    static string MapCollectionShape(ApiTypeShape shape, TsJsonUnionMappingContext context, string location)
+    static string MapCollectionShape(
+        ApiTypeShape shape,
+        TsJsonUnionMappingContext context,
+        string location,
+        string? displayType = null)
     {
-        string mapped = MapClosedShape(shape, context, location);
+        string mapped = MapClosedShape(
+            shape,
+            context,
+            location,
+            displayType);
         bool reference = shape.Kind == ApiTypeShapeKind.SzArray
             || shape is { Kind: ApiTypeShapeKind.Primitive, Primitive: ApiPrimitiveType.String };
         if (shape.Definition is { } identity)
@@ -204,6 +264,33 @@ static class TsJsonUnionMapper
         }
         return reference ? WithNull(mapped) : mapped;
     }
+
+    static IReadOnlyList<string>? GenericDisplayArguments(
+        string? displayType,
+        int expectedCount,
+        string location)
+    {
+        if (displayType is null)
+            return null;
+        if (!TsTypeMapper.TryParseGenericType(
+                displayType,
+                out _,
+                out IReadOnlyList<string> arguments)
+            || arguments.Count != expectedCount)
+        {
+            throw Unsupported(
+                location,
+                "closed generic display arguments are unavailable");
+        }
+        return arguments;
+    }
+
+    static bool IsNullableShape(ApiTypeShape shape) =>
+        shape is
+        {
+            Kind: ApiTypeShapeKind.GenericInstance,
+            Definition.FullName: "System.Nullable`1",
+        };
 
     static ApiTypeReferenceIdentity? LocalIdentity(
         TypeRef type,

--- a/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
@@ -410,7 +410,7 @@ static class TsTypeMapper
 
         if (mappingContext == TsTypeMappingContext.JsonWire
             && typeShape is { Kind: ApiTypeShapeKind.GenericInstance, Definition: { } unionIdentity }
-            && unionContext?.GenericArities.ContainsKey(unionIdentity) == true)
+            && unionContext?.LocalGenericArities.ContainsKey(unionIdentity) == true)
         {
             return TsJsonUnionMapper.MapClosedShape(
                 typeShape, unionContext, location ?? trimmed);

--- a/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
@@ -190,7 +190,12 @@ static class TsTypeMapper
             TsTypeMappingContext.JsonWire,
             wireTypeShape,
             identityNames,
-            unionContext);
+            unionContext is null
+                ? null
+                : unionContext with
+                {
+                    ConservativeReferenceArguments = true,
+                });
 
         if (IsJsonEnvelopeReturnType(trimmed))
         {

--- a/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
+++ b/src/ILInspector.TypeScriptGeneration/TsTypeMapper.cs
@@ -413,7 +413,10 @@ static class TsTypeMapper
             && unionContext?.LocalGenericArities.ContainsKey(unionIdentity) == true)
         {
             return TsJsonUnionMapper.MapClosedShape(
-                typeShape, unionContext, location ?? trimmed);
+                typeShape,
+                unionContext,
+                location ?? trimmed,
+                trimmed);
         }
 
         if (typeShape is
@@ -1489,7 +1492,7 @@ static class TsTypeMapper
             ? typeName["global::".Length..]
             : typeName;
 
-    static bool TryParseGenericType(
+    internal static bool TryParseGenericType(
         string typeName,
         out string? definition,
         out IReadOnlyList<string> arguments)

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -11,6 +11,7 @@ using ILInspector.JsExportSurface.NestedContextConstructorFixtures;
 using ILInspector.JsExportSurface.NestedContextFixtures.Contexts;
 using ILInspector.JsExportSurface.NestedContextUnsupportedFixtures.Contexts;
 using ILInspector.JsExportSurface.PublishabilityFixtures;
+using ILInspector.JsExportSurface.TypeScriptFixtures;
 using ILInspector.Metadata;
 
 namespace ILInspector.JsExportSurface.Tests;
@@ -30,6 +31,21 @@ public sealed class DtsEmitterTests
 
     private static string EmitFixtureDtsWithWireContracts()
         => DtsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
+
+    private static ILInspector.JsExportSurface.JsExportSurface
+        BuildTypeScriptFixtureSurface()
+    {
+        string path = typeof(TypeScriptFixtureExports).Assembly.Location;
+        using FileStream stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        ApiSurface apiSurface =
+            ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var bodyIndex = LibraryBodyIndex.Open(
+            path,
+            LibraryBodyAnalysisFeatures.MethodEvidence
+                | LibraryBodyAnalysisFeatures.JsonWireContractFlow);
+        return JsExportSurfaceBuilder.Build(apiSurface, bodyIndex);
+    }
 
     private static ILInspector.JsExportSurface.JsExportSurface
         BuildFixtureSurfaceWithWireContracts()
@@ -782,6 +798,132 @@ public sealed class DtsEmitterTests
                 + "Readonly<Record<string, ClosedGenericRootDto>>;",
             dts,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Facade_ProjectsGenericRecordAndClosedJsonArguments()
+    {
+        var diagnostics = new TypeScriptGenerationDiagnostics();
+        string facade = TypeScriptFacadeEmitter.Emit(
+            BuildTypeScriptFixtureSurface(),
+            "./dotnet.js",
+            diagnostics);
+
+        Assert.Contains(
+            """
+            export interface GenericEnvelope<T0> {
+              readonly content: T0;
+              readonly label: string;
+            }
+            """,
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export function getWidgetEnvelope(name: string): "
+                + "GenericEnvelope<WidgetDto>",
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export function getBlobEnvelope(): GenericEnvelope<string>",
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            """
+            export interface GenericCollision<T0> {
+              readonly content: T0;
+              readonly other: T;
+            }
+            """,
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            """
+            export interface NullableEnvelope<T0> {
+              readonly content: T0 | null;
+            }
+            """,
+            facade,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Kind<number>",
+            facade,
+            StringComparison.Ordinal);
+        Assert.False(diagnostics.HasUnmappedTypes);
+    }
+
+    [Fact]
+    public void Facade_RejectsGenericRecordParameterEmbeddedInClrArray()
+    {
+        ILInspector.JsExportSurface.JsExportSurface surface =
+            BuildTypeScriptFixtureSurface();
+        ApiType envelope = Assert.Single(
+            surface.Records,
+            type => type.Name.StartsWith(
+                "GenericEnvelope",
+                StringComparison.Ordinal));
+        string parameter = Assert.Single(envelope.TypeParameters).Name;
+        ApiMember content = Assert.Single(
+            envelope.Members,
+            member => member.Name == "Content");
+        content.ReturnType = $"{parameter}[]";
+        ApiSignature signature = Assert.IsType<ApiSignature>(
+            content.SignatureModel);
+        signature.ReturnType = $"{parameter}[]";
+        signature.ReturnTypeShape = null;
+
+        UnsupportedWireContractException failure =
+            Assert.Throws<UnsupportedWireContractException>(
+                () => TypeScriptFacadeEmitter.Emit(
+                    surface,
+                    "./dotnet.js"));
+
+        Assert.Contains(
+            "generic record parameter",
+            failure.Message,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "not parametric",
+            failure.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GenericArgumentMapping_ErasesContainingTypeArityFromNestedEnum()
+    {
+        var assembly = new ApiAssemblyIdentity(
+            "Fixture",
+            new Version(1, 0, 0, 0),
+            culture: null,
+            publicKeyToken: null);
+        var enumIdentity = new ApiTypeReferenceIdentity(
+            assembly,
+            "Fixture.Outer`1+Kind",
+            DefinitionName("Fixture", "Outer`1", "Kind"));
+        var context = new TsJsonUnionMappingContext(
+            assembly,
+            new Dictionary<ApiTypeReferenceIdentity, string>
+            {
+                [enumIdentity] = "Kind",
+            },
+            new Dictionary<ApiTypeReferenceIdentity, int>(),
+            new TsDelegateMappingContext(
+                new HashSet<string>(StringComparer.Ordinal),
+                new Dictionary<
+                    MetadataTypeDefinitionName,
+                    TsLocalTypeKind>(),
+                assembly));
+
+        string mapped = TsJsonUnionMapper.MapClosedShape(
+            ApiTypeShape.GenericInstance(
+                enumIdentity,
+                [
+                    ApiTypeShape.PrimitiveType(
+                        ApiPrimitiveType.Int32),
+                ]),
+            context,
+            "nested enum");
+
+        Assert.Equal("Kind", mapped);
     }
 
     [Fact]

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -820,11 +820,17 @@ public sealed class DtsEmitterTests
             StringComparison.Ordinal);
         Assert.Contains(
             "export function getWidgetEnvelope(name: string): "
-                + "GenericEnvelope<WidgetDto>",
+                + "GenericEnvelope<WidgetDto | null>",
             facade,
             StringComparison.Ordinal);
         Assert.Contains(
-            "export function getBlobEnvelope(): GenericEnvelope<string>",
+            "export function getBlobEnvelope(): "
+                + "GenericEnvelope<string | null>",
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export function getDirectNullableTextEnvelope(): "
+                + "GenericEnvelope<string | null>",
             facade,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -832,6 +838,7 @@ public sealed class DtsEmitterTests
             export interface GenericCollision<T0> {
               readonly content: T0;
               readonly other: T;
+              readonly included: T;
             }
             """,
             facade,

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -834,11 +834,22 @@ public sealed class DtsEmitterTests
             facade,
             StringComparison.Ordinal);
         Assert.Contains(
+            "export type GenericRecordChoice = "
+                + "GenericEnvelope<string | null> | number | null;",
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export function getGenericRecordChoice(): "
+                + "GenericRecordChoice",
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
             """
             export interface GenericCollision<T0> {
               readonly content: T0;
               readonly other: T;
               readonly included: T;
+              readonly includedItems: ReadonlyArray<T>;
             }
             """,
             facade,

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -844,6 +844,18 @@ public sealed class DtsEmitterTests
             """,
             facade,
             StringComparison.Ordinal);
+        Assert.Contains(
+            """
+            export interface NullableTextRoot {
+              readonly result: GenericEnvelope<string | null>;
+            }
+            """,
+            facade,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export function getNullableTextRoot(): NullableTextRoot",
+            facade,
+            StringComparison.Ordinal);
         Assert.DoesNotContain(
             "Kind<number>",
             facade,

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
@@ -35,6 +35,7 @@ for (
     "wrappedBlob",
     "widgetEnvelope",
     "blobEnvelope",
+    "directNullableTextEnvelope",
     "collisionEnvelope",
     "nullableIntEnvelope",
     "nullableIntEnvelopeNull",
@@ -93,6 +94,8 @@ const getBlobEnvelopeKey =
   facadeSource.match(/"(GetBlobEnvelope\.-?\d+)"/)?.[1];
 const getCollisionEnvelopeKey =
   facadeSource.match(/"(GetCollisionEnvelope\.-?\d+)"/)?.[1];
+const getDirectNullableTextEnvelopeKey =
+  facadeSource.match(/"(GetDirectNullableTextEnvelope\.-?\d+)"/)?.[1];
 const getNullableIntEnvelopeKey =
   facadeSource.match(/"(GetNullableIntEnvelope\.-?\d+)"/)?.[1];
 const getNullableTextRootKey =
@@ -202,6 +205,11 @@ assert.ok(
 assert.ok(
   getCollisionEnvelopeKey,
   "The generated GetCollisionEnvelope runtime dispatch key was not found.",
+);
+assert.ok(
+  getDirectNullableTextEnvelopeKey,
+  "The generated GetDirectNullableTextEnvelope runtime dispatch key "
+    + "was not found.",
 );
 assert.ok(
   getNullableIntEnvelopeKey,
@@ -336,6 +344,9 @@ function managedExports(methods = {}) {
             [getCollisionEnvelopeKey]:
               methods.getCollisionEnvelope
               ?? (() => unionPayloads.collisionEnvelope),
+            [getDirectNullableTextEnvelopeKey]:
+              methods.getDirectNullableTextEnvelope
+              ?? (() => unionPayloads.directNullableTextEnvelope),
             [getNullableIntEnvelopeKey]:
               methods.getNullableIntEnvelope
               ?? ((hasValue) => (hasValue
@@ -537,6 +548,14 @@ async function freshFacade() {
     {
       content: 7,
       other: { value: "concrete" },
+      included: { value: "included" },
+    },
+  );
+  assert.deepEqual(
+    facade.getDirectNullableTextEnvelope(),
+    {
+      content: null,
+      label: "direct-nullable",
     },
   );
   assert.deepEqual(
@@ -592,7 +611,8 @@ async function freshFacade() {
   );
   assert.equal(
     unionUsage.describeGenericEnvelopes(),
-    "generic:widget/AQID:blob/7:concrete/42:null/null:nullable",
+    "generic:widget/AQID:blob/null:direct-nullable"
+      + "/7:concrete:included/42:null/null:nullable",
   );
   assert.equal(unionUsage.missingSelectionEntry, null);
   assert.equal(unionUsage.missingMapEntry, null);

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
@@ -38,6 +38,7 @@ for (
     "collisionEnvelope",
     "nullableIntEnvelope",
     "nullableIntEnvelopeNull",
+    "nullableTextRoot",
     "selectionEnvelope",
   ]
 ) {
@@ -94,6 +95,8 @@ const getCollisionEnvelopeKey =
   facadeSource.match(/"(GetCollisionEnvelope\.-?\d+)"/)?.[1];
 const getNullableIntEnvelopeKey =
   facadeSource.match(/"(GetNullableIntEnvelope\.-?\d+)"/)?.[1];
+const getNullableTextRootKey =
+  facadeSource.match(/"(GetNullableTextRoot\.-?\d+)"/)?.[1];
 const getSelectionEnvelopeAsyncKey =
   facadeSource.match(/"(GetSelectionEnvelopeAsync\.-?\d+)"/)?.[1];
 const observeValueKey =
@@ -203,6 +206,10 @@ assert.ok(
 assert.ok(
   getNullableIntEnvelopeKey,
   "The generated GetNullableIntEnvelope runtime dispatch key was not found.",
+);
+assert.ok(
+  getNullableTextRootKey,
+  "The generated GetNullableTextRoot runtime dispatch key was not found.",
 );
 assert.ok(
   getSelectionEnvelopeAsyncKey,
@@ -334,6 +341,9 @@ function managedExports(methods = {}) {
               ?? ((hasValue) => (hasValue
                 ? unionPayloads.nullableIntEnvelope
                 : unionPayloads.nullableIntEnvelopeNull)),
+            [getNullableTextRootKey]:
+              methods.getNullableTextRoot
+              ?? (() => unionPayloads.nullableTextRoot),
             [getSelectionEnvelopeAsyncKey]:
               methods.getSelectionEnvelopeAsync
               ?? (async () => unionPayloads.selectionEnvelope),
@@ -538,6 +548,15 @@ async function freshFacade() {
     { content: null },
   );
   assert.deepEqual(
+    facade.getNullableTextRoot(),
+    {
+      result: {
+        content: null,
+        label: "nullable",
+      },
+    },
+  );
+  assert.deepEqual(
     await facade.getSelectionEnvelopeAsync("envelope"),
     {
       result: { name: "envelope", count: 5 },
@@ -573,7 +592,7 @@ async function freshFacade() {
   );
   assert.equal(
     unionUsage.describeGenericEnvelopes(),
-    "generic:widget/AQID:blob/7:concrete/42:null",
+    "generic:widget/AQID:blob/7:concrete/42:null/null:nullable",
   );
   assert.equal(unionUsage.missingSelectionEntry, null);
   assert.equal(unionUsage.missingMapEntry, null);

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
@@ -36,6 +36,7 @@ for (
     "widgetEnvelope",
     "blobEnvelope",
     "directNullableTextEnvelope",
+    "genericRecordChoice",
     "collisionEnvelope",
     "nullableIntEnvelope",
     "nullableIntEnvelopeNull",
@@ -96,6 +97,8 @@ const getCollisionEnvelopeKey =
   facadeSource.match(/"(GetCollisionEnvelope\.-?\d+)"/)?.[1];
 const getDirectNullableTextEnvelopeKey =
   facadeSource.match(/"(GetDirectNullableTextEnvelope\.-?\d+)"/)?.[1];
+const getGenericRecordChoiceKey =
+  facadeSource.match(/"(GetGenericRecordChoice\.-?\d+)"/)?.[1];
 const getNullableIntEnvelopeKey =
   facadeSource.match(/"(GetNullableIntEnvelope\.-?\d+)"/)?.[1];
 const getNullableTextRootKey =
@@ -210,6 +213,10 @@ assert.ok(
   getDirectNullableTextEnvelopeKey,
   "The generated GetDirectNullableTextEnvelope runtime dispatch key "
     + "was not found.",
+);
+assert.ok(
+  getGenericRecordChoiceKey,
+  "The generated GetGenericRecordChoice runtime dispatch key was not found.",
 );
 assert.ok(
   getNullableIntEnvelopeKey,
@@ -347,6 +354,9 @@ function managedExports(methods = {}) {
             [getDirectNullableTextEnvelopeKey]:
               methods.getDirectNullableTextEnvelope
               ?? (() => unionPayloads.directNullableTextEnvelope),
+            [getGenericRecordChoiceKey]:
+              methods.getGenericRecordChoice
+              ?? (() => unionPayloads.genericRecordChoice),
             [getNullableIntEnvelopeKey]:
               methods.getNullableIntEnvelope
               ?? ((hasValue) => (hasValue
@@ -549,6 +559,7 @@ async function freshFacade() {
       content: 7,
       other: { value: "concrete" },
       included: { value: "included" },
+      includedItems: [{ value: "included-array" }],
     },
   );
   assert.deepEqual(
@@ -556,6 +567,13 @@ async function freshFacade() {
     {
       content: null,
       label: "direct-nullable",
+    },
+  );
+  assert.deepEqual(
+    facade.getGenericRecordChoice(),
+    {
+      content: null,
+      label: "union-nullable",
     },
   );
   assert.deepEqual(
@@ -612,7 +630,8 @@ async function freshFacade() {
   assert.equal(
     unionUsage.describeGenericEnvelopes(),
     "generic:widget/AQID:blob/null:direct-nullable"
-      + "/7:concrete:included/42:null/null:nullable",
+      + "/null:union-nullable"
+      + "/7:concrete:included:included-array/42:null/null:nullable",
   );
   assert.equal(unionUsage.missingSelectionEntry, null);
   assert.equal(unionUsage.missingMapEntry, null);

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/runtime-probe.mjs
@@ -33,6 +33,11 @@ for (
     "boxedCount",
     "boxedWidget",
     "wrappedBlob",
+    "widgetEnvelope",
+    "blobEnvelope",
+    "collisionEnvelope",
+    "nullableIntEnvelope",
+    "nullableIntEnvelopeNull",
     "selectionEnvelope",
   ]
 ) {
@@ -81,6 +86,14 @@ const getBoxedWidgetKey =
   facadeSource.match(/"(GetBoxedWidget\.-?\d+)"/)?.[1];
 const getWrappedBlobKey =
   facadeSource.match(/"(GetWrappedBlob\.-?\d+)"/)?.[1];
+const getWidgetEnvelopeKey =
+  facadeSource.match(/"(GetWidgetEnvelope\.-?\d+)"/)?.[1];
+const getBlobEnvelopeKey =
+  facadeSource.match(/"(GetBlobEnvelope\.-?\d+)"/)?.[1];
+const getCollisionEnvelopeKey =
+  facadeSource.match(/"(GetCollisionEnvelope\.-?\d+)"/)?.[1];
+const getNullableIntEnvelopeKey =
+  facadeSource.match(/"(GetNullableIntEnvelope\.-?\d+)"/)?.[1];
 const getSelectionEnvelopeAsyncKey =
   facadeSource.match(/"(GetSelectionEnvelopeAsync\.-?\d+)"/)?.[1];
 const observeValueKey =
@@ -174,6 +187,22 @@ assert.ok(
 assert.ok(
   getWrappedBlobKey,
   "The generated GetWrappedBlob runtime dispatch key was not found.",
+);
+assert.ok(
+  getWidgetEnvelopeKey,
+  "The generated GetWidgetEnvelope runtime dispatch key was not found.",
+);
+assert.ok(
+  getBlobEnvelopeKey,
+  "The generated GetBlobEnvelope runtime dispatch key was not found.",
+);
+assert.ok(
+  getCollisionEnvelopeKey,
+  "The generated GetCollisionEnvelope runtime dispatch key was not found.",
+);
+assert.ok(
+  getNullableIntEnvelopeKey,
+  "The generated GetNullableIntEnvelope runtime dispatch key was not found.",
 );
 assert.ok(
   getSelectionEnvelopeAsyncKey,
@@ -293,6 +322,18 @@ function managedExports(methods = {}) {
               methods.getBoxedWidget ?? (() => unionPayloads.boxedWidget),
             [getWrappedBlobKey]:
               methods.getWrappedBlob ?? (() => unionPayloads.wrappedBlob),
+            [getWidgetEnvelopeKey]:
+              methods.getWidgetEnvelope ?? (() => unionPayloads.widgetEnvelope),
+            [getBlobEnvelopeKey]:
+              methods.getBlobEnvelope ?? (() => unionPayloads.blobEnvelope),
+            [getCollisionEnvelopeKey]:
+              methods.getCollisionEnvelope
+              ?? (() => unionPayloads.collisionEnvelope),
+            [getNullableIntEnvelopeKey]:
+              methods.getNullableIntEnvelope
+              ?? ((hasValue) => (hasValue
+                ? unionPayloads.nullableIntEnvelope
+                : unionPayloads.nullableIntEnvelopeNull)),
             [getSelectionEnvelopeAsyncKey]:
               methods.getSelectionEnvelopeAsync
               ?? (async () => unionPayloads.selectionEnvelope),
@@ -468,6 +509,35 @@ async function freshFacade() {
   // A closed byte[] union argument keeps its Base64 JSON string wire form.
   assert.equal(facade.getWrappedBlob(), "AQID");
   assert.deepEqual(
+    facade.getWidgetEnvelope("generic"),
+    {
+      content: { name: "generic", count: 12 },
+      label: "widget",
+    },
+  );
+  assert.deepEqual(
+    facade.getBlobEnvelope(),
+    {
+      content: "AQID",
+      label: "blob",
+    },
+  );
+  assert.deepEqual(
+    facade.getCollisionEnvelope(),
+    {
+      content: 7,
+      other: { value: "concrete" },
+    },
+  );
+  assert.deepEqual(
+    facade.getNullableIntEnvelope(true),
+    { content: 42 },
+  );
+  assert.deepEqual(
+    facade.getNullableIntEnvelope(false),
+    { content: null },
+  );
+  assert.deepEqual(
     await facade.getSelectionEnvelopeAsync("envelope"),
     {
       result: { name: "envelope", count: 5 },
@@ -500,6 +570,10 @@ async function freshFacade() {
     await unionUsage.summarizeEnvelope(),
     "envelope:5|first|envelope:6|outcome|kind-0|7/envelope|blob:BAU="
       + "|group:envelope,null",
+  );
+  assert.equal(
+    unionUsage.describeGenericEnvelopes(),
+    "generic:widget/AQID:blob/7:concrete/42:null",
   );
   assert.equal(unionUsage.missingSelectionEntry, null);
   assert.equal(unionUsage.missingMapEntry, null);

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
@@ -41,6 +41,9 @@ if (args is not [string outputPath])
         "nullableIntEnvelopeNull",
         TypeScriptFixtureExports.GetNullableIntEnvelope(false)),
     (
+        "nullableTextRoot",
+        TypeScriptFixtureExports.GetNullableTextRoot()),
+    (
         "selectionEnvelope",
         await TypeScriptFixtureExports.GetSelectionEnvelopeAsync("envelope")),
 ];

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
@@ -36,6 +36,9 @@ if (args is not [string outputPath])
     (
         "directNullableTextEnvelope",
         TypeScriptFixtureExports.GetDirectNullableTextEnvelope()),
+    (
+        "genericRecordChoice",
+        TypeScriptFixtureExports.GetGenericRecordChoice()),
     ("collisionEnvelope", TypeScriptFixtureExports.GetCollisionEnvelope()),
     (
         "nullableIntEnvelope",

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
@@ -33,6 +33,9 @@ if (args is not [string outputPath])
     ("wrappedBlob", TypeScriptFixtureExports.GetWrappedBlob()),
     ("widgetEnvelope", TypeScriptFixtureExports.GetWidgetEnvelope("generic")),
     ("blobEnvelope", TypeScriptFixtureExports.GetBlobEnvelope()),
+    (
+        "directNullableTextEnvelope",
+        TypeScriptFixtureExports.GetDirectNullableTextEnvelope()),
     ("collisionEnvelope", TypeScriptFixtureExports.GetCollisionEnvelope()),
     (
         "nullableIntEnvelope",

--- a/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/Fixtures/ts-jsexport-runtime/union-payloads.cs
@@ -31,6 +31,15 @@ if (args is not [string outputPath])
     ("boxedCount", TypeScriptFixtureExports.GetBoxedCount(11)),
     ("boxedWidget", TypeScriptFixtureExports.GetBoxedWidget("boxed")),
     ("wrappedBlob", TypeScriptFixtureExports.GetWrappedBlob()),
+    ("widgetEnvelope", TypeScriptFixtureExports.GetWidgetEnvelope("generic")),
+    ("blobEnvelope", TypeScriptFixtureExports.GetBlobEnvelope()),
+    ("collisionEnvelope", TypeScriptFixtureExports.GetCollisionEnvelope()),
+    (
+        "nullableIntEnvelope",
+        TypeScriptFixtureExports.GetNullableIntEnvelope(true)),
+    (
+        "nullableIntEnvelopeNull",
+        TypeScriptFixtureExports.GetNullableIntEnvelope(false)),
     (
         "selectionEnvelope",
         await TypeScriptFixtureExports.GetSelectionEnvelopeAsync("envelope")),


### PR DESCRIPTION
This builds a robust, foundational C#/TypeScript boundary: producer-owned
generic JSON records now retain their structure instead of forcing each Browser
consumer to invent a lowered mirror.

## Demo

Before, a closed generic JSON result could not name its declaration:

```text
GenericEnvelope<WidgetDto>
  -> manual BrowserGenericEnvelope projection
  -> TypeScript BrowserGenericEnvelope
```

After, the generated facade preserves the reusable declaration and exact closed
wire mapping while disclosing erased nullable-reference evidence:

```ts
export interface GenericEnvelope<T0> {
  readonly content: T0;
  readonly label: string;
}

export function getWidgetEnvelope(
  name: string,
): GenericEnvelope<WidgetDto | null>;

// byte[] retains its Base64 wire shape; direct-root reference
// nullability is unavailable and remains conservative.
export function getBlobEnvelope(): GenericEnvelope<string | null>;

export type GenericRecordChoice =
  | GenericEnvelope<string | null>
  | number
  | null;
```

The neighboring non-generic DTO and generic-union outputs are unchanged.

## What changed

- emits generic TypeScript interfaces for records reached through authenticated
  closed System.Text.Json shapes;
- maps each closed argument through the existing structured JSON wire mapper;
- supports direct parameter-valued members and constrained nullable value
  parameters;
- combines structured argument identity with reachable member-signature
  nullability, preserving closed uses such as `GenericEnvelope<string?>` as
  `GenericEnvelope<string | null>`;
- keeps reference-shaped arguments conservatively nullable when direct
  serializer-root metadata has erased nullable-reference annotations;
- applies the same conservative rule when union case signatures erase nested
  nullable-reference annotations;
- gives authenticated type identity precedence over display-name collisions;
- protects concrete `[JsonInclude]` field identities even when field metadata
  does not provide `ApiTypeShape`, including concrete array elements;
- erases inherited containing-type arity for non-generic nested declarations;
- rejects embedded non-parametric CLR positions such as `T[]`, which cannot be
  represented soundly because `byte[]` serializes as Base64; and
- adds compiler and runtime evidence for record, `byte[]`, nullable,
  generic-record union alternatives, and concrete-type-name-collision
  constructions.

## Adoption boundary

This unlocks the generic declaration needed by
`InspectionEnvelope<TypeDependencySectionResult>` in #6736. Direct adoption
still requires the envelope's Share, diagnostic, content, and collection graph
to carry independently supported System.Text.Json evidence; `ts-jsexport` does
not invent those contracts or generic runtime `[JSExport]` methods.

## Validation

- `dotnet run --project tests/ILInspector.JsExportSurface.Tests -c Release`
  (544 tests)
- `eng/test-ts-jsexport-typescript.sh`
- `eng/test-ts-jsexport-context-aot.sh linux-x64`
- `eng/test-inspect-web-multi-facade-canary.sh --fast`
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx --yes markdownlint-cli docs/design/ts-jsexport.md`

Closes #6739
