### PR TITLE
Classify broad .NET tool Package Query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,14 +358,16 @@ executable IDs before constructing a query:
 
 ```bash
 dotnet-inspect find -Q Packages
-dotnet-inspect find --package-prefix dotnet-inspect -S Packages \
+dotnet-inspect find --package-prefix dotnet-inspect --package-content -S Packages \
   --where "facet=package.query.dotnet-tool" --candidates 5 --matches 5
 dotnet-inspect find --package-prefix dotnet-inspect --package-content \
   --where "facet=package.query.dotnet-tool-v2" --candidates 5 --matches 5 --jsonl
 ```
 
 Repeat `--where` to combine facets; the engine rejects incompatible selections.
-Tool v1 and v2 are compatible alternatives. `--candidates` bounds candidate
+The broad tool facet reports CLI v1, CLI v2, or unrecognized settings from
+`DotnetToolSettings.xml`; tool v1 and v2 are compatible filtering alternatives.
+`--candidates` bounds candidate
 work (default 200), while `--matches` stops after matching packages (default
 100); each has a CLI maximum of 1,000. Content facets require
 `--package-content`, which defaults to and permits at most 20 candidates.

--- a/docs/design/cli-execution-bounds.md
+++ b/docs/design/cli-execution-bounds.md
@@ -183,7 +183,7 @@ example:
 
 ```console
 dotnet-inspect find --package-prefix dotnet-inspect \
-  --where "facet=package.query.dotnet-tool" --take 500 -n 20
+  --where "facet=package.query.has-dependencies" --take 500 -n 20
 ```
 
 `-n 20` requests up to 20 final matched-package rows. Source delegation may
@@ -405,7 +405,7 @@ The following request is valid:
 
 ```console
 dotnet-inspect find --package-prefix dotnet-inspect \
-  --where "facet=package.query.dotnet-tool" --take 500 -n 20
+  --where "facet=package.query.has-dependencies" --take 500 -n 20
 ```
 
 It authorizes inspection of at most 500 package candidates, then selects up to
@@ -418,7 +418,7 @@ The inverse numeric relationship is also valid:
 
 ```console
 dotnet-inspect find --package-prefix dotnet-inspect \
-  --where "facet=package.query.dotnet-tool" --take 10 -n 20
+  --where "facet=package.query.has-dependencies" --take 10 -n 20
 ```
 
 The operation may produce fewer than 20 final rows. L3 does not reject the

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -109,7 +109,7 @@ is:
 
 ```sh
 find -Q Packages
-find --package-prefix dotnet-inspect -S Packages \
+find --package-prefix dotnet-inspect --package-content -S Packages \
   --where "facet=package.query.dotnet-tool" --take 20 -n 5
 find --package-prefix dotnet-inspect --package-content \
   --where "facet=package.query.dotnet-tool-v2" --take 20 -n 5
@@ -486,9 +486,11 @@ predicates:
   `PackageQuery` still applies manifest predicates first, so a tool-format
   facet does not acquire non-tool packages. The current archive-derived
   facets inspect `DotnetToolSettings.xml` for tool v1/v2 and package paths for
-  `skills/SKILL.md` or `skills/**/SKILL.md`. Tool v1 and v2 are combining
-  members, so selecting both returns either format with evidence identifying
-  the matched version; the manifest-only any-tool facet remains exclusive.
+  `skills/SKILL.md` or `skills/**/SKILL.md`. The exclusive any-tool facet
+  preserves the nuspec package-type prefilter, then reports CLI v1, CLI v2, or
+  explicitly unrecognized settings from the admitted archive. Tool v1 and v2
+  are combining members, so selecting both returns either recognized format
+  with evidence identifying the matched version.
 - **Promoted assembly tier.** The one-candidate asset, pattern, semantic
   confirmation, evidence, and resource-lifetime contract is owned by
   [Package Query assembly-pattern

--- a/docs/design/package-query-experience.md
+++ b/docs/design/package-query-experience.md
@@ -167,11 +167,14 @@ and
   mutually exclusive facets, such as has-dependencies and no-dependencies,
   replace one another. Product-issued display groups render `.NET Tool`, `v1`,
   and `v2` as one segmented control while retaining three independently
-  focusable buttons and opaque facet IDs. `.NET Tool` matches any tool from
-  manifest evidence and replaces selected version segments. `v1` and `v2`
-  inspect `DotnetToolSettings.xml`; either replaces `.NET Tool`, while both
-  version segments may remain selected and form an OR-union. A matching row's
-  product evidence identifies the format it matched.
+  focusable buttons and opaque facet IDs. `.NET Tool` prefilters tools from
+  manifest evidence, opens each admitted package, and reports CLI v1, CLI v2,
+  or explicitly unrecognized settings from `DotnetToolSettings.xml`; it
+  replaces selected version segments. `v1` and `v2` filter to their recognized
+  settings versions; either replaces `.NET Tool`, while both version segments
+  may remain selected and form an OR-union. Every tool segment is bounded
+  package-content work, and a matching row's product evidence identifies the
+  observed format.
   `embedded SKILL.md` matches package entries at `skills/SKILL.md` or
   `skills/**/SKILL.md`, case-insensitively. The rail persistently discloses
   that content facets may download up to 20 candidate archives.
@@ -514,7 +517,7 @@ and browser-history and focus-return outcomes are proved by
 8. Run a sparse or zero-match query and confirm source, manifest, and
    package-content progress advances before completion without manufacturing
    rows. Confirm semantic completion crosses the Browser boundary only once.
-9. Select `v1`, `v2`, or `embedded SKILL.md`; confirm the request bound drops
+9. Select `.NET Tool`, `v1`, `v2`, or `embedded SKILL.md`; confirm the request bound drops
    to 20 candidates, archive acquisition uses the Browser package store and
    deadline, and acquisition/evaluation failures remain visible. Remove the
    final package-content facet and confirm the default returns to 200.

--- a/inspect-web/DotnetInspect.Web.Tests/BrowserEngineBoundaryTests.cs
+++ b/inspect-web/DotnetInspect.Web.Tests/BrowserEngineBoundaryTests.cs
@@ -96,9 +96,13 @@ public sealed partial class BrowserEngineBoundaryTests
                     [
                         PackageQuery.ToolFacetId,
                         PackageQuery.NoDependenciesFacetId,
-                    ]))).Plan;
+                    ],
+                    MaximumCandidates:
+                        PackageQuery.MaximumPackageContentCandidates))).Plan;
 
-        Assert.Equal(PackageQueryFacetTier.Nuspec, plan.Facets[0].Tier);
+        Assert.Equal(
+            PackageQueryFacetTier.PackageContent,
+            plan.Facets[0].Tier);
         Assert.Equal(
             [
                 PackageQuery.ToolFacetId,

--- a/inspect-web/browser/package-adoption.spec.ts
+++ b/inspect-web/browser/package-adoption.spec.ts
@@ -116,6 +116,7 @@ interface FixtureCoordinate {
   readonly packageId: string;
   readonly version: string;
   readonly archive: Buffer;
+  readonly manifest?: Buffer;
 }
 
 interface Deferred<T> {
@@ -132,6 +133,32 @@ function deferred<T>(): Deferred<T> {
 }
 
 const version = "1.0.0";
+
+function packageQueryManifest(
+  packageId: string,
+  packageVersion: string,
+  isTool: boolean,
+): Buffer {
+  return Buffer.from(
+    `<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>${packageId}</id>
+    <version>${packageVersion}</version>
+    <authors>Fixture</authors>
+    <description>Package Query fixture.</description>
+    ${isTool
+      ? `<packageTypes>
+      <packageType name="DotnetTool" />
+    </packageTypes>`
+      : ""}
+  </metadata>
+</package>
+`,
+    "utf8",
+  );
+}
+
 const healthy: FixtureCoordinate = {
   packageId: "InspectWeb.Adoption.Healthy",
   version,
@@ -242,6 +269,7 @@ const literalFixtures: readonly FixtureCoordinate[] = [
 class GalleryFixtureRegistry {
   readonly downloads = new Map<string, number>();
   private readonly archives = new Map<string, Buffer>();
+  private readonly manifests = new Map<string, Buffer>();
   private readonly versions = new Map<string, string>();
   private readonly downloadKeys = new Map<string, string>();
 
@@ -259,6 +287,13 @@ class GalleryFixtureRegistry {
         `/v3-flatcontainer/${fixture.packageId.toLowerCase()}/index.json`,
         fixture.version,
       );
+      if (fixture.manifest) {
+        this.manifests.set(
+          `/v3-flatcontainer/${fixture.packageId.toLowerCase()}/${fixture.version}`
+            + `/${fixture.packageId.toLowerCase()}.nuspec`,
+          fixture.manifest,
+        );
+      }
     }
   }
 
@@ -268,6 +303,10 @@ class GalleryFixtureRegistry {
 
   versionIndexFor(pathname: string): string | undefined {
     return this.versions.get(pathname);
+  }
+
+  manifestFor(pathname: string): Buffer | undefined {
+    return this.manifests.get(pathname);
   }
 
   recordDownload(pathname: string): void {
@@ -308,6 +347,15 @@ async function installGalleryRoutes(
         status: 200,
         headers: { ...corsHeaders, "content-type": "application/octet-stream" },
         body: archive,
+      });
+      return;
+    }
+    const manifestBytes = registry.manifestFor(pathname);
+    if (manifestBytes) {
+      await route.fulfill({
+        status: 200,
+        headers: { ...corsHeaders, "content-type": "application/xml" },
+        body: manifestBytes,
       });
       return;
     }
@@ -608,6 +656,100 @@ test.describe("Package Query website over real Wasm", () => {
     expect(searchRequests).toHaveLength(searchCount);
     expect(exactRequests.at(-1)?.pathname).toBe("/v3-flatcontainer/newtonsoft.missing/index.json");
     expect(enrichment).toEqual([]);
+  });
+
+  test("classifies Azure.Mcp as a CLI v2 tool through bounded package content", async ({
+    page,
+    context,
+  }) => {
+    const toolManifest = packageQueryManifest("Azure.Mcp", "2.0.5", true);
+    const tool: FixtureCoordinate = {
+      packageId: "Azure.Mcp",
+      version: "2.0.5",
+      manifest: toolManifest,
+      archive: storedZip([
+        { name: "Azure.Mcp.nuspec", bytes: toolManifest },
+        {
+          name: "tools/net10.0/any/DotnetToolSettings.xml",
+          bytes: Buffer.from(
+            `<DotNetCliTool Version="2">
+  <Commands>
+    <Command Name="azmcp" EntryPoint="Azure.Mcp.dll" Runner="dotnet" />
+  </Commands>
+</DotNetCliTool>
+`,
+            "utf8",
+          ),
+        },
+      ]),
+    };
+    const libraryManifest =
+      packageQueryManifest("Azure.Library", "1.0.0", false);
+    const library: FixtureCoordinate = {
+      packageId: "Azure.Library",
+      version: "1.0.0",
+      manifest: libraryManifest,
+      archive: storedZip([
+        { name: "Azure.Library.nuspec", bytes: libraryManifest },
+      ]),
+    };
+    const registry = new GalleryFixtureRegistry([tool, library]);
+    await installGalleryRoutes(context, registry);
+
+    await context.route("https://azuresearch-usnc.nuget.org/**", async route => {
+      const url = new URL(route.request().url());
+      expect(url.pathname).toBe("/query");
+      const data = url.searchParams.get("skip") === "0"
+        ? [
+            {
+              id: tool.packageId,
+              version: tool.version,
+              description: "Azure MCP Server.",
+              owners: ["Microsoft"],
+              totalDownloads: 2_208_344,
+              verified: true,
+            },
+            {
+              id: library.packageId,
+              version: library.version,
+              description: "Ordinary library fixture.",
+              owners: ["Fixture"],
+              totalDownloads: 1,
+              verified: false,
+            },
+          ]
+        : [];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: corsHeaders,
+        body: JSON.stringify({ totalHits: 2, data }),
+      });
+    });
+
+    await page.goto("/query");
+    const input = page.locator("#package-query-prefix");
+    await expect(input).toBeVisible({ timeout: 120_000 });
+    const toolFacet = page.locator(
+      '[data-query-facet="package.query.dotnet-tool"]',
+    );
+    await toolFacet.click();
+    await expect(toolFacet).toHaveAttribute("aria-pressed", "true");
+    await expect(page.locator(".query-facet-disclosure").nth(1))
+      .toContainText("Candidate bound K: 20");
+
+    await input.fill("Azure.*");
+    await page.locator("#package-query-run").click();
+
+    const row = page.locator(".query-row");
+    await expect(row).toHaveCount(1, { timeout: 30_000 });
+    await expect(row.locator("h2")).toHaveText(tool.packageId);
+    await expect(row.locator(".query-tier")).toHaveText("package-content");
+    await expect(row.locator(".query-evidence")).toContainText(
+      "RID-specific .NET tool CLI v2 format",
+    );
+    expect(registry.downloadCount(tool)).toBe(1);
+    expect(registry.downloadCount(library)).toBe(0);
   });
 
   test("retains 100 prefix results while mounting a bounded row window", async ({

--- a/inspect-web/test/package-query-view.test.ts
+++ b/inspect-web/test/package-query-view.test.ts
@@ -45,7 +45,7 @@ const TOOL_FACETS: readonly QueryFacetTerm[] = [
   {
     key: "package.query.dotnet-tool",
     label: ".NET Tool",
-    tier: "nuspec",
+    tier: "package-content",
     selectionGroupId: "package.query.dotnet-tool-format",
     displayGroupId: "package.query.display.dotnet-tool",
     displayGroupLabel: ".NET tool format",

--- a/inspect-web/test/package-query.test.ts
+++ b/inspect-web/test/package-query.test.ts
@@ -56,7 +56,7 @@ const SKILL_FACET: QueryFacetTerm = {
 const ANY_TOOL_FACET: QueryFacetTerm = {
   key: "package.query.dotnet-tool",
   label: ".NET Tool",
-  tier: "nuspec",
+  tier: "package-content",
   selectionGroupId: "package.query.dotnet-tool-format",
 };
 
@@ -202,6 +202,14 @@ test("package-content facets lower the candidate bound until the last one is rem
   assert.equal(withSkill.requestedMatchLimit, 100);
   assert.equal(withSkillAndManifest.requestedMatchLimit, 100);
   assert.equal(manifestOnly.requestedMatchLimit, 100);
+});
+
+test("the broad tool facet grants the same bounded package-content work as version facets", () => {
+  const base = createQueryRequest("Azure.");
+
+  for (const facet of [ANY_TOOL_FACET, TOOL_V1_FACET, TOOL_V2_FACET]) {
+    assert.equal(withFacet(base, facet).requestedLimit, 20);
+  }
 });
 
 test("withScopeQuery preserves facets and bounds while changing search text", () => {

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -154,15 +154,16 @@ Package Query IDs. Use it with patternless `find --package-prefix`:
 
 ```bash
 dnx dotnet-inspect -y -- find -Q Packages --json
-dnx dotnet-inspect -y -- find --package-prefix dotnet-inspect -S Packages \
+dnx dotnet-inspect -y -- find --package-prefix dotnet-inspect --package-content -S Packages \
   --where "facet=package.query.dotnet-tool" --candidates 5 --matches 5
 dnx dotnet-inspect -y -- find --package-prefix dotnet-inspect --package-content \
   --where "facet=package.query.dotnet-tool-v2" --candidates 5 --matches 5 --jsonl
 ```
 
 `--where` repeats select product facets, not arbitrary package-field
-expressions. Independent facets are ANDed; compatible tool v1/v2 alternatives
-are ORed. Query rows represent individual packages, with exact versions and
+expressions. Independent facets are ANDed; the broad tool facet reports CLI v1,
+CLI v2, or unrecognized settings, while compatible tool v1/v2 alternatives are
+ORed. Query rows represent individual packages, with exact versions and
 product-authored evidence. `--candidates` bounds work (default 200) and
 `--matches` bounds semantic matches (default 100), each at most 1,000.
 Package-content facets need `--package-content` and at most 20 candidates;

--- a/src/DotnetInspector.Queries/PackageQuery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.cs
@@ -362,15 +362,19 @@ public static partial class PackageQuery
             new PackageQueryFacetDescriptor(
                 ToolFacetId,
                 ".NET Tool",
-                "The package manifest declares the .NET tool package type.",
+                "Downloads the package and inspects its .NET tool CLI format.",
                 200,
-                PackageQueryFacetTier.Nuspec,
+                PackageQueryFacetTier.PackageContent,
                 ToolSelectionGroupId,
                 ToolDisplayGroupId,
                 ".NET tool format"),
             static match => match.RequiredManifest.IsToolPackage,
-            static (_, _) => Describe(
-                "The package manifest declares a .NET tool package.")),
+            static (_, content) => DescribeToolFormat(
+                (content
+                    ?? throw new InvalidOperationException(
+                        ".NET tool evidence requires package-content facts."))
+                    .ToolSettingsVersion),
+            static _ => true),
         new(
             new PackageQueryFacetDescriptor(
                 ToolV1FacetId,
@@ -385,8 +389,7 @@ public static partial class PackageQuery
                 CombinesWithinSelectionGroup = true,
             },
             static match => match.RequiredManifest.IsToolPackage,
-            static (_, _) => Describe(
-                "DotnetToolSettings.xml declares the portable .NET tool v1 format."),
+            static (_, _) => DescribeToolFormat("1"),
             static content => content.ToolSettingsVersion == "1"),
         new(
             new PackageQueryFacetDescriptor(
@@ -402,8 +405,7 @@ public static partial class PackageQuery
                 CombinesWithinSelectionGroup = true,
             },
             static match => match.RequiredManifest.IsToolPackage,
-            static (_, _) => Describe(
-                "DotnetToolSettings.xml declares the RID-specific .NET tool v2 format."),
+            static (_, _) => DescribeToolFormat("2"),
             static content => content.ToolSettingsVersion == "2"),
         new(
             new PackageQueryFacetDescriptor(
@@ -942,7 +944,7 @@ public static partial class PackageQuery
                 {
                     continue;
                 }
-                evidence.Add(CreateFacetEvidence(candidate, match, null));
+                AddFacetEvidence(candidate, match, null, evidence);
             }
         }
 
@@ -990,7 +992,7 @@ public static partial class PackageQuery
 
             foreach (PackageQueryFacetDefinition candidate in matched)
             {
-                evidence.Add(CreateFacetEvidence(candidate, match, content));
+                AddFacetEvidence(candidate, match, content, evidence);
             }
         }
 
@@ -1007,7 +1009,8 @@ public static partial class PackageQuery
         bool needsSkills = definitions.Any(definition =>
             definition.Descriptor.Id == EmbeddedSkillFacetId);
         bool needsToolSettings = definitions.Any(definition =>
-            definition.Descriptor.Id is ToolV1FacetId or ToolV2FacetId);
+            definition.Descriptor.Id
+                is ToolFacetId or ToolV1FacetId or ToolV2FacetId);
         PackageQueryEvidenceSummary? skills = needsSkills
             ? SummarizeItems(entries.Where(IsSkillDocument), StringComparer.Ordinal)
             : null;
@@ -1137,6 +1140,18 @@ public static partial class PackageQuery
             "dependency",
             "dependencies");
 
+    static PackageQueryFacetEvidence DescribeToolFormat(
+        string? settingsVersion) =>
+        settingsVersion switch
+        {
+            "1" => Describe(
+                "DotnetToolSettings.xml declares the portable .NET tool CLI v1 format."),
+            "2" => Describe(
+                "DotnetToolSettings.xml declares the RID-specific .NET tool CLI v2 format."),
+            _ => Describe(
+                "The package manifest declares a .NET tool, but its settings do not identify CLI v1 or CLI v2."),
+        };
+
     static PackageQueryEvidenceSummary SummarizeItems(
         IEnumerable<string> items,
         StringComparer comparer)
@@ -1182,6 +1197,27 @@ public static partial class PackageQuery
         {
             Summary = description.Summary,
         };
+    }
+
+    static void AddFacetEvidence(
+        PackageQueryFacetDefinition definition,
+        PackageQueryPackage package,
+        PackageContentFacts? content,
+        ImmutableArray<PackageQueryEvidence>.Builder evidence)
+    {
+        int insertionIndex = 1;
+        while (insertionIndex < evidence.Count
+            && DefinitionsById.TryGetValue(
+                evidence[insertionIndex].Id,
+                out PackageQueryFacetDefinition? existing)
+            && existing.Descriptor.Weight < definition.Descriptor.Weight)
+        {
+            insertionIndex++;
+        }
+
+        evidence.Insert(
+            insertionIndex,
+            CreateFacetEvidence(definition, package, content));
     }
 
     static string Pluralize(int count, string singular, string plural) =>

--- a/tests/DotnetInspect.Cli.Tests/PackageQueryCliTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/PackageQueryCliTests.cs
@@ -40,6 +40,7 @@ public class PackageQueryCliTests
     [InlineData("facet!=package.query.dotnet-tool", "supports --where")]
     [InlineData("downloads>=1000000", "supports --where")]
     [InlineData("facet=package.query.unknown", "Unknown")]
+    [InlineData("facet=package.query.dotnet-tool", "--package-content")]
     [InlineData("facet=package.query.dotnet-tool-v2", "--package-content")]
     [InlineData("", "Empty")]
     public void InvalidSelections_FailBeforeExecution(string expression, string message)

--- a/tests/DotnetInspector.Queries.Tests/PackageQueryTests.cs
+++ b/tests/DotnetInspector.Queries.Tests/PackageQueryTests.cs
@@ -28,7 +28,7 @@ public sealed class PackageQueryTests
         Assert.Equal(
             [
                 PackageQueryFacetTier.Nuspec,
-                PackageQueryFacetTier.Nuspec,
+                PackageQueryFacetTier.PackageContent,
                 PackageQueryFacetTier.PackageContent,
                 PackageQueryFacetTier.PackageContent,
                 PackageQueryFacetTier.Nuspec,
@@ -394,6 +394,13 @@ public sealed class PackageQueryTests
                     """,
                     readme: "<readme>README.md</readme>"),
             });
+        var content = new FakePackageQueryContentProvider(
+            new Dictionary<string, IPackageContent>
+            {
+                ["Contoso.Tool"] = new FakePackageContent(
+                    ("tools/net8.0/any/DotnetToolSettings.xml",
+                        "<DotNetCliTool Version=\"2\"><Commands /></DotNetCliTool>")),
+            });
         PackageQueryPlan plan = Accepted(
             PackageQuery.Plan(
                 new PackageQueryRequest(
@@ -412,11 +419,12 @@ public sealed class PackageQueryTests
             PackageQuery.ExecuteAsync(
                 source,
                 plan,
+                content,
                 TestContext.Current.CancellationToken));
 
         PackageQueryMatch match =
             Assert.Single(events.OfType<PackageQueryEvent.Match>()).Value;
-        Assert.Equal(PackageQueryFacetTier.Nuspec, match.Tier);
+        Assert.Equal(PackageQueryFacetTier.PackageContent, match.Tier);
         Assert.Equal(
             [
                 PackageQuery.PrefixEvidenceId,
@@ -440,6 +448,11 @@ public sealed class PackageQueryTests
             "1,500,000 total downloads",
             match.Evidence[4].Value,
             StringComparison.Ordinal);
+        Assert.Contains(
+            "CLI v2",
+            match.Evidence[2].Value,
+            StringComparison.Ordinal);
+        Assert.Equal(["Contoso.Tool"], content.Requests);
         Assert.All(
             match.Evidence,
             evidence =>
@@ -571,6 +584,13 @@ public sealed class PackageQueryTests
                     </packageTypes>
                     """),
             });
+        var content = new FakePackageQueryContentProvider(
+            new Dictionary<string, IPackageContent>
+            {
+                ["Contoso.Tool"] = new FakePackageContent(
+                    ("tools/net8.0/any/DotnetToolSettings.xml",
+                        "<DotNetCliTool><Commands /></DotNetCliTool>")),
+            });
         PackageQueryPlan plan = Accepted(
             PackageQuery.Plan(
                 new PackageQueryRequest(
@@ -586,6 +606,7 @@ public sealed class PackageQueryTests
             PackageQuery.ExecuteAsync(
                 source,
                 plan,
+                content,
                 TestContext.Current.CancellationToken));
 
         PackageQueryMatch match = Assert.Single(
@@ -598,6 +619,11 @@ public sealed class PackageQueryTests
                 PackageQuery.ToolFacetId,
             ],
             match.Evidence.Select(evidence => evidence.Id));
+        Assert.Contains(
+            "CLI v1",
+            match.Evidence[^1].Value,
+            StringComparison.Ordinal);
+        Assert.Equal(["Contoso.Tool"], content.Requests);
     }
 
     [Fact]
@@ -638,6 +664,44 @@ public sealed class PackageQueryTests
                     ("skills/SKILL.md", "# Library")),
             });
 
+        PackageQueryPlan anyToolPlan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.ToolFacetId],
+                    MaximumCandidates: 3,
+                    MaximumMatches: 3)));
+        List<PackageQueryEvent> anyToolEvents = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                anyToolPlan,
+                content,
+                TestContext.Current.CancellationToken));
+        List<PackageQueryMatch> anyTools =
+        [
+            .. anyToolEvents
+                .OfType<PackageQueryEvent.Match>()
+                .Select(item => item.Value),
+        ];
+        Assert.Equal(
+            ["Contoso.V1", "Contoso.V2"],
+            anyTools.Select(item => item.Package.PackageId));
+        Assert.Equal(
+            [
+                "DotnetToolSettings.xml declares the portable .NET tool CLI v1 format.",
+                "DotnetToolSettings.xml declares the RID-specific .NET tool CLI v2 format.",
+            ],
+            anyTools.Select(item => item.Evidence[^1].Value));
+        Assert.All(
+            anyTools,
+            item => Assert.Equal(
+                PackageQueryFacetTier.PackageContent,
+                item.Tier));
+        Assert.Equal(
+            ["Contoso.V1", "Contoso.V2"],
+            content.Requests);
+
+        content.Requests.Clear();
         PackageQueryPlan v1Plan = Accepted(
             PackageQuery.Plan(
                 new PackageQueryRequest(
@@ -718,11 +782,11 @@ public sealed class PackageQueryTests
             bothVersions.Select(item =>
                 item.Evidence.Select(evidence => evidence.Id)));
         Assert.Contains(
-            "v1 format",
+            "CLI v1 format",
             bothVersions[0].Evidence[^1].Value,
             StringComparison.Ordinal);
         Assert.Contains(
-            "v2 format",
+            "CLI v2 format",
             bothVersions[1].Evidence[^1].Value,
             StringComparison.Ordinal);
         Assert.Equal(
@@ -796,6 +860,54 @@ public sealed class PackageQueryTests
         Assert.Equal(
             ["Contoso.V1", "Contoso.V2", "Contoso.Library"],
             content.Requests);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("<DotNetCliTool Version=\"3\"><Commands /></DotNetCliTool>")]
+    public async Task ExecuteAsync_BroadToolReportsUnrecognizedSettingsWithoutGuessing(
+        string? settings)
+    {
+        var source = SourceFor(
+            Manifest(
+                "Contoso.Tool",
+                packageTypes:
+                """
+                <packageTypes>
+                  <packageType name="DotnetTool" />
+                </packageTypes>
+                """),
+            "Contoso.Tool");
+        var content = new FakePackageQueryContentProvider(
+            new Dictionary<string, IPackageContent>
+            {
+                ["Contoso.Tool"] = settings is null
+                    ? new FakePackageContent()
+                    : new FakePackageContent(
+                        ("tools/net8.0/any/DotnetToolSettings.xml",
+                            settings)),
+            });
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.ToolFacetId],
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        PackageQueryMatch match = Assert.Single(
+            (await CollectAsync(
+                PackageQuery.ExecuteAsync(
+                    source,
+                    plan,
+                    content,
+                    TestContext.Current.CancellationToken)))
+                .OfType<PackageQueryEvent.Match>()).Value;
+
+        Assert.Equal(
+            "The package manifest declares a .NET tool, but its settings do not identify CLI v1 or CLI v2.",
+            match.Evidence[^1].Value);
+        Assert.Equal(["Contoso.Tool"], content.Requests);
     }
 
     [Fact]
@@ -1221,6 +1333,8 @@ public sealed class PackageQueryTests
             PackageQuery.ExecuteAsync(
                 source,
                 plan,
+                new FakePackageQueryContentProvider(
+                    new Dictionary<string, IPackageContent>()),
                 TestContext.Current.CancellationToken));
         PackageQueryProgress[] progress =
         [
@@ -1264,6 +1378,8 @@ public sealed class PackageQueryTests
             PackageQuery.ExecuteAsync(
                 source,
                 plan,
+                new FakePackageQueryContentProvider(
+                    new Dictionary<string, IPackageContent>()),
                 TestContext.Current.CancellationToken));
 
         Assert.Empty(events.OfType<PackageQueryEvent.Match>());
@@ -1529,6 +1645,8 @@ public sealed class PackageQueryTests
             PackageQuery.ExecuteAsync(
                 source,
                 plan,
+                new FakePackageQueryContentProvider(
+                    new Dictionary<string, IPackageContent>()),
                 TestContext.Current.CancellationToken));
 
         Assert.Empty(events.OfType<PackageQueryEvent.Match>());


### PR DESCRIPTION
This advances dotnet-inspect's mission to build robust, capable features that provide foundational inspection and compelling user experiences: Package Query now answers the tool-format question directly from the package's authoritative settings.

## Summary

The broad `.NET Tool` facet now performs bounded package-content inspection after its existing nuspec package-type prefilter. It reports portable CLI v1, RID-specific CLI v2, or explicitly unrecognized settings from `DotnetToolSettings.xml` through the shared Package Query evidence model.

The facet is now disclosed as package-content work: Inspect Web automatically lowers the candidate bound to 20, and CLI callers use the existing `--package-content` gesture. The v1/v2 filtering facets retain their existing semantics, ordinary libraries are rejected before archive acquisition, and package acquisition/evaluation failures remain visible.

Mixed nuspec/content evidence is inserted by product facet order, preserving the existing ordered-evidence contract when the broad tool facet moved tiers.

## Demo

Before, searching `Azure.*` with `.NET Tool` produced only generic manifest evidence:

```text
Azure.Mcp
2.0.5
nuspec
The package manifest declares a .NET tool package.
```

After, the same real-Wasm Package Query interaction produces:

```text
Azure.Mcp
2.0.5
package-content
DotnetToolSettings.xml declares the RID-specific .NET tool CLI v2 format.
```

The Browser gate also includes an ordinary `Azure.Library` candidate and proves that its archive is not downloaded.

CLI uses the same shared evidence:

```console
$ dotnet-inspect find --package-prefix Azure.Mcp --package-content \
    --where "facet=package.query.dotnet-tool" --candidates 20 --matches 5 --jsonl
{"package":"Azure.Mcp","version":"2.0.5","tier":"PackageContent","source":"https://api.nuget.org:443/v3/index.json","evidence":"Package ID matches prefix \"Azure.Mcp\".; DotnetToolSettings.xml declares the RID-specific .NET tool CLI v2 format."}
```

## Validation

- `dotnet run --project tests/DotnetInspector.Queries.Tests -c Release -- --filter-class '*PackageQueryTests'` — 43 passed
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release -- --filter-class '*PackageQueryCliTests'` — 39 passed
- `dotnet run --project inspect-web/DotnetInspect.Web.Tests -c Release` — 477 passed
- `npm test` and `npm run lint` in `inspect-web`
- `eng/test-inspect-web-package-adoption-gate.sh --grep 'classifies Azure.Mcp'` — Firefox real-Wasm gate passed
- `dotnet build dotnet-inspect.slnx -c Release`
- `markdownlint` on all changed Markdown

Closes #6743