### PR TITLE
timeline: adopt shared section catalog

### DIFF
--- a/src/DotnetInspect.Cli/Commands/TimelineCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/TimelineCommand.cs
@@ -1339,7 +1339,7 @@ public static class TimelineCommand
 
     // Timeline has no fixed-size overview: both sections grow with the version range. Preserve
     // the deliberate bare -S refusal while routing named selection through the shared resolver.
-    static bool TryResolveSections(
+    internal static bool TryResolveSections(
         TimelineOptions options,
         out HashSet<string> sections)
     {
@@ -1357,11 +1357,8 @@ public static class TimelineCommand
             infoSections: [],
             TimelineSections.Catalog.SelectionCategoryMap,
             selectDefault: false);
-        if (selection.Unresolved.Count > 0)
-        {
-            SelectOutput.WriteUnresolved(selection);
+        if (SelectOutput.WriteUnresolved(selection))
             return false;
-        }
 
         sections = selection.Sections
             ?? new HashSet<string>(

--- a/src/DotnetInspect.Cli/Commands/TimelineCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/TimelineCommand.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using DotnetInspect.Cli.Inspectors;
 using DotnetInspect.Cli.Options;
 using DotnetInspect.Cli.Output;
+using DotnetInspect.Cli.Sections;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using DotnetInspect.Cli.Services;
@@ -20,12 +21,15 @@ namespace DotnetInspect.Cli.Commands;
 public static class TimelineCommand
 {
     public const string Name = "timeline";
-    public const string EvaluationsSection = "Evaluations";
-    public const string TransitionsSection = "Transitions";
+    public const string EvaluationsSection = TimelineSections.Evaluations;
+    public const string TransitionsSection = TimelineSections.Transitions;
 
     public static async Task<int> ExecuteAsync(TimelineOptions options)
     {
-        if (!TryValidate(options, out var range, out var descriptor, out var selectedSections, out var error))
+        if (!TryResolveSections(options, out var selectedSections))
+            return 1;
+
+        if (!TryValidate(options, selectedSections, out var range, out var descriptor, out var error))
         {
             CommandError.Write($"{error}");
             return 1;
@@ -1266,16 +1270,13 @@ public static class TimelineCommand
 
     static bool TryValidate(
         TimelineOptions options,
+        HashSet<string> selectedSections,
         out PackageVersionRange? range,
         out string? descriptor,
-        out HashSet<string> selectedSections,
         out string? error)
     {
         range = null;
         descriptor = NormalizeDescriptor(options.Finding);
-        selectedSections = ResolveSections(options.Select, options.SelectDefault, out error);
-        if (error is not null)
-            return false;
 
         if (!PackageVersionRange.TryParse(options.PackageVersionRange, out range, out error))
         {
@@ -1336,43 +1337,37 @@ public static class TimelineCommand
             || descriptor == AnalysisFindings.CallSiteDescriptor.Id
             || descriptor == AnalysisFindings.UnsafetyDescriptor.Id;
 
-    // Bare -S asks for the fixed/bounded overview: the sections whose row count is structurally
-    // constant across every target. Both timeline sections grow with the version range, so there
-    // is no such subset here and bare -S is refused rather than silently widened to the default
-    // view. It was refused before #3547 too, but by leaking the internal '@Default' marker into
-    // the message; the refusal is what is preserved, not the spelling.
-    static HashSet<string> ResolveSections(string[]? select, bool selectDefault, out string? error)
+    // Timeline has no fixed-size overview: both sections grow with the version range. Preserve
+    // the deliberate bare -S refusal while routing named selection through the shared resolver.
+    static bool TryResolveSections(
+        TimelineOptions options,
+        out HashSet<string> sections)
     {
-        HashSet<string> sections = new(StringComparer.OrdinalIgnoreCase);
-        if (selectDefault && (select is null || select.Length == 0))
+        sections = new(StringComparer.OrdinalIgnoreCase);
+        if (options.SelectDefault && (options.Select is null || options.Select.Length == 0))
         {
-            error = "Bare -S has no fixed sections for timeline. Use -S Evaluations or -S Transitions.";
-            return sections;
+            CommandError.Write(
+                "Bare -S has no fixed sections for timeline. Use -S Evaluations or -S Transitions.");
+            return false;
         }
 
-        if (select is null || select.Length == 0)
+        SelectResult selection = SelectResolver.ResolveSelectAsSections(
+            options.Select,
+            TimelineSections.Catalog.SelectableSectionNames,
+            infoSections: [],
+            TimelineSections.Catalog.SelectionCategoryMap,
+            selectDefault: false);
+        if (selection.Unresolved.Count > 0)
         {
-            sections.Add(EvaluationsSection);
-            sections.Add(TransitionsSection);
-            error = null;
-            return sections;
+            SelectOutput.WriteUnresolved(selection);
+            return false;
         }
 
-        foreach (string value in select)
-        {
-            if (value.Equals(EvaluationsSection, StringComparison.OrdinalIgnoreCase))
-                sections.Add(EvaluationsSection);
-            else if (value.Equals(TransitionsSection, StringComparison.OrdinalIgnoreCase))
-                sections.Add(TransitionsSection);
-            else
-            {
-                error = $"Unknown timeline section '{value}'. Use Evaluations or Transitions.";
-                return sections;
-            }
-        }
-
-        error = null;
-        return sections;
+        sections = selection.Sections
+            ?? new HashSet<string>(
+                [EvaluationsSection, TransitionsSection],
+                StringComparer.OrdinalIgnoreCase);
+        return true;
     }
 
     internal static int Write(
@@ -1382,9 +1377,7 @@ public static class TimelineCommand
     {
         if (options.Count)
         {
-            var schema = TimelineViewContext.Default
-                .GetSchemaInfo<TimelineDocumentView>()!
-                .ToDocumentSchema();
+            var schema = TimelineSections.CreateSchema();
             if (!ProjectionDiagnostics.ValidateProjection(
                     schema, selectedSections, options.Fields, options.Columns))
             {

--- a/src/DotnetInspect.Cli/Sections/TimelineSections.cs
+++ b/src/DotnetInspect.Cli/Sections/TimelineSections.cs
@@ -1,0 +1,52 @@
+using DotnetInspect.Cli.Views;
+using Markout;
+
+namespace DotnetInspect.Cli.Sections;
+
+/// <summary>
+/// The fixed section catalog for the timeline correlation document.
+/// </summary>
+public static class TimelineSections
+{
+    public const string Evaluations = "Evaluations";
+    public const string Transitions = "Transitions";
+
+    public static SectionCatalog<TimelineDocumentView> Catalog { get; } =
+        CreatePipeline().Compile();
+
+    public static DocumentSchema CreateSchema() =>
+        TimelineViewContext.Default
+            .GetSchemaInfo<TimelineDocumentView>()!
+            .ToDocumentSchema();
+
+    private static SectionPipeline<TimelineDocumentView> CreatePipeline()
+        => new SectionPipeline<TimelineDocumentView>()
+            .UseCuratedCatalog()
+            .WithoutComputedPoles()
+            .Add<EvaluationRows>()
+            .Add<TransitionRows>();
+
+    public sealed class EvaluationRows :
+        ISectionDescriptor<TimelineDocumentView>
+    {
+        public static string Name => Evaluations;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static SectionSizeClass SizeClass => SectionSizeClass.Verbose;
+        public static SectionCost Cost => SectionCost.NetworkFree;
+        public static bool CanRender(TimelineDocumentView model) =>
+            model.Evaluations is { Count: > 0 };
+    }
+
+    public sealed class TransitionRows :
+        ISectionDescriptor<TimelineDocumentView>
+    {
+        public static string Name => Transitions;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static SectionSizeClass SizeClass => SectionSizeClass.Verbose;
+        public static SectionCost Cost => SectionCost.NetworkFree;
+        public static bool CanRender(TimelineDocumentView model) =>
+            model.Transitions is { Count: > 0 };
+    }
+}

--- a/tests/DotnetInspect.Cli.Tests/TimelineCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/TimelineCommandTests.cs
@@ -8,6 +8,7 @@ using DotnetInspect.Cli.Commands;
 using DotnetInspect.Cli.Inspectors;
 using DotnetInspect.Cli.Options;
 using DotnetInspect.Cli.Output;
+using DotnetInspect.Cli.Sections;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using DotnetInspect.Cli.Services;
@@ -22,6 +23,21 @@ namespace DotnetInspect.Cli.Tests;
 [Collection("Console")]
 public sealed class TimelineCommandTests
 {
+    [Fact]
+    public void SectionCatalog_DeclaresTimelineSections()
+    {
+        Assert.Equal(
+            [TimelineSections.Evaluations, TimelineSections.Transitions],
+            TimelineSections.Catalog.SelectableSectionNames);
+        Assert.Empty(TimelineSections.Catalog.SelectionCategoryMap);
+        Assert.Contains(
+            TimelineSections.Evaluations,
+            TimelineSections.CreateSchema().SectionNames);
+        Assert.Contains(
+            TimelineSections.Transitions,
+            TimelineSections.CreateSchema().SectionNames);
+    }
+
     [Fact]
     public async Task Count_AppliesRowsAndValidatesProjectedColumns()
     {

--- a/tests/DotnetInspect.Cli.Tests/TimelineCommandTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/TimelineCommandTests.cs
@@ -39,6 +39,27 @@ public sealed class TimelineCommandTests
     }
 
     [Fact]
+    public async Task PartialSectionSelection_WarnsAndKeepsMatchedSection()
+    {
+        HashSet<string>? sections = null;
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            TimelineCommand.TryResolveSections(
+                new TimelineOptions
+                {
+                    Select =
+                    [
+                        TimelineSections.Evaluations,
+                        "NoSuchSection"
+                    ]
+                },
+                out sections)));
+
+        Assert.Contains(TimelineSections.Evaluations, sections!);
+        Assert.DoesNotContain(TimelineSections.Transitions, sections!);
+        Assert.Contains("NoSuchSection", result.Error);
+    }
+
+    [Fact]
     public async Task Count_AppliesRowsAndValidatesProjectedColumns()
     {
         var view = new TimelineDocumentView


### PR DESCRIPTION
## Demo

The `timeline` command continues to render both `Evaluations` and `Transitions` by default, while named selection now uses the shared section resolver:

```bash
dotnet-inspect timeline --package Markout@0.33.0..0.35.2 \
  --type Markout.MarkoutWriterOptions --finding api.member \
  -S Evaluations
```

Bare `-S` still fails explicitly because timeline has no fixed-size overview; the diagnostic continues to direct users to `Evaluations` or `Transitions`.

## Change

This is the first focused slice for #6650 and #6639. It adds the reusable `TimelineSections` catalog and schema, routes timeline named section selection through `SelectResolver`, and keeps existing output, count, projection, and bare-selection behavior.

It deliberately does not change row planning, sparse/dense acquisition, sharing, PackageHouse, Workspace, or envelope adoption; those remain separate owner-scoped slices.

## Validation

- `dotnet build src/DotnetInspect.Cli/DotnetInspect.Cli.csproj -c Release --no-restore`
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --no-restore -- --filter-class "*TimelineCommandTests"` — 36 passed
- Targeted bare-selection and count tests — 3 passed
- `git diff --check`

Closes no issue; implementation slice for #6650.