### PR TITLE
Adopt semantic row limits for package search

### DIFF
--- a/docs/design/cli-execution-bounds.md
+++ b/docs/design/cli-execution-bounds.md
@@ -26,13 +26,13 @@ The end-to-end tracker has four steps:
    with `--take` and the universal row-selection grammar;
 3. adopt the result command-wide for `find`, with selective Package Query and
    package profiling exposing both `--take` and `-n`; and
-4. complete package-search source delegation, eventually retiring plain
-   `package search --take` in favor of semantic `-n` plus a proven source
-   strategy only where the full multi-source result remains equivalent. The
-   current adoption is deliberately narrower: package search lowers `-n`
-   through the shared semantic row path and uses it as the default upstream
-   demand, while an explicit `--take` remains an independent per-feed work
-   bound. The source-completion and exact early-stop proof remain future work.
+4. complete package-search source delegation, evaluating whether plain
+   `package search --take` can eventually retire in favor of semantic `-n`
+   plus a proven source strategy where the full multi-source result remains
+   equivalent. The current adoption is deliberately narrower: package search
+   lowers `-n` through the shared semantic row path, while `--take` remains
+   an independent per-feed work bound. The source-completion and exact
+   early-stop proof remain future work.
 
 Steps 1 through 3 are implemented: #6489 reconciles Package Query and adopts
 the command-wide `find` surface. Step 4 remains separate future work.
@@ -574,20 +574,21 @@ That focused adoption decides whether ordinary type/member early exit can be
 proven equivalent through source delegation or must be removed. This design
 does not decide it.
 
-### Step 4: retire plain `package search --take`
+### Step 4: evaluate plain `package search --take`
 
-Plain package search has no named selective, enrichment, fan-out, or
-aggregation scenario that makes a user-authored work count independently
-useful from the final row count. Its multi-source implementation still maps,
-deduplicates, merges, and limits provider rows, so its adoption:
+Plain package search still needs a source-delegation design before its
+independent work bound can be retired or lowered from semantic `-n`. Its
+multi-source implementation maps, deduplicates, and merges provider rows, so
+the current adoption:
 
-- retires the CLI `--take` option;
-- uses `-n` to select final package rows;
-- may lower `-n` to provider request counts only through source delegation
-  that proves the complete effective cross-source order, source mapping,
-  deduplication, failure, and completion behavior; and
+- retains `--take` as an explicit per-feed source-work bound;
+- uses `-n` to select final package rows without deriving source demand from
+  an arbitrary ordered semantic plan;
 - preserves provider caps, source failures, and incomplete merged-search
-  evidence rather than treating the delegated count as exhaustion.
+  evidence rather than treating a delegated count as exhaustion; and
+- leaves retirement or source-owned lowering to a future adoption after the
+  complete effective cross-source order, source mapping, deduplication,
+  failure, and completion behavior are proven.
 
 If package search later adds selective enrichment, fan-out, or aggregation
 that makes an independent work maximum useful, that owner may propose a new

--- a/docs/design/cli-execution-bounds.md
+++ b/docs/design/cli-execution-bounds.md
@@ -26,8 +26,13 @@ The end-to-end tracker has four steps:
    with `--take` and the universal row-selection grammar;
 3. adopt the result command-wide for `find`, with selective Package Query and
    package profiling exposing both `--take` and `-n`; and
-4. retire plain `package search --take`, using semantic `-n` plus proven source
-   delegation only where the full multi-source result remains equivalent.
+4. complete package-search source delegation, eventually retiring plain
+   `package search --take` in favor of semantic `-n` plus a proven source
+   strategy only where the full multi-source result remains equivalent. The
+   current adoption is deliberately narrower: package search lowers `-n`
+   through the shared semantic row path and uses it as the default upstream
+   demand, while an explicit `--take` remains an independent per-feed work
+   bound. The source-completion and exact early-stop proof remain future work.
 
 Steps 1 through 3 are implemented: #6489 reconciles Package Query and adopts
 the command-wide `find` surface. Step 4 remains separate future work.

--- a/src/DotnetInspect.Cli/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/DotnetInspect.Cli/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -419,15 +419,10 @@ public static class PackageCommandDefinitions
             }
 
             var projection = ProjectionAudit.Requested(parseResult, opts);
-            bool explicitSourceTake =
-                parseResult.GetResult(takeOption) is { Implicit: false };
             var options = new PackageSearchOptions
             {
                 Query = query,
-                Take = explicitSourceTake
-                    ? parseResult.GetValue(takeOption)
-                    : parseResult.GetValue(opts.Limit)
-                        ?? parseResult.GetValue(takeOption),
+                Take = parseResult.GetValue(takeOption),
                 Prerelease =
                     parseResult.GetValue(inheritedPrereleaseOption)
                     || parseResult.GetValue(prereleaseOption),

--- a/src/DotnetInspect.Cli/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/DotnetInspect.Cli/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -254,7 +254,9 @@ public static class PackageCommandDefinitions
 
         var takeOption = new Option<int>("--take")
         {
-            Description = "Maximum number of results (default: 20)",
+            Description =
+                "Maximum number of source results to obtain per feed "
+                + "(default: 20); use -n for final package rows",
             DefaultValueFactory = _ => 20
         };
         var prereleaseOption = new Option<bool>("--preview") { Description = "Include prerelease versions" };
@@ -298,6 +300,13 @@ public static class PackageCommandDefinitions
                     "-n requires a positive package search result limit greater than zero.");
             }
 
+            if (result.GetResult(takeOption) is { Implicit: false }
+                && result.GetValue(takeOption) <= 0)
+            {
+                result.AddError(
+                    "--take requires a positive package search source limit greater than zero.");
+            }
+
             bool hasDirection =
                 result.GetValue(opts.Head) || result.GetValue(opts.Tail);
             bool hasRows =
@@ -322,16 +331,38 @@ public static class PackageCommandDefinitions
                     + "because bounded remote pages do not establish a suffix.");
             }
 
-            if (result.GetResult(takeOption) is { Implicit: false }
-                && resultLimit > 0)
-            {
-                result.AddError(
-                    "--take and -n both limit package search results; choose one.");
-            }
         });
+
+        CliRowSelectionCommandRegistry.Register(
+            searchCommand,
+            new(
+                opts.Limit,
+                opts.Rows,
+                top: null,
+                orderBy: null,
+                opts.Head,
+                opts.Tail,
+                new Option<bool>("--lines"),
+                new Option<bool>("--tail-lines")),
+            CliRowSelectionCapabilities.HeadTail
+                | CliRowSelectionCapabilities.Window,
+            result =>
+                result.GetResult(opts.Limit) is { Implicit: false }
+                || result.GetValue(opts.Head)
+                || result.GetValue(opts.Tail));
 
         searchCommand.SetAction(async (parseResult, ct) =>
         {
+            if (!CliRowSelectionCommandRegistry.TryGetPreparedSemanticIntent(
+                    parseResult,
+                    "Package search",
+                    out var rowSelection,
+                    out string? rowSelectionError))
+            {
+                CommandError.Write(rowSelectionError!);
+                return 1;
+            }
+
             var acceptedParentOptions = new HashSet<Option>
             {
                 opts.Json,
@@ -388,11 +419,15 @@ public static class PackageCommandDefinitions
             }
 
             var projection = ProjectionAudit.Requested(parseResult, opts);
+            bool explicitSourceTake =
+                parseResult.GetResult(takeOption) is { Implicit: false };
             var options = new PackageSearchOptions
             {
                 Query = query,
-                Take = parseResult.GetValue(opts.Limit)
-                    ?? parseResult.GetValue(takeOption),
+                Take = explicitSourceTake
+                    ? parseResult.GetValue(takeOption)
+                    : parseResult.GetValue(opts.Limit)
+                        ?? parseResult.GetValue(takeOption),
                 Prerelease =
                     parseResult.GetValue(inheritedPrereleaseOption)
                     || parseResult.GetValue(prereleaseOption),
@@ -406,6 +441,7 @@ public static class PackageCommandDefinitions
                 Paths = projection.Paths,
                 OutputPath = parseResult.GetValue(inheritedOutOption),
                 Rows = projection.Rows,
+                RowSelection = rowSelection,
                 Fields = projection.Fields,
                 Columns = projection.Columns,
                 SourceOptions = opts.ParseNuGetSourceOptions(parseResult)

--- a/src/DotnetInspect.Cli/Commands/PackageSearchCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/PackageSearchCommand.cs
@@ -75,21 +75,6 @@ public class PackageSearchCommand
                 NuGetFetchOptions.FromRequestTimeout(
                     context.HttpClient.Timeout));
 
-            if (!CliSemanticRowSelection.TrySelectOrApplyLegacy(
-                    options.RowSelection,
-                    options.Rows,
-                    outcome.Results,
-                    "PackageSearch",
-                    failure =>
-                        $"Package search row selection stage "
-                        + $"{failure.Failure.StageNumber} requires row "
-                        + $"{failure.Failure.RequiredPosition}, but only "
-                        + $"{failure.Failure.AvailableCount} rows are available.",
-                    out IReadOnlyList<NuGetSearchResult> results))
-            {
-                return 1;
-            }
-
             // Sources that could not be searched are reported even when other sources
             // succeeded: a partial answer must not read like a complete one.
             foreach (var failure in outcome.Failures)
@@ -108,6 +93,21 @@ public class PackageSearchCommand
                 outcome.Failures.Count > 0 || outcome.SourceSelectionIncomplete
                     ? 1
                     : 0;
+
+            if (!CliSemanticRowSelection.TrySelectOrApplyLegacy(
+                    options.RowSelection,
+                    options.Rows,
+                    outcome.Results,
+                    "PackageSearch",
+                    failure =>
+                        $"Package search row selection stage "
+                        + $"{failure.Failure.StageNumber} requires row "
+                        + $"{failure.Failure.RequiredPosition}, but only "
+                        + $"{failure.Failure.AvailableCount} rows are available.",
+                    out IReadOnlyList<NuGetSearchResult> results))
+            {
+                return 1;
+            }
 
             // --count reduces the payload, so it is resolved before the format flags that
             // render it. Ordering these the other way lets --json answer a count request

--- a/src/DotnetInspect.Cli/Commands/PackageSearchCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/PackageSearchCommand.cs
@@ -2,6 +2,8 @@ using System.Text.Json.Serialization;
 using DotnetInspect.Cli.Options;
 using DotnetInspect.Cli.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Sections;
+using DotnetInspect.Cli.CommandLine;
 using DotnetInspect.Cli.Views;
 using Markout;
 using NuGetFetch;
@@ -73,7 +75,20 @@ public class PackageSearchCommand
                 NuGetFetchOptions.FromRequestTimeout(
                     context.HttpClient.Timeout));
 
-            var results = RowWindow.Apply(options.Rows, outcome.Results);
+            if (!CliSemanticRowSelection.TrySelectOrApplyLegacy(
+                    options.RowSelection,
+                    options.Rows,
+                    outcome.Results,
+                    "PackageSearch",
+                    failure =>
+                        $"Package search row selection stage "
+                        + $"{failure.Failure.StageNumber} requires row "
+                        + $"{failure.Failure.RequiredPosition}, but only "
+                        + $"{failure.Failure.AvailableCount} rows are available.",
+                    out IReadOnlyList<NuGetSearchResult> results))
+            {
+                return 1;
+            }
 
             // Sources that could not be searched are reported even when other sources
             // succeeded: a partial answer must not read like a complete one.
@@ -146,7 +161,7 @@ public record PackageSearchOptions : IProjectionOptions
     /// <summary>Search query (keyword or package name prefix).</summary>
     public string Query { get; init; } = "";
 
-    /// <summary>Maximum number of results.</summary>
+    /// <summary>Maximum number of source results to obtain per feed.</summary>
     public int Take { get; init; } = 20;
 
     /// <summary>Include prerelease versions.</summary>
@@ -181,6 +196,9 @@ public record PackageSearchOptions : IProjectionOptions
 
     /// <summary>Inherited result-row window.</summary>
     public RowWindow? Rows { get; init; }
+
+    /// <summary>Typed semantic selection of package-search rows.</summary>
+    public RowSelectionIntent<string>? RowSelection { get; init; }
 
     /// <summary>Field projection inherited from the package command.</summary>
     public string[]? Fields { get; init; }

--- a/src/DotnetInspect.Cli/Commands/PackageSearchCommand.cs
+++ b/src/DotnetInspect.Cli/Commands/PackageSearchCommand.cs
@@ -96,9 +96,18 @@ public class PackageSearchCommand
             {
                 CommandError.WriteWarning($"could not search {failure}");
             }
+            if (outcome.SearchLimitReached)
+            {
+                CommandError.WriteWarning(
+                    $"Package search reached the {options.Take}-result per-feed "
+                    + "source limit; additional matches may be omitted.");
+            }
 
             // A genuine zero-result search succeeded; an incomplete one did not.
-            var exitCode = outcome.Failures.Count > 0 ? 1 : 0;
+            var exitCode =
+                outcome.Failures.Count > 0 || outcome.SourceSelectionIncomplete
+                    ? 1
+                    : 0;
 
             // --count reduces the payload, so it is resolved before the format flags that
             // render it. Ordering these the other way lets --json answer a count request

--- a/src/DotnetInspector.Packages/NuGetSearchService.cs
+++ b/src/DotnetInspector.Packages/NuGetSearchService.cs
@@ -51,7 +51,13 @@ public record NuGetSearchOutcome(
     /// selection before package-source mapping.
     /// </summary>
     public bool SourceSelectionIncomplete =>
-        PrefixSearchLimits.Count > 0;
+        SearchLimitReached || PrefixSearchLimits.Count > 0;
+
+    /// <summary>
+    /// Whether an ordinary keyword-search source returned its requested page
+    /// maximum, so additional matches may have been omitted.
+    /// </summary>
+    public bool SearchLimitReached { get; init; }
 }
 
 /// <summary>
@@ -134,6 +140,7 @@ public static class NuGetSearchService
         bool operationTimedOut = false;
         var prefixSearchLimits =
             new HashSet<PrefixSearchCompletion>();
+        bool searchLimitReached = false;
         bool useFactoryClients =
             ReferenceEquals(client, HttpClientFactory.Shared);
         _ = NuGetFetchOptions.RequestTimeoutForClient(
@@ -288,6 +295,8 @@ public static class NuGetSearchService
                             prerelease,
                             auth,
                             operationCancellation.Token);
+                        if (found.Count >= take)
+                            searchLimitReached = true;
                     }
                     else
                     {
@@ -359,7 +368,7 @@ public static class NuGetSearchService
             var sourceKeys = new HashSet<(string Id, NuGetVersion Version)>(
                 SearchResultKeyComparer.Instance);
             bool aggregationTimedOut = false;
-            foreach (SearchResult result in found)
+            foreach (SearchResult result in found.Take(take))
             {
                 if (HasOperationExpired(
                         operationStarted,
@@ -437,8 +446,6 @@ public static class NuGetSearchService
             prefixSearchLimits.Add(
                 PrefixSearchCompletion.TakeReached);
         }
-        List<NuGetSearchResult> finalResults =
-            eligibleResults.Take(take).ToList();
         if (!operationTimedOut)
         {
             ThrowIfOperationExpired(
@@ -446,8 +453,9 @@ public static class NuGetSearchService
                 fetchOptions.OperationTimeout,
                 operationCancellation.Token);
         }
-        return new NuGetSearchOutcome(finalResults, failures)
+        return new NuGetSearchOutcome(eligibleResults, failures)
         {
+            SearchLimitReached = searchLimitReached,
             PrefixSearchLimits =
                 [.. prefixSearchLimits.Order()],
         };

--- a/src/DotnetInspector.Packages/NuGetSearchService.cs
+++ b/src/DotnetInspector.Packages/NuGetSearchService.cs
@@ -368,7 +368,11 @@ public static class NuGetSearchService
             var sourceKeys = new HashSet<(string Id, NuGetVersion Version)>(
                 SearchResultKeyComparer.Instance);
             bool aggregationTimedOut = false;
-            foreach (SearchResult result in found.Take(take))
+            IEnumerable<SearchResult> resultsToAggregate =
+                resultFilter is null
+                    ? found.Take(take)
+                    : found;
+            foreach (SearchResult result in resultsToAggregate)
             {
                 if (HasOperationExpired(
                         operationStarted,
@@ -453,7 +457,11 @@ public static class NuGetSearchService
                 fetchOptions.OperationTimeout,
                 operationCancellation.Token);
         }
-        return new NuGetSearchOutcome(eligibleResults, failures)
+        IReadOnlyList<NuGetSearchResult> finalResults =
+            resultFilter is null
+                ? eligibleResults
+                : eligibleResults.Take(take).ToList();
+        return new NuGetSearchOutcome(finalResults, failures)
         {
             SearchLimitReached = searchLimitReached,
             PrefixSearchLimits =

--- a/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
@@ -12757,21 +12757,31 @@ public partial class CommandExecutionTests
         Assert.DoesNotContain("NuGet source", error);
     }
 
-    [Theory]
-    [InlineData("--count", "--count cannot be combined with -n")]
-    [InlineData("--take=3", "--take and -n both limit package search results")]
-    public async Task ProjectedJsonRoutingAudit_PackageSearchItemLimitConflictsFailBeforeNetwork(
-        string conflict,
-        string expected)
+    [Fact]
+    public async Task ProjectedJsonRoutingAudit_PackageSearchSourceAndItemLimitsCompose()
+    {
+        var (exit, output, error) = await RunPackageSearchFixtureAsync(
+            "package", "-n2",
+            "search", "Fixture", "--take=3", "--json");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(2, output.Split(
+            '\n',
+            StringSplitOptions.RemoveEmptyEntries).Length);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task ProjectedJsonRoutingAudit_PackageSearchCountStillConflictsWithItemLimit()
     {
         var (exit, output, error) = await RunAppAsync(
             "package", "-n2",
-            "search", "ThisQueryMustNotReachTheNetwork", conflict,
+            "search", "ThisQueryMustNotReachTheNetwork", "--count",
             "--source", "http://127.0.0.1:9/index.json");
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains(expected, error);
+        Assert.Contains("--count cannot be combined with -n", error);
         Assert.DoesNotContain("NuGet source", error);
     }
 

--- a/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
@@ -12593,6 +12593,19 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task ProjectedJsonRoutingAudit_PackageSearchSelectionFailureKeepsBoundEvidence()
+    {
+        var (exit, output, error) = await RunPackageSearchFixtureAsync(
+            "package", "--rows", "3..6",
+            "search", "Fixture", "--take", "2");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("requested row window", error);
+        Assert.Contains("per-feed source limit", error);
+    }
+
+    [Fact]
     public async Task ProjectedJsonRoutingAudit_PackageSearchOutputPathFailsBeforeNetwork()
     {
         var outputPath = Path.Combine(

--- a/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/CommandExecutionTests.cs
@@ -12510,12 +12510,12 @@ public partial class CommandExecutionTests
                 "package", "--rows", "1", "--out", outputPath,
                 "search", "Fixture", "--count", "--take", "2");
 
-            Assert.Equal(0, exit);
+            Assert.Equal(1, exit);
             Assert.Empty(output);
             Assert.Equal("1\n", await File.ReadAllTextAsync(
                 outputPath,
                 TestContext.Current.CancellationToken));
-            Assert.Empty(error);
+            Assert.Contains("per-feed source limit", error);
         }
         finally
         {
@@ -12585,9 +12585,10 @@ public partial class CommandExecutionTests
             "package", "--rows", "5..6",
             "search", "Fixture", "--take", "2");
 
-        Assert.Equal(0, exit);
+        Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("requested row window", error);
+        Assert.Contains("per-feed source limit", error);
         Assert.DoesNotContain("No packages found", error);
     }
 
@@ -12764,11 +12765,11 @@ public partial class CommandExecutionTests
             "package", "-n2",
             "search", "Fixture", "--take=3", "--json");
 
-        Assert.Equal(0, exit);
+        Assert.Equal(1, exit);
         Assert.Equal(2, output.Split(
             '\n',
             StringSplitOptions.RemoveEmptyEntries).Length);
-        Assert.Empty(error);
+        Assert.Contains("per-feed source limit", error);
     }
 
     [Fact]

--- a/tests/DotnetInspect.Cli.Tests/NuGetSearchSourcesTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/NuGetSearchSourcesTests.cs
@@ -1189,6 +1189,33 @@ public class NuGetSearchSourcesTests
     }
 
     [Fact]
+    public async Task SearchAsync_PerFeedTakeDoesNotCapAggregateResults()
+    {
+        const string indexA = "https://a.example/v3/index.json";
+        const string indexB = "https://b.example/v3/index.json";
+        const string searchA = "https://a.example/v3/query";
+        const string searchB = "https://b.example/v3/query";
+
+        var handler = new RouteHandler
+        {
+            [indexA] = $$"""{"resources":[{"@id":"{{searchA}}","@type":"SearchQueryService"}]}""",
+            [indexB] = $$"""{"resources":[{"@id":"{{searchB}}","@type":"SearchQueryService"}]}""",
+            [searchA] = """{"data":[{"id":"A.Package","version":"1.0.0"}]}""",
+            [searchB] = """{"data":[{"id":"B.Package","version":"1.0.0"}]}"""
+        };
+        using var client = new HttpClient(handler);
+
+        NuGetSearchOutcome outcome = await NuGetSearchService.SearchAsync(
+            client,
+            "q",
+            take: 1,
+            sourceOptions: new NuGetSourceOptions { Sources = [indexA, indexB] });
+
+        Assert.Equal(["A.Package", "B.Package"], outcome.Results.Select(r => r.PackageId));
+        Assert.True(outcome.SearchLimitReached);
+    }
+
+    [Fact]
     public async Task SearchAsync_PackageSourceMappingFiltersEachResultByReportingAlias()
     {
         const string indexA = "https://a.example/v3/index.json";

--- a/tests/DotnetInspect.Cli.Tests/NuGetSearchSourcesTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/NuGetSearchSourcesTests.cs
@@ -1328,6 +1328,32 @@ public class NuGetSearchSourcesTests
     }
 
     [Fact]
+    public async Task SearchByPrefixAsync_AppliesAggregateLimitAcrossSources()
+    {
+        const string indexA = "https://a.example/v3/index.json";
+        const string indexB = "https://b.example/v3/index.json";
+        const string searchA = "https://a.example/v3/query";
+        const string searchB = "https://b.example/v3/query";
+        var handler = new RouteHandler
+        {
+            [indexA] = $$"""{"resources":[{"@id":"{{searchA}}","@type":"SearchQueryService"}]}""",
+            [indexB] = $$"""{"resources":[{"@id":"{{searchB}}","@type":"SearchQueryService"}]}""",
+            [searchA] = """{"data":[{"id":"Contoso.A","version":"1.0.0"}]}""",
+            [searchB] = """{"data":[{"id":"Contoso.B","version":"1.0.0"}]}""",
+        };
+        using var client = new HttpClient(handler);
+
+        List<NuGetSearchResult> results =
+            await NuGetSearchService.SearchByPrefixAsync(
+                client,
+                "Contoso.",
+                take: 1,
+                sourceOptions: new NuGetSourceOptions { Sources = [indexA, indexB] });
+
+        Assert.Single(results);
+    }
+
+    [Fact]
     public async Task SearchByPrefixWithStateAsync_PreservesLimitBeforeSourceMapping()
     {
         const string index = "https://a.example/v3/index.json";


### PR DESCRIPTION
## Summary

This is the package-search adoption slice for #4677. It routes explicit semantic `-n`/direction gestures through the shared typed row-selection path while preserving legacy `--rows N` behavior.

## Demo

Before, `package search foo -n 2` used `2` as the package-source `take` value and had no shared semantic selection. Now it requests at most two source results when no explicit `--take` is supplied, then applies the shared row selection before rendering or counting. With `package search foo --take 10 -n 2`, `--take` remains the source-work cap and `-n` selects the final two rows.

The help text now distinguishes source-result demand from final semantic rows, and `--take` rejects non-positive values.

## Scope boundary

This slice does not claim full source delegation or exact multi-source early-stop equivalence. Completion evidence, independent source-work/result-retention limits, and a source-delegation protocol remain a separate source-owner slice documented in `docs/design/cli-execution-bounds.md`.

## Validation

- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release --no-build -- --filter-method '*PackageSearch*'` (43 passed)
- Full Release solution build passed after restore.
- `git diff --check` passed.

Part of #4677.
