### PR TITLE
Label scheduled Deep Inspect failures

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -848,6 +848,7 @@ jobs:
       - name: Open or update the tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_LABEL: nightly-failure
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash
         run: |
@@ -858,10 +859,14 @@ jobs:
             --json number,title \
             --jq "map(select(.title == \"$title\")) | .[0].number // empty")
           if [ -n "$num" ]; then
+            gh api --method POST \
+              "repos/${{ github.repository }}/issues/$num/labels" \
+              -f "labels[]=$ISSUE_LABEL" >/dev/null
             gh issue comment --repo "${{ github.repository }}" "$num" \
               --body "Another scheduled Deep Inspect run failed: $RUN_URL"
           else
             gh issue create --repo "${{ github.repository }}" \
               --title "$title" \
+              --label "$ISSUE_LABEL" \
               --body $'A scheduled Deep Inspect run failed.\n\nRun: '"$RUN_URL"$'\n\nThe failed lane(s) are visible on the run. This issue was opened automatically; it will not auto-close, so close it once the failure is triaged.'
           fi


### PR DESCRIPTION
Scheduled Deep Inspect failures now carry a stable `nightly-failure` label,
making long-running regressions queryable and triageable instead of leaving
classification implicit in a generic tracking issue.

## Demo

Before: scheduled failures opened or updated #5992 without a distinguishing
label.

After: a new tracker is created with `nightly-failure`; an existing tracker has
the label restored before the workflow posts its next run link. #5992 is
already labeled.

Neighboring behavior is unchanged: manual Deep Inspect dispatches do not open
or update the scheduled-failure tracker.

## Summary

- define the repository `nightly-failure` label
- apply it to the active scheduled-failure tracker
- make the scheduled reporter preserve the label on both create and reuse paths

## Validation

- parsed `.github/workflows/deep-inspect.yml` as YAML
- ran `git diff --check`
- verified the live label definition and #5992 assignment through GitHub
