### PR TITLE
Expose NuGet search page completion evidence

### DIFF
--- a/docs/design/cli-execution-bounds.md
+++ b/docs/design/cli-execution-bounds.md
@@ -582,6 +582,12 @@ multi-source implementation maps, deduplicates, and merges provider rows, so
 the current adoption:
 
 - retains `--take` as an explicit per-feed source-work bound;
+- carries typed page-shape evidence from each NuGet source: a full page is
+  reported as `RequestedLimit`, while a shorter page is reported as
+  `ShortPage`;
+- treats `ShortPage` as non-bound evidence rather than authoritative corpus
+  exhaustion, because a provider may impose a lower page maximum than the
+  requested `take`;
 - uses `-n` to select final package rows without deriving source demand from
   an arbitrary ordered semantic plan;
 - preserves provider caps, source failures, and incomplete merged-search

--- a/src/DotnetInspector.Packages/NuGetSearchService.cs
+++ b/src/DotnetInspector.Packages/NuGetSearchService.cs
@@ -289,13 +289,16 @@ public static class NuGetSearchService
                         fetchOptions);
                     if (resultFilter is null)
                     {
-                        found = await service.SearchAsync(
-                            query,
-                            take,
-                            prerelease,
-                            auth,
-                            operationCancellation.Token);
-                        if (found.Count >= take)
+                        SearchPageResult page =
+                            await service.SearchWithStateAsync(
+                                query,
+                                take,
+                                prerelease,
+                                auth,
+                                operationCancellation.Token);
+                        found = page.Results;
+                        if (page.Completion
+                            == SearchPageCompletion.RequestedLimit)
                             searchLimitReached = true;
                     }
                     else

--- a/src/NuGetFetch/NuGetRecords.cs
+++ b/src/NuGetFetch/NuGetRecords.cs
@@ -30,6 +30,25 @@ public record VersionIndex(
 public record SearchResponse(
     IReadOnlyList<SearchResult> Data);
 
+/// <summary>Why a keyword-search page stopped.</summary>
+public enum SearchPageCompletion
+{
+    /// <summary>The source returned fewer rows than requested.</summary>
+    ShortPage,
+
+    /// <summary>The requested page maximum was reached.</summary>
+    RequestedLimit,
+}
+
+/// <summary>A keyword-search page with explicit completion evidence.</summary>
+public sealed record SearchPageResult(
+    IReadOnlyList<SearchResult> Results,
+    SearchPageCompletion Completion)
+{
+    public bool Truncated =>
+        Completion == SearchPageCompletion.RequestedLimit;
+}
+
 public record SearchResult(
     string Id,
     string Version,

--- a/src/NuGetFetch/SearchService.cs
+++ b/src/NuGetFetch/SearchService.cs
@@ -67,11 +67,30 @@ public partial class SearchService
         AuthenticationHeaderValue? auth = null,
         CancellationToken cancellationToken = default)
     {
+        SearchPageResult page = await SearchWithStateAsync(
+            query,
+            take,
+            prerelease,
+            auth,
+            cancellationToken).ConfigureAwait(false);
+        return page.Results;
+    }
+
+    /// <summary>
+    /// Searches NuGet and preserves whether the requested page maximum was reached.
+    /// </summary>
+    public async Task<SearchPageResult> SearchWithStateAsync(
+        string query,
+        int take = 20,
+        bool prerelease = false,
+        AuthenticationHeaderValue? auth = null,
+        CancellationToken cancellationToken = default)
+    {
         using var operation = new NuGetOperationDeadline(
             _options,
             _client.Timeout,
             cancellationToken);
-        return await SearchAsync(
+        return await SearchWithStateAsync(
             query,
             take,
             prerelease,
@@ -85,13 +104,33 @@ public partial class SearchService
         bool prerelease,
         AuthenticationHeaderValue? auth,
         NuGetOperationDeadline operation) =>
-        await SearchPageAsync(
+        (await SearchWithStateAsync(
+            query,
+            take,
+            prerelease,
+            auth,
+            operation).ConfigureAwait(false)).Results;
+
+    internal async Task<SearchPageResult> SearchWithStateAsync(
+        string query,
+        int take,
+        bool prerelease,
+        AuthenticationHeaderValue? auth,
+        NuGetOperationDeadline operation)
+    {
+        IReadOnlyList<SearchResult> results = await SearchPageAsync(
             query,
             skip: 0,
             take,
             prerelease,
             auth,
             operation).ConfigureAwait(false);
+        return new(
+            results,
+            results.Count >= take
+                ? SearchPageCompletion.RequestedLimit
+                : SearchPageCompletion.ShortPage);
+    }
 
     private async Task<IReadOnlyList<SearchResult>> SearchPageAsync(
         string query,

--- a/tests/DotnetInspect.Cli.Tests/NuGetSearchSourcesTests.cs
+++ b/tests/DotnetInspect.Cli.Tests/NuGetSearchSourcesTests.cs
@@ -1216,6 +1216,33 @@ public class NuGetSearchSourcesTests
     }
 
     [Fact]
+    public async Task SearchAsync_ShortPerFeedPagesDoNotReportRequestedLimit()
+    {
+        const string indexA = "https://a.example/v3/index.json";
+        const string indexB = "https://b.example/v3/index.json";
+        const string searchA = "https://a.example/v3/query";
+        const string searchB = "https://b.example/v3/query";
+
+        var handler = new RouteHandler
+        {
+            [indexA] = $$"""{"resources":[{"@id":"{{searchA}}","@type":"SearchQueryService"}]}""",
+            [indexB] = $$"""{"resources":[{"@id":"{{searchB}}","@type":"SearchQueryService"}]}""",
+            [searchA] = """{"data":[{"id":"A.Package","version":"1.0.0"}]}""",
+            [searchB] = """{"data":[{"id":"B.Package","version":"1.0.0"}]}"""
+        };
+        using var client = new HttpClient(handler);
+
+        NuGetSearchOutcome outcome = await NuGetSearchService.SearchAsync(
+            client,
+            "q",
+            take: 2,
+            sourceOptions: new NuGetSourceOptions { Sources = [indexA, indexB] });
+
+        Assert.Equal(["A.Package", "B.Package"], outcome.Results.Select(r => r.PackageId));
+        Assert.False(outcome.SearchLimitReached);
+    }
+
+    [Fact]
     public async Task SearchAsync_PackageSourceMappingFiltersEachResultByReportingAlias()
     {
         const string indexA = "https://a.example/v3/index.json";

--- a/tests/NuGetFetch.Tests/SearchServiceTests.cs
+++ b/tests/NuGetFetch.Tests/SearchServiceTests.cs
@@ -36,6 +36,47 @@ public class SearchServiceTests
     }
 
     [Fact]
+    public async Task SearchWithStateAsync_ShortPageIsReported()
+    {
+        var handler = new CapturingHandler(
+            """{"data":[{"id":"Contoso.Package","version":"1.0.0"}]}""");
+        using var client = new HttpClient(handler);
+        var service = new SearchService(client, SearchUrl);
+
+        SearchPageResult result = await service.SearchWithStateAsync(
+            "Contoso",
+            take: 2,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(SearchPageCompletion.ShortPage, result.Completion);
+        Assert.False(result.Truncated);
+        Assert.Single(result.Results);
+    }
+
+    [Fact]
+    public async Task SearchWithStateAsync_FullPageRemainsBounded()
+    {
+        var handler = new CapturingHandler(
+            """
+            {"data":[
+              {"id":"Contoso.One","version":"1.0.0"},
+              {"id":"Contoso.Two","version":"1.0.0"}
+            ]}
+            """);
+        using var client = new HttpClient(handler);
+        var service = new SearchService(client, SearchUrl);
+
+        SearchPageResult result = await service.SearchWithStateAsync(
+            "Contoso",
+            take: 2,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(SearchPageCompletion.RequestedLimit, result.Completion);
+        Assert.True(result.Truncated);
+        Assert.Equal(2, result.Results.Count);
+    }
+
+    [Fact]
     public async Task SearchAsync_ReplacesExistingSemVerLevel()
     {
         var handler = new CapturingHandler("""{"data":[]}""");


### PR DESCRIPTION
## Demo

A package search request now preserves source page evidence instead of reducing every response to a row list:

- a response filling the requested page is surfaced as `RequestedLimit` and continues to produce the existing incomplete-result warning;
- a shorter response is surfaced as `ShortPage` without claiming authoritative corpus exhaustion;
- the rows-only `SearchAsync` API remains compatible for existing callers.

The package-search aggregate regression covers both full and short per-feed pages across multiple sources.

## Change

This is a focused follow-up to #4677 and #6776. It establishes typed lower-level evidence for a future source-delegation adoption without claiming cross-source completion, exact counts, or provider-independent exhaustion.

## Validation

- `dotnet build tests/NuGetFetch.Tests/NuGetFetch.Tests.csproj -c Release`
- `dotnet run --project tests/NuGetFetch.Tests -c Release -- --filter-not-trait 'Network=Live'` — 1,046 passed, 2 platform skips
- `dotnet build tests/DotnetInspect.Cli.Tests/DotnetInspect.Cli.Tests.csproj -c Release`
- `dotnet run --project tests/DotnetInspect.Cli.Tests -c Release -- --filter-class '*NuGetSearchSourcesTests'` — 148 passed
- `npx --yes markdownlint-cli docs/design/cli-execution-bounds.md`
- `git diff --check`

Closes #4677
